### PR TITLE
Remove `await` from respond in http_bench.ts

### DIFF
--- a/http/http_bench.ts
+++ b/http/http_bench.ts
@@ -8,7 +8,7 @@ const body = new TextEncoder().encode("Hello World");
 
 async function main(): Promise<void> {
   for await (const request of server) {
-    await request.respond({ status: 200, body });
+    request.respond({ status: 200, body });
   }
 }
 


### PR DESCRIPTION
Just realized that we have been awaiting here all the time... Essentially blocking next accept of connection due to `await`ing writes... Removing this `await` more accurately reflect the actual possible performance, and notice the drop of tail latency.

Tested with `wrk -d 10 http://localhost:4500` on my machine:

Before:
```
Running 10s test @ http://localhost:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    12.29ms   30.71ms 273.26ms   89.79%
    Req/Sec    10.84k     3.41k   21.87k    73.00%
  215872 requests in 10.01s, 10.29MB read
Requests/sec:  21573.06
Transfer/sec:      1.03MB
```

After
```
Running 10s test @ http://localhost:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   363.19us  163.29us   3.56ms   93.19%
    Req/Sec    14.08k   744.86    15.21k    84.16%
  283099 requests in 10.10s, 13.50MB read
Requests/sec:  28026.48
Transfer/sec:      1.34MB
```

This also actually makes me think about the problem with `for await` design here: seems making people more easily fall into the similar sequential mindset...