### PR TITLE
"Num" module, with clamp function

### DIFF
--- a/num/mod.ts
+++ b/num/mod.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 export interface ClampConfig {
-    min?: number,
-    max?: number
+  min?: number;
+  max?: number;
 }
 
- /**
+/**
  * Clamps a number between a minimum and maximum value
  * @param {number} number - The input number
  * @param {Object} config - A ClampConfig
@@ -12,31 +12,29 @@ export interface ClampConfig {
  * @param {number} [max] - The maximum value. Defaults to positive infinity.
  */
 export function clamp(number: number, config: ClampConfig): number {
-    let {max, min} = config;
+  let { max, min } = config;
 
-    if (max === undefined) {
-        max = Number.POSITIVE_INFINITY;
-    }
+  if (max === undefined) {
+    max = Number.POSITIVE_INFINITY;
+  }
 
-    if (min === undefined) {
-        min = Number.NEGATIVE_INFINITY;
-    }
+  if (min === undefined) {
+    min = Number.NEGATIVE_INFINITY;
+  }
 
-    if (max < min || (max === min && Object.is(max, -0))) {
-        let tmp = max;
-        max = min;
-        min = tmp;
-    }
+  if (max < min || (max === min && Object.is(max, -0))) {
+    let tmp = max;
+    max = min;
+    min = tmp;
+  }
 
-    if (number === 0 && min === 0) {
-        return Object.is(min, -0) ? number : min;
-
-    } else if (number === 0 && max === 0) {
-        return Object.is(max, -0) ? max : number;
-
-    } else {
-        number = number > max ? max : number;
-        number = number < min ? min : number;
-        return number;
-    }
+  if (number === 0 && min === 0) {
+    return Object.is(min, -0) ? number : min;
+  } else if (number === 0 && max === 0) {
+    return Object.is(max, -0) ? max : number;
+  } else {
+    number = number > max ? max : number;
+    number = number < min ? min : number;
+    return number;
+  }
 }

--- a/num/mod.ts
+++ b/num/mod.ts
@@ -22,37 +22,21 @@ export function clamp(number: number, config: ClampConfig): number {
         min = Number.NEGATIVE_INFINITY;
     }
 
