### PR TITLE
testing: introduce `fail` function

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -74,6 +74,13 @@ const assertions = {
     }
   },
 
+  /**
+   * Forcefully throws a failed assertion
+   */
+  fail(msg?: string): void {
+    assert(false, `Failed assertion${msg ? `: ${msg}` : "."}`);
+  },
+
   /** Executes a function, expecting it to throw.  If it does not, then it
    * throws.  An error class and a string that should be included in the
    * error message can also be asserted.

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -31,6 +31,13 @@ test(function testingAssertEqual() {
   assert(assertEqual === assert.equal);
 });
 
+test(function testingAssertFail() {
+  let didThrow = false;
+
+  assert.throws(assert.fail, Error, "Failed assertion.");
+  assert.throws(() => { assert.fail("foo"); }, Error, "Failed assertion: foo");
+});
+
 test(function testingAssertEqualActualUncoercable() {
   let didThrow = false;
   const a = Object.create(null);


### PR DESCRIPTION
Introduces these two:

```ts
fail('some message'); // equivalent to assert(false, msg)
assert(throws(fn), true);
```

For now, `throws` returns a boolean and is expected to be used with `assert` just like `equal`.

If we want node compatibility, see #122 (`throws` does the assertion and throws the assertion error in node rather than returning a bool).