### PR TITLE
Improve assert

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -1,14 +1,41 @@
 # Testing
 
+This module provides a few basic utilities to make testing easier and
+consistent in Deno.
+
 ## Usage
 
+The module exports a `test` function which is the test harness in Deno. It
+accepts either a function (including async functions) or an object which
+contains a `name` property and a `fn` property. When running tests and
+outputting the results, the name of the past function is used, or if the
+object is passed, the `name` property is used to identify the test.
+
+The module also exports `assert`, `assertEqual`, and `equal`.
+
+`equal` is a deep comparision function, where `actual` and `expected` are
+compared deeply, and if they vary, `equal` returns `false`.
+
+The export `assert` is a function, but it is also decorated with other useful
+functions:
+
+- `assert()` - Expects a boolean value, throws if the value is `false`.
+- `assert.equal()` - Uses the `equal` comparison and throws if the `actual` and
+  `expected` are not equal.
+- `assert.strictEqual()` - Compares `actual` and `expected` strictly, therefore
+  for non-primitives the values must reference the same instance.
+- `assert.throws()` - Expects the passed `fn` to throw. If `fn` does not throw,
+  this function does. Also compares any errors thrown to an optional expected
+  `Error` class and checks that the error `.message` includes an optional
+  string.
+
+`assertEqual()` is the same as `assert.equal()` but maintained for backwards
+compatibility.
+
+Basic usage:
+
 ```ts
-import {
-  test,
-  assert,
-  equal,
-  assertEqual
-} from "https://deno.land/x/testing/mod.ts";
+import { test, assert, equal } from "https://deno.land/x/testing/mod.ts";
 
 test({
   name: "testing example",
@@ -17,8 +44,8 @@ test({
     assert(!equal("hello", "world"));
     assert(equal({ hello: "world" }, { hello: "world" }));
     assert(!equal({ world: "hello" }, { hello: "world" }));
-    assertEqual("world", "world");
-    assertEqual({ hello: "world" }, { hello: "world" });
+    assert.equal("world", "world");
+    assert.equal({ hello: "world" }, { hello: "world" });
   }
 });
 ```
@@ -31,7 +58,51 @@ test(function example() {
   assert(!equal("hello", "world"));
   assert(equal({ hello: "world" }, { hello: "world" }));
   assert(!equal({ world: "hello" }, { hello: "world" }));
-  assertEqual("world", "world");
-  assertEqual({ hello: "world" }, { hello: "world" });
+  assert.equal("world", "world");
+  assert.equal({ hello: "world" }, { hello: "world" });
+});
+```
+
+Using `assert.strictEqual()`:
+
+```ts
+test(function isStrictlyEqual() {
+  const a = {};
+  const b = a;
+  assert.strictEqual(a, b);
+});
+
+// This test fails
+test(function isNotStrictlyEqual() {
+  const a = {};
+  const b = {};
+  assert.strictEqual(a, b);
+});
+```
+
+Using `assert.throws()`:
+
+```ts
+test(function doesThrow() {
+  assert.throws(() => {
+    throw new TypeError("hello world!");
+  });
+  assert.throws(() => {
+    throw new TypeError("hello world!");
+  }, TypeError);
+  assert.throws(
+    () => {
+      throw new TypeError("hello world!");
+    },
+    TypeError,
+    "hello"
+  );
+});
+
+// This test will not pass
+test(function fails() {
+  assert.throws(() => {
+    console.log("Hello world");
+  });
 });
 ```

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -28,6 +28,7 @@ test(function testingAssertEqual() {
   const a = Object.create(null);
   a.b = "foo";
   assertEqual(a, a);
+  assert(assert.equal === assertEqual);
 });
 
 test(function testingAssertEqualActualUncoercable() {
@@ -53,5 +54,110 @@ test(function testingAssertEqualExpectedUncoercable() {
     console.log(e.message);
     assert(e.message === "actual: bar expected: [Cannot display]");
   }
+  assert(didThrow);
+});
+
+test(function testingAssertStrictEqual() {
+  const a = {};
+  const b = a;
+  assert.strictEqual(a, b);
+});
+
+test(function testingAssertNotStrictEqual() {
+  let didThrow = false;
+  const a = {};
+  const b = {};
+  try {
+    assert.strictEqual(a, b);
+  } catch (e) {
+    assert(e.message === "actual: [object Object] expected: [object Object]");
+    didThrow = true;
+  }
+  assert(didThrow);
+});
+
+test(function testingDoesThrow() {
+  let count = 0;
+  assert.throws(() => {
+    count++;
+    throw new Error();
+  });
+  assert(count === 1);
+});
+
+test(function testingDoesNotThrow() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    assert.throws(() => {
+      count++;
+      console.log("Hello world");
+    });
+  } catch (e) {
+    assert(e.message === "Expected function to throw.");
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(function testingThrowsErrorType() {
+  let count = 0;
+  assert.throws(() => {
+    count++;
+    throw new TypeError();
+  }, TypeError);
+  assert(count === 1);
+});
+
+test(function testingThrowsNotErrorType() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    assert.throws(() => {
+      count++;
+      throw new TypeError();
+    }, RangeError);
+  } catch (e) {
+    assert(e.message === `Expected error to be instance of "RangeError".`);
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(function testingThrowsMsgIncludes() {
+  let count = 0;
+  assert.throws(
+    () => {
+      count++;
+      throw new TypeError("Hello world!");
+    },
+    TypeError,
+    "world"
+  );
+  assert(count === 1);
+});
+
+test(function testingThrowsMsgNotIncludes() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    assert.throws(
+      () => {
+        count++;
+        throw new TypeError("Hello world!");
+      },
+      TypeError,
+      "foobar"
+    );
+  } catch (e) {
+    assert(
+      e.message ===
+        `Expected error message to include "foobar", but got "Hello world!".`
+    );
+    didThrow = true;
+  }
+  assert(count === 1);
   assert(didThrow);
 });


### PR DESCRIPTION
This PR improves `assert` in the `testing` module.

It decorates the `assert` function with three additional functions for assertion:

* `assert.equal()` - This is the same as `assertEqual()` already present.
* `assert.strictEqual()` - This checks that `actual` and `expected` are strictly equal.
* `assert.throws()` - This takes a function which is expected to throw.  If it does not, then the assertion will throw.  It can also take optional error class, where the class of the thrown error is checked, and a string which should be included in the thrown error message.
