### PR TITLE
Fix wrong definition & rename function

### DIFF
--- a/logging/levels.ts
+++ b/logging/levels.ts
@@ -22,10 +22,10 @@ const byLevel = {
   [LogLevel.CRITICAL]: "CRITICAL"
 };
 
-export function getLevelByName(name) {
+export function getLevelByName(name: string): number {
   return byName[name];
 }
 
-export function getNameByLevel(level) {
+export function getNameByLevel(level: number): string {
   return byLevel[level];
 }

--- a/logging/levels.ts
+++ b/logging/levels.ts
@@ -11,7 +11,7 @@ const byName = {
   INFO: LogLevel.INFO,
   WARNING: LogLevel.WARNING,
   ERROR: LogLevel.ERROR,
-  CRITICAL: LogLevel.DEBUG
+  CRITICAL: LogLevel.CRITICAL
 };
 
 const byLevel = {

--- a/logging/levels.ts
+++ b/logging/levels.ts
@@ -26,6 +26,6 @@ export function getLevelByName(name) {
   return byName[name];
 }
 
-export function getLevelName(level) {
+export function getNameByLevel(level) {
   return byLevel[level];
 }


### PR DESCRIPTION
This is the change for this PR:
- Fixed wrong definition in log naming.
- Would it be better to name `getLevelName` to `getNameByLevel`? Because the first function is named as `getLevelByName`, so could be better to make it similar...
- Define param/return value type

If you have any suggestion, please reply.
Thanks.