### PR TITLE
http/server : Header parsing perf enhancement

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -61,18 +61,17 @@ export async function writeResponse(w: Writer, r: Response): Promise<void> {
     throw Error("bad status code");
   }
 
-  let out = `HTTP/${protoMajor}.${protoMinor} ${statusCode} ${statusText}\r\n`;
+  const out = [];
+  out.push(`HTTP/${protoMajor}.${protoMinor} ${statusCode} ${statusText}\r\n`);
 
   setContentLength(r);
 
   if (r.headers) {
-    for (const [key, value] of r.headers) {
-      out += `${key}: ${value}\r\n`;
-    }
+    r.headers.forEach((v, k) => out.push(`${k}: ${v}\r\n`));
   }
-  out += "\r\n";
+  out.push("\r\n");
 
-  const header = new TextEncoder().encode(out);
+  const header = new TextEncoder().encode(out.join(""));
   let n = await writer.write(header);
   assert(header.byteLength == n);
 


### PR DESCRIPTION
Just changed the header parsing way to use an array instead of string concat. This speeds up 0.02ms earch request in average.

Here is the test code to use with `--allow-high-precision`
```ts
let s, e;
let headers: Headers = new Headers();
for (let i = 0; i < 10; i++) {
  headers.append(
    "head-" + i,
    Math.random()
      .toString(36)
      .substring(7)
  );
}
const average = arr => arr.reduce( ( p, c ) => p + c, 0 ) / arr.length;
const str = [];
const arr = [];
for (let i = 0; i < 500; i++) {
  s = performance.now();
  let out = "";
  if (headers) {
    for (const [key, value] of headers) {
      out += `${key}: ${value}\r\n`;
    }
  }
  out += "\r\n";
  e = performance.now();
  str.push(e - s);

  s = performance.now();
  let outArr = [];
  if (headers) {
    headers.forEach((v,k) => outArr.push(`${k}: ${v}\r\n`))
  }
  outArr.push("\r\n");
  outArr.join("");
  e = performance.now();
  arr.push(e - s);

}
console.log(`String implementation: ${average(str)}ms`);
console.log(`Array implementation: ${average(arr)}ms`);

// String implementation: 0.07737456799999913ms
// Array implementation: 0.05701406000000017ms
```