### PR TITLE
Re-enabling colors after color testing

### DIFF
--- a/colors/test.ts
+++ b/colors/test.ts
@@ -19,4 +19,6 @@ test(function enablingColors() {
   assert.equal(getEnabled(), true);
   setEnabled(false);
   assert.equal(bgBlue(red("Hello world")), "Hello world");
+  setEnabled(true);
+  assert.equal(red("Hello world"), "[31mHello world[39m");
 });


### PR DESCRIPTION
While testing for the color module the colors are disabled and not re-enabled. So unit tests of the deno_std are done without colors.

Just fixed it.