-    if (max < min || (max === 0 && isNegativeZero(max))) {
+    if (max < min || (max === min && Object.is(max, -0))) {
         let tmp = max;
         max = min;
         min = tmp;
     }
 
-    // If number & max are both zero, make sure a maximum of negative zero is respected
-    if (number === max && max === 0 && isNegativeZero(max)) {
-        number = max;
+    if (number === 0 && min === 0) {
+        return Object.is(min, -0) ? number : min;
+
+    } else if (number === 0 && max === 0) {
+        return Object.is(max, -0) ? max : number;
+
+    } else {
+        number = number > max ? max : number;
+        number = number < min ? min : number;
+        return number;
     }
-
-    if (number > max) {
-        number = max;
-    }
-
-    // Similarly, if number and min are both zero, make sure a minimum of positive zero is respected
-    if (number === min && min === 0 && !isNegativeZero(min)) {
-        number = min;
-    }
-
-    if (number < min) {
-        number = min;
-    }
-
-    return number;
-}
-
-/**
- * Is this number negative zero?
- * @param {number} number - Number to test 
- */
-export function isNegativeZero(number: number): boolean {
-    return 1 / number === Number.NEGATIVE_INFINITY;
 }

--- a/num/mod.ts
+++ b/num/mod.ts
@@ -1,0 +1,58 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+export interface ClampConfig {
+    min?: number,
+    max?: number
+}
+
+ /**
+ * Clamps a number between a minimum and maximum value
+ * @param {number} number - The input number
+ * @param {Object} config - A ClampConfig
+ * @param {number} [min] - The minimum value. Defaults to negative infinity.
+ * @param {number} [max] - The maximum value. Defaults to positive infinity.
+ */
+export function clamp(number: number, config: ClampConfig): number {
+    let {max, min} = config;
+
+    if (max === undefined) {
+        max = Number.POSITIVE_INFINITY;
+    }
+
+    if (min === undefined) {
+        min = Number.NEGATIVE_INFINITY;
+    }
+
+    if (max < min || (max === 0 && isNegativeZero(max))) {
+        let tmp = max;
+        max = min;
+        min = tmp;
+    }
+
+    // If number & max are both zero, make sure a maximum of negative zero is respected
+    if (number === max && max === 0 && isNegativeZero(max)) {
+        number = max;
+    }
+
+    if (number > max) {
+        number = max;
+    }
+
+    // Similarly, if number and min are both zero, make sure a minimum of positive zero is respected
+    if (number === min && min === 0 && !isNegativeZero(min)) {
+        number = min;
+    }
+
+    if (number < min) {
+        number = min;
+    }
+
+    return number;
+}
+
+/**
+ * Is this number negative zero?
+ * @param {number} number - Number to test 
+ */
+export function isNegativeZero(number: number): boolean {
+    return 1 / number === Number.NEGATIVE_INFINITY;
+}

--- a/num/test.ts
+++ b/num/test.ts
@@ -3,112 +3,70 @@ import { test, assertEqual, assert } from "../testing/mod.ts";
 import { clamp } from "mod.ts";
 
 test(function clampNumber() {
-    // Numbers between ranges go untouched
+  // Numbers between ranges go untouched
 
-    assertEqual(
-        clamp(50, {min: 25, max: 75}),
-        50
-    );
+  assertEqual(clamp(50, { min: 25, max: 75 }), 50);
 
-    assertEqual(
-        clamp(-50, {min: -75, max: -25}),
-        -50
-    );
+  assertEqual(clamp(-50, { min: -75, max: -25 }), -50);
 
-    assertEqual(
-        Object.is(clamp(0, {min: -0, max: 100}), -0),
-        false
-    );
+  assertEqual(Object.is(clamp(0, { min: -0, max: 100 }), -0), false);
 
-    assertEqual(
-        clamp(Number.MAX_SAFE_INTEGER, {min: 0, max: Infinity}),
-        Number.MAX_SAFE_INTEGER
-    );
+  assertEqual(
+    clamp(Number.MAX_SAFE_INTEGER, { min: 0, max: Infinity }),
+    Number.MAX_SAFE_INTEGER
+  );
 
-    assertEqual(
-        clamp(Number.MIN_SAFE_INTEGER, {min: Number.NEGATIVE_INFINITY, max: 0}),
-        Number.MIN_SAFE_INTEGER
-    );
+  assertEqual(
+    clamp(Number.MIN_SAFE_INTEGER, { min: Number.NEGATIVE_INFINITY, max: 0 }),
+    Number.MIN_SAFE_INTEGER
+  );
 
-    // Numbers below range are bumped upwards
+  // Numbers below range are bumped upwards
 
-    assertEqual(
-        clamp(0, {min: 25, max: 75}),
-        25
-    );
+  assertEqual(clamp(0, { min: 25, max: 75 }), 25);
 
-    assertEqual(
-        clamp(-50, {min: 0, max: 50}),
-        0
-    );
+  assertEqual(clamp(-50, { min: 0, max: 50 }), 0);
 
-    assertEqual(
-        clamp(Number.NEGATIVE_INFINITY, {min: Number.MIN_SAFE_INTEGER, max: 0}),
-        Number.MIN_SAFE_INTEGER
-    );
+  assertEqual(
+    clamp(Number.NEGATIVE_INFINITY, { min: Number.MIN_SAFE_INTEGER, max: 0 }),
+    Number.MIN_SAFE_INTEGER
+  );
 
-    assertEqual(
-        Object.is(clamp(-0, {min: 0, max: 100}), -0),
-        false
-    );
+  assertEqual(Object.is(clamp(-0, { min: 0, max: 100 }), -0), false);
 
-    // Numbers above range are bumped downwards
+  // Numbers above range are bumped downwards
 
-    assertEqual(
-        clamp(100, {min: 25, max: 75}),
-        75
-    );
+  assertEqual(clamp(100, { min: 25, max: 75 }), 75);
 
-    assertEqual(
-        clamp(-10, {min: -75, max: -25}),
-        -25
-    );
+  assertEqual(clamp(-10, { min: -75, max: -25 }), -25);
 
-    assertEqual(
-        Object.is(clamp(+0, {min: -100, max: -0}), -0),
-        true
-    );
+  assertEqual(Object.is(clamp(+0, { min: -100, max: -0 }), -0), true);
 
-    // NaN is left as is
-    assertEqual(
-        clamp(NaN, {min: 0, max: 100}), 
-        NaN
-    );
+  // NaN is left as is
+  assertEqual(clamp(NaN, { min: 0, max: 100 }), NaN);
 
-    // Swaps min & max if wrong way around
+  // Swaps min & max if wrong way around
 
-    assertEqual(
-        clamp(75, {min: 50, max: 0}),
-        50
-    );
+  assertEqual(clamp(75, { min: 50, max: 0 }), 50);
 
-    assertEqual(
-        clamp(75, {min: -50, max: -100}),
-        -50
-    );
+  assertEqual(clamp(75, { min: -50, max: -100 }), -50);
 
-    assertEqual(
-        Object.is(clamp(+0, {min: -0, max: -100}), -0),
-        true
-    );
+  assertEqual(Object.is(clamp(+0, { min: -0, max: -100 }), -0), true);
 
-    // Min defaults to minus infinity
-    
-    assertEqual(
-        clamp(Number.MIN_SAFE_INTEGER, {max: 50}),
-        Number.MIN_SAFE_INTEGER
-    );
+  // Min defaults to minus infinity
 
-    // Max defaults to plus infinity
+  assertEqual(
+    clamp(Number.MIN_SAFE_INTEGER, { max: 50 }),
+    Number.MIN_SAFE_INTEGER
+  );
 
-    assertEqual(
-        clamp(Number.MAX_SAFE_INTEGER, {min: 0}),
-        Number.MAX_SAFE_INTEGER
-    );
+  // Max defaults to plus infinity
 
-    // If min & max equal, returns it
-    assertEqual(
-        clamp(100, {min: 50, max: 50}),
-        50
-    );
-})
+  assertEqual(
+    clamp(Number.MAX_SAFE_INTEGER, { min: 0 }),
+    Number.MAX_SAFE_INTEGER
+  );
+
+  // If min & max equal, returns it
+  assertEqual(clamp(100, { min: 50, max: 50 }), 50);
+});

