### PR TITLE
Add JSON body support for HTTP

### DIFF
--- a/net/http.ts
+++ b/net/http.ts
@@ -100,7 +100,7 @@ export async function listenAndServe(
 export interface Response {
   status?: number;
   headers?: Headers;
-  body?: Uint8Array | Reader;
+  body?: Uint8Array | Object | Reader;
 }
 
 export function setContentLength(r: Response): void {
@@ -113,6 +113,9 @@ export function setContentLength(r: Response): void {
       if (r.body instanceof Uint8Array) {
         const bodyLength = r.body.byteLength;
         r.headers.append("Content-Length", bodyLength.toString());
+      } else if (r.body instanceof Object) {
+        const body = new TextEncoder().encode(JSON.stringify(r.body));
+        r.headers.append("Content-Length", body.byteLength.toString());
       } else {
         r.headers.append("Transfer-Encoding", "chunked");
       }
@@ -257,6 +260,10 @@ export class ServerRequest {
       if (r.body instanceof Uint8Array) {
         n = await this.w.write(r.body);
         assert(r.body.byteLength == n);
+      } else if (r.body instanceof Object) {
+        const body = new TextEncoder().encode(JSON.stringify(r.body));        
+        n = await this.w.write(body);
+        assert(body.byteLength == n);
       } else {
         if (r.headers.has("content-length")) {
           await this._streamBody(


### PR DESCRIPTION
Fixes #54. Add JSON body support. Will be useful for APIs. Testing code:
``` ts
import { serve } from "./net/http.ts";
const s = serve("0.0.0.0:8000");

async function main() {
  for await (const req of s) {
    req.respond({ body: { name: "John", surname: "Doe" } });
  }
}

main();
```