### PR TITLE
Print test status on the same line as test name

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -125,20 +125,24 @@ async function runTests() {
   for (let i = 0; i < tests.length; i++) {
     const { fn, name } = tests[i];
     let result = green_ok();
-    console.log("test", name);
+    // See https://github.com/denoland/deno/pull/1452
+    // about this usage of groupCollapsed
+    console.groupCollapsed(`test ${name} `);
     try {
       await fn();
       passed++;
+      console.log("...", result);
+      console.groupEnd();
     } catch (e) {
       result = red_failed();
+      console.log("...", result);
+      console.groupEnd();
       console.error((e && e.stack) || e);
       failed++;
       if (exitOnFail) {
         break;
       }
     }
-    // TODO Do this on the same line as test name is printed.
-    console.log("...", result);
   }
 
   // Attempting to match the output of Rust's test runner.


### PR DESCRIPTION
As discussed in https://github.com/denoland/deno/pull/1355 and https://github.com/denoland/deno/pull/1363, this PR uses `groupCollapsed` method for printing the status of a test in the same line as its name.

The output looks like the below:
<img width="1196" alt="2019-01-09 14 16 53" src="https://user-images.githubusercontent.com/613956/50878354-acf53600-1419-11e9-8e84-db27312bb1c7.png">

When it has an error:
<img width="1217" alt="2019-01-09 14 21 12" src="https://user-images.githubusercontent.com/613956/50878405-e4fc7900-1419-11e9-99c7-3bb2f471b275.png">
