### PR TITLE
Enforce HTTP/1.1 pipeline response order

### DIFF
--- a/http/racing_server.ts
+++ b/http/racing_server.ts
@@ -1,0 +1,33 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { serve, ServerRequest } from "./server.ts";
+
+const addr = Deno.args[1] || "127.0.0.1:4501";
+const server = serve(addr);
+
+const body = new TextEncoder().encode("Hello 1\n");
+const body2 = new TextEncoder().encode("World 2\n");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+async function delayedRespond(request: ServerRequest): Promise<void> {
+  await sleep(3000);
+  await request.respond({ status: 200, body });
+}
+
+async function main(): Promise<void> {
+  let isFirst = true;
+  for await (const request of server) {
+    if (isFirst) {
+      isFirst = false;
+      delayedRespond(request);
+    } else {
+      request.respond({ status: 200, body: body2 });
+    }
+  }
+}
+
+main();
+
+console.log("Racing server listening...\n");

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -1,0 +1,65 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+const { run } = Deno;
+
+import { test } from "../testing/mod.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
+import { BufReader } from "../io/bufio.ts";
+import { TextProtoReader } from "../textproto/mod.ts";
+
+let server;
+async function startServer(): Promise<void> {
+  server = run({
+    args: ["deno", "--A", "http/racing_server.ts"],
+    stdout: "piped"
+  });
+  // Once fileServer is ready it will write to its stdout.
+  const r = new TextProtoReader(new BufReader(server.stdout));
+  const [s, err] = await r.readLine();
+  assert(err == null);
+  assert(s.includes("Racing server listening..."));
+}
+function killServer(): void {
+  server.close();
+  server.stdout.close();
+}
+
+let nc;
+let ncIn = `GET / HTTP/1.1
+
+GET / HTTP/1.1
+
+`;
+let ncOut = `HTTP/1.1 200 OK
+content-length: 8
+
+Hello 1
+HTTP/1.1 200 OK
+content-length: 8
+
+World 2
+`;
+
+// Do not run this test on windows
+if (Deno.build.os !== "win") {
+  test(async function serverPipelineRace(): Promise<void> {
+    await startServer();
+
+    nc = run({
+      args: ["nc", "localhost", "4501"],
+      stdin: "piped",
+      stdout: "piped"
+    });
+    const r = new TextProtoReader(new BufReader(nc.stdout));
+    await nc.stdin.write(new TextEncoder().encode(ncIn));
+    const ncOutLines = ncOut.split("\n");
+    // length - 1 to disregard last empty line
+    for (let i = 0; i < ncOutLines.length - 1; i++) {
+      const [s, err] = await r.readLine();
+      assert(!err);
+      assertEquals(s, ncOutLines[i]);
+    }
+    nc.close();
+    nc.stdout.close();
+    killServer();
+  });
+}

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -1,4 +1,3 @@
-// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { dial, run } = Deno;
 
 import { test } from "../testing/mod.ts";
@@ -9,7 +8,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 let server;
 async function startServer(): Promise<void> {
   server = run({
-    args: ["deno", "--A", "http/racing_server.ts"],
+    args: ["deno", "-A", "http/racing_server.ts"],
     stdout: "piped"
   });
   // Once fileServer is ready it will write to its stdout.
@@ -27,15 +26,26 @@ let input = `GET / HTTP/1.1
 
 GET / HTTP/1.1
 
+GET / HTTP/1.1
+
+GET / HTTP/1.1
+
 `;
+const HUGE_BODY_SIZE = 1024 * 1024;
 let output = `HTTP/1.1 200 OK
 content-length: 8
 
 Hello 1
 HTTP/1.1 200 OK
+content-length: ${HUGE_BODY_SIZE}
+
+${"a".repeat(HUGE_BODY_SIZE)}HTTP/1.1 200 OK
+content-length: ${HUGE_BODY_SIZE}
+
+${"b".repeat(HUGE_BODY_SIZE)}HTTP/1.1 200 OK
 content-length: 8
 
-World 2
+World 4
 `;
 
 test(async function serverPipelineRace(): Promise<void> {

--- a/http/test.ts
+++ b/http/test.ts
@@ -1,3 +1,4 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./server_test.ts";
 import "./file_server_test.ts";
+import "./racing_server_test.ts";


### PR DESCRIPTION
+ Using a `Map` to track pipelined requests and resolve only when the previous request is responded.
+ Added test (`racing_server_test.ts`). This test have been confirmed to fail before this patch.


Slight performance impact, yet tail latency is still about the same:

Before:
```
Running 10s test @ http://localhost:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   382.03us  216.38us   6.15ms   94.04%
    Req/Sec    13.63k     1.64k   15.48k    86.14%
  274043 requests in 10.10s, 13.07MB read
Requests/sec:  27133.13
Transfer/sec:      1.29MB
```

After:
```
Running 10s test @ http://localhost:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   388.00us  176.04us   2.82ms   93.29%
    Req/Sec    13.18k   832.27    14.60k    67.33%
  264768 requests in 10.10s, 12.63MB read
Requests/sec:  26214.26
Transfer/sec:      1.25MB
```
