### PR TITLE
 Add setUp and tearDown to simplify tests.

### DIFF
--- a/examples/test.ts
+++ b/examples/test.ts
@@ -13,7 +13,8 @@ test(function t2() {
 /** A more complicated test that runs a subprocess. */
 test(async function catSmoke() {
   const p = run({
-    args: ["deno", "examples/cat.ts", "README.md"]
+    args: ["deno", "examples/cat.ts", "README.md"],
+    stdout: "piped"
   });
   const s = await p.status();
   assertEqual(s.code, 0);

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1,51 +1,42 @@
-import { readFile } from "deno";
+import { readFile, run } from "deno";
 
-import { test, assert, assertEqual } from "../testing/mod.ts";
+import { test, assert, assertEqual, setUp, tearDown } from "../testing/mod.ts";
 
-// Promise to completeResolve when all tests completes
-let completeResolve;
-export const completePromise = new Promise(res => (completeResolve = res));
-let completedTestCount = 0;
-
-function maybeCompleteTests() {
-  completedTestCount++;
-  // Change this when adding more tests
-  if (completedTestCount === 3) {
-    completeResolve();
-  }
-}
-
-export function runTests(serverReadyPromise: Promise<any>) {
-  test(async function serveFile() {
-    await serverReadyPromise;
-    const res = await fetch("http://localhost:4500/azure-pipelines.yml");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    assertEqual(res.headers.get("content-type"), "text/yaml; charset=utf-8");
-    const downloadedFile = await res.text();
-    const localFile = new TextDecoder().decode(
-      await readFile("./azure-pipelines.yml")
-    );
-    assertEqual(downloadedFile, localFile);
-    maybeCompleteTests();
+var fileServer;
+setUp(async function startFileServer() {
+  fileServer = run({
+    args: ["deno", "--allow-net", "http/file_server.ts", ".", "--cors"]
   });
+  // Wait for fileServer to spool up.
+  await new Promise(res => setTimeout(res, 1000));
+});
+tearDown(function killFileServer() {
+  fileServer.close();
+});
 
-  test(async function serveDirectory() {
-    await serverReadyPromise;
-    const res = await fetch("http://localhost:4500/");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    const page = await res.text();
-    assert(page.includes("azure-pipelines.yml"));
-    maybeCompleteTests();
-  });
+test(async function serveFile() {
+  const res = await fetch("http://localhost:4500/azure-pipelines.yml");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  assertEqual(res.headers.get("content-type"), "text/yaml; charset=utf-8");
+  const downloadedFile = await res.text();
+  const localFile = new TextDecoder().decode(
+    await readFile("./azure-pipelines.yml")
+  );
+  assertEqual(downloadedFile, localFile);
+});
 
-  test(async function serveFallback() {
-    await serverReadyPromise;
-    const res = await fetch("http://localhost:4500/badfile.txt");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    assertEqual(res.status, 404);
-    maybeCompleteTests();
-  });
-}
+test(async function serveDirectory() {
+  const res = await fetch("http://localhost:4500/");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  const page = await res.text();
+  assert(page.includes("azure-pipelines.yml"));
+});
+
+test(async function serveFallback() {
+  const res = await fetch("http://localhost:4500/badfile.txt");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  assertEqual(res.status, 404);
+});

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -14,10 +14,11 @@ setUp(async function startFileServer() {
   const r = new TextProtoReader(new BufReader(fileServer.stdout));
   const [s, err] = await r.readLine();
   assert(err == null);
-  assert(s.includes("server listening"))
+  assert(s.includes("server listening"));
 });
 tearDown(function killFileServer() {
   fileServer.close();
+  fileServer.stdout.close();
 });
 
 test(async function serveFile() {

--- a/test.ts
+++ b/test.ts
@@ -17,6 +17,7 @@ import "fs/path/resolve_test.ts";
 import "fs/path/zero_length_strings_test.ts";
 import "io/bufio_test.ts";
 import "http/http_test.ts";
+import "http/file_server_test.ts";
 import "log/test.ts";
 import "media_types/test.ts";
 import "testing/test.ts";
@@ -24,15 +25,3 @@ import "textproto/test.ts";
 import "ws/ioutil_test.ts";
 import "ws/sha1_test.ts";
 import "ws/test.ts";
-
-import { runTests, completePromise } from "http/file_server_test.ts";
-
-const fileServer = run({
-  args: ["deno", "--allow-net", "http/file_server.ts", ".", "--cors"]
-});
-
-runTests(new Promise(res => setTimeout(res, 5000)));
-(async () => {
-  await completePromise;
-  fileServer.close();
-})();

--- a/test.ts
+++ b/test.ts
@@ -21,6 +21,8 @@ import "log/test.ts";
 import "media_types/test.ts";
 import "testing/test.ts";
 import "textproto/test.ts";
+import "ws/ioutil_test.ts";
+import "ws/sha1_test.ts";
 import "ws/test.ts";
 
 import { runTests, completePromise } from "http/file_server_test.ts";

--- a/testing/main.ts
+++ b/testing/main.ts
@@ -1,0 +1,20 @@
+import { args } from "deno";
+import { runTests, cancelTests, setFilter } from "./mod.ts";
+import { parse } from "../flags/mod.ts";
+import { resolve } from "../fs/path.ts";
+
+cancelTests();
+
+const a = parse(args);
+const filter = a.grep || ".*";
+// TODO support globs and recursive.
+const test_files = a._.slice(1).map(p => resolve(p));
+
+setFilter(filter);
+
+(async () => {
+  for (let fn of test_files) {
+    await import(fn);
+  }
+  await runTests();
+})();

--- a/ws/ioutil.ts
+++ b/ws/ioutil.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { BufReader } from "./bufio.ts";
+import { BufReader } from "../io/bufio.ts";
 
 /* Read big endian 16bit short from BufReader */
 export async function readShort(buf: BufReader): Promise<number> {

--- a/ws/ioutil_test.ts
+++ b/ws/ioutil_test.ts
@@ -1,7 +1,7 @@
 import { Reader, ReadResult } from "deno";
 import { assertEqual, test } from "../testing/mod.ts";
 import { readInt, readLong, readShort, sliceLongToBytes } from "./ioutil.ts";
-import { BufReader } from "./bufio.ts";
+import { BufReader } from "../io/bufio.ts";
 
 class BinaryReader implements Reader {
   index = 0;

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Buffer, Writer, Conn } from "deno";
-import { ServerRequest } from "../http/http.ts";
+import { ServerRequest } from "../http/mod.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
-import { readLong, readShort, sliceLongToBytes } from "../io/ioutil.ts";
+import { readLong, readShort, sliceLongToBytes } from "./ioutil.ts";
 import { Sha1 } from "./sha1.ts";
 
 export const OpCodeContinue = 0x0;

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -12,7 +12,7 @@ import {
   readFrame,
   unmask
 } from "./mod.ts";
-import { serve } from "../http/http.ts";
+import { serve } from "../http/mod.ts";
 
 test(async function testReadUnmaskedTextFrame() {
   // unmasked single text frame with payload "Hello"


### PR DESCRIPTION
This also adds a main.ts which allows one to to grep
through tests. Ideally this would recursively import
all test.ts or *_test.ts files.

The idea was that this could later be called by [`deno test`](https://github.com/denoland/deno/issues/20).

Note: The first commit is a small cleanup after #105.