### PR TITLE
[Testing] Pretty output + Silent mode

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
-import { green, red, gray, italic } from "../colors/mod.ts";
+import { green, red, gray, yellow, italic } from "../colors/mod.ts";
 export type TestFunction = () => void | Promise<void>;
 
 export interface TestDefinition {
@@ -239,6 +239,9 @@ async function runTestsSerial(
     // See https://github.com/denoland/deno/pull/1452
     // about this usage of groupCollapsed
     if (disableLog) {
+      Deno.stdout.writeSync(
+        new TextEncoder().encode(`${yellow("RUNNING")} ${name}`)
+      );
       consoleDisabler("disable");
     }
     try {
@@ -247,12 +250,14 @@ async function runTestsSerial(
       await fn();
       end = performance.now();
       if (disableLog) {
+        Deno.stdout.writeSync(new TextEncoder().encode("\x1b[2K\r"));
         consoleDisabler("restore");
       }
       stats.passed++;
       console.log(GREEN_OK + "    ", name, promptTestTime(end - start));
     } catch (err) {
       if (disableLog) {
+        Deno.stdout.writeSync(new TextEncoder().encode("\x1b[2K\r"));
         consoleDisabler("restore");
       }
       console.log(RED_FAILED, name);

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -50,7 +50,6 @@ function consoleDisabler(action: DisableAction = "disable") {
 
 let filterRegExp: RegExp | null;
 const candidates: TestDefinition[] = [];
-// const noop = function() {};
 let filtered = 0;
 
 // Must be called before any test() that needs to be filtered.
@@ -185,11 +184,9 @@ function initTestCases(
   stats: TestStats,
   results: TestResults,
   tests: TestDefinition[],
-  exitOnFail: boolean,
+  exitOnFail: boolean
 ): Array<Promise<void>> {
-  return tests.map(
-    createTestCase.bind(null, stats, results, exitOnFail)
-  );
+  return tests.map(createTestCase.bind(null, stats, results, exitOnFail));
 }
 
 async function runTestsParallel(
@@ -203,9 +200,7 @@ async function runTestsParallel(
     if (disableLog) {
       consoleDisabler("disable");
     }
-    await Promise.all(
-      initTestCases(stats, results, tests, exitOnFail)
-    );
+    await Promise.all(initTestCases(stats, results, tests, exitOnFail));
   } catch (_) {
     // The error was thrown to stop awaiting all promises if exitOnFail === true
     // stats.failed has been incremented and the error stored in results

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -20,6 +20,10 @@ export interface TestDefinition {
 // Replacement of the global `console` function to be in silent mode
 const noop = function(): void {};
 
+// Clear the current line of the console.
+// see: http://ascii-table.com/ansi-escape-sequences-vt-100.php
+const CLEAR_LINE = "\x1b[2K\r";
+
 // Save Object of the global `console` in case of silent mode
 type Console = typeof window.console;
 // ref https://console.spec.whatwg.org/#console-namespace
@@ -58,8 +62,8 @@ function disableConsole(): void {
 }
 
 const encoder = new TextEncoder();
-function print(txt: string, carriageReturn: boolean = true): void {
-  if (carriageReturn) {
+function print(txt: string, newline: boolean = true): void {
+  if (newline) {
     txt += "\n";
   }
   Deno.stdout.writeSync(encoder.encode(`${txt}`));
@@ -132,11 +136,7 @@ function createTestResults(tests: TestDefinition[]): TestResults {
 }
 
 function formatTestTime(time: number = 0): string {
-  if (time >= 1000) {
-    return `${(time / 1000).toFixed(2)}s`;
-  } else {
-    return `${time.toFixed(2)}ms`;
-  }
+  return `${time.toFixed(2)}ms`;
 }
 
 function promptTestTime(time: number = 0, displayWarning = false): string {
@@ -267,7 +267,7 @@ async function runTestsSerial(
       end = performance.now();
       if (disableLog) {
         // Rewriting the current prompt line to erase `running ....`
-        print("\x1b[2K\r", false);
+        print(CLEAR_LINE, false);
       }
       stats.passed++;
       print(
@@ -275,7 +275,7 @@ async function runTestsSerial(
       );
     } catch (err) {
       if (disableLog) {
-        print("\x1b[2K\r", false);
+        print(CLEAR_LINE, false);
       }
       print(`${RED_FAILED} ${name}`);
       print(err.stack);

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -25,14 +25,18 @@ let defaultConsole = {};
 
 function enableConsole(): void {
   for (const key in defaultConsole) {
+    // @ts-ignore
     console[key] = defaultConsole[key];
   }
 }
 
 function disableConsole(): void {
   for (const key in console) {
+    // @ts-ignore
     if (console[key] instanceof Function) {
+      // @ts-ignore
       defaultConsole[key] = console[key];
+      // @ts-ignore
       console[key] = noopConsole;
     }
   }

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -114,9 +114,9 @@ function createTestResults(tests: TestDefinition[]): TestResults {
 
 function formatTestTime(time: number = 0): string {
   if (time >= 1000) {
-    return `${time / 1000}s`;
+    return `${(time / 1000).toFixed(2)}s`;
   } else {
-    return `${time}ms`;
+    return `${time.toFixed(2)}ms`;
   }
 }
 

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -301,6 +301,9 @@ export async function runTests({
   const results: TestResults = createTestResults(tests);
   print(`running ${tests.length} tests`);
   const start = performance.now();
+  if (Deno.args.includes("--quiet")) {
+    disableLog = true;
+  }
   if (disableLog) {
     disableConsole();
   }

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -18,28 +18,43 @@ export interface TestDefinition {
 }
 
 // Replacement of the global `console` function to be in silent mode
-const noopConsole = function(): void {};
+const noop = function(): void {};
 
 // Save Object of the global `console` in case of silent mode
-let defaultConsole = {};
+type Console = typeof window.console;
+// ref https://console.spec.whatwg.org/#console-namespace
+// For historical web-compatibility reasons, the namespace object for
+// console must have as its [[Prototype]] an empty object, created as if
+// by ObjectCreate(%ObjectPrototype%), instead of %ObjectPrototype%.
+const disabledConsole = Object.create({}) as Console;
+Object.assign(disabledConsole, {
+  log: noop,
+  debug: noop,
+  info: noop,
+  dir: noop,
+  warn: noop,
+  error: noop,
+  assert: noop,
+  count: noop,
+  countReset: noop,
+  table: noop,
+  time: noop,
+  timeLog: noop,
+  timeEnd: noop,
+  group: noop,
+  groupCollapsed: noop,
+  groupEnd: noop,
+  clear: noop
+});
+
+const originalConsole = window.console;
 
 function enableConsole(): void {
-  for (const key in defaultConsole) {
-    // @ts-ignore
-    console[key] = defaultConsole[key];
-  }
+  window.console = originalConsole;
 }
 
 function disableConsole(): void {
-  for (const key in console) {
-    // @ts-ignore
-    if (console[key] instanceof Function) {
-      // @ts-ignore
-      defaultConsole[key] = console[key];
-      // @ts-ignore
-      console[key] = noopConsole;
-    }
-  }
+  window.console = disabledConsole;
 }
 
 const encoder = new TextEncoder();


### PR DESCRIPTION
Following : https://github.com/denoland/deno_std/issues/306

Here is a proposal of pretty output for tests (for more readability):
![2019-03-29 14_14_59-MINGW64__c_projects_deno_std](https://user-images.githubusercontent.com/6959636/55236860-24747d80-5231-11e9-94b8-61b983374952.png)

Also added the option for `disableLogs` in the test. It is usefull for CI when there is still debug in the tests, then you directly have information of which tests is buggy and you're not flooded with all the debug logs. Currently it is set to `false` and only work for `serialTesting`. Do you think this is usefull and should i expand it to parallel? (needs a bit more refactor)

### EDIT

I've added the timers on each tests and on the whole runtime. See:
![2019-04-16 14_02_54-mod ts (Working Tree) - deno_std - Visual Studio Code](https://user-images.githubusercontent.com/6959636/56208287-13a97180-6051-11e9-8282-05e0ca2f46f6.png)

Added on Silent mode the display of the currently running TEST:
![2019-04-16 16_54_26-mod ts - deno_std - Visual Studio Code](https://user-images.githubusercontent.com/6959636/56220647-144e0200-6069-11e9-916e-aea623106f1b.png)
