### PR TITLE
Request body & Streaming

### DIFF
--- a/net/bufio_test.ts
+++ b/net/bufio_test.ts
@@ -108,7 +108,7 @@ test(async function bufioBufReader() {
   for (let i = 0; i < texts.length - 1; i++) {
     texts[i] = str + "\n";
     all += texts[i];
-    str += String.fromCharCode((i % 26) + 97);
+    str += String.fromCharCode(i % 26 + 97);
   }
   texts[texts.length - 1] = all;
 
@@ -293,7 +293,7 @@ test(async function bufioWriter() {
   const data = new Uint8Array(8192);
 
   for (let i = 0; i < data.byteLength; i++) {
-    data[i] = charCode(" ") + (i % (charCode("~") - charCode(" ")));
+    data[i] = charCode(" ") + i % (charCode("~") - charCode(" "));
   }
 
   const w = new Buffer();

--- a/net/bufio_test.ts
+++ b/net/bufio_test.ts
@@ -108,7 +108,7 @@ test(async function bufioBufReader() {
   for (let i = 0; i < texts.length - 1; i++) {
     texts[i] = str + "\n";
     all += texts[i];
-    str += String.fromCharCode(i % 26 + 97);
+    str += String.fromCharCode((i % 26) + 97);
   }
   texts[texts.length - 1] = all;
 
@@ -293,7 +293,7 @@ test(async function bufioWriter() {
   const data = new Uint8Array(8192);
 
   for (let i = 0; i < data.byteLength; i++) {
-    data[i] = charCode(" ") + i % (charCode("~") - charCode(" "));
+    data[i] = charCode(" ") + (i % (charCode("~") - charCode(" ")));
   }
 
   const w = new Buffer();

--- a/net/http.ts
+++ b/net/http.ts
@@ -129,7 +129,7 @@ export class ServerRequest {
   r: BufReader;
   w: BufWriter;
 
-  public async *readChunk() {
+  public async *bodyStream() {
     if (this.headers.has("content-length")) {
       const len = +this.headers.get("content-length");
       if (Number.isNaN(len)) {
@@ -205,8 +205,8 @@ export class ServerRequest {
   }
 
   // Read the body of the request into a single Uint8Array
-  public async readAll(): Promise<Uint8Array> {
-    return readAllIterator(this.readChunk());
+  public async body(): Promise<Uint8Array> {
+    return readAllIterator(this.bodyStream());
   }
 
   private async _streamBody(body: Reader, bodyLength: number) {

--- a/net/http.ts
+++ b/net/http.ts
@@ -28,11 +28,14 @@ interface ServeEnv {
   serveDeferred: Deferred;
 }
 
-// Continuously read more requests from conn until EOF
-// Mutually calling with maybeHandleReq
-// TODO: make them async function after this change is done
-// https://github.com/tc39/ecma262/pull/1250
-// See https://v8.dev/blog/fast-async
+/** Continuously read more requests from conn until EOF
+ * Calls maybeHandleReq.
+ * bufr is empty on a fresh TCP connection.
+ * Would be passed around and reused for later request on same conn
+ * TODO: make them async function after this change is done
+ * https://github.com/tc39/ecma262/pull/1250
+ * See https://v8.dev/blog/fast-async
+ */
 function serveConn(env: ServeEnv, conn: Conn, bufr?: BufReader) {
   readRequest(conn, bufr).then(maybeHandleReq.bind(null, env, conn));
 }

--- a/net/http.ts
+++ b/net/http.ts
@@ -33,8 +33,8 @@ interface ServeEnv {
 // TODO: make them async function after this change is done
 // https://github.com/tc39/ecma262/pull/1250
 // See https://v8.dev/blog/fast-async
-export function serveConn(env: ServeEnv, conn: Conn) {
-  readRequest(conn).then(maybeHandleReq.bind(null, env, conn));
+function serveConn(env: ServeEnv, conn: Conn, bufr?: BufReader) {
+  readRequest(conn, bufr).then(maybeHandleReq.bind(null, env, conn));
 }
 function maybeHandleReq(env: ServeEnv, conn: Conn, maybeReq: any) {
   const [req, _err] = maybeReq;
@@ -44,8 +44,6 @@ function maybeHandleReq(env: ServeEnv, conn: Conn, maybeReq: any) {
   }
   env.reqQueue.push(req); // push req to queue
   env.serveDeferred.resolve(); // signal while loop to process it
-  // TODO: protection against client req flooding
-  serveConn(env, conn); // try read more (reusing connection)
 }
 
 export async function* serve(addr: string) {
@@ -77,6 +75,9 @@ export async function* serve(addr: string) {
     env.reqQueue = [];
     for (const result of queueToProcess) {
       yield result;
+      // Continue read more from conn when user is done with the current req
+      // Moving this here makes it easier to manage
+      serveConn(env, result.conn, result.r);
     }
   }
   listener.close();
@@ -121,7 +122,153 @@ export class ServerRequest {
   method: string;
   proto: string;
   headers: Headers;
+  conn: Conn;
+  r: BufReader;
   w: BufWriter;
+
+  // TODO: implement stream request body
+  public async *readChunk() {
+    if (this.headers.has("content-length")) {
+      const len = +this.headers.get("content-length");
+      if (Number.isNaN(len)) {
+        return new Uint8Array(0);
+      }
+      let buf = new Uint8Array(1024);
+      let rr = await this.r.read(buf);
+      let nread = rr.nread;
+      while (!rr.eof && nread < len) {
+        yield buf.subarray(0, rr.nread);
+        buf = new Uint8Array(1024);
+        rr = await this.r.read(buf);
+        nread += rr.nread;
+      }
+      yield buf.subarray(0, rr.nread);
+    } else if (this.headers.get("transfer-encoding") === "chunked") {
+      // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
+      let len = 0;
+      const chunks = [];
+      const tp = new TextProtoReader(this.r);
+      let [line, _] = await tp.readLine();
+      // TODO: handle chunk extension
+      let [chunkSizeString, optExt] = line.split(";");
+      let chunkSize = parseInt(chunkSizeString, 16);
+      if (Number.isNaN(chunkSize) || chunkSize < 0) {
+        throw new Error("Invalid chunk size");
+      }
+      while (chunkSize > 0) {
+        let data = new Uint8Array(chunkSize);
+        let [nread, err] = await this.r.readFull(data);
+        if (nread !== chunkSize) {
+          throw new Error("Chunk data does not match size");
+        }
+        yield data;
+        len += chunkSize;
+        await this.r.readLine(); // Consume \r\n
+        [line, _] = await tp.readLine();
+        chunkSize = parseInt(line, 16);
+      }
+      const [entityHeaders, err] = await tp.readMIMEHeader();
+      if (!err) {
+        for (let [k, v] of entityHeaders) {
+          this.headers.set(k, v);
+        }
+      }
+      /* Pseudo code from https://tools.ietf.org/html/rfc2616#section-19.4.6
+      length := 0
+      read chunk-size, chunk-extension (if any) and CRLF
+      while (chunk-size > 0) {
+        read chunk-data and CRLF
+        append chunk-data to entity-body
+        length := length + chunk-size
+        read chunk-size and CRLF
+      }
+      read entity-header
+      while (entity-header not empty) {
+        append entity-header to existing header fields
+        read entity-header
+      }
+      Content-Length := length
+      Remove "chunked" from Transfer-Encoding
+      */
+    } else {
+      yield new Uint8Array(0);
+    }
+  }
+
+  // Read the body of the request into a single Uint8Array
+  public async readAll(): Promise<Uint8Array> {
+    if (this.headers.has("content-length")) {
+      const len = +this.headers.get("content-length");
+      if (Number.isNaN(len)) {
+        return new Uint8Array(0);
+      }
+      const body = new Uint8Array(len);
+      let rr = await this.r.read(body);
+      let nread = rr.nread;
+      while (!rr.eof && nread < len) {
+        rr = await this.r.read(body.subarray(nread));
+        nread += rr.nread;
+      }
+      return body;
+    } else if (this.headers.get("transfer-encoding") === "chunked") {
+      // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
+      let len = 0;
+      const chunks = [];
+      const tp = new TextProtoReader(this.r);
+      let [line, _] = await tp.readLine();
+      // TODO: handle chunk extension
+      let [chunkSizeString, optExt] = line.split(";");
+      let chunkSize = parseInt(chunkSizeString, 16);
+      if (Number.isNaN(chunkSize) || chunkSize < 0) {
+        throw new Error("Invalid chunk size");
+      }
+      while (chunkSize > 0) {
+        let data = new Uint8Array(chunkSize);
+        let [nread, err] = await this.r.readFull(data);
+        if (nread !== chunkSize) {
+          throw new Error("Chunk data does not match size");
+        }
+        chunks.push(data);
+        len += chunkSize;
+        await this.r.readLine(); // Consume \r\n
+        [line, _] = await tp.readLine();
+        chunkSize = parseInt(line, 16);
+      }
+      const [entityHeaders, err] = await tp.readMIMEHeader();
+      if (!err) {
+        for (let [k, v] of entityHeaders) {
+          this.headers.set(k, v);
+        }
+      }
+      // TODO: should we set content-length?
+      const body = new Uint8Array(len);
+      let offset = 0;
+      for (let chunk of chunks) {
+        body.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return body;
+      /* Pseudo code from https://tools.ietf.org/html/rfc2616#section-19.4.6
+      length := 0
+      read chunk-size, chunk-extension (if any) and CRLF
+      while (chunk-size > 0) {
+        read chunk-data and CRLF
+        append chunk-data to entity-body
+        length := length + chunk-size
+        read chunk-size and CRLF
+      }
+      read entity-header
+      while (entity-header not empty) {
+        append entity-header to existing header fields
+        read entity-header
+      }
+      Content-Length := length
+      Remove "chunked" from Transfer-Encoding
+      */
+    } else {
+      return new Uint8Array(0);
+    }
+  }
 
   private async _streamBody(body: Reader, bodyLength: number) {
     const n = await copy(this.w, body);
@@ -187,12 +334,19 @@ export class ServerRequest {
   }
 }
 
-async function readRequest(c: Conn): Promise<[ServerRequest, BufState]> {
-  const bufr = new BufReader(c);
+async function readRequest(
+  c: Conn,
+  bufr?: BufReader
+): Promise<[ServerRequest, BufState]> {
+  if (!bufr) {
+    bufr = new BufReader(c);
+  }
   const bufw = new BufWriter(c);
   const req = new ServerRequest();
+  req.conn = c;
+  req.r = bufr!;
   req.w = bufw;
-  const tp = new TextProtoReader(bufr);
+  const tp = new TextProtoReader(bufr!);
 
   let s: string;
   let err: BufState;
@@ -206,7 +360,23 @@ async function readRequest(c: Conn): Promise<[ServerRequest, BufState]> {
 
   [req.headers, err] = await tp.readMIMEHeader();
 
-  // TODO: handle body
-
   return [req, err];
+}
+
+async function collect(
+  it: AsyncIterableIterator<Uint8Array>
+): Promise<Uint8Array> {
+  const chunks = [];
+  let len = 0;
+  for await (const chunk of it) {
+    chunks.push(chunk);
+    len += chunk.length;
+  }
+  const collected = new Uint8Array(len);
+  let offset = 0;
+  for (let chunk of chunks) {
+    collected.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return collected;
 }

--- a/net/http.ts
+++ b/net/http.ts
@@ -146,6 +146,7 @@ export class ServerRequest {
       }
       yield buf.subarray(0, rr.nread);
     } else if (this.headers.get("transfer-encoding") === "chunked") {
+      // TODO: handle other transfer-encoding types and support comma list
       // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
       const tp = new TextProtoReader(this.r);
       let [line, _] = await tp.readLine();

--- a/net/http.ts
+++ b/net/http.ts
@@ -196,7 +196,7 @@ export class ServerRequest {
 
   // Read the body of the request into a single Uint8Array
   public async readAll(): Promise<Uint8Array> {
-    return collect(this.readChunk());
+    return readAllIterator(this.readChunk());
   }
 
   private async _streamBody(body: Reader, bodyLength: number) {
@@ -292,7 +292,7 @@ async function readRequest(
   return [req, err];
 }
 
-async function collect(
+async function readAllIterator(
   it: AsyncIterableIterator<Uint8Array>
 ): Promise<Uint8Array> {
   const chunks = [];

--- a/net/http.ts
+++ b/net/http.ts
@@ -298,6 +298,10 @@ async function collect(
     chunks.push(chunk);
     len += chunk.length;
   }
+  if (chunks.length === 0) {
+    // No need for copy
+    return chunks[0];
+  }
   const collected = new Uint8Array(len);
   let offset = 0;
   for (let chunk of chunks) {

--- a/net/http_test.ts
+++ b/net/http_test.ts
@@ -60,14 +60,14 @@ test(async function responseWrite() {
   }
 });
 
-test(async function requestReadBodyWithContentLength() {
+test(async function requestBodyWithContentLength() {
   {
     const req = new ServerRequest();
     req.headers = new Headers();
     req.headers.set("content-length", "5");
     const buf = new Buffer(enc.encode("Hello"));
     req.r = new BufReader(buf);
-    const body = dec.decode(await req.readAll());
+    const body = dec.decode(await req.body());
     assertEqual(body, "Hello");
   }
 
@@ -79,12 +79,12 @@ test(async function requestReadBodyWithContentLength() {
     req.headers.set("Content-Length", "5000");
     const buf = new Buffer(enc.encode(longText));
     req.r = new BufReader(buf);
-    const body = dec.decode(await req.readAll());
+    const body = dec.decode(await req.body());
     assertEqual(body, longText);
   }
 });
 
-test(async function requestReadBodyWithTransferEncoding() {
+test(async function requestBodyWithTransferEncoding() {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -104,7 +104,7 @@ test(async function requestReadBodyWithTransferEncoding() {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const body = dec.decode(await req.readAll());
+    const body = dec.decode(await req.body());
     assertEqual(body, shortText);
   }
 
@@ -128,12 +128,12 @@ test(async function requestReadBodyWithTransferEncoding() {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const body = dec.decode(await req.readAll());
+    const body = dec.decode(await req.body());
     assertEqual(body, longText);
   }
 });
 
-test(async function requestReadStreamWithContentLength() {
+test(async function requestBodyStreamWithContentLength() {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -141,7 +141,7 @@ test(async function requestReadStreamWithContentLength() {
     req.headers.set("content-length", "" + shortText.length);
     const buf = new Buffer(enc.encode(shortText));
     req.r = new BufReader(buf);
-    const it = await req.readChunk();
+    const it = await req.bodyStream();
     let offset = 0;
     for await (const chunk of it) {
       const s = dec.decode(chunk);
@@ -158,7 +158,7 @@ test(async function requestReadStreamWithContentLength() {
     req.headers.set("Content-Length", "5000");
     const buf = new Buffer(enc.encode(longText));
     req.r = new BufReader(buf);
-    const it = await req.readChunk();
+    const it = await req.bodyStream();
     let offset = 0;
     for await (const chunk of it) {
       const s = dec.decode(chunk);
@@ -168,7 +168,7 @@ test(async function requestReadStreamWithContentLength() {
   }
 });
 
-test(async function requestReadStreamWithTransferEncoding() {
+test(async function requestBodyStreamWithTransferEncoding() {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -188,7 +188,7 @@ test(async function requestReadStreamWithTransferEncoding() {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const it = await req.readChunk();
+    const it = await req.bodyStream();
     let offset = 0;
     for await (const chunk of it) {
       const s = dec.decode(chunk);
@@ -217,7 +217,7 @@ test(async function requestReadStreamWithTransferEncoding() {
     chunksData += "0\r\n\r\n";
     const buf = new Buffer(enc.encode(chunksData));
     req.r = new BufReader(buf);
-    const it = await req.readChunk();
+    const it = await req.bodyStream();
     let offset = 0;
     for await (const chunk of it) {
       const s = dec.decode(chunk);

--- a/net/http_test.ts
+++ b/net/http_test.ts
@@ -18,12 +18,15 @@ import {
   Response
 } from "./http";
 import { Buffer } from "deno";
-import { BufWriter } from "./bufio";
+import { BufWriter, BufReader } from "./bufio";
 
 interface ResponseTest {
   response: Response;
   raw: string;
 }
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
 
 const responseTests: ResponseTest[] = [
   // Default response
@@ -54,5 +57,172 @@ test(async function responseWrite() {
 
     await request.respond(testCase.response);
     assertEqual(buf.toString(), testCase.raw);
+  }
+});
+
+test(async function requestReadBodyWithContentLength() {
+  {
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("content-length", "5");
+    const buf = new Buffer(enc.encode("Hello"));
+    req.r = new BufReader(buf);
+    const body = dec.decode(await req.readAll());
+    assertEqual(body, "Hello");
+  }
+
+  // Larger than internal buf
+  {
+    const longText = "1234\n".repeat(1000);
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("Content-Length", "5000");
+    const buf = new Buffer(enc.encode(longText));
+    req.r = new BufReader(buf);
+    const body = dec.decode(await req.readAll());
+    assertEqual(body, longText);
+  }
+});
+
+test(async function requestReadBodyWithTransferEncoding() {
+  {
+    const shortText = "Hello";
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("transfer-encoding", "chunked");
+    let chunksData = "";
+    let chunkOffset = 0;
+    const maxChunkSize = 70;
+    while (chunkOffset < shortText.length) {
+      const chunkSize = Math.min(maxChunkSize, shortText.length - chunkOffset);
+      chunksData += `${chunkSize.toString(16)}\r\n${shortText.substr(
+        chunkOffset,
+        chunkSize
+      )}\r\n`;
+      chunkOffset += chunkSize;
+    }
+    chunksData += "0\r\n\r\n";
+    const buf = new Buffer(enc.encode(chunksData));
+    req.r = new BufReader(buf);
+    const body = dec.decode(await req.readAll());
+    assertEqual(body, shortText);
+  }
+
+  // Larger than internal buf
+  {
+    const longText = "1234\n".repeat(1000);
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("transfer-encoding", "chunked");
+    let chunksData = "";
+    let chunkOffset = 0;
+    const maxChunkSize = 70;
+    while (chunkOffset < longText.length) {
+      const chunkSize = Math.min(maxChunkSize, longText.length - chunkOffset);
+      chunksData += `${chunkSize.toString(16)}\r\n${longText.substr(
+        chunkOffset,
+        chunkSize
+      )}\r\n`;
+      chunkOffset += chunkSize;
+    }
+    chunksData += "0\r\n\r\n";
+    const buf = new Buffer(enc.encode(chunksData));
+    req.r = new BufReader(buf);
+    const body = dec.decode(await req.readAll());
+    assertEqual(body, longText);
+  }
+});
+
+test(async function requestReadStreamWithContentLength() {
+  {
+    const shortText = "Hello";
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("content-length", "" + shortText.length);
+    const buf = new Buffer(enc.encode(shortText));
+    req.r = new BufReader(buf);
+    const it = await req.readChunk();
+    let offset = 0;
+    for await (const chunk of it) {
+      const s = dec.decode(chunk);
+      assertEqual(shortText.substr(offset, s.length), s);
+      offset += s.length;
+    }
+  }
+
+  // Larger than internal buf
+  {
+    const longText = "1234\n".repeat(1000);
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("Content-Length", "5000");
+    const buf = new Buffer(enc.encode(longText));
+    req.r = new BufReader(buf);
+    const it = await req.readChunk();
+    let offset = 0;
+    for await (const chunk of it) {
+      const s = dec.decode(chunk);
+      assertEqual(longText.substr(offset, s.length), s);
+      offset += s.length;
+    }
+  }
+});
+
+test(async function requestReadStreamWithTransferEncoding() {
+  {
+    const shortText = "Hello";
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("transfer-encoding", "chunked");
+    let chunksData = "";
+    let chunkOffset = 0;
+    const maxChunkSize = 70;
+    while (chunkOffset < shortText.length) {
+      const chunkSize = Math.min(maxChunkSize, shortText.length - chunkOffset);
+      chunksData += `${chunkSize.toString(16)}\r\n${shortText.substr(
+        chunkOffset,
+        chunkSize
+      )}\r\n`;
+      chunkOffset += chunkSize;
+    }
+    chunksData += "0\r\n\r\n";
+    const buf = new Buffer(enc.encode(chunksData));
+    req.r = new BufReader(buf);
+    const it = await req.readChunk();
+    let offset = 0;
+    for await (const chunk of it) {
+      const s = dec.decode(chunk);
+      assertEqual(shortText.substr(offset, s.length), s);
+      offset += s.length;
+    }
+  }
+
+  // Larger than internal buf
+  {
+    const longText = "1234\n".repeat(1000);
+    const req = new ServerRequest();
+    req.headers = new Headers();
+    req.headers.set("transfer-encoding", "chunked");
+    let chunksData = "";
+    let chunkOffset = 0;
+    const maxChunkSize = 70;
+    while (chunkOffset < longText.length) {
+      const chunkSize = Math.min(maxChunkSize, longText.length - chunkOffset);
+      chunksData += `${chunkSize.toString(16)}\r\n${longText.substr(
+        chunkOffset,
+        chunkSize
+      )}\r\n`;
+      chunkOffset += chunkSize;
+    }
+    chunksData += "0\r\n\r\n";
+    const buf = new Buffer(enc.encode(chunksData));
+    req.r = new BufReader(buf);
+    const it = await req.readChunk();
+    let offset = 0;
+    for await (const chunk of it) {
+      const s = dec.decode(chunk);
+      assertEqual(longText.substr(offset, s.length), s);
+      offset += s.length;
+    }
   }
 });


### PR DESCRIPTION
Allow reading request body & streaming request.

Added 2 methods to `ServerRequest`: `bodyStream` (returns an async iterator for chunks) and `body` (returns a collected Uint8Array of body)

Added 1 method to `BufReader`: `readFull` (corresponding to [`io.ReadFull`](https://golang.org/pkg/io/#ReadFull) of Golang. We don't have `io` implemented so this is placed directly at `BufReader` for now)

e.g. Echo http server
```typescript
import * as deno from "deno";
import { serve } from "./http.ts";

const addr = deno.args[1] || "127.0.0.1:4500";
const server = serve(addr);

async function main(): Promise<void> {
  for await (const request of server) {
    const body = await request.body();
    await request.respond({ status: 200, body });
  }
}

main();
```
