### PR TITLE
Added EOL detect / format

### DIFF
--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+/** EndOfLine character enum */
+export enum EOL {
+  LF = "\n",
+  CRLF = "\r\n"
+}
+
+const regDetect = /(?:\r?\n)/g;
+const regCRLF = /\r\n/g;
+const regLF = /\n/g;
+
+/**
+ * Detect the EOL character for string input.
+ * returns null if no newline
+ */
+export function detect(content: string): EOL | null {
+  const d = content.match(regDetect);
+  if (!d || d.length === 0) {
+    return null;
+  }
+  const crlf = d.filter(x => x === EOL.CRLF);
+  if (crlf.length > 0) {
+    return EOL.CRLF;
+  } else {
+    return EOL.LF;
+  }
+}
+
+/** Format the file to the targeted EOL */
+export function format(content: string, eol: EOL): string {
+  const _eol = detect(content);
+  if (_eol === eol) {
+    return content;
+  } else {
+    if (_eol === EOL.CRLF) {
+      return content.replace(regCRLF, eol);
+    } else {
+      return content.replace(regLF, eol);
+    }
+  }
+}

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -30,7 +30,9 @@ export function detect(content: string): EOL | null {
 /** Format the file to the targeted EOL */
 export function format(content: string, eol: EOL): string {
   const _eol = detect(content);
-  if (_eol === eol) {
+  if (!_eol) {
+    return content;
+  } else if (_eol === eol) {
     return content;
   } else {
     if (_eol === EOL.CRLF) {

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -7,8 +7,6 @@ export enum EOL {
 }
 
 const regDetect = /(?:\r?\n)/g;
-const regCRLF = /\r\n/g;
-const regLF = /\n/g;
 
 /**
  * Detect the EOL character for string input.
@@ -29,16 +27,5 @@ export function detect(content: string): EOL | null {
 
 /** Format the file to the targeted EOL */
 export function format(content: string, eol: EOL): string {
-  const _eol = detect(content);
-  if (!_eol) {
-    return content;
-  } else if (_eol === eol) {
-    return content;
-  } else {
-    if (_eol === EOL.CRLF) {
-      return content.replace(regCRLF, eol);
-    } else {
-      return content.replace(regLF, eol);
-    }
-  }
+  return content.replace(regDetect, eol);
 }

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -4,6 +4,8 @@ import { assertEquals } from "../testing/asserts.ts";
 import { format, detect, EOL } from "./eol.ts";
 
 const CRLFinput = "deno\r\nis not\r\nnode";
+const Mixedinput = "deno\nis not\r\nnode";
+const Mixedinput2 = "deno\r\nis not\nnode";
 const LFinput = "deno\nis not\nnode";
 const NoNLinput = "deno is not node";
 
@@ -23,4 +25,8 @@ test(function testFormat() {
   assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
   assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
   assertEquals(format(NoNLinput, EOL.CRLF), NoNLinput);
+  assertEquals(format(Mixedinput, EOL.CRLF), CRLFinput);
+  assertEquals(format(Mixedinput, EOL.LF), LFinput);
+  assertEquals(format(Mixedinput2, EOL.CRLF), CRLFinput);
+  assertEquals(format(Mixedinput2, EOL.LF), LFinput);
 });

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -5,6 +5,7 @@ import { format, detect, EOL } from "./eol.ts";
 
 const CRLFinput = "deno\r\nis not\r\nnode";
 const LFinput = "deno\nis not\nnode";
+const NoNLinput = "deno is not node";
 
 test(function detectCRLF() {
   assertEquals(detect(CRLFinput), EOL.CRLF);
@@ -13,12 +14,13 @@ test(function detectLF() {
   assertEquals(detect(LFinput), EOL.LF);
 });
 test(function detectNoNewLine() {
-  const input = "deno is not node";
-  assertEquals(detect(input), null);
+  assertEquals(detect(NoNLinput), null);
 });
 test(function testFormat() {
   assertEquals(format(CRLFinput, EOL.LF), LFinput);
   assertEquals(format(LFinput, EOL.LF), LFinput);
   assertEquals(format(LFinput, EOL.CRLF), CRLFinput);
   assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
+  assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
+  assertEquals(format(NoNLinput, EOL.CRLF), NoNLinput);
 });

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -3,21 +3,20 @@ import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { format, detect, EOL } from "./eol.ts";
 
+const CRLFinput = "deno\r\nis not\r\nnode";
+const LFinput = "deno\nis not\nnode";
+
 test(function detectCRLF() {
-  const input = "deno\r\nis not\r\nnode";
-  assertEquals(detect(input), EOL.CRLF);
+  assertEquals(detect(CRLFinput), EOL.CRLF);
 });
 test(function detectLF() {
-  const input = "deno\nis not\nnode";
-  assertEquals(detect(input), EOL.LF);
+  assertEquals(detect(LFinput), EOL.LF);
 });
 test(function detectNoNewLine() {
   const input = "deno is not node";
   assertEquals(detect(input), null);
 });
 test(function testFormat() {
-  const CRLFinput = "deno\r\nis not\r\nnode";
-  const LFinput = "deno\nis not\nnode";
   assertEquals(format(CRLFinput, EOL.LF), LFinput);
   assertEquals(format(LFinput, EOL.LF), LFinput);
   assertEquals(format(LFinput, EOL.CRLF), CRLFinput);

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -1,0 +1,25 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { format, detect, EOL } from "./eol.ts";
+
+test(function detectCRLF() {
+  const input = "deno\r\nis not\r\nnode";
+  assertEquals(detect(input), EOL.CRLF);
+});
+test(function detectLF() {
+  const input = "deno\nis not\nnode";
+  assertEquals(detect(input), EOL.LF);
+});
+test(function detectNoNewLine() {
+  const input = "deno is not node";
+  assertEquals(detect(input), null);
+});
+test(function testFormat() {
+  const CRLFinput = "deno\r\nis not\r\nnode";
+  const LFinput = "deno\nis not\nnode";
+  assertEquals(format(CRLFinput, EOL.LF), LFinput);
+  assertEquals(format(LFinput, EOL.LF), LFinput);
+  assertEquals(format(LFinput, EOL.CRLF), CRLFinput);
+  assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
+});

--- a/fs/test.ts
+++ b/fs/test.ts
@@ -3,6 +3,7 @@ import "./path/test.ts";
 import "./walk_test.ts";
 import "./globrex_test.ts";
 import "./glob_test.ts";
+import "./eol_test.ts";
 import "./exists_test.ts";
 import "./empty_dir_test.ts";
 import "./ensure_dir_test.ts";


### PR DESCRIPTION
As files may be used in a Linux env but may come from a windows env, EOL is not the same. Added a FS helper for the detection / format. ATM it gets a string input, maybe coupled with readFileStr ( https://github.com/denoland/deno_std/pull/276 ) in the future?
