### PR TITLE
Added runTests to examples

### DIFF
--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,5 +1,5 @@
 import { run } from "deno";
-import { test, assertEqual } from "../testing/mod.ts";
+import { test, assertEqual, runTests } from "../testing/mod.ts";
 
 /** Example of how to do basic tests */
 test(function t1() {
@@ -9,6 +9,8 @@ test(function t1() {
 test(function t2() {
   assertEqual("world", "world");
 });
+
+runTests();
 
 /** A more complicated test that runs a subprocess. */
 /* TODO re-enable this test. Seems to be broken on Windows.

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env deno --allow-run --allow-net --allow-write
 import "colors/test.ts";
 import "datetime/test.ts";
-import "examples/test.ts";
 import "flags/test.ts";
 import "fs/path/basename_test.ts";
 import "fs/path/dirname_test.ts";


### PR DESCRIPTION
## Why?

For users following the documentation, when they run 

```sh
> deno https://deno.land/x/examples/test.ts
```
nothing happens.

## What's changed?

Added `runTests()` in the `examples/test.ts` file so the code snippet from the documentation above would run, we also need to remove the `examples/test.ts` from the main test file else the added `runTests()` call would break the main test.
