### PR TITLE
move test file out of tests dir in flags module

### DIFF
--- a/flags/all_bool_test.ts
+++ b/flags/all_bool_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 // flag boolean true (default all --args to boolean)
 test(function flagBooleanTrue() {

--- a/flags/bool_test.ts
+++ b/flags/bool_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function flagBooleanDefaultFalse() {
   const argv = parse(["moo"], {

--- a/flags/dash_test.ts
+++ b/flags/dash_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function hyphen() {
   assertEquals(parse(["-n", "-"]), { n: "-", _: [] });

--- a/flags/default_bool_test.ts
+++ b/flags/default_bool_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function booleanDefaultTrue() {
   const argv = parse([], {

--- a/flags/dotted_test.ts
+++ b/flags/dotted_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function dottedAlias() {
   const argv = parse(["--a.b", "22"], {

--- a/flags/kv_short_test.ts
+++ b/flags/kv_short_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function short() {
   const argv = parse(["-b=123"]);

--- a/flags/long_test.ts
+++ b/flags/long_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function longOpts() {
   assertEquals(parse(["--bool"]), { bool: true, _: [] });

--- a/flags/num_test.ts
+++ b/flags/num_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function nums() {
   const argv = parse([

--- a/flags/parse_test.ts
+++ b/flags/parse_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function _arseArgs() {
   assertEquals(parse(["--no-moo"]), { moo: false, _: [] });

--- a/flags/short_test.ts
+++ b/flags/short_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function numbericShortArgs() {
   assertEquals(parse(["-n123"]), { n: 123, _: [] });

--- a/flags/stop_early_test.ts
+++ b/flags/stop_early_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 // stops parsing on the first non-option when stopEarly is set
 test(function stopParsing() {

--- a/flags/test.ts
+++ b/flags/test.ts
@@ -1,14 +1,14 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import "./tests/all_bool.ts";
-import "./tests/bool.ts";
-import "./tests/dash.ts";
-import "./tests/default_bool.ts";
-import "./tests/dotted.ts";
-import "./tests/kv_short.ts";
-import "./tests/long.ts";
-import "./tests/num.ts";
-import "./tests/parse.ts";
-import "./tests/short.ts";
-import "./tests/stop_early.ts";
-import "./tests/unknown.ts";
-import "./tests/whitespace.ts";
+import "./all_bool_test.ts";
+import "./bool_test.ts";
+import "./dash_test.ts";
+import "./default_bool_test.ts";
+import "./dotted_test.ts";
+import "./kv_short_test.ts";
+import "./long_test.ts";
+import "./num_test.ts";
+import "./parse_test.ts";
+import "./short_test.ts";
+import "./stop_early_test.ts";
+import "./unknown_test.ts";
+import "./whitespace_test.ts";

--- a/flags/unknown_test.ts
+++ b/flags/unknown_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function booleanAndAliasIsNotUnknown() {
   const unknown = [];

--- a/flags/whitespace_test.ts
+++ b/flags/whitespace_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { test } from "../../testing/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
-import { parse } from "../mod.ts";
+import { test } from "../testing/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { parse } from "./mod.ts";
 
 test(function whitespaceShouldBeWhitespace() {
   assertEquals(parse(["-x", "\t"]).x, "\t");


### PR DESCRIPTION
Should follow the [style guide](https://deno.land/style_guide.html#unittestsshouldbeexplicit).

> Each module should come with its test as a sibling with the name modulename_test.ts. For example the module foo.ts should come with its sibling foo_test.ts.
