### PR TITLE
Handle unread body from request

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -10,7 +10,7 @@ const { ErrorKind, cwd, args, stat, readDir, open } = Deno;
 import {
   listenAndServe,
   ServerRequest,
-  setContentLength,
+  setHeaders,
   Response
 } from "./server.ts";
 import { extname } from "../fs/path.ts";
@@ -181,7 +181,7 @@ async function serveDir(
     body: page,
     headers
   };
-  setContentLength(res);
+  setHeaders(res, req);
   return res;
 }
 

--- a/http/server.ts
+++ b/http/server.ts
@@ -41,6 +41,7 @@ export function setHeaders(r: Response, req: ServerRequest): void {
     }
   } else {
     r.headers.append("content-length", "0");
+<<<<<<< HEAD
   } 
 }
 async function writeChunkedBody(w: Writer, r: Reader): Promise<void> {
@@ -96,6 +97,8 @@ export async function writeResponse(w: Writer, r: Response, req: ServerRequest):
         await writeChunkedBody(writer, r.body);
       }
     }
+=======
+>>>>>>> handle bodyless response
   }
   await writer.flush();
 }

--- a/http/server.ts
+++ b/http/server.ts
@@ -7,7 +7,6 @@ import { BufReader, BufState, BufWriter } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { STATUS_TEXT } from "./http_status.ts";
 import { assert } from "../testing/asserts.ts";
-import { reset } from "colors/mod";
 
 interface Deferred {
   promise: Promise<{}>;
@@ -41,7 +40,6 @@ export function setHeaders(r: Response, req: ServerRequest): void {
     }
   } else {
     r.headers.append("content-length", "0");
-<<<<<<< HEAD
   } 
 }
 async function writeChunkedBody(w: Writer, r: Reader): Promise<void> {
@@ -97,8 +95,6 @@ export async function writeResponse(w: Writer, r: Response, req: ServerRequest):
         await writeChunkedBody(writer, r.body);
       }
     }
-=======
->>>>>>> handle bodyless response
   }
   await writer.flush();
 }
@@ -234,9 +230,11 @@ export class ServerRequest {
   }
 
   async respond(r: Response): Promise<void> {
+    console.log('   connection:', this.conn);
     await this._finishRequest();
     await writeResponse(this.w, r, this);
     if (!this._shouldReuseConnection()) {
+      console.log(this.conn);
       this.conn.close();
     }
   }
