### PR TITLE
 refactor: make acceptWebSocket independent from ServerRequest

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -221,5 +221,3 @@ test(async function requestBodyStreamWithTransferEncoding() {
     }
   }
 });
-
-setTimeout(runTests, 0);

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -6,7 +6,7 @@
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
 import { Buffer } from "deno";
-import { test, assert, assertEqual } from "../testing/mod.ts";
+import { test, assert, assertEqual, runTests } from "../testing/mod.ts";
 import {
   listenAndServe,
   ServerRequest,
@@ -221,3 +221,5 @@ test(async function requestBodyStreamWithTransferEncoding() {
     }
   }
 });
+
+setTimeout(runTests, 0);

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -6,14 +6,9 @@
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
 import { Buffer } from "deno";
-import { test, assert, assertEqual, runTests } from "../testing/mod.ts";
-import {
-  listenAndServe,
-  ServerRequest,
-  setContentLength,
-  Response
-} from "./server.ts";
-import { BufWriter, BufReader } from "../io/bufio.ts";
+import { assertEqual, test } from "../testing/mod.ts";
+import { Response, ServerRequest } from "./server.ts";
+import { BufReader, BufWriter } from "../io/bufio.ts";
 
 interface ResponseTest {
   response: Response;

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Buffer, Writer, Conn } from "deno";
-import { ServerRequest } from "../http/server.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { readLong, readShort, sliceLongToBytes } from "../io/ioutil.ts";
 import { Sha1 } from "./sha1.ts";
+import { writeResponse } from "../http/server.ts";
 
 export enum OpCode {
   Continue = 0x0,
@@ -71,6 +71,7 @@ export type WebSocket = {
 
 class WebSocketImpl implements WebSocket {
   encoder = new TextEncoder();
+
   constructor(private conn: Conn, private mask?: Uint8Array) {}
 
   async *receive(): AsyncIterableIterator<WebSocketEvent> {
@@ -278,19 +279,22 @@ export function unmask(payload: Uint8Array, mask?: Uint8Array) {
   }
 }
 
-export function acceptable(req: ServerRequest): boolean {
+export function acceptable(headers: Headers): boolean {
   return (
-    req.headers.get("upgrade") === "websocket" &&
-    req.headers.has("sec-websocket-key")
+    headers.get("upgrade") === "websocket" && headers.has("sec-websocket-key")
   );
 }
 
-export async function acceptWebSocket(req: ServerRequest): Promise<WebSocket> {
-  if (acceptable(req)) {
-    const sock = new WebSocketImpl(req.conn);
-    const secKey = req.headers.get("sec-websocket-key");
+export async function acceptWebSocket(req: {
+  conn: Conn;
+  headers: Headers;
+}): Promise<WebSocket> {
+  const { conn, headers } = req;
+  if (acceptable(headers)) {
+    const sock = new WebSocketImpl(conn);
+    const secKey = headers.get("sec-websocket-key");
     const secAccept = createSecAccept(secKey);
-    await req.respond({
+    await writeResponse(conn, {
       status: 101,
       headers: new Headers({
         Upgrade: "websocket",

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -279,9 +279,11 @@ export function unmask(payload: Uint8Array, mask?: Uint8Array) {
   }
 }
 
-export function acceptable(headers: Headers): boolean {
+export function acceptable(req: { headers: Headers }): boolean {
   return (
-    headers.get("upgrade") === "websocket" && headers.has("sec-websocket-key")
+    req.headers.get("upgrade") === "websocket" &&
+    req.headers.has("sec-websocket-key") &&
+    req.headers.get("sec-websocket-key").length > 0
   );
 }
 
@@ -290,7 +292,7 @@ export async function acceptWebSocket(req: {
   headers: Headers;
 }): Promise<WebSocket> {
   const { conn, headers } = req;
-  if (acceptable(headers)) {
+  if (acceptable(req)) {
     const sock = new WebSocketImpl(conn);
     const secKey = headers.get("sec-websocket-key");
     const secAccept = createSecAccept(secKey);

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { Buffer } from "deno";
 import { BufReader } from "../io/bufio.ts";
-import { assert, assertEqual, runTests, test } from "../testing/mod.ts";
+import { assert, assertEqual, test } from "../testing/mod.ts";
 import {
   acceptable,
   createSecAccept,

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Buffer } from "deno";
-import { BufReader } from "../io/bufio.ts";
-import { test, assert, assertEqual } from "../testing/mod.ts";
-import { createSecAccept, OpCode, readFrame, unmask } from "./mod.ts";
-import { serve } from "../http/server.ts";
+import {Buffer} from "deno";
+import {BufReader} from "../io/bufio.ts";
+import {assert, assertEqual, runTests, test} from "../testing/mod.ts";
+import {createSecAccept, OpCode, readFrame, unmask} from "./mod.ts";
 
 test(async function testReadUnmaskedTextFrame() {
   // unmasked single text frame with payload "Hello"
@@ -127,3 +126,5 @@ test(async function testCreateSecAccept() {
   const d = createSecAccept(nonce);
   assertEqual(d, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
 });
+
+setTimeout(runTests,0)

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -1,8 +1,14 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import {Buffer} from "deno";
-import {BufReader} from "../io/bufio.ts";
-import {assert, assertEqual, runTests, test} from "../testing/mod.ts";
-import {createSecAccept, OpCode, readFrame, unmask} from "./mod.ts";
+import { Buffer } from "deno";
+import { BufReader } from "../io/bufio.ts";
+import { assert, assertEqual, runTests, test } from "../testing/mod.ts";
+import {
+  acceptable,
+  createSecAccept,
+  OpCode,
+  readFrame,
+  unmask
+} from "./mod.ts";
 
 test(async function testReadUnmaskedTextFrame() {
   // unmasked single text frame with payload "Hello"
@@ -127,4 +133,30 @@ test(async function testCreateSecAccept() {
   assertEqual(d, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
 });
 
-setTimeout(runTests,0)
+test(function testAcceptable() {
+  const ret = acceptable({
+    headers: new Headers({
+      upgrade: "websocket",
+      "sec-websocket-key": "aaa"
+    })
+  });
+  assertEqual(ret, true);
+});
+
+const invalidHeaders = [
+  { "sec-websocket-key": "aaa" },
+  { upgrade: "websocket" },
+  { upgrade: "invalid", "sec-websocket-key": "aaa" },
+  { upgrade: "websocket", "sec-websocket-ky": "" }
+];
+
+test(function testAcceptableInvalid() {
+  for (const pat of invalidHeaders) {
+    const ret = acceptable({
+      headers: new Headers(pat)
+    });
+    assertEqual(ret, false);
+  }
+});
+
+setTimeout(runTests, 0);

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -158,5 +158,3 @@ test(function testAcceptableInvalid() {
     assertEqual(ret, false);
   }
 });
-
-setTimeout(runTests, 0);


### PR DESCRIPTION
- made `acceptWebSocket`, `acceptable` independent from `ServerRequest`
  - These are still compatible with existing code
- made `ServerRequest` more stateless
- add tests for `acceptable`
- reformated