### PR TITLE
[WIP] Deno_std Browser testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
     pool:
       vmImage: "Ubuntu-16.04"
     steps:
-      - script: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - script: npm install puppeteer eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
       - script: curl -L https://deno.land/x/install/install.sh | sh -s $(DENO_VERSION)
       - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
       - script: npx eslint **/*.ts
@@ -20,7 +20,7 @@ jobs:
     pool:
       vmImage: "macOS-10.13"
     steps:
-      - script: npm -g install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - script: npm -g puppeteer install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
       - script: curl -L https://deno.land/x/install/install.sh | sh -s $(DENO_VERSION)
       - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
       - script: eslint **/*.ts
@@ -31,7 +31,7 @@ jobs:
     pool:
       vmImage: "vs2017-win2016"
     steps:
-      - bash: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - bash: npm install puppeteer eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
       - powershell: iwr https://deno.land/x/install/install.ps1 -out install.ps1; .\install.ps1 $(DENO_VERSION)
       - bash: echo "##vso[task.prependpath]C:\Users\VssAdministrator\.deno\\bin"
       - bash: npx eslint **/*.ts

--- a/strings/e2e/test.e2e.js
+++ b/strings/e2e/test.e2e.js
@@ -2,11 +2,12 @@ const puppeteer = require("puppeteer");
 const assert = require("assert");
 (async () => {
   // TODO (zekth) Fix chrome Path for all envs
-  const browser = await puppeteer.launch({
-    headless: true,
-    executablePath:
-      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-  });
+  // const browser = await puppeteer.launch({
+  //   headless: true,
+  //   executablePath:
+  //     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  // });
+  const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const logs = [];
   page.on("console", msg => logs.push(msg.text()));

--- a/strings/e2e/test.e2e.js
+++ b/strings/e2e/test.e2e.js
@@ -1,0 +1,23 @@
+const puppeteer = require("puppeteer");
+const assert = require("assert");
+(async () => {
+  // TODO (zekth) Fix chrome Path for all envs
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath:
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  });
+  const page = await browser.newPage();
+  const logs = [];
+  page.on("console", msg => logs.push(msg.text()));
+
+  try {
+    await page.goto("http://localhost:4500/strings/e2e/test.html");
+    await page.waitFor(500);
+    assert(logs[0] === "**deno");
+    console.log("OK");
+  } catch (e) {
+    console.log("FAILED");
+  }
+  await browser.close();
+})();

--- a/strings/e2e/test.html
+++ b/strings/e2e/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script type="module" crossorigin="anonymous">
+      import { pad } from "../pad.js";
+      console.log(pad("deno", 6, { char: "*", side: "left" }));
+    </script>
+  </body>
+</html>

--- a/strings/pad_test.ts
+++ b/strings/pad_test.ts
@@ -1,6 +1,57 @@
 import { test } from "../testing/mod.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 import { pad } from "./pad.ts";
+import { BufReader } from "../io/bufio.ts";
+import { TextProtoReader } from "../textproto/mod.ts";
+const { run } = Deno;
+
+let fileServer;
+
+async function startFileServer(): Promise<void> {
+  fileServer = run({
+    args: [
+      "deno",
+      "--allow-read",
+      "--allow-net",
+      "http/file_server.ts",
+      ".",
+      "--cors"
+    ],
+    stdout: "piped"
+  });
+  // Once fileServer is ready it will write to its stdout.
+  const r = new TextProtoReader(new BufReader(fileServer.stdout));
+  const [s, err] = await r.readLine();
+  assert(err == null);
+  assert(s.includes("server listening"));
+}
+
+function killFileServer(): void {
+  fileServer.close();
+  fileServer.stdout.close();
+}
+
+test({
+  name: "[PAD] Browser test",
+  async fn() {
+    await startFileServer();
+    try {
+      const c = new TextDecoder();
+      run({
+        args: ["tsc", "-m", "ES6", "strings/pad.ts"],
+        stdout: "piped"
+      });
+      const puppeteer = run({
+        args: ["node", "strings/e2e/test.e2e.js"],
+        stdout: "piped"
+      });
+      let out = await puppeteer.output();
+      assertEquals(c.decode(out), "OK\n");
+    } finally {
+      killFileServer();
+    }
+  }
+});
 
 test(function padTest() {
   const expected1 = "**deno";


### PR DESCRIPTION
as mentionned in: https://github.com/denoland/deno_std/issues/333
Here is a draft of e2e testing in `chrome headless` browser using puppeteer.

First of all there is some additionnal step to setup the environment:
```bash
npm install puppeteer # This will provide the binary to use chrome Headless
```

In the `./strings/e2e/` folder there is 2 files:
- test.e2e.js : This is the description of the test using puppeteer
- test.html : File to be served througth the http server to test the module

How the test is done:
- start http/file_server.ts
- node ./strings/e2e/test.e2e.js
- stop http/file_server.ts

If the test pass the console prompt OK, otherwise FAILED. And we inspect the output.

Also i'd prefer to use the same asserts as the tests itselves and use a more generic way to implement Browser testing. Any idea is welcome.

Added to this, once https://github.com/denoland/deno/pull/2089 will land it will be easier to wrap everything in a more generic approach.

NOTE: Atm it's using the default chrome path. There is some differences between environment, got to fix it.