### PR TITLE
Add back test auto-start

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1,64 +1,55 @@
 import { readFile, run } from "deno";
 
-import { test, assert, assertEqual } from "../testing/mod.ts";
+import { test, assert, assertEqual, TestFunction } from "../testing/mod.ts";
 import { BufReader } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 
-let fileServer;
-async function startFileServer() {
-  fileServer = run({
-    args: ["deno", "--allow-net", "http/file_server.ts", ".", "--cors"],
-    stdout: "piped"
-  });
-  // Once fileServer is ready it will write to its stdout.
-  const r = new TextProtoReader(new BufReader(fileServer.stdout));
-  const [s, err] = await r.readLine();
-  assert(err == null);
-  assert(s.includes("server listening"));
-}
-function killFileServer() {
-  fileServer.close();
-  fileServer.stdout.close();
+async function testFileServer(t: TestFunction): Promise<void> {
+  const name = t.name;
+  async function fn() {
+    let fileServer;
+    try {
+      fileServer = run({
+        args: ["deno", "--allow-net", "http/file_server.ts", ".", "--cors"],
+        stdout: "piped"
+      });
+      // Once fileServer is ready it will write to its stdout.
+      const r = new TextProtoReader(new BufReader(fileServer.stdout));
+      const [s, err] = await r.readLine();
+      assert(err == null);
+      assert(s.includes("server listening"));
+      await t();
+    } finally {
+      fileServer.close();
+      fileServer.stdout.close();
+    }
+  }
+  test({ name, fn });
 }
 
-test(async function serveFile() {
-  await startFileServer();
-  try {
-    const res = await fetch("http://localhost:4500/azure-pipelines.yml");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    assertEqual(res.headers.get("content-type"), "text/yaml; charset=utf-8");
-    const downloadedFile = await res.text();
-    const localFile = new TextDecoder().decode(
-      await readFile("./azure-pipelines.yml")
-    );
-    assertEqual(downloadedFile, localFile);
-  } finally {
-    killFileServer();
-  }
+testFileServer(async function serveFile() {
+  const res = await fetch("http://localhost:4500/azure-pipelines.yml");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  assertEqual(res.headers.get("content-type"), "text/yaml; charset=utf-8");
+  const downloadedFile = await res.text();
+  const localFile = new TextDecoder().decode(
+    await readFile("./azure-pipelines.yml")
+  );
+  assertEqual(downloadedFile, localFile);
 });
 
-test(async function serveDirectory() {
-  await startFileServer();
-  try {
-    const res = await fetch("http://localhost:4500/");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    const page = await res.text();
-    assert(page.includes("azure-pipelines.yml"));
-  } finally {
-    killFileServer();
-  }
+testFileServer(async function serveDirectory() {
+  const res = await fetch("http://localhost:4500/");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  const page = await res.text();
+  assert(page.includes("azure-pipelines.yml"));
 });
 
-test(async function serveFallback() {
-  await startFileServer();
-  try {
-    const res = await fetch("http://localhost:4500/badfile.txt");
-    assert(res.headers.has("access-control-allow-origin"));
-    assert(res.headers.has("access-control-allow-headers"));
-    assertEqual(res.status, 404);
-  } finally {
-    killFileServer();
-  }
+testFileServer(async function serveFallback() {
+  const res = await fetch("http://localhost:4500/badfile.txt");
+  assert(res.headers.has("access-control-allow-origin"));
+  assert(res.headers.has("access-control-allow-headers"));
+  assertEqual(res.status, 404);
 });

--- a/test.ts
+++ b/test.ts
@@ -25,5 +25,3 @@ import "testing/test.ts";
 import "textproto/test.ts";
 import "ws/sha1_test.ts";
 import "ws/test.ts";
-
-import "testing/main.ts";

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -211,7 +211,12 @@ export function setFilter(s: string): void {
   filterRegExp = new RegExp(s, "i");
 }
 
+let testTimeout;
 export function test(t: TestDefinition | TestFunction): void {
+  if (!testTimeout) {
+    testTimeout = setTimeout(runTests, 0);
+  }
+
   const fn: TestFunction = typeof t === "function" ? t : t.fn;
   const name: string = t.name;
 


### PR DESCRIPTION
Refactor the testFileServer to use it's own setup/teardown partial.

---

As suggested by @piscisaureus this starts the tests after the first `test` call.