### PR TITLE
Add missing copyright headers

### DIFF
--- a/colors/example.ts
+++ b/colors/example.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { bgBlue, red, bold, italic } from "./mod.ts";
 
 console.log(bgBlue(italic(red(bold("Hello world!")))));

--- a/colors/test.ts
+++ b/colors/test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assert, test } from "../testing/mod.ts";
 import { red, bgBlue, setEnabled, getEnabled } from "./mod.ts";
 import "./example.ts";

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export type DateFormat = "mm-dd-yyyy" | "dd-mm-yyyy" | "yyyy-mm-dd";
 
 /**

--- a/datetime/test.ts
+++ b/datetime/test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual, assert } from "../testing/mod.ts";
 import * as datetime from "mod.ts";
 

--- a/examples/cat.ts
+++ b/examples/cat.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as deno from "deno";
 
 async function cat(filenames: string[]): Promise<void> {

--- a/examples/echo_server.ts
+++ b/examples/echo_server.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { listen, copy } from "deno";
 
 (async () => {

--- a/examples/gist.ts
+++ b/examples/gist.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env deno --allow-net --allow-env
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 import { args, env, exit, readFile } from "deno";
 import { parse } from "https://deno.land/x/flags/mod.ts";

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { run } from "deno";
 import { test, assertEqual } from "../testing/mod.ts";
 

--- a/flags/example.ts
+++ b/flags/example.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { args } from "deno";
 import { parse } from "./mod.ts";
 

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export interface ArgParsingOptions {
   unknown?: Function;
   boolean?: Boolean | string | string[];

--- a/flags/test.ts
+++ b/flags/test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./tests/all_bool.ts";
 import "./tests/bool.ts";
 import "./tests/dash.ts";

--- a/flags/tests/all_bool.ts
+++ b/flags/tests/all_bool.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/bool.ts
+++ b/flags/tests/bool.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/dash.ts
+++ b/flags/tests/dash.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/default_bool.ts
+++ b/flags/tests/default_bool.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/dotted.ts
+++ b/flags/tests/dotted.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/kv_short.ts
+++ b/flags/tests/kv_short.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/long.ts
+++ b/flags/tests/long.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/num.ts
+++ b/flags/tests/num.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/parse.ts
+++ b/flags/tests/parse.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/short.ts
+++ b/flags/tests/short.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/stop_early.ts
+++ b/flags/tests/stop_early.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/unknown.ts
+++ b/flags/tests/unknown.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/flags/tests/whitespace.ts
+++ b/flags/tests/whitespace.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual } from "../../testing/mod.ts";
 import { parse } from "../mod.ts";
 

--- a/fs/path.ts
+++ b/fs/path.ts
@@ -1,2 +1,3 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export * from "./path/mod.ts";
 export * from "./path/interface.ts";

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env deno --allow-net
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.
 // TODO Stream responses instead of reading them into memory.

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { readFile, run } from "deno";
 
 import { test, assert, assertEqual } from "../testing/mod.ts";

--- a/http/http_bench.ts
+++ b/http/http_bench.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import * as deno from "deno";
 import { serve } from "./mod.ts";
 

--- a/http/http_status.ts
+++ b/http/http_status.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export enum Status {
   Continue = 100, // RFC 7231, 6.2.1
   SwitchingProtocols = 101, // RFC 7231, 6.2.2

--- a/http/server.ts
+++ b/http/server.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { listen, Conn, toAsyncIterator, Reader, copy } from "deno";
 import { BufReader, BufState, BufWriter } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";

--- a/io/ioutil_test.ts
+++ b/io/ioutil_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Reader, ReadResult } from "deno";
 import { assertEqual, test } from "../testing/mod.ts";
 import { readInt, readLong, readShort, sliceLongToBytes } from "./ioutil.ts";

--- a/io/util.ts
+++ b/io/util.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Buffer, Reader } from "deno";
 
 // `off` is the offset into `dst` where it will at which to begin writing values

--- a/io/util_test.ts
+++ b/io/util_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assert } from "../testing/mod.ts";
 import { copyBytes } from "./util.ts";
 

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { open, File, Writer } from "deno";
 import { getLevelByName } from "./levels.ts";
 import { LogRecord } from "./logger.ts";

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assertEqual, test } from "../testing/mod.ts";
 import { LogRecord, Logger } from "./logger.ts";
 import { LogLevel, getLevelName, getLevelByName } from "./levels.ts";

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export const LogLevel = {
   NOTSET: 0,
   DEBUG: 10,

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { LogLevel, getLevelByName, getLevelName } from "./levels.ts";
 import { BaseHandler } from "./handlers.ts";
 

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assertEqual, test } from "../testing/mod.ts";
 import { LogRecord, Logger } from "./logger.ts";
 import { LogLevel } from "./levels.ts";

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Logger } from "./logger.ts";
 import {
   BaseHandler,

--- a/log/test.ts
+++ b/log/test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assertEqual, test } from "../testing/mod.ts";
 import * as log from "./mod.ts";
 import { BaseHandler } from "./handlers.ts";

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env deno --allow-run --allow-net --allow-write
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "colors/test.ts";
 import "datetime/test.ts";
 import "examples/test.ts";

--- a/ws/sha1_test.ts
+++ b/ws/sha1_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { assert, test } from "../testing/mod.ts";
 import { Sha1 } from "./sha1.ts";
 


### PR DESCRIPTION
Add headers like this to all files without it and written by Deno's authors: `// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.`