### PR TITLE
fs.walk performance improvement

### DIFF
--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -31,7 +31,8 @@ export async function* walk(
       options.onError(err);
     }
   }
-  for (let f of ls) {
+  for (var i = 0; i < ls.length; i++) {
+    let f = ls[i]
     if (f.isSymlink()) {
       if (options.followSymlinks) {
         f = await resolve(f);
@@ -71,7 +72,8 @@ export function* walkSync(
       options.onError(err);
     }
   }
-  for (let f of ls) {
+  for (var i = 0; i < ls.length; i++) {
+    let f = ls[i]
     if (f.isSymlink()) {
       if (options.followSymlinks) {
         f = resolveSync(f);

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -31,7 +31,7 @@ export async function* walk(
       options.onError(err);
     }
   }
-  for (var i = 0; i < ls.length; i++) {
+  for (var i = ls.length-1; i >= 0; i--) {
     let f = ls[i]
     if (f.isSymlink()) {
       if (options.followSymlinks) {
@@ -72,7 +72,7 @@ export function* walkSync(
       options.onError(err);
     }
   }
-  for (var i = 0; i < ls.length; i++) {
+  for (var i = ls.length-1; i >= 0; i--) {
     let f = ls[i]
     if (f.isSymlink()) {
       if (options.followSymlinks) {

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -31,8 +31,8 @@ export async function* walk(
       options.onError(err);
     }
   }
-  for (var i = ls.length-1; i >= 0; i--) {
-    let f = ls[i]
+  for (var i = ls.length - 1; i >= 0; i--) {
+    let f = ls[i];
     if (f.isSymlink()) {
       if (options.followSymlinks) {
         f = await resolve(f);
@@ -72,8 +72,8 @@ export function* walkSync(
       options.onError(err);
     }
   }
-  for (var i = ls.length-1; i >= 0; i--) {
-    let f = ls[i]
+  for (var i = ls.length - 1; i >= 0; i--) {
+    let f = ls[i];
     if (f.isSymlink()) {
       if (options.followSymlinks) {
         f = resolveSync(f);

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -31,7 +31,8 @@ export async function* walk(
       options.onError(err);
     }
   }
-  for (var i = ls.length - 1; i >= 0; i--) {
+  const length = ls.length;
+  for (var i = 0; i < length; i++) {
     let f = ls[i];
     if (f.isSymlink()) {
       if (options.followSymlinks) {
@@ -72,7 +73,8 @@ export function* walkSync(
       options.onError(err);
     }
   }
-  for (var i = ls.length - 1; i >= 0; i--) {
+  const length = ls.length;
+  for (var i = 0; i < length; i++) {
     let f = ls[i];
     if (f.isSymlink()) {
       if (options.followSymlinks) {


### PR DESCRIPTION
In fs.walk there is 2 loops with `for of` which is known to be slower than the classic `for` loop.
https://github.com/denoland/deno_std/blob/master/fs/walk.ts#L34
https://github.com/denoland/deno_std/blob/master/fs/walk.ts#L74
For example this snippet:
```javascript
const NS_PER_SEC = 1e9;
var t = [];
for (var i = 0; i < 5000; i++) {
    t.push(Math.floor(Math.random() * Math.floor(666)))
}
var start = process.hrtime();
for (let f of t) {
  if (true) {
    continue;
  }
}

var diff = process.hrtime(start);
console.log(`Benchmark took ${diff[0] * NS_PER_SEC + diff[1]} nanoseconds`);

var start2 = process.hrtime();
for (var i = 0; i < t.length; i++) {
  var f = t[i];
  if (true) {
    continue;
  }
}

var diff2 = process.hrtime(start2);
console.log(`Benchmark took ${diff2[0] * NS_PER_SEC + diff2[1]} nanoseconds`);

var start3 = process.hrtime();
for (var i = t.length-1; i >= 0; i--) {
  var f = t[i];
  if (true) {
    continue;
  }
}

var diff3 = process.hrtime(start3);
console.log(`Benchmark took ${diff3[0] * NS_PER_SEC + diff3[1]} nanoseconds`);
```

outputs:
```
Benchmark took 343077 nanoseconds
Benchmark took 230644 nanoseconds
Benchmark took 176871 nanoseconds
```

So if the walker is used on watch event or on big nested folders this is a little optimization.