### PR TITLE
EventEmitter as part of the standard library

### DIFF
--- a/events/eventemitter.ts
+++ b/events/eventemitter.ts
@@ -1,0 +1,58 @@
+type Subscriber = (...args: unknown[]) => void
+
+/**
+ * Very basic implementation of EventEmitter.
+ *
+ * @export
+ * @class EventEmitter
+ */
+export class EventEmitter {
+  private _subscribers: { [key: string]: Subscriber[] };
+
+  constructor() {
+    this._subscribers = {};
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    const subscribers = this._subscribers[event];
+    if (!subscribers) {
+      return;
+    }
+
+    for (const fn of subscribers) {
+      fn(...args);
+    }
+  }
+
+  addEventListener(event: string, subscriber: Subscriber) {
+    if (!this._subscribers[event]) {
+      this._subscribers[event] = [];
+    }
+
+    this._subscribers[event].push(subscriber);
+  }
+
+  removeEventListener(event: string, subscriber: Subscriber) {
+    if (!this._subscribers[event]) {
+      return;
+    }
+
+    this._subscribers[event] = this._subscribers[event].filter(fn => fn !== subscriber);
+  }
+
+  on(event: string, subscriber: Subscriber) {
+    this.addEventListener(event, subscriber);
+  }
+
+  off(event: string, subscriber: Subscriber) {
+    this.removeEventListener(event, subscriber);
+  }
+
+  prependEventListener(event: string, subscriber: Subscriber) {
+    if (!this._subscribers[event]) {
+      this._subscribers[event] = [];
+    }
+
+    this._subscribers[event].unshift(subscriber);
+  }
+}

--- a/events/mod.ts
+++ b/events/mod.ts
@@ -1,11 +1,9 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
 type Subscriber = (...args: unknown[]) => void
 
-/**
- * Very basic implementation of EventEmitter.
- *
- * @export
- * @class EventEmitter
- */
+
+/** EventEmitter allows for event-based programming. */
 export class EventEmitter {
   private _subscribers: { [key: string]: Subscriber[] };
 

--- a/events/package.ts
+++ b/events/package.ts
@@ -1,0 +1,1 @@
+export { assertEqual, test } from "../testing/mod.ts";

--- a/events/test.ts
+++ b/events/test.ts
@@ -1,0 +1,52 @@
+import { assertEqual, test } from "./package.ts";
+import { EventEmitter } from "./eventemitter.ts";
+
+test(function testBasicEvent() {
+  const emitter = new EventEmitter();
+  let counter = 0;
+
+  emitter.on("evt", () => counter++);
+  emitter.emit("evt");
+  assertEqual(counter, 1);
+});
+
+test(function correctEventOrder() {
+  const emitter = new EventEmitter();
+  let callOrder: string[] = [];
+
+  emitter.on("evt", () => callOrder.push("listener1"));
+  emitter.on("evt", () => callOrder.push("listener2"));
+  emitter.on("evt", () => callOrder.push("listener3"));
+
+  emitter.emit("evt");
+  assertEqual(callOrder, ["listener1", "listener2", "listener3"]);
+})
+
+test(function prependEvent() {
+  const emitter = new EventEmitter();
+  let callOrder: string[] = [];
+
+  emitter.on("evt", () => callOrder.push("listener1"));
+  emitter.on("evt", () => callOrder.push("listener2"));
+  emitter.prependEventListener("evt", () => callOrder.push("listener3"));
+
+  emitter.emit("evt");
+  assertEqual(callOrder, ["listener3", "listener1", "listener2"]);
+});
+
+test(function removeEventListener() {
+  const emitter = new EventEmitter();
+  let callRecord: string[] = [];
+
+  const removableListener = () => callRecord.push("listener2");
+
+  emitter.on("evt", () => callRecord.push("listener1"));
+  emitter.on("evt", removableListener);
+
+  emitter.emit("evt");
+
+  emitter.off("evt", removableListener);
+
+  emitter.emit("evt");
+  assertEqual(callRecord, ["listener1", "listener2", "listener1"]);
+});


### PR DESCRIPTION
While working on a basic IRC server for `deno_std`, I decided to work with an event-based API, so I reimplemented an EventEmitter class to allow for that.