### PR TITLE
Add assert.throwsAsync, make module easier to maintain

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -28,6 +28,11 @@ functions:
   this function does. Also compares any errors thrown to an optional expected
   `Error` class and checks that the error `.message` includes an optional
   string.
+- `assert.throwsAsync()` - Expects the passed `fn` to be async and throw (or
+  return a `Promise` that rejects). If the `fn` does not throw or reject, this
+  function will throw asynchronously. Also compares any errors thrown to an
+  optional expected `Error` class and checks that the error `.message` includes
+  an optional string.
 
 `assertEqual()` is the same as `assert.equal()` but maintained for backwards
 compatibility.
@@ -102,6 +107,36 @@ test(function doesThrow() {
 // This test will not pass
 test(function fails() {
   assert.throws(() => {
+    console.log("Hello world");
+  });
+});
+```
+
+Using `assert.throwsAsync()`:
+
+```ts
+test(async function doesThrow() {
+  assert.throwsAsync(async () => {
+    throw new TypeError("hello world!");
+  });
+  assert.throwsAsync(async () => {
+    throw new TypeError("hello world!");
+  }, TypeError);
+  assert.throwsAsync(
+    async () => {
+      throw new TypeError("hello world!");
+    },
+    TypeError,
+    "hello"
+  );
+  assert.throwsAsync(async () => {
+    return Promise.reject(new Error());
+  });
+});
+
+// This test will not pass
+test(async function fails() {
+  assert.throwsAsync(async () => {
     console.log("Hello world");
   });
 });

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -108,6 +108,38 @@ const assertions = {
       msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
       throw new Error(msg);
     }
+  },
+
+  async throwsAsync(
+    fn: () => Promise<void>,
+    ErrorClass?: Constructor,
+    msgIncludes = "",
+    msg = ""
+  ): Promise<void> {
+    let doesThrow = false;
+    try {
+      await fn();
+    } catch (e) {
+      if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
+        msg = `Expected error to be instance of "${ErrorClass.name}"${
+          msg ? `: ${msg}` : "."
+        }`;
+        throw new Error(msg);
+      }
+      if (msgIncludes) {
+        if (!e.message.includes(msgIncludes)) {
+          msg = `Expected error message to include "${msgIncludes}", but got "${
+            e.message
+          }"${msg ? `: ${msg}` : "."}`;
+          throw new Error(msg);
+        }
+      }
+      doesThrow = true;
+    }
+    if (!doesThrow) {
+      msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
+      throw new Error(msg);
+    }
   }
 };
 

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -27,15 +27,15 @@ test(function testingEqual() {
 test(function testingAssertEqual() {
   const a = Object.create(null);
   a.b = "foo";
-  assertEqual(a, a);
-  assert(assert.equal === assertEqual);
+  assert.equal(a, a);
+  assert(assertEqual === assert.equal);
 });
 
 test(function testingAssertEqualActualUncoercable() {
   let didThrow = false;
   const a = Object.create(null);
   try {
-    assertEqual(a, "bar");
+    assert.equal(a, "bar");
   } catch (e) {
     didThrow = true;
     console.log(e.message);
@@ -48,7 +48,7 @@ test(function testingAssertEqualExpectedUncoercable() {
   let didThrow = false;
   const a = Object.create(null);
   try {
-    assertEqual("bar", a);
+    assert.equal("bar", a);
   } catch (e) {
     didThrow = true;
     console.log(e.message);
@@ -145,6 +145,118 @@ test(function testingThrowsMsgNotIncludes() {
   try {
     assert.throws(
       () => {
+        count++;
+        throw new TypeError("Hello world!");
+      },
+      TypeError,
+      "foobar"
+    );
+  } catch (e) {
+    assert(
+      e.message ===
+        `Expected error message to include "foobar", but got "Hello world!".`
+    );
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(async function testingDoesThrowAsync() {
+  let count = 0;
+  await assert.throwsAsync(async () => {
+    count++;
+    throw new Error();
+  });
+  assert(count === 1);
+});
+
+test(async function testingDoesReject() {
+  let count = 0;
+  await assert.throwsAsync(() => {
+    count++;
+    return Promise.reject(new Error());
+  });
+  assert(count === 1);
+});
+
+test(async function testingDoesNotThrowAsync() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    await assert.throwsAsync(async () => {
+      count++;
+      console.log("Hello world");
+    });
+  } catch (e) {
+    assert(e.message === "Expected function to throw.");
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(async function testingDoesNotRejectAsync() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    await assert.throwsAsync(() => {
+      count++;
+      console.log("Hello world");
+      return Promise.resolve();
+    });
+  } catch (e) {
+    assert(e.message === "Expected function to throw.");
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(async function testingThrowsAsyncErrorType() {
+  let count = 0;
+  await assert.throwsAsync(async () => {
+    count++;
+    throw new TypeError();
+  }, TypeError);
+  assert(count === 1);
+});
+
+test(async function testingThrowsAsyncNotErrorType() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    await assert.throwsAsync(async () => {
+      count++;
+      throw new TypeError();
+    }, RangeError);
+  } catch (e) {
+    assert(e.message === `Expected error to be instance of "RangeError".`);
+    didThrow = true;
+  }
+  assert(count === 1);
+  assert(didThrow);
+});
+
+test(async function testingThrowsAsyncMsgIncludes() {
+  let count = 0;
+  await assert.throwsAsync(
+    async () => {
+      count++;
+      throw new TypeError("Hello world!");
+    },
+    TypeError,
+    "world"
+  );
+  assert(count === 1);
+});
+
+test(async function testingThrowsMsgNotIncludes() {
+  let count = 0;
+  let didThrow = false;
+  try {
+    await assert.throwsAsync(
+      async () => {
         count++;
         throw new TypeError("Hello world!");
       },


### PR DESCRIPTION
This PR:

- Adds `assert.throwsAsync()` which is like `assert.throws()` but deals with `async` functions (or functions that return a `Promise`).
- Reorganises the way the `assert` is done so it doesn't require a seperate interface for the decoration of the function which will make it much easier to maintain and add to.
