### PR TITLE
datetime: correct hh:mm formats and add test cases

### DIFF
--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -57,13 +57,13 @@ export function parseDateTime(
     const datePattern = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/;
     [, y, m, d, ho, mi] = datePattern.exec(datetimeStr);
   } else if (format === "hh:mm mm-dd-yyyy") {
-    const datePattern = /^(\d{2})-(\d{2})-(\d{4}) (\d{2}):(\d{2})$/;
+    const datePattern = /^(\d{2}):(\d{2}) (\d{2})-(\d{2})-(\d{4})$/;
     [, ho, mi, m, d, y] = datePattern.exec(datetimeStr);
   } else if (format === "hh:mm dd-mm-yyyy") {
-    const datePattern = /^(\d{2})-(\d{2})-(\d{4}) (\d{2}):(\d{2})$/;
+    const datePattern = /^(\d{2}):(\d{2}) (\d{2})-(\d{2})-(\d{4})$/;
     [, ho, mi, d, m, y] = datePattern.exec(datetimeStr);
   } else if (format === "hh:mm yyyy-mm-dd") {
-    const datePattern = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/;
+    const datePattern = /^(\d{2}):(\d{2}) (\d{4})-(\d{2})-(\d{2})$/;
     [, ho, mi, y, m, d] = datePattern.exec(datetimeStr);
   } else {
     throw new Error("Invalid datetime format!");

--- a/datetime/test.ts
+++ b/datetime/test.ts
@@ -1,4 +1,4 @@
-import { test, assertEqual } from "../testing/mod.ts";
+import { test, assertEqual, assert } from "../testing/mod.ts";
 import * as datetime from "mod.ts";
 
 test(function parseDateTime() {
@@ -6,13 +6,61 @@ test(function parseDateTime() {
     datetime.parseDateTime("01-03-2019 16:34", "mm-dd-yyyy hh:mm"),
     new Date(2019, 1, 3, 16, 34)
   );
+  assertEqual(
+    datetime.parseDateTime("03-01-2019 16:34", "dd-mm-yyyy hh:mm"),
+    new Date(2019, 1, 3, 16, 34)
+  );
+  assertEqual(
+    datetime.parseDateTime("2019-01-03 16:34", "yyyy-mm-dd hh:mm"),
+    new Date(2019, 1, 3, 16, 34)
+  );
+  assertEqual(
+    datetime.parseDateTime("16:34 01-03-2019", "hh:mm mm-dd-yyyy"),
+    new Date(2019, 1, 3, 16, 34)
+  );
+  assertEqual(
+    datetime.parseDateTime("16:34 03-01-2019", "hh:mm dd-mm-yyyy"),
+    new Date(2019, 1, 3, 16, 34)
+  );
+  assertEqual(
+    datetime.parseDateTime("16:34 2019-01-03", "hh:mm yyyy-mm-dd"),
+    new Date(2019, 1, 3, 16, 34)
+  );
 });
+
+test(function invalidParseDateTimeFormatThrows() {
+  try {
+    (datetime as any).parseDateTime("2019-01-01 00:00", "x-y-z");
+    assert(false, 'no exception was thrown');
+  } catch (e) {
+    assertEqual(e.message, "Invalid datetime format!");
+  }
+});
+
 test(function parseDate() {
   assertEqual(
     datetime.parseDate("01-03-2019", "mm-dd-yyyy"),
     new Date(2019, 1, 3)
   );
+  assertEqual(
+    datetime.parseDate("03-01-2019", "dd-mm-yyyy"),
+    new Date(2019, 1, 3)
+  );
+  assertEqual(
+    datetime.parseDate("2019-01-03", "yyyy-mm-dd"),
+    new Date(2019, 1, 3)
+  );
 });
+
+test(function invalidParseDateFormatThrows() {
+  try {
+    (datetime as any).parseDate("2019-01-01", "x-y-z");
+    assert(false, 'no exception was thrown');
+  } catch (e) {
+    assertEqual(e.message, "Invalid date format!");
+  }
+});
+
 test(function currentDayOfYear() {
   assertEqual(
     datetime.currentDayOfYear(),


### PR DESCRIPTION
Adding a few tests.

Guess nobody uses this module much either seeing as half the formats had incorrect regex, so I fixed that too.