### PR TITLE
Add runIfMain method

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -290,3 +290,9 @@ export async function runTests() {
     }, 0);
   }
 }
+
+export async function runIfMain(meta: ImportMeta) {
+  if (window.location.toString() === meta.url) {
+    runTests();
+  }
+}


### PR DESCRIPTION
This PR adds `runIfMain` method to `testing` module. 

Ref #152.

Usage: 
```ts
// test.ts
import { test, runIfMain, assertEqual } from "https://deno.land/x/testing/mod.ts";

test(function simple() {
  const a = 1;
  assertEqual(a, 1);
});

runIfMain(import.meta);
```

Then if you do:

```
$ deno test.ts
Compiling file://dev/test.ts
Compiling file://dev/deno_std/testing/mod.ts
running 1 tests
test simple ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```