### PR TITLE
Replace remaining "deno" module usages with Deno global var

### DIFF
--- a/examples/cat.ts
+++ b/examples/cat.ts
@@ -1,12 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
-
 async function cat(filenames: string[]): Promise<void> {
   for (let filename of filenames) {
-    let file = await deno.open(filename);
-    await deno.copy(deno.stdout, file);
+    let file = await Deno.open(filename);
+    await Deno.copy(Deno.stdout, file);
     file.close();
   }
 }
 
-cat(deno.args.slice(1));
+cat(Deno.args.slice(1));

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -1,4 +1,3 @@
-import { FileInfo } from "deno";
 import { globrex } from "./globrex.ts";
 
 export interface GlobOptions {

--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -1,5 +1,5 @@
 const { mkdir, open } = Deno;
-import { FileInfo } from "deno";
+type FileInfo = Deno.FileInfo;
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { glob } from "./glob.ts";

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -1,5 +1,5 @@
 const { readDir, readDirSync, readlink, readlinkSync, stat, statSync } = Deno;
-import { FileInfo } from "deno";
+type FileInfo = Deno.FileInfo;
 
 export interface WalkOptions {
   maxDepth?: number;

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,5 +1,5 @@
 const { cwd, chdir, makeTempDir, mkdir, open, build, remove, symlink } = Deno;
-import { FileInfo } from "deno";
+type FileInfo = Deno.FileInfo;
 import { walk, walkSync, WalkOptions } from "./walk.ts";
 import { test, TestFunction } from "../testing/mod.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -7,7 +7,6 @@
 // https://github.com/indexzero/http-server/blob/master/test/http-server-test.js
 
 const { ErrorKind, cwd, args, stat, readDir, open } = Deno;
-import { DenoError } from "deno";
 import {
   listenAndServe,
   ServerRequest,
@@ -181,8 +180,8 @@ async function serveFile(req: ServerRequest, filename: string) {
 
 async function serveFallback(req: ServerRequest, e: Error) {
   if (
-    e instanceof DenoError &&
-    (e as DenoError<any>).kind === ErrorKind.NotFound
+    e instanceof Deno.DenoError &&
+    (e as Deno.DenoError<any>).kind === ErrorKind.NotFound
   ) {
     return {
       status: 404,

--- a/http/http_bench.ts
+++ b/http/http_bench.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import * as deno from "deno";
 import { serve } from "./server.ts";
 
-const addr = deno.args[1] || "127.0.0.1:4500";
+const addr = Deno.args[1] || "127.0.0.1:4500";
 const server = serve(addr);
 
 const body = new TextEncoder().encode("Hello World");

--- a/http/server.ts
+++ b/http/server.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { listen, toAsyncIterator, copy } = Deno;
-import { Conn, Reader, Writer } from "deno";
+type Conn = Deno.Conn;
+type Reader = Deno.Reader;
+type Writer = Deno.Writer;
 import { BufReader, BufState, BufWriter } from "../io/bufio.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { STATUS_TEXT } from "./http_status.ts";

--- a/io/bufio.ts
+++ b/io/bufio.ts
@@ -3,7 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { Reader, ReadResult, Writer } from "deno";
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
+type Writer = Deno.Writer;
 import { charCode, copyBytes } from "./util.ts";
 import { assert } from "../testing/asserts.ts";
 

--- a/io/bufio_test.ts
+++ b/io/bufio_test.ts
@@ -4,7 +4,8 @@
 // license that can be found in the LICENSE file.
 
 const { Buffer } = Deno;
-import { Reader, ReadResult } from "deno";
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
 import { test } from "../testing/mod.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { BufReader, BufWriter } from "./bufio.ts";

--- a/io/iotest.ts
+++ b/io/iotest.ts
@@ -2,8 +2,8 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-
-import { Reader, ReadResult } from "deno";
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
 
 /** OneByteReader returns a Reader that implements
  * each non-empty Read by reading one byte from r.

--- a/io/ioutil.ts
+++ b/io/ioutil.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { BufReader } from "./bufio.ts";
-import { Reader, Writer } from "deno";
+type Reader = Deno.Reader;
+type Writer = Deno.Writer;
 import { assert } from "../testing/asserts.ts";
 
 /** copy N size at the most. If read size is lesser than N, then returns nread */

--- a/io/ioutil_test.ts
+++ b/io/ioutil_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { Buffer } = Deno;
-import { Reader, ReadResult } from "deno";
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import {

--- a/io/readers.ts
+++ b/io/readers.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Reader, ReadResult } from "deno";
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
 import { encode } from "../strings/strings.ts";
 
 /** Reader utility for strings */

--- a/io/util.ts
+++ b/io/util.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { Buffer, mkdir, open } = Deno;
-import { File, Reader } from "deno";
+type File = Deno.File;
+type Reader = Deno.Reader;
 import { encode } from "../strings/strings.ts";
 import * as path from "../fs/path.ts";
 // `off` is the offset into `dst` where it will at which to begin writing values

--- a/io/writers.ts
+++ b/io/writers.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { Writer } from "deno";
+type Writer = Deno.Writer;
 import { decode, encode } from "../strings/strings.ts";
 
 /** Writer utility for buffering string chunks */

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { open } = Deno;
-import { File, Writer } from "deno";
+type File = Deno.File;
+type Writer = Deno.Writer;
 import { getLevelByName, LogLevel } from "./levels.ts";
 import { LogRecord } from "./logger.ts";
 import { red, yellow, blue, bold } from "../colors/mod.ts";

--- a/multipart/multipart.ts
+++ b/multipart/multipart.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 const { Buffer, copy, remove } = Deno;
-import { Closer, Reader, ReadResult, Writer } from "deno";
+type Closer = Deno.Closer;
+type Reader = Deno.Reader;
+type ReadResult = Deno.ReadResult;
+type Writer = Deno.Writer;
 import { FormFile } from "./formfile.ts";
 import {
   bytesFindIndex,

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { Buffer } = Deno;
-import { Writer, Conn } from "deno";
+type Conn = Deno.Conn;
+type Writer = Deno.Writer;
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { readLong, readShort, sliceLongToBytes } from "../io/ioutil.ts";
 import { Sha1 } from "./sha1.ts";


### PR DESCRIPTION
'deno' builtin module is going to be removed soon ( https://github.com/denoland/deno/pull/1895 ). This PR replace those usages with Deno global variable.