--- a/num/test.ts
+++ b/num/test.ts
@@ -1,0 +1,124 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test, assertEqual, assert } from "../testing/mod.ts";
+import {isNegativeZero, clamp} from "mod.ts";
+
+test(function checkNegativeZero() {
+    assertEqual(isNegativeZero(-0), true);
+    assertEqual(isNegativeZero(+0), false);
+    assertEqual(isNegativeZero(-1), false);
+    assertEqual(isNegativeZero(+1), false);
+    assertEqual(isNegativeZero(Number.NEGATIVE_INFINITY), false);
+    assertEqual(isNegativeZero(Number.POSITIVE_INFINITY), false);
+    assertEqual(isNegativeZero(NaN), false);
+});
+
+test(function clampNumber() {
+    // Numbers between ranges go untouched
+
+    assertEqual(
+        clamp(50, {min: 25, max: 75}),
+        50
+    );
+
+    assertEqual(
+        clamp(-50, {min: -75, max: -25}),
+        -50
+    );
+
+    assertEqual(
+        isNegativeZero(clamp(0, {min: -0, max: 100})),
+        false
+    );
+
+    assertEqual(
+        clamp(Number.MAX_SAFE_INTEGER, {min: 0, max: Infinity}),
+        Number.MAX_SAFE_INTEGER
+    );
+
+    assertEqual(
+        clamp(Number.MIN_SAFE_INTEGER, {min: Number.NEGATIVE_INFINITY, max: 0}),
+        Number.MIN_SAFE_INTEGER
+    );
+
+    // Numbers below range are bumped upwards
+
+    assertEqual(
+        clamp(0, {min: 25, max: 75}),
+        25
+    );
+
+    assertEqual(
+        clamp(-50, {min: 0, max: 50}),
+        0
+    );
+
+    assertEqual(
+        clamp(Number.NEGATIVE_INFINITY, {min: Number.MIN_SAFE_INTEGER, max: 0}),
+        Number.MIN_SAFE_INTEGER
+    );
+
+    assertEqual(
+        isNegativeZero(clamp(-0, {min: 0, max: 100})),
+        false
+    );
+
+    // Numbers above range are bumped downwards
+
+    assertEqual(
+        clamp(100, {min: 25, max: 75}),
+        75
+    );
+
+    assertEqual(
+        clamp(-10, {min: -75, max: -25}),
+        -25
+    );
+
+    assertEqual(
+        isNegativeZero(clamp(+0, {min: -100, max: -0})),
+        true
+    );
+
+    // NaN is left as is
+    assertEqual(
+        clamp(NaN, {min: 0, max: 100}), 
+        NaN
+    );
+
+    // Swaps min & max if wrong way around
+
+    assertEqual(
+        clamp(75, {min: 50, max: 0}),
+        50
+    );
+
+    assertEqual(
+        clamp(75, {min: -50, max: -100}),
+        -50
+    );
+
+    assertEqual(
+        isNegativeZero(clamp(+0, {min: -0, max: -100})),
+        true
+    );
+
+    // Min defaults to minus infinity
+    
+    assertEqual(
+        clamp(Number.MIN_SAFE_INTEGER, {max: 50}),
+        Number.MIN_SAFE_INTEGER
+    );
+
+    // Max defaults to plus infinity
+
+    assertEqual(
+        clamp(Number.MAX_SAFE_INTEGER, {min: 0}),
+        Number.MAX_SAFE_INTEGER
+    );
+
+    // If min & max equal, returns it
+    assertEqual(
+        clamp(100, {min: 50, max: 50}),
+        50
+    );
+})

