### PR TITLE
Purposal : make color detects capabilities of terminal

### DIFF
--- a/colors/mod.ts
+++ b/colors/mod.ts
@@ -9,6 +9,11 @@ interface Code {
 
 let enabled = false;
 
+function termSupportColor(term: string): boolean {
+  const supportedTerms: string[] = ["xterm", "xterm-256color"];
+  return supportedTerms.some(t => t == term);
+}
+
 if (!noColor && permissions().env) {
   if (env()["TERM"]) {
     const term = env()["TERM"];
@@ -16,11 +21,6 @@ if (!noColor && permissions().env) {
       enabled = true;
     }
   }
-}
-
-function termSupportColor(term: string) {
-  const supportedTerms: string[] = ["xterm", "xterm-256color"];
-  return supportedTerms.some(t => t == term);
 }
 
 export function setEnabled(value: boolean): void {

--- a/colors/mod.ts
+++ b/colors/mod.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-const { noColor } = Deno;
+const { noColor, env, permissions } = Deno;
 
 interface Code {
   open: string;
@@ -7,7 +7,21 @@ interface Code {
   regexp: RegExp;
 }
 
-let enabled = !noColor;
+let enabled = false;
+
+if (!noColor && permissions().env) {
+  if (env()["TERM"]) {
+    const term = env()["TERM"];
+    if (term && termSupportColor(term)) {
+      enabled = true;
+    }
+  }
+}
+
+function termSupportColor(term: string) {
+  const supportedTerms: string[] = ["xterm", "xterm-256color"];
+  return supportedTerms.some(t => t == term);
+}
 
 export function setEnabled(value: boolean): void {
   if (noColor) {


### PR DESCRIPTION
Here is the draft to make the color module to detect the capabilities of the terminal.
Ref: https://github.com/denoland/deno_std/issues/243

FYI: this breaks the Tests due to the term detection ATM. If the purposal is ok for you, i'll refactor the tests.

Note: The pipeline needs to update to Deno v0.3.2 too