### PR TITLE
Update CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,10 @@
-variables:
-  DENO_VERSION: 'v0.2.8'
-
 jobs:
 
 - job: 'Linux'
   pool:
     vmImage: 'Ubuntu-16.04'
   steps:
-  - script: curl -L https://deno.land/x/install/install.py | python - $(DENO_VERSION)
+  - script: curl -L https://deno.land/x/install/install.sh | sh
   - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
   - script: deno test.ts --allow-run --allow-net --allow-write
 
@@ -15,7 +12,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
-  - script: curl -L https://deno.land/x/install/install.py | python - $(DENO_VERSION)
+  - script: curl -L https://deno.land/x/install/install.sh | sh
   - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
   - script: deno test.ts --allow-run --allow-net --allow-write
 
@@ -23,6 +20,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - powershell: iwr https://deno.land/x/install/install.ps1 -Outfile 'install.ps1'; ./install.ps1 $(DENO_VERSION)
+  - powershell: iex (iwr https://deno.land/x/install/install.ps1)
   - script: echo '##vso[task.prependpath]C:\Users\VssAdministrator\.deno\bin\'
   - script: 'C:\Users\VssAdministrator\.deno\bin\deno.exe test.ts --allow-run --allow-net --allow-write'


### PR DESCRIPTION
~~Blocked by: [deno_install#25](https://github.com/denoland/deno_install/pull/25)~~

Thanks to the new installers, manual version bumps aren't necessary anymore.