### PR TITLE
Added string pad

### DIFF
--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -1,0 +1,47 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+/** FillOption Object */
+export interface FillOption {
+  /** Char to fill in */
+  char: string;
+  /** Final string max lenght */
+  strLen: number;
+  /** Side to fill in */
+  side: Side;
+  /** If strict, output string can't be greater than strLen*/
+  strict?: boolean;
+  /** char/string used to specify the string has been truncated */
+  strictChar?: string;
+  /** Side of truncate */
+  strictSide?: Side;
+}
+
+export enum Side {
+  Left = "left",
+  Right = "right"
+}
+
+/** pad helper for strings. Also resolve substring  */
+export function pad(input: string, opts: FillOption): string {
+  let out = input;
+  const outL = out.length;
+  if (outL < opts.strLen) {
+    if (opts.side === Side.Left) {
+      out = out.padStart(opts.strLen, opts.char);
+    } else {
+      out = out.padEnd(opts.strLen, opts.char);
+    }
+  } else if (opts.strict && outL > opts.strLen) {
+    let addChar = opts.strictChar ? opts.strictChar : "";
+    if (opts.strictSide === Side.Left) {
+      let toDrop = outL - opts.strLen;
+      if (opts.strictChar) {
+        toDrop += opts.strictChar.length;
+      }
+      out = `${addChar}${out.slice(toDrop, outL)}`;
+    } else {
+      out = `${out.substring(0, opts.strLen - addChar.length)}${addChar}`;
+    }
+  }
+  return out;
+}

