### PR TITLE
Remove export = module 

### DIFF
--- a/path/index.ts
+++ b/path/index.ts
@@ -119,7 +119,7 @@ function _format(sep: string, pathObject: FormatInputPathObject) {
   return dir + sep + base;
 }
 
-const win32 = {
+export const win32 = {
   // path.resolve([from ...], to)
   resolve: function resolve(...pathSegments: string[]) {
     let resolvedDevice = "";
@@ -1004,7 +1004,7 @@ const win32 = {
   posix: null
 };
 
-const posix = {
+export const posix = {
   // path.resolve([from ...], to)
   resolve: function resolve(...pathSegments: string[]) {
     let resolvedPath = "";
@@ -1422,4 +1422,18 @@ posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
 const module = platform.os === "win" ? win32 : posix;
-export = module;
+export default module;
+
+export const resolve = module.resolve;
+export const normalize = module.normalize;
+export const isAbsolute = module.isAbsolute;
+export const join = module.join;
+export const relative = module.relative;
+export const toNamespacedPath = module.toNamespacedPath;
+export const dirname = module.dirname;
+export const basename = module.basename;
+export const extname = module.extname;
+export const format = module.format;
+export const parse = module.parse;
+export const sep = module.sep;
+export const delimiter = module.delimiter;

--- a/path/index.ts
+++ b/path/index.ts
@@ -1422,7 +1422,6 @@ posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
 const module = platform.os === "win" ? win32 : posix;
-export default module;
 
 export const resolve = module.resolve;
 export const normalize = module.normalize;

--- a/path/parse_format_test.ts
+++ b/path/parse_format_test.ts
@@ -161,7 +161,7 @@ function checkFormat(path, testCases) {
 
 test(function parseTrailingWin32() {
   windowsTrailingTests.forEach(function(p) {
-    const actual = path.win32.parse(p[0]);
+    const actual = path.win32.parse(p[0] as string);
     const expected = p[1];
     assertEqual(actual, expected);
   });
@@ -169,7 +169,7 @@ test(function parseTrailingWin32() {
 
 test(function parseTrailing() {
   posixTrailingTests.forEach(function(p) {
-    const actual = path.posix.parse(p[0]);
+    const actual = path.posix.parse(p[0] as string);
     const expected = p[1];
     assertEqual(actual, expected);
   });


### PR DESCRIPTION
Otherwise I'm getting this with latest native ES module refactoring PR:
```
/Users/kevinqian/.deno/deps/https/deno.land/x/std/path/index.ts:1425:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.

1425 export = module;
     ~~~~~~~~~~~~~~~~
```
(Probably because we are changing TS compiler target from AMD to ESNext?)