### PR TITLE
fix: url match logic of http server

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -109,6 +109,10 @@ test(function httpMatchNearest() {
     0
   );
   assert.equal(
+    findLongestAndNearestMatch("/foo", ["/foo", "/foo/bar"]).index,
+    0,
+  );
+  assert.equal(
     findLongestAndNearestMatch("/foo/bar", [
       "/",
       "/foo",
@@ -131,6 +135,15 @@ test(function httpMatchNearest() {
     findLongestAndNearestMatch("/deno/land", [/d(.+?)o/, /d(.+?)d/]).index,
     1
   );
+  assert.equal(findLongestAndNearestMatch("/foo", ["/", "/a/foo"]).index, 0);
+  assert.equal(findLongestAndNearestMatch("/foo", [
+    /\/foo/,
+    /\/bar\/foo/
+  ]).index, 0)
+  assert.equal(findLongestAndNearestMatch("/foo",[
+    /\/a\/foo/,
+    /\/foo/
+  ]).index, 1)
 });
 
 test(async function httpServer() {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -6,10 +6,11 @@
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
 import { Buffer, copy, Reader } from "deno";
-import { assert, assertEqual, test } from "../testing/mod.ts";
+import { assert, assertEqual, runTests, test } from "../testing/mod.ts";
 import {
   createResponder,
   createServer,
+  findLongestAndNearestMatch,
   readRequest,
   readResponse,
   ServerResponse,
@@ -100,6 +101,36 @@ test(async function httpReadRequestChunkedBody() {
   const dest = new Buffer();
   await copy(dest, req.body);
   assert.equal(dest.toString(), "deno.land");
+});
+
+test(function httpMatchNearest() {
+  assert.equal(
+    findLongestAndNearestMatch("/foo", ["/foo", "/bar", "/f"]).index,
+    0
+  );
+  assert.equal(
+    findLongestAndNearestMatch("/foo/bar", [
+      "/",
+      "/foo",
+      "/hoo",
+      "/hoo/foo/bar",
+      "/foo/bar"
+    ]).index,
+    4
+  );
+  assert.equal(
+    findLongestAndNearestMatch("/foo/bar/foo", ["/foo", "/foo/bar", "/bar/foo"])
+      .index,
+    1
+  );
+  assert.equal(
+    findLongestAndNearestMatch("/foo", ["/", "/hoo", "/hoo/foo"]).index,
+    0
+  );
+  assert.equal(
+    findLongestAndNearestMatch("/deno/land", [/d(.+?)o/, /d(.+?)d/]).index,
+    1
+  );
 });
 
 test(async function httpServer() {
@@ -283,3 +314,4 @@ test(async function httpServerResponderShouldThrow() {
     );
   }
 });
+setTimeout(runTests, 0);

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -314,4 +314,3 @@ test(async function httpServerResponderShouldThrow() {
     );
   }
 });
-setTimeout(runTests, 0);

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -110,7 +110,7 @@ test(function httpMatchNearest() {
   );
   assert.equal(
     findLongestAndNearestMatch("/foo", ["/foo", "/foo/bar"]).index,
-    0,
+    0
   );
   assert.equal(
     findLongestAndNearestMatch("/foo/bar", [
@@ -136,14 +136,14 @@ test(function httpMatchNearest() {
     1
   );
   assert.equal(findLongestAndNearestMatch("/foo", ["/", "/a/foo"]).index, 0);
-  assert.equal(findLongestAndNearestMatch("/foo", [
-    /\/foo/,
-    /\/bar\/foo/
-  ]).index, 0)
-  assert.equal(findLongestAndNearestMatch("/foo",[
-    /\/a\/foo/,
-    /\/foo/
-  ]).index, 1)
+  assert.equal(
+    findLongestAndNearestMatch("/foo", [/\/foo/, /\/bar\/foo/]).index,
+    0
+  );
+  assert.equal(
+    findLongestAndNearestMatch("/foo", [/\/a\/foo/, /\/foo/]).index,
+    1
+  );
 });
 
 test(async function httpServer() {


### PR DESCRIPTION
- Use only pathname for matching instead of full url
- Fixed url match logic for regular expression
   
Currently, both `"/foo"` and `"/bar/foo"` are matched to `/\/foo/` and the later is used because it is longer than the former. This is correct but strange behavior for url routing. I changed logic of evaluation for priority of matches:
- Matches with the earliest index (RegexMatchArray.index) is prior to others.
- The longest match is picked from them.

With this logic,
- `"/foo"` is prior to `"/bar/foo"` because the former matched to `/\/foo/` at index 0.
- `"/foo/bar"` is prior to `"/foo"` because the former has longer match than the later.