--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -15,15 +15,30 @@ export interface FillOption {
 }
 
 /**
- * pad helper for strings. Also resolve substring
+ * Pad helper for strings.
+ * Input string is processed to output a string with a minimal length.
+ * If the parameter `strict` is set to true, the output string length
+ * is equal to the `strLen` parameter.
  * @param input Input string
  * @param strLen Output string lenght
  * @param opts Configuration object
- * @param [opts.char=" "] Support advanced ext globbing
- * @param [opts.side="left"] Support advanced ext globbing
- * @param [opts.strict=false] Support advanced ext globbing
- * @param [opts.strictChar=""] Support advanced ext globbing
- * @param [opts.strictSide="right"] Support advanced ext globbing
+ * @param [opts.char=" "] Character used to fill in
+ * @param [opts.side="left"] Side to fill in
+ * @param [opts.strict=false] Flag to truncate the string if length > strLen
+ * @param [opts.strictChar=""] Character to add if string is truncated
+ * @param [opts.strictSide="right"] Side to truncate
+ * @example
+ * ```typescript
+ * pad("deno", 6, { char: "*", side: Side.Left }) // output : "**deno"
+ * pad("deno", 6, { char: "*", side: Side.Right}) // output : "deno**"
+ * pad("denosorusrex", 6 {
+ *  char: "*",
+ *  side: Side.Left,
+ *  strict: true,
+ *  strictSide: Side.Right,
+ *  strictChar: "..."
+ * }) // output : "den..."
+ * ```
  */
 export function pad(
   input: string,

--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -5,18 +5,13 @@ export interface FillOption {
   /** Char to fill in */
   char: string;
   /** Side to fill in */
-  side: Side;
+  side: "left" | "right";
   /** If strict, output string can't be greater than strLen*/
   strict?: boolean;
   /** char/string used to specify the string has been truncated */
   strictChar?: string;
   /** Side of truncate */
-  strictSide?: Side;
-}
-
-export enum Side {
-  Left = "left",
-  Right = "right"
+  strictSide?: "left" | "right";
 }
 
 /**
@@ -25,10 +20,10 @@ export enum Side {
  * @param strLen Output string lenght
  * @param opts Configuration object
  * @param [opts.char=" "] Support advanced ext globbing
- * @param [opts.side=Side.Left] Support advanced ext globbing
+ * @param [opts.side="left"] Support advanced ext globbing
  * @param [opts.strict=false] Support advanced ext globbing
  * @param [opts.strictChar=""] Support advanced ext globbing
- * @param [opts.strictSide=Side.Right] Support advanced ext globbing
+ * @param [opts.strictSide="right"] Support advanced ext globbing
  */
 export function pad(
   input: string,
@@ -36,22 +31,22 @@ export function pad(
   opts: FillOption = {
     char: " ",
     strict: false,
-    side: Side.Left,
+    side: "left",
     strictChar: "",
-    strictSide: Side.Right
+    strictSide: "right"
   }
 ): string {
   let out = input;
   const outL = out.length;
   if (outL < strLen) {
-    if (opts.side === Side.Left) {
+    if (opts.side === "left") {
       out = out.padStart(strLen, opts.char);
     } else {
       out = out.padEnd(strLen, opts.char);
     }
   } else if (opts.strict && outL > strLen) {
     let addChar = opts.strictChar ? opts.strictChar : "";
-    if (opts.strictSide === Side.Left) {
+    if (opts.strictSide === "left") {
       let toDrop = outL - strLen;
       if (opts.strictChar) {
         toDrop += opts.strictChar.length;

--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -19,6 +19,18 @@ export interface FillOption {
  * Input string is processed to output a string with a minimal length.
  * If the parameter `strict` is set to true, the output string length
  * is equal to the `strLen` parameter.
+ * Example:
+ *
+ *    pad("deno", 6, { char: "*", side: "left" }) // output : "**deno"
+ *    pad("deno", 6, { char: "*", side: "right"}) // output : "deno**"
+ *    pad("denosorusrex", 6 {
+ *      char: "*",
+ *      side: "left",
+ *      strict: true,
+ *      strictSide: "right",
+ *      strictChar: "..."
+ *    }) // output : "den..."
+ *
  * @param input Input string
  * @param strLen Output string lenght
  * @param opts Configuration object
@@ -27,18 +39,6 @@ export interface FillOption {
  * @param [opts.strict=false] Flag to truncate the string if length > strLen
  * @param [opts.strictChar=""] Character to add if string is truncated
  * @param [opts.strictSide="right"] Side to truncate
- * @example
- * ```typescript
- * pad("deno", 6, { char: "*", side: "left" }) // output : "**deno"
- * pad("deno", 6, { char: "*", side: "right"}) // output : "deno**"
- * pad("denosorusrex", 6 {
- *  char: "*",
- *  side: "left",
- *  strict: true,
- *  strictSide: "right",
- *  strictChar: "..."
- * }) // output : "den..."
- * ```
  */
 export function pad(
   input: string,

--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -29,13 +29,13 @@ export interface FillOption {
  * @param [opts.strictSide="right"] Side to truncate
  * @example
  * ```typescript
- * pad("deno", 6, { char: "*", side: Side.Left }) // output : "**deno"
- * pad("deno", 6, { char: "*", side: Side.Right}) // output : "deno**"
+ * pad("deno", 6, { char: "*", side: "left" }) // output : "**deno"
+ * pad("deno", 6, { char: "*", side: "right"}) // output : "deno**"
  * pad("denosorusrex", 6 {
  *  char: "*",
- *  side: Side.Left,
+ *  side: "left",
  *  strict: true,
- *  strictSide: Side.Right,
+ *  strictSide: "right",
  *  strictChar: "..."
  * }) // output : "den..."
  * ```

--- a/strings/pad.ts
+++ b/strings/pad.ts
@@ -4,8 +4,6 @@
 export interface FillOption {
   /** Char to fill in */
   char: string;
-  /** Final string max lenght */
-  strLen: number;
   /** Side to fill in */
   side: Side;
   /** If strict, output string can't be greater than strLen*/
@@ -21,26 +19,46 @@ export enum Side {
   Right = "right"
 }
 
-/** pad helper for strings. Also resolve substring  */
-export function pad(input: string, opts: FillOption): string {
+/**
+ * pad helper for strings. Also resolve substring
+ * @param input Input string
+ * @param strLen Output string lenght
+ * @param opts Configuration object
+ * @param [opts.char=" "] Support advanced ext globbing
+ * @param [opts.side=Side.Left] Support advanced ext globbing
+ * @param [opts.strict=false] Support advanced ext globbing
+ * @param [opts.strictChar=""] Support advanced ext globbing
+ * @param [opts.strictSide=Side.Right] Support advanced ext globbing
+ */
+export function pad(
+  input: string,
+  strLen: number,
+  opts: FillOption = {
+    char: " ",
+    strict: false,
+    side: Side.Left,
+    strictChar: "",
+    strictSide: Side.Right
+  }
+): string {
   let out = input;
   const outL = out.length;
-  if (outL < opts.strLen) {
+  if (outL < strLen) {
     if (opts.side === Side.Left) {
-      out = out.padStart(opts.strLen, opts.char);
+      out = out.padStart(strLen, opts.char);
     } else {
-      out = out.padEnd(opts.strLen, opts.char);
+      out = out.padEnd(strLen, opts.char);
     }
-  } else if (opts.strict && outL > opts.strLen) {
+  } else if (opts.strict && outL > strLen) {
     let addChar = opts.strictChar ? opts.strictChar : "";
     if (opts.strictSide === Side.Left) {
-      let toDrop = outL - opts.strLen;
+      let toDrop = outL - strLen;
       if (opts.strictChar) {
         toDrop += opts.strictChar.length;
       }
       out = `${addChar}${out.slice(toDrop, outL)}`;
     } else {
-      out = `${out.substring(0, opts.strLen - addChar.length)}${addChar}`;
+      out = `${out.substring(0, strLen - addChar.length)}${addChar}`;
     }
   }
   return out;

--- a/strings/pad_test.ts
+++ b/strings/pad_test.ts
@@ -11,31 +11,20 @@ test(function padTest() {
   const expected6 = "sorusrex";
   const expected7 = "den...";
   const expected8 = "...rex";
+  assertEquals(pad("deno", 6, { char: "*", side: Side.Left }), expected1);
+  assertEquals(pad("deno", 4, { char: "*", side: Side.Left }), expected2);
+  assertEquals(pad("deno", 6, { char: "*", side: Side.Right }), expected3);
   assertEquals(
-    pad("deno", { char: "*", strLen: 6, side: Side.Left }),
-    expected1
-  );
-  assertEquals(
-    pad("deno", { char: "*", strLen: 4, side: Side.Left }),
-    expected2
-  );
-  assertEquals(
-    pad("deno", { char: "*", strLen: 6, side: Side.Right }),
-    expected3
-  );
-  assertEquals(
-    pad("denosorusrex", {
+    pad("denosorusrex", 4, {
       char: "*",
-      strLen: 4,
       side: Side.Right,
       strict: false
     }),
     expected4
   );
   assertEquals(
-    pad("denosorusrex", {
+    pad("denosorusrex", 9, {
       char: "*",
-      strLen: 9,
       side: Side.Left,
       strict: true,
       strictSide: Side.Right
@@ -43,9 +32,8 @@ test(function padTest() {
     expected5
   );
   assertEquals(
-    pad("denosorusrex", {
+    pad("denosorusrex", 8, {
       char: "*",
-      strLen: 8,
       side: Side.Left,
       strict: true,
       strictSide: Side.Left
@@ -53,9 +41,8 @@ test(function padTest() {
     expected6
   );
   assertEquals(
-    pad("denosorusrex", {
+    pad("denosorusrex", 6, {
       char: "*",
-      strLen: 6,
       side: Side.Left,
       strict: true,
       strictSide: Side.Right,
@@ -64,9 +51,8 @@ test(function padTest() {
     expected7
   );
   assertEquals(
-    pad("denosorusrex", {
+    pad("denosorusrex", 6, {
       char: "*",
-      strLen: 6,
       side: Side.Left,
       strict: true,
       strictSide: Side.Left,
@@ -75,9 +61,8 @@ test(function padTest() {
     expected8
   );
   assertEquals(
-    pad("deno", {
+    pad("deno", 4, {
       char: "*",
-      strLen: 4,
       side: Side.Left,
       strict: true,
       strictSide: Side.Right,

--- a/strings/pad_test.ts
+++ b/strings/pad_test.ts
@@ -74,4 +74,15 @@ test(function padTest() {
     }),
     expected8
   );
+  assertEquals(
+    pad("deno", {
+      char: "*",
+      strLen: 4,
+      side: Side.Left,
+      strict: true,
+      strictSide: Side.Right,
+      strictChar: "..."
+    }),
+    expected2
+  );
 });

--- a/strings/pad_test.ts
+++ b/strings/pad_test.ts
@@ -1,6 +1,6 @@
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
-import { Side, pad } from "./pad.ts";
+import { pad } from "./pad.ts";
 
 test(function padTest() {
   const expected1 = "**deno";
@@ -11,13 +11,13 @@ test(function padTest() {
   const expected6 = "sorusrex";
   const expected7 = "den...";
   const expected8 = "...rex";
-  assertEquals(pad("deno", 6, { char: "*", side: Side.Left }), expected1);
-  assertEquals(pad("deno", 4, { char: "*", side: Side.Left }), expected2);
-  assertEquals(pad("deno", 6, { char: "*", side: Side.Right }), expected3);
+  assertEquals(pad("deno", 6, { char: "*", side: "left" }), expected1);
+  assertEquals(pad("deno", 4, { char: "*", side: "left" }), expected2);
+  assertEquals(pad("deno", 6, { char: "*", side: "right" }), expected3);
   assertEquals(
     pad("denosorusrex", 4, {
       char: "*",
-      side: Side.Right,
+      side: "right",
       strict: false
     }),
     expected4
@@ -25,27 +25,27 @@ test(function padTest() {
   assertEquals(
     pad("denosorusrex", 9, {
       char: "*",
-      side: Side.Left,
+      side: "left",
       strict: true,
-      strictSide: Side.Right
+      strictSide: "right"
     }),
     expected5
   );
   assertEquals(
     pad("denosorusrex", 8, {
       char: "*",
-      side: Side.Left,
+      side: "left",
       strict: true,
-      strictSide: Side.Left
+      strictSide: "left"
     }),
     expected6
   );
   assertEquals(
     pad("denosorusrex", 6, {
       char: "*",
-      side: Side.Left,
+      side: "left",
       strict: true,
-      strictSide: Side.Right,
+      strictSide: "right",
       strictChar: "..."
     }),
     expected7
@@ -53,9 +53,9 @@ test(function padTest() {
   assertEquals(
     pad("denosorusrex", 6, {
       char: "*",
-      side: Side.Left,
+      side: "left",
       strict: true,
-      strictSide: Side.Left,
+      strictSide: "left",
       strictChar: "..."
     }),
     expected8
@@ -63,9 +63,9 @@ test(function padTest() {
   assertEquals(
     pad("deno", 4, {
       char: "*",
-      side: Side.Left,
+      side: "left",
       strict: true,
-      strictSide: Side.Right,
+      strictSide: "right",
       strictChar: "..."
     }),
     expected2

--- a/strings/pad_test.ts
+++ b/strings/pad_test.ts
@@ -1,0 +1,77 @@
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { Side, pad } from "./pad.ts";
+
+test(function padTest() {
+  const expected1 = "**deno";
+  const expected2 = "deno";
+  const expected3 = "deno**";
+  const expected4 = "denosorusrex";
+  const expected5 = "denosorus";
+  const expected6 = "sorusrex";
+  const expected7 = "den...";
+  const expected8 = "...rex";
+  assertEquals(
+    pad("deno", { char: "*", strLen: 6, side: Side.Left }),
+    expected1
+  );
+  assertEquals(
+    pad("deno", { char: "*", strLen: 4, side: Side.Left }),
+    expected2
+  );
+  assertEquals(
+    pad("deno", { char: "*", strLen: 6, side: Side.Right }),
+    expected3
+  );
+  assertEquals(
+    pad("denosorusrex", {
+      char: "*",
+      strLen: 4,
+      side: Side.Right,
+      strict: false
+    }),
+    expected4
+  );
+  assertEquals(
+    pad("denosorusrex", {
+      char: "*",
+      strLen: 9,
+      side: Side.Left,
+      strict: true,
+      strictSide: Side.Right
+    }),
+    expected5
+  );
+  assertEquals(
+    pad("denosorusrex", {
+      char: "*",
+      strLen: 8,
+      side: Side.Left,
+      strict: true,
+      strictSide: Side.Left
+    }),
+    expected6
+  );
+  assertEquals(
+    pad("denosorusrex", {
+      char: "*",
+      strLen: 6,
+      side: Side.Left,
+      strict: true,
+      strictSide: Side.Right,
+      strictChar: "..."
+    }),
+    expected7
+  );
+  assertEquals(
+    pad("denosorusrex", {
+      char: "*",
+      strLen: 6,
+      side: Side.Left,
+      strict: true,
+      strictSide: Side.Left,
+      strictChar: "..."
+    }),
+    expected8
+  );
+});

--- a/test.ts
+++ b/test.ts
@@ -28,6 +28,7 @@ import "./media_types/test.ts";
 import "./multipart/formfile_test.ts";
 import "./multipart/multipart_test.ts";
 import "./prettier/main_test.ts";
+import "./strings/pad_test.ts";
 import "./testing/test.ts";
 import "./textproto/test.ts";
 import "./ws/test.ts";


### PR DESCRIPTION
Added string pad helper in strings. Shorthand for combination of str.padStart / str.padLeft / str.slice / str.substring.

Was needing this for a console reporter, so added it in deno_std. Maybe some opinions on the naming?

Usage:
```ts
pad("deno", 6, { char: "*", side: Side.Left }) // output : "**deno"
pad("deno", 6, { char: "*", side: Side.Right}) // output : "deno**"
pad("denosorusrex", 6 {
      char: "*",
      side: Side.Left,
      strict: true,
      strictSide: Side.Right,
      strictChar: "..."
    }) // output : "den..."
pad("denosorusrex", 6, {
      char: "*",
      side: Side.Left,
      strict: true,
      strictSide: Side.Left,
      strictChar: "..."
    }) // output : "...rex"
```