### PR TITLE
Fix "/.deno/deps/https/deno.land/x/media_types/db_1.37.0"' has no default export.

### DIFF
--- a/media_types/deps.ts
+++ b/media_types/deps.ts
@@ -11,5 +11,5 @@ interface DB {
   };
 }
 
-import _db from "./db_1.37.0.json";
+import * as _db from "./db_1.37.0.json";
 export const db: DB = _db;


### PR DESCRIPTION
The import behavior should be usable while --allowSyntheticDefaultImports flag isn't present.