@@ -245,6 +243,7 @@ export class ServerRequest {
     // We need to check if body was read from connection
     // before responding to request. If body wasn't consumed
     // we'll need to handle it.
+    console.log('finish req', this._bodyConsumed);
     if (this._bodyConsumed) {
       return;
     }
@@ -275,6 +274,7 @@ export class ServerRequest {
   }
 
   private _shouldReuseConnection() {
+    console.log('should reuse', this.closeConnectionEarly);
     if (this.closeConnectionEarly) {
       return false;
     }

--- a/http/server.ts
+++ b/http/server.ts
@@ -148,7 +148,7 @@ export class ServerRequest {
 
   public async *bodyStream(): AsyncIterableIterator<Uint8Array> {
     if (this._bodyConsumed) {
-      throw new Error("Request body has already been consumed.")
+      throw new Error("Request body has already been consumed.");
     }
 
     if (this.headers.has("content-length")) {
@@ -244,7 +244,7 @@ export class ServerRequest {
   private async _finishRequest() {
     if (this._bodyConsumed) {
       return;
-    } 
+    }
 
     if (this.headers.has("content-length")) {
       const ct = parseInt(this.headers.get("content-length"), 10);
@@ -264,7 +264,7 @@ export class ServerRequest {
         }
       }
     }
-    
+
     this._bodyConsumed = true;
   }
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -277,7 +277,7 @@ test(async function requestUnreadSmallBody() {
 test(async function requestUnreadBigBody() {
   {
     const req = new ServerRequest();
-    // body is smaller than `maxPostHandlerReadBytes`
+    // body is greater than `maxPostHandlerReadBytes`
     const body = "x\n".repeat(1 << 20);
 
     req.headers = new Headers();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -5,18 +5,11 @@
 // Ported from
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
-<<<<<<< HEAD
 const { Buffer } = Deno;
 import { test } from "../testing/mod.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
-=======
-import { Buffer } from "deno";
-import { test, assert, assertEqual } from "../testing/mod.ts";
-import { ServerRequest, Response } from "./server.ts";
-import { BufWriter, BufReader } from "../io/bufio.ts";
->>>>>>> format
 
 interface ResponseTest {
   response: Response;
@@ -46,18 +39,6 @@ const responseTests: ResponseTest[] = [
   }
 ];
 
-<<<<<<< HEAD
-// test(async function responseWrite() {
-//   for (const testCase of responseTests) {
-//     const buf = new Buffer();
-//     const bufw = new BufWriter(buf);
-//     const request = new ServerRequest();
-//     request.w = bufw;
-//     await request.respond(testCase.response);
-//     assertEqual(buf.toString(), testCase.raw);
-//   }
-// });
-=======
 test(async function responseWrite() {
   for (const testCase of responseTests) {
     const buf = new Buffer();
@@ -67,10 +48,9 @@ test(async function responseWrite() {
     request.w = bufw;
 
     await request.respond(testCase.response);
-    assertEqual(buf.toString(), testCase.raw);
+    assertEquals(buf.toString(), testCase.raw);
   }
 });
->>>>>>> handle bodyless response
 
 
 test(async function requestBodyWithContentLength() {
@@ -264,7 +244,7 @@ test(async function requestUnreadSmallBody() {
       err = e;
     }
     assert(!!err);
-    assert(err.message, "Error: Request body has already been consumed");
+    assertEquals(err.message, "Request body has already been consumed.");
 
     const response = wbuf.toString();
 
@@ -298,7 +278,7 @@ test(async function requestUnreadBigBody() {
       err = e;
     }
     assert(!!err);
-    assert(err.message, "Error: Request body has already been consumed");
+    assertEquals(err.message, "Error: Request body has already been consumed");
 
     const response = wbuf.toString();
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -221,6 +221,7 @@ test(async function requestBodyStreamWithTransferEncoding() {
 test(async function requestUnreadSmallBody() {
   {
     const req = new ServerRequest();
+    // body is smaller than `maxPostHandlerReadBytes`
     const body = "x\n".repeat(100 << 10);
 
     req.headers = new Headers();
@@ -244,14 +245,17 @@ test(async function requestUnreadSmallBody() {
     assert(err.message, "Error: Request body has already been consumed");
 
     const response = wbuf.toString();
-    console.log("response\n\n", response);
+
     if (response.indexOf("connection: close") > -1) {
       throw new Error("Unexpected \"Connection: close\" header.")
     }
   }
+});
 
+test(async function requestUnreadBigBody() {
   {
     const req = new ServerRequest();
+    // body is smaller than `maxPostHandlerReadBytes`
     const body = "x\n".repeat(1 << 20);
 
     req.headers = new Headers();
@@ -275,7 +279,6 @@ test(async function requestUnreadSmallBody() {
     assert(err.message, "Error: Request body has already been consumed");
 
     const response = wbuf.toString();
-    console.log("response\n\n", response);
     
     if (response.indexOf("connection: close") === -1) {
       throw new Error("Expected \"Connection: close\" header.")

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -23,7 +23,10 @@ const responseTests: ResponseTest[] = [
   // Default response
   {
     response: {},
-    raw: "HTTP/1.1 200 OK\r\n" + "\r\n"
+    raw: 
+      "HTTP/1.1 200 OK\r\n" + 
+      "content-length: 0\r\n" +
+      "\r\n"
   },
   // HTTP/1.1, chunked coding; empty trailer; close
   {
@@ -39,6 +42,7 @@ const responseTests: ResponseTest[] = [
   }
 ];
 
+<<<<<<< HEAD
 // test(async function responseWrite() {
 //   for (const testCase of responseTests) {
 //     const buf = new Buffer();
@@ -49,6 +53,20 @@ const responseTests: ResponseTest[] = [
 //     assertEqual(buf.toString(), testCase.raw);
 //   }
 // });
+=======
+test(async function responseWrite() {
+  for (const testCase of responseTests) {
+    const buf = new Buffer();
+    const bufw = new BufWriter(buf);
+    const request = new ServerRequest();
+    request.headers = new Headers();
+    request.w = bufw;
+
+    await request.respond(testCase.response);
+    assertEqual(buf.toString(), testCase.raw);
+  }
+});
+>>>>>>> handle bodyless response
 
 
 test(async function requestBodyWithContentLength() {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -5,11 +5,18 @@
 // Ported from
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
+<<<<<<< HEAD
 const { Buffer } = Deno;
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
+=======
+import { Buffer } from "deno";
+import { test, assert, assertEqual } from "../testing/mod.ts";
+import { ServerRequest, Response } from "./server.ts";
+import { BufWriter, BufReader } from "../io/bufio.ts";
+>>>>>>> format
 
 interface ResponseTest {
   response: Response;
@@ -23,10 +30,7 @@ const responseTests: ResponseTest[] = [
   // Default response
   {
     response: {},
-    raw: 
-      "HTTP/1.1 200 OK\r\n" + 
-      "content-length: 0\r\n" +
-      "\r\n"
+    raw: "HTTP/1.1 200 OK\r\n" + "content-length: 0\r\n" + "\r\n"
   },
   // HTTP/1.1, chunked coding; empty trailer; close
   {
@@ -265,7 +269,7 @@ test(async function requestUnreadSmallBody() {
     const response = wbuf.toString();
 
     if (response.indexOf("connection: close") > -1) {
-      throw new Error("Unexpected \"Connection: close\" header.")
+      throw new Error('Unexpected "Connection: close" header.');
     }
   }
 });
@@ -297,9 +301,9 @@ test(async function requestUnreadBigBody() {
     assert(err.message, "Error: Request body has already been consumed");
 
     const response = wbuf.toString();
-    
+
     if (response.indexOf("connection: close") === -1) {
-      throw new Error("Expected \"Connection: close\" header.")
+      throw new Error('Expected "Connection: close" header.');
     }
   }
 });


### PR DESCRIPTION
Follow up #22 #49.

This PR provides most basic implementation that handles unread request body without reading all data to memory. As discussed in #49 it follows Golang's implementation. 