### PR TITLE
Clean up the test failure output

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -286,7 +286,8 @@ export async function runTests() {
     // Use setTimeout to avoid the error being ignored due to unhandled
     // promise rejections being swallowed.
     setTimeout(() => {
-      throw new Error(`There were ${failed} test failures.`);
+      console.error(`There were ${failed} test failures.`);
+      Deno.exit(1);
     }, 0);
   }
 }

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -6,11 +6,18 @@ interface Constructor {
   new (...args: any[]): any;
 }
 
+export class AssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssertionError";
+  }
+}
+
 const assertions = {
   /** Make an assertion, if not `true`, then throw. */
   assert(expr: boolean, msg = ""): void {
     if (!expr) {
-      throw new Error(msg);
+      throw new AssertionError(msg);
     }
   },
 
@@ -40,7 +47,7 @@ const assertions = {
       if (!msg) {
         msg = `actual: ${actualString} expected: ${expectedString}`;
       }
-      throw new Error(msg);
+      throw new AssertionError(msg);
     }
   },
 
@@ -70,7 +77,7 @@ const assertions = {
       if (!msg) {
         msg = `actual: ${actualString} expected: ${expectedString}`;
       }
-      throw new Error(msg);
+      throw new AssertionError(msg);
     }
   },
 
@@ -95,25 +102,25 @@ const assertions = {
     try {
       fn();
     } catch (e) {
-      if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
+      if (ErrorClass && !(e instanceof ErrorClass)) {
         msg = `Expected error to be instance of "${ErrorClass.name}"${
           msg ? `: ${msg}` : "."
         }`;
-        throw new Error(msg);
+        throw new AssertionError(msg);
       }
       if (msgIncludes) {
         if (!e.message.includes(msgIncludes)) {
           msg = `Expected error message to include "${msgIncludes}", but got "${
             e.message
           }"${msg ? `: ${msg}` : "."}`;
-          throw new Error(msg);
+          throw new AssertionError(msg);
         }
       }
       doesThrow = true;
     }
     if (!doesThrow) {
       msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
-      throw new Error(msg);
+      throw new AssertionError(msg);
     }
   },
 
@@ -127,25 +134,25 @@ const assertions = {
     try {
       await fn();
     } catch (e) {
-      if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
+      if (ErrorClass && !(e instanceof ErrorClass)) {
         msg = `Expected error to be instance of "${ErrorClass.name}"${
           msg ? `: ${msg}` : "."
         }`;
-        throw new Error(msg);
+        throw new AssertionError(msg);
       }
       if (msgIncludes) {
         if (!e.message.includes(msgIncludes)) {
           msg = `Expected error message to include "${msgIncludes}", but got "${
             e.message
           }"${msg ? `: ${msg}` : "."}`;
-          throw new Error(msg);
+          throw new AssertionError(msg);
         }
       }
       doesThrow = true;
     }
     if (!doesThrow) {
       msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
-      throw new Error(msg);
+      throw new AssertionError(msg);
     }
   }
 };
@@ -265,6 +272,7 @@ export async function runTests() {
       result = red_failed();
       console.log("...", result);
       console.groupEnd();
+      console.log();
       console.error(e);
       failed++;
       if (exitOnFail) {
@@ -286,7 +294,8 @@ export async function runTests() {
     // Use setTimeout to avoid the error being ignored due to unhandled
     // promise rejections being swallowed.
     setTimeout(() => {
-      throw new Error(`There were ${failed} test failures.`);
+      console.error(`There were ${failed} test failures.`);
+      Deno.exit(1);
     }, 0);
   }
 }

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -6,18 +6,11 @@ interface Constructor {
   new (...args: any[]): any;
 }
 
-export class AssertionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AssertionError";
-  }
-}
-
 const assertions = {
   /** Make an assertion, if not `true`, then throw. */
   assert(expr: boolean, msg = ""): void {
     if (!expr) {
-      throw new AssertionError(msg);
+      throw new Error(msg);
     }
   },
 
@@ -47,7 +40,7 @@ const assertions = {
       if (!msg) {
         msg = `actual: ${actualString} expected: ${expectedString}`;
       }
-      throw new AssertionError(msg);
+      throw new Error(msg);
     }
   },
 
@@ -77,7 +70,7 @@ const assertions = {
       if (!msg) {
         msg = `actual: ${actualString} expected: ${expectedString}`;
       }
-      throw new AssertionError(msg);
+      throw new Error(msg);
     }
   },
 
@@ -102,25 +95,25 @@ const assertions = {
     try {
       fn();
     } catch (e) {
-      if (ErrorClass && !(e instanceof ErrorClass)) {
+      if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
         msg = `Expected error to be instance of "${ErrorClass.name}"${
           msg ? `: ${msg}` : "."
         }`;
-        throw new AssertionError(msg);
+        throw new Error(msg);
       }
       if (msgIncludes) {
         if (!e.message.includes(msgIncludes)) {
           msg = `Expected error message to include "${msgIncludes}", but got "${
             e.message
           }"${msg ? `: ${msg}` : "."}`;
-          throw new AssertionError(msg);
+          throw new Error(msg);
         }
       }
       doesThrow = true;
     }
     if (!doesThrow) {
       msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
-      throw new AssertionError(msg);
+      throw new Error(msg);
     }
   },
 
@@ -134,25 +127,25 @@ const assertions = {
     try {
       await fn();
     } catch (e) {
-      if (ErrorClass && !(e instanceof ErrorClass)) {
+      if (ErrorClass && !(Object.getPrototypeOf(e) === ErrorClass.prototype)) {
         msg = `Expected error to be instance of "${ErrorClass.name}"${
           msg ? `: ${msg}` : "."
         }`;
-        throw new AssertionError(msg);
+        throw new Error(msg);
       }
       if (msgIncludes) {
         if (!e.message.includes(msgIncludes)) {
           msg = `Expected error message to include "${msgIncludes}", but got "${
             e.message
           }"${msg ? `: ${msg}` : "."}`;
-          throw new AssertionError(msg);
+          throw new Error(msg);
         }
       }
       doesThrow = true;
     }
     if (!doesThrow) {
       msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
-      throw new AssertionError(msg);
+      throw new Error(msg);
     }
   }
 };
@@ -272,7 +265,6 @@ export async function runTests() {
       result = red_failed();
       console.log("...", result);
       console.groupEnd();
-      console.log();
       console.error(e);
       failed++;
       if (exitOnFail) {
@@ -294,8 +286,7 @@ export async function runTests() {
     // Use setTimeout to avoid the error being ignored due to unhandled
     // promise rejections being swallowed.
     setTimeout(() => {
-      console.error(`There were ${failed} test failures.`);
-      Deno.exit(1);
+      throw new Error(`There were ${failed} test failures.`);
     }, 0);
   }
 }


### PR DESCRIPTION
Specifically, don't throw an exception when the tests fail,
instead return with exit status 1.

Before:

<img width="1047" alt="screen shot 2019-02-19 at 23 11 18" src="https://user-images.githubusercontent.com/1931852/53073023-be5f4280-349b-11e9-803e-8a2336a2d668.png">

After:

<img width="1046" alt="screen shot 2019-02-19 at 23 10 52" src="https://user-images.githubusercontent.com/1931852/53073034-c6b77d80-349b-11e9-8fe3-fec15ed0ebe3.png">
