### PR TITLE
assertEquals fix

### DIFF
--- a/datetime/test.ts
+++ b/datetime/test.ts
@@ -5,28 +5,28 @@ import * as datetime from "./mod.ts";
 
 test(function parseDateTime() {
   assertEquals(
-    datetime.parseDateTime("01-03-2019 16:34", "mm-dd-yyyy hh:mm"),
-    new Date(2019, 1, 3, 16, 34)
+    datetime.parseDateTime("01-03-2019 16:30", "mm-dd-yyyy hh:mm"),
+    new Date(2019, 0, 3, 16, 30)
   );
   assertEquals(
-    datetime.parseDateTime("03-01-2019 16:34", "dd-mm-yyyy hh:mm"),
-    new Date(2019, 1, 3, 16, 34)
+    datetime.parseDateTime("03-01-2019 16:31", "dd-mm-yyyy hh:mm"),
+    new Date(2019, 0, 3, 16, 31)
   );
   assertEquals(
-    datetime.parseDateTime("2019-01-03 16:34", "yyyy-mm-dd hh:mm"),
-    new Date(2019, 1, 3, 16, 34)
+    datetime.parseDateTime("2019-01-03 16:32", "yyyy-mm-dd hh:mm"),
+    new Date(2019, 0, 3, 16, 32)
   );
   assertEquals(
-    datetime.parseDateTime("16:34 01-03-2019", "hh:mm mm-dd-yyyy"),
-    new Date(2019, 1, 3, 16, 34)
+    datetime.parseDateTime("16:33 01-03-2019", "hh:mm mm-dd-yyyy"),
+    new Date(2019, 0, 3, 16, 33)
   );
   assertEquals(
     datetime.parseDateTime("16:34 03-01-2019", "hh:mm dd-mm-yyyy"),
-    new Date(2019, 1, 3, 16, 34)
+    new Date(2019, 0, 3, 16, 34)
   );
   assertEquals(
-    datetime.parseDateTime("16:34 2019-01-03", "hh:mm yyyy-mm-dd"),
-    new Date(2019, 1, 3, 16, 34)
+    datetime.parseDateTime("16:35 2019-01-03", "hh:mm yyyy-mm-dd"),
+    new Date(2019, 0, 3, 16, 35)
   );
 });
 
@@ -43,15 +43,15 @@ test(function invalidParseDateTimeFormatThrows() {
 test(function parseDate() {
   assertEquals(
     datetime.parseDate("01-03-2019", "mm-dd-yyyy"),
-    new Date(2019, 1, 3)
+    new Date(2019, 0, 3)
   );
   assertEquals(
     datetime.parseDate("03-01-2019", "dd-mm-yyyy"),
-    new Date(2019, 1, 3)
+    new Date(2019, 0, 3)
   );
   assertEquals(
     datetime.parseDate("2019-01-03", "yyyy-mm-dd"),
-    new Date(2019, 1, 3)
+    new Date(2019, 0, 3)
   );
 });
 

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -16,6 +16,16 @@ export class AssertionError extends Error {
 export function equal(c: unknown, d: unknown): boolean {
   const seen = new Map();
   return (function compare(a: unknown, b: unknown) {
+    // Have to render RegExp & Date for string comparison
+    // unless it's mistreated as object
+    if (
+      a &&
+      b &&
+      ((a instanceof RegExp && b instanceof RegExp) ||
+        (a instanceof Date && b instanceof Date))
+    ) {
+      return String(a) === String(b);
+    }
     if (Object.is(a, b)) {
       return true;
     }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -36,6 +36,10 @@ test(function testingEqual() {
       { hello: "world", hi: { there: "everyone else" } }
     )
   );
+  assert(equal(/deno/, /deno/));
+  assert(!equal(/deno/, /node/));
+  assert(equal(new Date(2019, 0, 3), new Date(2019, 0, 3)));
+  assert(!equal(new Date(2019, 0, 3), new Date(2019, 1, 3)));
 });
 
 test(function testingNotEquals() {


### PR DESCRIPTION
This fixes : https://github.com/denoland/deno_std/issues/304

Had to add a special case in `equal` for `RegExp` and `Date` objects. Also fixed assertion in the datetime module.