### PR TITLE
Avoid textproto crashing on empty reader

### DIFF
--- a/net/textproto.ts
+++ b/net/textproto.ts
@@ -118,11 +118,12 @@ export class TextProtoReader {
 
   async readLineSlice(): Promise<[Uint8Array, BufState]> {
     // this.closeDot();
-    let line: null | Uint8Array;
+    let line: Uint8Array;
     while (true) {
       let [l, more, err] = await this.r.readLine();
       if (err != null) {
-        return [null, err];
+        // Go's len(typed nil) works fine, but not in JS
+        return [new Uint8Array(0), err];
       }
       // Avoid the copy if the first call produced a full line.
       if (line == null && !more) {

--- a/net/textproto_test.ts
+++ b/net/textproto_test.ts
@@ -93,3 +93,10 @@ test(async function textprotoAppend() {
   const joined = append(u1, u2);
   assertEqual(dec.decode(joined), "Hello World");
 });
+
+test(async function textprotoReadEmpty() {
+  let r = reader("");
+  let [m, err] = await r.readMIMEHeader();
+  // Should not crash!
+  assertEqual(err, "EOF");
+});


### PR DESCRIPTION
This avoids crashing on suddenly terminated connections.

Before:
```
$ deno net/http_bench.ts --allow-net &
[2] 40718
$ telnet 127.0.0.1 4500
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
^]
telnet> ^C
TypeError: Cannot read property 'byteLength' of null
    at readMIMEHeader (file:///Users/kevinqian/Desktop/Programming/Deno/deno_std/net/textproto.ts:75:14)
[2]-  Exit 1                  deno net/http_bench.ts --allow-net
```

After:
```
$ deno net/http_bench.ts --allow-net &
[1] 41093
$ telnet 127.0.0.1 4500
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
^]
telnet> ^C
$ pkill deno # this means deno server is still up and running just fine
[1]+  Terminated: 15          deno net/http_bench.ts --allow-net
```