### PR TITLE
Skip formatting of deleted files

### DIFF
--- a/format.ts
+++ b/format.ts
@@ -38,6 +38,18 @@ async function getSourceFiles() {
     .split(/\r?\n/);
 }
 
+async function readFileIfExists(filename: string): Promise<string | null> {
+  let data;
+  try {
+    data = await readFile(filename);
+  } catch (e) {
+    // The file is deleted. Returns null.
+    return null;
+  }
+
+  return decoder.decode(data);
+}
+
 /**
  * Checks if the file has been formatted with prettier.
  */
@@ -45,7 +57,13 @@ async function checkFile(
   filename: string,
   parser: "typescript" | "markdown"
 ): Promise<boolean> {
-  const text = decoder.decode(await readFile(filename));
+  const text = await readFileIfExists(filename);
+
+  if (!text) {
+    // The file is deleted. Skip.
+    return;
+  }
+
   const formatted = prettier.check(text, {
     parser,
     plugins: prettierPlugins
@@ -66,7 +84,13 @@ async function formatFile(
   filename: string,
   parser: "typescript" | "markdown"
 ): Promise<void> {
-  const text = decoder.decode(await readFile(filename));
+  const text = await readFileIfExists(filename);
+
+  if (!text) {
+    // The file is deleted. Skip.
+    return;
+  }
+
   const formatted = prettier.format(text, {
     parser,
     plugins: prettierPlugins

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -13,31 +13,31 @@ class TestHandler extends BaseHandler {
 
 test(function simpleHandler() {
   const cases = new Map<number, string[]>([
-    [LogLevel.DEBUG, [
-      "DEBUG debug-test",
-      "INFO info-test",
-      "WARNING warning-test",
-      "ERROR error-test",
-      "CRITICAL critical-test"
-    ]],
-    [LogLevel.INFO, [
-      "INFO info-test",
-      "WARNING warning-test",
-      "ERROR error-test",
-      "CRITICAL critical-test"
-    ]],
-    [LogLevel.WARNING, [
-      "WARNING warning-test",
-      "ERROR error-test",
-      "CRITICAL critical-test"
-    ]],
-    [LogLevel.ERROR, [
-      "ERROR error-test",
-      "CRITICAL critical-test"
-    ]],
-    [LogLevel.CRITICAL, [
-      "CRITICAL critical-test"
-    ]]
+    [
+      LogLevel.DEBUG,
+      [
+        "DEBUG debug-test",
+        "INFO info-test",
+        "WARNING warning-test",
+        "ERROR error-test",
+        "CRITICAL critical-test"
+      ]
+    ],
+    [
+      LogLevel.INFO,
+      [
+        "INFO info-test",
+        "WARNING warning-test",
+        "ERROR error-test",
+        "CRITICAL critical-test"
+      ]
+    ],
+    [
+      LogLevel.WARNING,
+      ["WARNING warning-test", "ERROR error-test", "CRITICAL critical-test"]
+    ],
+    [LogLevel.ERROR, ["ERROR error-test", "CRITICAL critical-test"]],
+    [LogLevel.CRITICAL, ["CRITICAL critical-test"]]
   ]);
 
   for (const [testCase, messages] of cases.entries()) {

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -8,7 +8,7 @@ class TestHandler extends BaseHandler {
   public records: LogRecord[] = [];
 
   handle(record: LogRecord): void {
-    this.records.push({...record, datetime: null });
+    this.records.push({ ...record, datetime: null });
     super.handle(record);
   }
 
@@ -83,22 +83,13 @@ test(function logFunctions() {
 
   doLog("WARNING");
 
-  assertEqual(handler.messages, [
-    "WARNING baz",
-    "ERROR boo",
-    "CRITICAL doo"
-  ]);
+  assertEqual(handler.messages, ["WARNING baz", "ERROR boo", "CRITICAL doo"]);
 
   doLog("ERROR");
 
-  assertEqual(handler.messages, [
-    "ERROR boo",
-    "CRITICAL doo"
-  ]);
+  assertEqual(handler.messages, ["ERROR boo", "CRITICAL doo"]);
 
   doLog("CRITICAL");
 
-  assertEqual(handler.messages, [
-    "CRITICAL doo"
-  ]);
+  assertEqual(handler.messages, ["CRITICAL doo"]);
 });

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -23,11 +23,11 @@ export interface LogConfig {
 const DEFAULT_LEVEL = "INFO";
 const DEFAULT_CONFIG: LogConfig = {
   handlers: {
-    "default": new ConsoleHandler(DEFAULT_LEVEL)
+    default: new ConsoleHandler(DEFAULT_LEVEL)
   },
 
   loggers: {
-    "default": {
+    default: {
       level: DEFAULT_LEVEL,
       handlers: ["default"]
     }
@@ -48,19 +48,19 @@ export const handlers = {
 };
 
 export const debug = (msg: string, ...args: any[]) =>
-  getLogger('default').debug(msg, ...args);
+  getLogger("default").debug(msg, ...args);
 export const info = (msg: string, ...args: any[]) =>
-  getLogger('default').info(msg, ...args);
+  getLogger("default").info(msg, ...args);
 export const warning = (msg: string, ...args: any[]) =>
-  getLogger('default').warning(msg, ...args);
+  getLogger("default").warning(msg, ...args);
 export const error = (msg: string, ...args: any[]) =>
-  getLogger('default').error(msg, ...args);
+  getLogger("default").error(msg, ...args);
 export const critical = (msg: string, ...args: any[]) =>
-  getLogger('default').critical(msg, ...args);
+  getLogger("default").critical(msg, ...args);
 
 export function getLogger(name?: string) {
   if (!name) {
-    return state.loggers.get('default');
+    return state.loggers.get("default");
   }
 
   if (!state.loggers.has(name)) {
@@ -78,8 +78,8 @@ export function getHandler(name: string) {
 
 export async function setup(config: LogConfig) {
   state.config = {
-    handlers: {...DEFAULT_CONFIG.handlers, ...config.handlers},
-    loggers: {...DEFAULT_CONFIG.loggers, ...config.loggers}
+    handlers: { ...DEFAULT_CONFIG.handlers, ...config.handlers },
+    loggers: { ...DEFAULT_CONFIG.loggers, ...config.loggers }
   };
 
   // tear down existing handlers

--- a/log/test.ts
+++ b/log/test.ts
@@ -52,10 +52,7 @@ test(async function defaultHandlers() {
     logger("foo");
     logger("bar", 1, 2);
 
-    assertEqual(handler.messages, [
-      `${levelName} foo`,
-      `${levelName} bar`
-    ]);
+    assertEqual(handler.messages, [`${levelName} foo`, `${levelName} bar`]);
   }
 });
 
@@ -64,7 +61,7 @@ test(async function getLogger() {
 
   await log.setup({
     handlers: {
-      default: handler 
+      default: handler
     },
     loggers: {
       default: {
@@ -77,9 +74,7 @@ test(async function getLogger() {
   const logger = log.getLogger();
 
   assertEqual(logger.levelName, "DEBUG");
-  assertEqual(logger.handlers, [
-    handler
-  ]);
+  assertEqual(logger.handlers, [handler]);
 });
 
 test(async function getLoggerWithName() {
@@ -100,17 +95,13 @@ test(async function getLoggerWithName() {
   const logger = log.getLogger("bar");
 
   assertEqual(logger.levelName, "INFO");
-  assertEqual(logger.handlers, [
-    fooHandler
-  ]);
+  assertEqual(logger.handlers, [fooHandler]);
 });
 
 test(async function getLoggerUnknown() {
   await log.setup({
-    handlers: {
-    },
-    loggers: {
-    }
+    handlers: {},
+    loggers: {}
   });
 
   const logger = log.getLogger("nonexistent");


### PR DESCRIPTION
This is a fix for the @hayd's [comment](https://github.com/denoland/deno_std/pull/156#discussion_r251283970). When a file is deleted and not staged, the formatter crashes when try to format that deleted file. This change skips formatting those files. (The diffs under //log directory are just the result of formatting, not relevant)