### PR TITLE
Use performance.now in benching module

### DIFF
--- a/benching/mod.ts
+++ b/benching/mod.ts
@@ -61,10 +61,10 @@ function assertTiming(clock: BenchmarkClock): void {
 function createBenchmarkTimer(clock: BenchmarkClock): BenchmarkTimer {
   return {
     start(): void {
-      clock.start = Date.now();
+      clock.start = performance.now();
     },
     stop(): void {
-      clock.stop = Date.now();
+      clock.stop = performance.now();
     }
   };
 }


### PR DESCRIPTION
Use `performance.now` instead of `Date.now` for faster measurements.