### PR TITLE
Set content-length header if no body if present

### DIFF
--- a/net/http.ts
+++ b/net/http.ts
@@ -117,6 +117,8 @@ export function setContentLength(r: Response): void {
         r.headers.append("Transfer-Encoding", "chunked");
       }
     }
+  } else {
+    r.headers.append("Content-Length", "0");
   }
 }
 


### PR DESCRIPTION
Browser waits on response forever right now if no body if passed in: `req.respond()`.