### PR TITLE
support NO_COLOR in colors module

### DIFF
--- a/colors/README.md
+++ b/colors/README.md
@@ -16,6 +16,8 @@ import { bgBlue, red, bold } from "https://deno.land/x/std/colors/mod.ts";
 console.log(bgBlue(red(bold("Hello world!"))));
 ```
 
+This module supports `NO_COLOR` environmental variable disabling any coloring if `NO_COLOR` is set.
+
 ## TODO
 
 - Currently, it just assumes it is running in an environment that supports ANSI

--- a/colors/mod.ts
+++ b/colors/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { noColor } from "deno";
 
 interface Code {
   open: string;
@@ -6,9 +7,13 @@ interface Code {
   regexp: RegExp;
 }
 
-let enabled = true;
+let enabled = !noColor;
 
 export function setEnabled(value: boolean) {
+  if (noColor) {
+    return;
+  }
+
   enabled = value;
 }
 


### PR DESCRIPTION
Ref denoland/deno#1716 and #175 

This PR support `deno.noColor` disabling any coloring. It'd be good to test it, but currently there is no way to override `noColor` in tests. Any ideas?

Depends on: #181 