### PR TITLE
Remove default export from flags module

### DIFF
--- a/examples/gist.ts
+++ b/examples/gist.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env deno --allow-net --allow-env
 
 import { args, env, exit, readFile } from "deno";
-import parseArgs from "https://deno.land/x/flags/index.ts";
+import { parse } from "https://deno.land/x/flags/index.ts";
 
 function pathBase(p: string): string {
   const parts = p.split("/");
@@ -16,7 +16,7 @@ async function main() {
     exit(1);
   }
 
-  const parsedArgs = parseArgs(args.slice(1));
+  const parsedArgs = parse(args.slice(1));
 
   if (parsedArgs._.length === 0) {
     console.error(

--- a/flags/README.md
+++ b/flags/README.md
@@ -6,9 +6,9 @@ Command line arguments parser for Deno based on minimist
 
 ``` ts
 import { args } from "deno";
-import parseArgs from "https://deno.land/x/flags/index.ts";
+import { parse } from "https://deno.land/x/flags/index.ts";
 
-console.dir(parseArgs(args));
+console.dir(parse(args));
 ```
 
 ```
@@ -30,7 +30,7 @@ $ deno example.ts -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
 
 # API
 
-## const parsedArgs = parseArgs(args, options = {});
+## const parsedArgs = parse(args, options = {});
 
 `parsedArgs._` contains all the arguments that didn't have an option associated with
 them.

--- a/flags/example.ts
+++ b/flags/example.ts
@@ -1,4 +1,4 @@
 import { args } from "deno";
-import parseArgs from "./index.ts";
+import { parse } from "./index.ts";
 
-console.dir(parseArgs(args));
+console.dir(parse(args));

--- a/flags/index.ts
+++ b/flags/index.ts
@@ -18,7 +18,7 @@ const DEFAULT_OPTIONS = {
   stopEarly: false
 };
 
-export default function parseArgs(
+export function parse(
   args,
   initialOptions?: ArgParsingOptions
 ): { [key: string]: any } {

--- a/flags/tests/all_bool.ts
+++ b/flags/tests/all_bool.ts
@@ -1,9 +1,9 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 // flag boolean true (default all --args to boolean)
 test(function flagBooleanTrue() {
-    const argv = parseArgs(['moo', '--honk', 'cow'], {
+    const argv = parse(['moo', '--honk', 'cow'], {
         boolean: true
     });
     
@@ -17,7 +17,7 @@ test(function flagBooleanTrue() {
 
 // flag boolean true only affects double hyphen arguments without equals signs
 test(function flagBooleanTrueOnlyAffectsDoubleDash() {
-    var argv = parseArgs(['moo', '--honk', 'cow', '-p', '55', '--tacos=good'], {
+    var argv = parse(['moo', '--honk', 'cow', '-p', '55', '--tacos=good'], {
         boolean: true
     });
     

--- a/flags/tests/bool.ts
+++ b/flags/tests/bool.ts
@@ -1,8 +1,8 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function flagBooleanDefaultFalse() {
-    const argv = parseArgs(['moo'], {
+    const argv = parse(['moo'], {
         boolean: ['t', 'verbose'],
         default: { verbose: false, t: false }
     });
@@ -18,7 +18,7 @@ test(function flagBooleanDefaultFalse() {
 });
 
 test(function booleanGroups() {
-    const argv = parseArgs([ '-x', '-z', 'one', 'two', 'three' ], {
+    const argv = parse([ '-x', '-z', 'one', 'two', 'three' ], {
         boolean: ['x','y','z']
     });
     
@@ -40,11 +40,11 @@ test(function booleanAndAliasWithChainableApi() {
     const opts = {
         herp: { alias: 'h', boolean: true }
     };
-    const aliasedArgv = parseArgs(aliased, {
+    const aliasedArgv = parse(aliased, {
         boolean: 'herp',
         alias: { h: 'herp' }
     });
-    const propertyArgv = parseArgs(regular, {
+    const propertyArgv = parse(regular, {
         boolean: 'herp',
         alias: { h: 'herp' }
     });
@@ -65,8 +65,8 @@ test(function booleanAndAliasWithOptionsHash() {
         alias: { 'h': 'herp' },
         boolean: 'herp'
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
     const expected = {
         herp: true,
         h: true,
@@ -84,9 +84,9 @@ test(function booleanAndAliasArrayWithOptionsHash() {
         alias: { 'h': ['herp', 'harp'] },
         boolean: 'h'
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
-    const altPropertyArgv = parseArgs(alt, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
+    const altPropertyArgv = parse(alt, opts);
     const expected = {
         harp: true,
         herp: true,
@@ -105,8 +105,8 @@ test(function booleanAndAliasUsingExplicitTrue() {
         alias: { h: 'herp' },
         boolean: 'h'
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
     const expected = {
         herp: true,
         h: true,
@@ -120,14 +120,14 @@ test(function booleanAndAliasUsingExplicitTrue() {
 // regression, see https://github.com/substack/node-optimist/issues/71
 // boolean and --x=true
 test(function booleanAndNonBoolean() {
-    const parsed = parseArgs(['--boool', '--other=true'], {
+    const parsed = parse(['--boool', '--other=true'], {
         boolean: 'boool'
     });
 
     assertEqual(parsed.boool, true);
     assertEqual(parsed.other, 'true');
 
-    const parsed2 = parseArgs(['--boool', '--other=false'], {
+    const parsed2 = parse(['--boool', '--other=false'], {
         boolean: 'boool'
     });
     
@@ -136,7 +136,7 @@ test(function booleanAndNonBoolean() {
 });
 
 test(function booleanParsingTrue() {
-    const parsed = parseArgs(['--boool=true'], {
+    const parsed = parse(['--boool=true'], {
         default: {
             boool: false
         },
@@ -147,7 +147,7 @@ test(function booleanParsingTrue() {
 });
 
 test(function booleanParsingFalse() {
-    const parsed = parseArgs(['--boool=false'], {
+    const parsed = parse(['--boool=false'], {
         default: {
           boool: true
         },

--- a/flags/tests/dash.ts
+++ b/flags/tests/dash.ts
@@ -1,28 +1,28 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function hyphen() {
-    assertEqual(parseArgs([ '-n', '-' ]), { n: '-', _: [] });
-    assertEqual(parseArgs([ '-' ]), { _: [ '-' ] });
-    assertEqual(parseArgs([ '-f-' ]), { f: '-', _: [] });
+    assertEqual(parse([ '-n', '-' ]), { n: '-', _: [] });
+    assertEqual(parse([ '-' ]), { _: [ '-' ] });
+    assertEqual(parse([ '-f-' ]), { f: '-', _: [] });
     assertEqual(
-        parseArgs([ '-b', '-' ], { boolean: 'b' }),
+        parse([ '-b', '-' ], { boolean: 'b' }),
         { b: true, _: [ '-' ] }
     );
     assertEqual(
-        parseArgs([ '-s', '-' ], { string: 's' }),
+        parse([ '-s', '-' ], { string: 's' }),
         { s: '-', _: [] }
     );
 });
 
 test(function doubleDash() {
-    assertEqual(parseArgs([ '-a', '--', 'b' ]), { a: true, _: [ 'b' ] });
-    assertEqual(parseArgs([ '--a', '--', 'b' ]), { a: true, _: [ 'b' ] });
-    assertEqual(parseArgs([ '--a', '--', 'b' ]), { a: true, _: [ 'b' ] });
+    assertEqual(parse([ '-a', '--', 'b' ]), { a: true, _: [ 'b' ] });
+    assertEqual(parse([ '--a', '--', 'b' ]), { a: true, _: [ 'b' ] });
+    assertEqual(parse([ '--a', '--', 'b' ]), { a: true, _: [ 'b' ] });
 });
 
 test(function moveArgsAfterDoubleDashIntoOwnArray() {
     assertEqual(
-        parseArgs([ '--name', 'John', 'before', '--', 'after' ], { '--': true }),
+        parse([ '--name', 'John', 'before', '--', 'after' ], { '--': true }),
         { name: 'John', _: [ 'before' ], '--': [ 'after' ] });
 });

--- a/flags/tests/default_bool.ts
+++ b/flags/tests/default_bool.ts
@@ -1,8 +1,8 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function booleanDefaultTrue() {
-    const argv = parseArgs([], {
+    const argv = parse([], {
         boolean: 'sometrue',
         default: { sometrue: true }
     });
@@ -10,7 +10,7 @@ test(function booleanDefaultTrue() {
 });
 
 test(function booleanDefaultFalse() {
-    const argv = parseArgs([], {
+    const argv = parse([], {
         boolean: 'somefalse',
         default: { somefalse: false }
     });
@@ -18,12 +18,12 @@ test(function booleanDefaultFalse() {
 });
 
 test(function booleanDefaultNull() {
-    const argv = parseArgs([], {
+    const argv = parse([], {
         boolean: 'maybe',
         default: { maybe: null }
     });
     assertEqual(argv.maybe, null);
-    const argv2 = parseArgs(['--maybe'], {
+    const argv2 = parse(['--maybe'], {
         boolean: 'maybe',
         default: { maybe: null }
     });

--- a/flags/tests/dotted.ts
+++ b/flags/tests/dotted.ts
@@ -1,19 +1,19 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function dottedAlias() {
-    const argv = parseArgs(['--a.b', '22'], {default: {'a.b': 11}, alias: {'a.b': 'aa.bb'}});
+    const argv = parse(['--a.b', '22'], {default: {'a.b': 11}, alias: {'a.b': 'aa.bb'}});
     assertEqual(argv.a.b, 22);
     assertEqual(argv.aa.bb, 22);
 });
 
 test(function dottedDefault() {
-    const argv = parseArgs('', {default: {'a.b': 11}, alias: {'a.b': 'aa.bb'}});
+    const argv = parse('', {default: {'a.b': 11}, alias: {'a.b': 'aa.bb'}});
     assertEqual(argv.a.b, 11);
     assertEqual(argv.aa.bb, 11);
 });
 
 test(function dottedDefaultWithNoAlias() {
-    const argv = parseArgs('', {default: {'a.b': 11}});
+    const argv = parse('', {default: {'a.b': 11}});
     assertEqual(argv.a.b, 11);
 });

--- a/flags/tests/kv_short.ts
+++ b/flags/tests/kv_short.ts
@@ -1,12 +1,12 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function short() {
-    const argv = parseArgs([ '-b=123' ]);
+    const argv = parse([ '-b=123' ]);
     assertEqual(argv, { b: 123, _: [] });
 });
 
 test(function multiShort() {
-    const argv = parseArgs([ '-a=whatever', '-b=robots' ]);
+    const argv = parse([ '-a=whatever', '-b=robots' ]);
     assertEqual(argv, { a: 'whatever', b: 'robots', _: [] });
 });

--- a/flags/tests/long.ts
+++ b/flags/tests/long.ts
@@ -1,25 +1,25 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function longOpts() {
     assertEqual(
-        parseArgs([ '--bool' ]),
+        parse([ '--bool' ]),
         { bool : true, _ : [] },
     );
     assertEqual(
-        parseArgs([ '--pow', 'xixxle' ]),
+        parse([ '--pow', 'xixxle' ]),
         { pow : 'xixxle', _ : [] },
     );
     assertEqual(
-        parseArgs([ '--pow=xixxle' ]),
+        parse([ '--pow=xixxle' ]),
         { pow : 'xixxle', _ : [] },
     );
     assertEqual(
-        parseArgs([ '--host', 'localhost', '--port', '555' ]),
+        parse([ '--host', 'localhost', '--port', '555' ]),
         { host : 'localhost', port : 555, _ : [] },
     );
     assertEqual(
-        parseArgs([ '--host=localhost', '--port=555' ]),
+        parse([ '--host=localhost', '--port=555' ]),
         { host : 'localhost', port : 555, _ : [] },
     );
 });

--- a/flags/tests/num.ts
+++ b/flags/tests/num.ts
@@ -1,8 +1,8 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function nums() {
-    const argv = parseArgs([
+    const argv = parse([
         '-x', '1234',
         '-y', '5.67',
         '-z', '1e7',
@@ -27,7 +27,7 @@ test(function nums() {
 });
 
 test(function alreadyNumber() {
-    const argv = parseArgs([ '-x', 1234, 789 ]);
+    const argv = parse([ '-x', 1234, 789 ]);
     assertEqual(argv, { x : 1234, _ : [ 789 ] });
     assertEqual(typeof argv.x, 'number');
     assertEqual(typeof argv._[0], 'number');

--- a/flags/tests/parse.ts
+++ b/flags/tests/parse.ts
@@ -1,21 +1,21 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 
 test(function _arseArgs() {
     assertEqual(
-        parseArgs([ '--no-moo' ]),
+        parse([ '--no-moo' ]),
         { moo : false, _ : [] },
     );
     assertEqual(
-        parseArgs([ '-v', 'a', '-v', 'b', '-v', 'c' ]),
+        parse([ '-v', 'a', '-v', 'b', '-v', 'c' ]),
         { v : ['a','b','c'], _ : [] },
     );
 });
  
 test(function comprehensive() {
     assertEqual(
-        parseArgs([
+        parse([
             '--name=meowmers', 'bare', '-cats', 'woo',
             '-h', 'awesome', '--multi=quux',
             '--key', 'value',
@@ -40,13 +40,13 @@ test(function comprehensive() {
 });
 
 test(function flagBoolean() {
-    const argv = parseArgs([ '-t', 'moo' ], { boolean: 't' });
+    const argv = parse([ '-t', 'moo' ], { boolean: 't' });
     assertEqual(argv, { t : true, _ : [ 'moo' ] });
     assertEqual(typeof argv.t, 'boolean');
 });
 
 test(function flagBooleanValue() {
-    const argv = parseArgs(['--verbose', 'false', 'moo', '-t', 'true'], {
+    const argv = parse(['--verbose', 'false', 'moo', '-t', 'true'], {
         boolean: [ 't', 'verbose' ],
         default: { verbose: true }
     });
@@ -62,29 +62,29 @@ test(function flagBooleanValue() {
 });
 
 test(function newlinesInParams() {
-    const args = parseArgs([ '-s', "X\nX" ])
+    const args = parse([ '-s', "X\nX" ])
     assertEqual(args, { _ : [], s : "X\nX" });
     
     // reproduce in bash:
     // VALUE="new
     // line"
     // deno program.js --s="$VALUE"
-    const args2 = parseArgs([ "--s=X\nX" ])
+    const args2 = parse([ "--s=X\nX" ])
     assertEqual(args2, { _ : [], s : "X\nX" });
 });
 
 test(function strings() {
-    const s = parseArgs([ '-s', '0001234' ], { string: 's' }).s;
+    const s = parse([ '-s', '0001234' ], { string: 's' }).s;
     assertEqual(s, '0001234');
     assertEqual(typeof s, 'string');
     
-    const x = parseArgs([ '-x', '56' ], { string: 'x' }).x;
+    const x = parse([ '-x', '56' ], { string: 'x' }).x;
     assertEqual(x, '56');
     assertEqual(typeof x, 'string');
 });
 
 test(function stringArgs() {
-    const s = parseArgs([ '  ', '  ' ], { string: '_' })._;
+    const s = parse([ '  ', '  ' ], { string: '_' })._;
     assertEqual(s.length, 2);
     assertEqual(typeof s[0], 'string');
     assertEqual(s[0], '  ');
@@ -93,15 +93,15 @@ test(function stringArgs() {
 });
 
 test(function emptyStrings() {
-    const s = parseArgs([ '-s' ], { string: 's' }).s;
+    const s = parse([ '-s' ], { string: 's' }).s;
     assertEqual(s, '');
     assertEqual(typeof s, 'string');
 
-    const str = parseArgs([ '--str' ], { string: 'str' }).str;
+    const str = parse([ '--str' ], { string: 'str' }).str;
     assertEqual(str, '');
     assertEqual(typeof str, 'string');
 
-    const letters = parseArgs([ '-art' ], {
+    const letters = parse([ '-art' ], {
         string: [ 'a', 't' ]
     });
 
@@ -112,7 +112,7 @@ test(function emptyStrings() {
 
 
 test(function stringAndAlias() {
-    const x = parseArgs([ '--str',  '000123' ], {
+    const x = parse([ '--str',  '000123' ], {
         string: 's',
         alias: { s: 'str' }
     });
@@ -122,7 +122,7 @@ test(function stringAndAlias() {
     assertEqual(x.s, '000123');
     assertEqual(typeof x.s, 'string');
 
-    const y = parseArgs([ '-s',  '000123' ], {
+    const y = parse([ '-s',  '000123' ], {
         string: 'str',
         alias: { str: 's' }
     });
@@ -135,17 +135,17 @@ test(function stringAndAlias() {
 
 test(function slashBreak() {
     assertEqual(
-        parseArgs([ '-I/foo/bar/baz' ]),
+        parse([ '-I/foo/bar/baz' ]),
         { I : '/foo/bar/baz', _ : [] }
     );
     assertEqual(
-        parseArgs([ '-xyz/foo/bar/baz' ]),
+        parse([ '-xyz/foo/bar/baz' ]),
         { x : true, y : true, z : '/foo/bar/baz', _ : [] }
     );
 });
 
 test(function alias() {
-    const argv = parseArgs([ '-f', '11', '--zoom', '55' ], {
+    const argv = parse([ '-f', '11', '--zoom', '55' ], {
         alias: { z: 'zoom' }
     });
     assertEqual(argv.zoom, 55);
@@ -154,7 +154,7 @@ test(function alias() {
 });
 
 test(function multiAlias() {
-    const argv = parseArgs([ '-f', '11', '--zoom', '55' ], {
+    const argv = parse([ '-f', '11', '--zoom', '55' ], {
         alias: { z: [ 'zm', 'zoom' ] }
     });
     assertEqual(argv.zoom, 55);
@@ -164,7 +164,7 @@ test(function multiAlias() {
 });
 
 test(function nestedDottedObjects() {
-    const argv = parseArgs([
+    const argv = parse([
         '--foo.bar', '3', '--foo.baz', '4',
         '--foo.quux.quibble', '5', '--foo.quux.o_O',
         '--beep.boop'

--- a/flags/tests/short.ts
+++ b/flags/tests/short.ts
@@ -1,44 +1,44 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function numbericShortArgs() {
-    assertEqual(parseArgs([ '-n123' ]), { n: 123, _: [] });
+    assertEqual(parse([ '-n123' ]), { n: 123, _: [] });
     assertEqual(
-        parseArgs([ '-123', '456' ]),
+        parse([ '-123', '456' ]),
         { 1: true, 2: true, 3: 456, _: [] }
     );
 });
 
 test(function short() {
     assertEqual(
-        parseArgs([ '-b' ]),
+        parse([ '-b' ]),
         { b : true, _ : [] },
     );
     assertEqual(
-        parseArgs([ 'foo', 'bar', 'baz' ]),
+        parse([ 'foo', 'bar', 'baz' ]),
         { _ : [ 'foo', 'bar', 'baz' ] },
     );
     assertEqual(
-        parseArgs([ '-cats' ]),
+        parse([ '-cats' ]),
         { c : true, a : true, t : true, s : true, _ : [] },
     );
     assertEqual(
-        parseArgs([ '-cats', 'meow' ]),
+        parse([ '-cats', 'meow' ]),
         { c : true, a : true, t : true, s : 'meow', _ : [] },
     );
     assertEqual(
-        parseArgs([ '-h', 'localhost' ]),
+        parse([ '-h', 'localhost' ]),
         { h : 'localhost', _ : [] },
     );
     assertEqual(
-        parseArgs([ '-h', 'localhost', '-p', '555' ]),
+        parse([ '-h', 'localhost', '-p', '555' ]),
         { h : 'localhost', p : 555, _ : [] },
     );
 });
  
 test(function mixedShortBoolAndCapture() {
     assertEqual(
-        parseArgs([ '-h', 'localhost', '-fp', '555', 'script.js' ]),
+        parse([ '-h', 'localhost', '-fp', '555', 'script.js' ]),
         {
             f : true, p : 555, h : 'localhost',
             _ : [ 'script.js' ]
@@ -48,7 +48,7 @@ test(function mixedShortBoolAndCapture() {
  
 test(function shortAndLong() {
     assertEqual(
-        parseArgs([ '-h', 'localhost', '-fp', '555', 'script.js' ]),
+        parse([ '-h', 'localhost', '-fp', '555', 'script.js' ]),
         {
             f : true, p : 555, h : 'localhost',
             _ : [ 'script.js' ]

--- a/flags/tests/stop_early.ts
+++ b/flags/tests/stop_early.ts
@@ -1,9 +1,9 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 // stops parsing on the first non-option when stopEarly is set
 test(function stopParsing() {
-    const argv = parseArgs(['--aaa', 'bbb', 'ccc', '--ddd'], {
+    const argv = parse(['--aaa', 'bbb', 'ccc', '--ddd'], {
         stopEarly: true
     });
 

--- a/flags/tests/unknown.ts
+++ b/flags/tests/unknown.ts
@@ -1,5 +1,5 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function booleanAndAliasIsNotUnknown() {
     const unknown = [];
@@ -14,8 +14,8 @@ test(function booleanAndAliasIsNotUnknown() {
         boolean: 'h',
         unknown: unknownFn
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
 
     assertEqual(unknown, ['--derp', '-d']);
 });
@@ -26,7 +26,7 @@ test(function flagBooleanTrueAnyDoubleHyphenArgumentIsNotUnknown() {
         unknown.push(arg);
         return false;
     }
-    const argv = parseArgs(['--honk', '--tacos=good', 'cow', '-p', '55'], {
+    const argv = parse(['--honk', '--tacos=good', 'cow', '-p', '55'], {
         boolean: true,
         unknown: unknownFn
     });
@@ -50,8 +50,8 @@ test(function stringAndAliasIsNotUnkown() {
         string: 'h',
         unknown: unknownFn
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
 
     assertEqual(unknown, ['--derp', '-d']);
 });
@@ -69,8 +69,8 @@ test(function defaultAndAliasIsNotUnknown() {
         alias: { 'h': 'herp' },
         unknown: unknownFn
     };
-    const aliasedArgv = parseArgs(aliased, opts);
-    const propertyArgv = parseArgs(regular, opts);
+    const aliasedArgv = parse(aliased, opts);
+    const propertyArgv = parse(regular, opts);
 
     assertEqual(unknown, []);
 });
@@ -86,7 +86,7 @@ test(function valueFollowingDoubleHyphenIsNotUnknown() {
         '--': true,
         unknown: unknownFn
     };
-    const argv = parseArgs(aliased, opts);
+    const argv = parse(aliased, opts);
 
     assertEqual(unknown, ['--bad']);
     assertEqual(argv, {

--- a/flags/tests/whitespace.ts
+++ b/flags/tests/whitespace.ts
@@ -1,6 +1,6 @@
 import { test, assertEqual } from "https://deno.land/x/testing/testing.ts";
-import parseArgs from "../index.ts";
+import { parse } from "../index.ts";
 
 test(function whitespaceShouldBeWhitespace() {
-    assertEqual(parseArgs([ '-x', '\t' ]).x, '\t');
+    assertEqual(parse([ '-x', '\t' ]).x, '\t');
 });


### PR DESCRIPTION
This PR removes default export from `flags` module and replaces it with `parse` named export.