### PR TITLE
[TOML] Full support of inline table

### DIFF
--- a/toml/README.md
+++ b/toml/README.md
@@ -22,7 +22,7 @@ TypeScript side is a bit different.
 - :heavy_check_mark: [Local Date](https://github.com/toml-lang/toml#local-date)
 - :exclamation: [Local Time](https://github.com/toml-lang/toml#local-time)
 - :heavy_check_mark: [Table](https://github.com/toml-lang/toml#table)
-- :exclamation: [Inline Table](https://github.com/toml-lang/toml#inline-table)
+- :heavy_check_mark: [Inline Table](https://github.com/toml-lang/toml#inline-table)
 - :exclamation: [Array of Tables](https://github.com/toml-lang/toml#array-of-tables)
 
 :exclamation: _Supported with warnings see [Warning](#Warning)._
@@ -45,18 +45,18 @@ Because local time does not exist in JavaScript, the local time is stored as a s
 
 #### Inline Table
 
-Inline tables are supported but nested inline property name are **not**. See below:
+Inline tables are supported. See below:
 
 ```toml
-animal = { type = { name = "pug" } } 
+animal = { type = { name = "pug" } }
 # Supported
 animal = { type.name = "pug" }
-# not supported. Will output { "animal" : {"type.name":"pug"} }
+# not supported. Will output { animal : { type : { name : "pug" } }
 animal.as.leaders = "tosin"
-# Supported will output animal: { as: { leaders: "tosin" } }
+# Supported will output { animal: { as: { leaders: "tosin" } } }
 "tosin.abasi" = "guitarist"
 # Supported will output
-"tosin.abasi": "guitarist"
+"tosin.abasi" : "guitarist"
 ```
 
 #### Array of Tables

--- a/toml/README.md
+++ b/toml/README.md
@@ -48,9 +48,15 @@ Because local time does not exist in JavaScript, the local time is stored as a s
 Inline tables are supported but nested inline property name are **not**. See below:
 
 ```toml
-animal = { type = { name = "pug" } } # Supported
+animal = { type = { name = "pug" } } 
+# Supported
 animal = { type.name = "pug" }
 # not supported. Will output { "animal" : {"type.name":"pug"} }
+animal.as.leaders = "tosin"
+# Supported will output animal: { as: { leaders: "tosin" } }
+"tosin.abasi" = "guitarist"
+# Supported will output
+"tosin.abasi": "guitarist"
 ```
 
 #### Array of Tables

--- a/toml/README.md
+++ b/toml/README.md
@@ -49,13 +49,13 @@ Inline tables are supported. See below:
 
 ```toml
 animal = { type = { name = "pug" } }
-# Supported
+# Output
 animal = { type.name = "pug" }
-# not supported. Will output { animal : { type : { name : "pug" } }
+# Output { animal : { type : { name : "pug" } }
 animal.as.leaders = "tosin"
-# Supported will output { animal: { as: { leaders: "tosin" } } }
+# Output { animal: { as: { leaders: "tosin" } } }
 "tosin.abasi" = "guitarist"
-# Supported will output
+# Output
 "tosin.abasi" : "guitarist"
 ```
 

--- a/toml/parser.ts
+++ b/toml/parser.ts
@@ -333,14 +333,8 @@ class Parser {
       }
       if (this._isDeclaration(line)) {
         let kv = this._processDeclaration(line);
-        let pathDeclaration = this._parseDeclarationName(kv.key);
         let key = kv.key;
         let value = kv.value;
-        if (pathDeclaration.length > 1) {
-          key = pathDeclaration.shift();
-          value = this._unflat(pathDeclaration, value as object);
-        }
-        key = key.replace(/"/g, "");
         if (!this.context.currentGroup) {
           this.context.output[key] = value;
         } else {
@@ -363,11 +357,20 @@ class Parser {
   _propertyClean(obj: object): void {
     const keys = Object.keys(obj);
     for (let i = 0; i < keys.length; i++) {
-      const k = keys[i];
-      const v = obj[k];
-      console.log(`k:${k} v:${v}\n`);
-      if(v instanceof Object){
-        this._propertyClean(v)
+      let k = keys[i];
+      let v = obj[k];
+      let pathDeclaration = this._parseDeclarationName(k);
+      delete obj[k];
+      if (pathDeclaration.length > 1) {
+        k = pathDeclaration.shift();
+        k = k.replace(/"/g, "");
+        v = this._unflat(pathDeclaration, v as object);
+      } else {
+        k = k.replace(/"/g, "");
+      }
+      obj[k] = v;
+      if (v instanceof Object) {
+        this._propertyClean(v);
       }
     }
   }

--- a/toml/parser.ts
+++ b/toml/parser.ts
@@ -238,7 +238,6 @@ class Parser {
           .replace(result[2], ":");
         dataString = dataString.replace(ogVal, newVal);
       }
-      // TODO : unflat if necessary
       return JSON.parse(dataString);
     }
 

--- a/toml/parser.ts
+++ b/toml/parser.ts
@@ -357,9 +357,24 @@ class Parser {
       this._groupToOutput();
     }
   }
+  _cleanOutput(): void {
+    this._propertyClean(this.context.output);
+  }
+  _propertyClean(obj: object): void {
+    const keys = Object.keys(obj);
+    for (let i = 0; i < keys.length; i++) {
+      const k = keys[i];
+      const v = obj[k];
+      console.log(`k:${k} v:${v}\n`);
+      if(v instanceof Object){
+        this._propertyClean(v)
+      }
+    }
+  }
   parse(): object {
     this._sanitize();
     this._parseLines();
+    this._cleanOutput();
     return this.context.output;
   }
 }

--- a/toml/parser_test.ts
+++ b/toml/parser_test.ts
@@ -181,6 +181,20 @@ test({
   fn() {
     const expected = {
       inlinetable: {
+        nile: {
+          also: {
+            malevolant: {
+              creation: {
+                drum: {
+                  kit: "Tama"
+                }
+              }
+            }
+          },
+          derek: {
+            roddy: "drummer"
+          }
+        },
         name: {
           first: "Tom",
           last: "Preston-Werner"

--- a/toml/parser_test.ts
+++ b/toml/parser_test.ts
@@ -189,9 +189,15 @@ test({
           x: 1,
           y: 2
         },
-        animal: {
+        dog: {
           type: {
             name: "pug"
+          }
+        },
+        "tosin.abasi": "guitarist",
+        animal: {
+          as: {
+            leaders: "tosin"
           }
         }
       }

--- a/toml/testdata/inlineTable.toml
+++ b/toml/testdata/inlineTable.toml
@@ -4,4 +4,4 @@ point = { x = 1, y = 2 }
 dog = { type = { name = "pug" } }
 animal.as.leaders = "tosin"
 "tosin.abasi" = "guitarist"
-nile = { derek.roddy = "drummer", also = { malevolant.creation = "drummer" } }
+nile = { derek.roddy = "drummer", also = { malevolant.creation = { drum.kit = "Tama" } } }

--- a/toml/testdata/inlineTable.toml
+++ b/toml/testdata/inlineTable.toml
@@ -1,4 +1,6 @@
 [inlinetable]
 name = { first = "Tom", last = "Preston-Werner" }
 point = { x = 1, y = 2 }
-animal = { type = { name = "pug" } }
+dog = { type = { name = "pug" } }
+animal.as.leaders = "tosin"
+"tosin.abasi" = "guitarist"

--- a/toml/testdata/inlineTable.toml
+++ b/toml/testdata/inlineTable.toml
@@ -4,3 +4,4 @@ point = { x = 1, y = 2 }
 dog = { type = { name = "pug" } }
 animal.as.leaders = "tosin"
 "tosin.abasi" = "guitarist"
+nile = { derek.roddy = "drummer", also = { malevolant.creation = "drummer" } }


### PR DESCRIPTION
this adds the full support of inline table (even nested see tests):

```toml
animal = { type = { name = "pug" } }
# Output
animal = { type.name = "pug" }
# Output { animal : { type : { name : "pug" } }
animal.as.leaders = "tosin"
# Output { animal: { as: { leaders: "tosin" } } }
"tosin.abasi" = "guitarist"
# Output
"tosin.abasi" : "guitarist"
```