--- a/num/test.ts
+++ b/num/test.ts
@@ -1,16 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { test, assertEqual, assert } from "../testing/mod.ts";
-import {isNegativeZero, clamp} from "mod.ts";
-
-test(function checkNegativeZero() {
-    assertEqual(isNegativeZero(-0), true);
-    assertEqual(isNegativeZero(+0), false);
-    assertEqual(isNegativeZero(-1), false);
-    assertEqual(isNegativeZero(+1), false);
-    assertEqual(isNegativeZero(Number.NEGATIVE_INFINITY), false);
-    assertEqual(isNegativeZero(Number.POSITIVE_INFINITY), false);
-    assertEqual(isNegativeZero(NaN), false);
-});
+import { clamp } from "mod.ts";
 
 test(function clampNumber() {
     // Numbers between ranges go untouched
@@ -26,7 +16,7 @@ test(function clampNumber() {
     );
 
     assertEqual(
-        isNegativeZero(clamp(0, {min: -0, max: 100})),
+        Object.is(clamp(0, {min: -0, max: 100}), -0),
         false
     );
 
@@ -58,7 +48,7 @@ test(function clampNumber() {
     );
 
     assertEqual(
-        isNegativeZero(clamp(-0, {min: 0, max: 100})),
+        Object.is(clamp(-0, {min: 0, max: 100}), -0),
         false
     );
 
@@ -75,7 +65,7 @@ test(function clampNumber() {
     );
 
     assertEqual(
-        isNegativeZero(clamp(+0, {min: -100, max: -0})),
+        Object.is(clamp(+0, {min: -100, max: -0}), -0),
         true
     );
 
@@ -98,7 +88,7 @@ test(function clampNumber() {
     );
 
     assertEqual(
-        isNegativeZero(clamp(+0, {min: -0, max: -100})),
+        Object.is(clamp(+0, {min: -0, max: -100}), -0),
         true
     );
 

--- a/test.ts
+++ b/test.ts
@@ -10,6 +10,7 @@ import "http/server_test.ts";
 import "http/file_server_test.ts";
 import "log/test.ts";
 import "media_types/test.ts";
+import "num/test.ts";
 import "prettier/main_test.ts";
 import "testing/test.ts";
 import "textproto/test.ts";


### PR DESCRIPTION
Hello Deno!

I've been thinking of getting involved with this project for a little while, and thought the best way to start would be to contribute something small to the standard library.

To that end, I have written a little `clamp` function for constraining numbers, in a module named `num`.

## The num module

Where should utilities operating on numbers reside? Should operations on single numbers be considered distinct from maths operations? What should a number module be called?

For the sake of the PR I created a module named `num`, but it's very much a stake-in-the-ground, straw-man-kind-of-thing.

## The clamp function

This is not the most exciting piece of code, but it is complicated ever so slightly by the existence of negative zero in IEEE 754 numbers.

This means that the function has to check for negative zero whenever the input and min / max equate to 0, which adds some overhead. After twiddling around and doing some performance profiling in the browser, it seemed like the `Object.is` check outperformed the alternatives (dividing 1 by the number and testing for positive / negative infinity; calling atan2(0, x) and checking for zero or pi).

## The tests

I have of course included some unit tests. Do give them a spin.