### PR TITLE
feat: add ensureDir/ensureFile for fs modules

### DIFF
--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+/**
+ * Ensures that the directory exists. If the directory structure does not exist, it is created. Like mkdir -p.
+ * @export
+ * @param {string} dir
+ * @returns {Promise<void>}
+ */
+export async function ensureDir(dir: string): Promise<void> {
+  try {
+    // if dir exists
+    await Deno.stat(dir);
+  } catch {
+    // if dir not exists. then create it.
+    await Deno.mkdir(dir, true);
+  }
+}
+
+/**
+ * Ensures that the directory exists. If the directory structure does not exist, it is created. Like mkdir -p.
+ * @export
+ * @param {string} dir
+ * @returns {void}
+ */
+export function ensureDirSync(dir: string): void {
+  try {
+    // if dir exists
+    Deno.statSync(dir);
+  } catch {
+    // if dir not exists. then create it.
+    Deno.mkdirSync(dir, true);
+  }
+}

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -1,0 +1,71 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test } from "../testing/mod.ts";
+import { assertThrows, assertThrowsAsync } from "../testing/asserts.ts";
+import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
+import * as path from "./path/mod.ts";
+
+const testdataDir = path.resolve("fs", "testdata");
+
+test(async function ensureDirIfItNotExist() {
+  const baseDir = path.join(testdataDir, "ensure_dir_not_exist");
+  const testDir = path.join(baseDir, "test");
+
+  await ensureDir(testDir);
+
+  assertThrowsAsync(async () => {
+    await Deno.stat(testDir).then(() => {
+      throw new Error("test dir should exists.");
+    });
+  });
+
+  await Deno.remove(baseDir, { recursive: true });
+});
+
+test(function ensureDirSyncIfItNotExist() {
+  const baseDir = path.join(testdataDir, "ensure_dir_sync_not_exist");
+  const testDir = path.join(baseDir, "test");
+
+  ensureDirSync(testDir);
+
+  assertThrows(() => {
+    Deno.statSync(testDir);
+    throw new Error("test dir should exists.");
+  });
+
+  Deno.removeSync(baseDir, { recursive: true });
+});
+
+test(async function ensureDirIfItExist() {
+  const baseDir = path.join(testdataDir, "ensure_dir_exist");
+  const testDir = path.join(baseDir, "test");
+
+  // create test directory
+  await Deno.mkdir(testDir, true);
+
+  await ensureDir(testDir);
+
+  assertThrowsAsync(async () => {
+    await Deno.stat(testDir).then(() => {
+      throw new Error("test dir should still exists.");
+    });
+  });
+
+  await Deno.remove(baseDir, { recursive: true });
+});
+
+test(function ensureDirSyncIfItExist() {
+  const baseDir = path.join(testdataDir, "ensure_dir_sync_exist");
+  const testDir = path.join(baseDir, "test");
+
+  // create test directory
+  Deno.mkdirSync(testDir, true);
+
+  ensureDirSync(testDir);
+
+  assertThrows(() => {
+    Deno.statSync(testDir);
+    throw new Error("test dir should still exists.");
+  });
+
+  Deno.removeSync(baseDir, { recursive: true });
+});

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import * as path from "./path/mod.ts";
+import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
+/**
+ * Ensures that the file exists.
+ * If the file that is requested to be created is in directories that do not exist, these directories are created. If the file already exists, it is NOT MODIFIED.
+ * @export
+ * @param {string} filePath
+ * @returns {Promise<void>}
+ */
+export async function ensureFile(filePath: string): Promise<void> {
+  try {
+    // if file exists
+    await Deno.stat(filePath);
+  } catch {
+    // if file not exists
+    // ensure dir exists
+    await ensureDir(path.dirname(filePath));
+    // create file
+    await Deno.writeFile(filePath, new Uint8Array());
+  }
+}
+
+/**
+ * Ensures that the file exists.
+ * If the file that is requested to be created is in directories that do not exist, these directories are created. If the file already exists, it is NOT MODIFIED.
+ * @export
+ * @param {string} filePath
+ * @returns {void}
+ */
+export function ensureFileSync(filePath: string): void {
+  try {
+    // if file exists
+    Deno.statSync(filePath);
+  } catch {
+    // if file not exists
+    // ensure dir exists
+    ensureDirSync(path.dirname(filePath));
+    // create file
+    Deno.writeFileSync(filePath, new Uint8Array());
+  }
+}

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -1,0 +1,71 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test } from "../testing/mod.ts";
+import { assertThrows, assertThrowsAsync } from "../testing/asserts.ts";
+import { ensureFile, ensureFileSync } from "./ensure_file.ts";
+import * as path from "./path/mod.ts";
+
+const testdataDir = path.resolve("fs", "testdata");
+
+test(async function ensureFileIfItNotExist() {
+  const testDir = path.join(testdataDir, "ensure_file_1");
+  const testFile = path.join(testDir, "test.txt");
+
+  await ensureFile(testFile);
+
+  assertThrowsAsync(async () => {
+    await Deno.stat(testFile).then(() => {
+      throw new Error("test file should exists.");
+    });
+  });
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+test(function ensureFileSyncIfItNotExist() {
+  const testDir = path.join(testdataDir, "ensure_file_2");
+  const testFile = path.join(testDir, "test.txt");
+
+  ensureFileSync(testFile);
+
+  assertThrows(() => {
+    Deno.statSync(testFile);
+    throw new Error("test file should exists.");
+  });
+
+  Deno.removeSync(testDir, { recursive: true });
+});
+
+test(async function ensureFileIfItExist() {
+  const testDir = path.join(testdataDir, "ensure_file_3");
+  const testFile = path.join(testDir, "test.txt");
+
+  await Deno.mkdir(testDir, true);
+  await Deno.writeFile(testFile, new Uint8Array());
+
+  await ensureFile(testFile);
+
+  assertThrowsAsync(async () => {
+    await Deno.stat(testFile).then(() => {
+      throw new Error("test file should exists.");
+    });
+  });
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+test(function ensureFileSyncIfItExist() {
+  const testDir = path.join(testdataDir, "ensure_file_4");
+  const testFile = path.join(testDir, "test.txt");
+
+  Deno.mkdirSync(testDir, true);
+  Deno.writeFileSync(testFile, new Uint8Array());
+
+  ensureFileSync(testFile);
+
+  assertThrows(() => {
+    Deno.statSync(testFile);
+    throw new Error("test file should exists.");
+  });
+
+  Deno.removeSync(testDir, { recursive: true });
+});

--- a/test.ts
+++ b/test.ts
@@ -15,6 +15,7 @@ import "./fs/globrex_test.ts";
 import "./fs/glob_test.ts";
 import "./fs/exists_test.ts";
 import "./fs/empty_dir_test.ts";
+import "./fs/ensure_dir_test.ts";
 import "./io/test.ts";
 import "./http/server_test.ts";
 import "./http/file_server_test.ts";

--- a/test.ts
+++ b/test.ts
@@ -16,6 +16,7 @@ import "./fs/glob_test.ts";
 import "./fs/exists_test.ts";
 import "./fs/empty_dir_test.ts";
 import "./fs/ensure_dir_test.ts";
+import "./fs/ensure_file_test.ts";
 import "./io/test.ts";
 import "./http/server_test.ts";
 import "./http/file_server_test.ts";


### PR DESCRIPTION
part of #261

Because `ensureFile` depends on `ensureDir`

so. put them in one PR
