### PR TITLE
Fix media_types running under Deno with ESM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DENO_VERSION: 'v0.2.6'
+  DENO_VERSION: 'v0.2.7'
 
 jobs:
 

--- a/media_types/deps.ts
+++ b/media_types/deps.ts
@@ -11,5 +11,5 @@ interface DB {
   };
 }
 
-import * as _db from "./db_1.37.0.json";
+import _db from "./db_1.37.0.json";
 export const db: DB = _db;


### PR DESCRIPTION
Fixes the importing of JSON.  Requires a build of Deno that includes denoland/deno#1514 (e.g. current `master`).

Upgrading to a version of Deno that includes ESM will "break" `media_types` and the other patch and this one will "fix" it.