### PR TITLE
fix: replace Deno.platform with Deno.build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DENO_VERSION: "v0.3.1"
+  DENO_VERSION: "v0.3.2"
   TS_VERSION: "3.2.1"
 
 # TODO DRY up the jobs

--- a/fs/globrex.ts
+++ b/fs/globrex.ts
@@ -2,10 +2,9 @@
 // MIT License
 // Copyright (c) 2018 Terkel Gjervig Nielsen
 
-import * as deno from "deno";
 import { GlobOptions } from "./glob.ts";
 
-const isWin = deno.platform.os === "win";
+const isWin = Deno.build.os === "win";
 const SEP = isWin ? `\\\\+` : `\\/`;
 const SEP_ESC = isWin ? `\\\\` : `/`;
 const GLOBSTAR = `((?:[^/]*(?:/|$))*)`;

--- a/fs/globrex_test.ts
+++ b/fs/globrex_test.ts
@@ -2,12 +2,11 @@
 // MIT License
 // Copyright (c) 2018 Terkel Gjervig Nielsen
 
-import * as deno from "deno";
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { globrex } from "./globrex.ts";
 
-const isWin = deno.platform.os === "win";
+const isWin = Deno.build.os === "win";
 const t = { equal: assertEquals, is: assertEquals };
 
 function match(glob, strUnix, strWin?, opts = {}) {

--- a/fs/path/constants.ts
+++ b/fs/path/constants.ts
@@ -1,7 +1,7 @@
 // Copyright the Browserify authors. MIT License.
 // Ported from https://github.com/browserify/path-browserify/
 
-const { platform } = Deno;
+const { build } = Deno;
 
 // Alphabet chars.
 export const CHAR_UPPERCASE_A = 65; /* A */
@@ -48,5 +48,5 @@ export const CHAR_EQUAL = 61; /* = */
 export const CHAR_0 = 48; /* 0 */
 export const CHAR_9 = 57; /* 9 */
 
-export const isWindows = platform.os === "win";
+export const isWindows = build.os === "win";
 export const EOL = isWindows ? "\r\n" : "\n";

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,19 +1,10 @@
-const {
-  cwd,
-  chdir,
-  makeTempDir,
-  mkdir,
-  open,
-  platform,
-  remove,
-  symlink
-} = Deno;
+const { cwd, chdir, makeTempDir, mkdir, open, build, remove, symlink } = Deno;
 import { FileInfo } from "deno";
 import { walk, walkSync, WalkOptions } from "./walk.ts";
 import { test, TestFunction } from "../testing/mod.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 
-const isWindows = platform.os === "win";
+const isWindows = build.os === "win";
 
 export async function testWalk(
   setup: (string) => void | Promise<void>,

--- a/prettier/util.ts
+++ b/prettier/util.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-const { platform, run } = Deno;
+const { build, run } = Deno;
 
 // Runs a command in cross-platform way
 export function xrun(opts): Deno.Process {
   return run({
     ...opts,
-    args: platform.os === "win" ? ["cmd.exe", "/c", ...opts.args] : opts.args
+    args: build.os === "win" ? ["cmd.exe", "/c", ...opts.args] : opts.args
   });
 }
 
-export const executableSuffix = platform.os === "win" ? ".exe" : "";
+export const executableSuffix = build.os === "win" ? ".exe" : "";


### PR DESCRIPTION
This PR replaces Deno.platform.os usages with Deno.build.os. It is renamed in https://github.com/denoland/deno/pull/1879 and included in [v0.3.2](https://github.com/denoland/deno/blob/master/Releases.md#v032--20190306)