### PR TITLE
Typo/refactor : Eslint warnings + updates with PR

### DIFF
--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -38,7 +38,7 @@ function hasKey(obj, keys): boolean {
 export function parse(
   args,
   initialOptions?: ArgParsingOptions
-): { [key: string]: unknown } {
+): { [key: string]: any } {
   // eslint-disable-line @typescript-eslint/no-explicit-any
   const options: ArgParsingOptions = {
     ...DEFAULT_OPTIONS,

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -38,7 +38,7 @@ function hasKey(obj, keys): boolean {
 export function parse(
   args,
   initialOptions?: ArgParsingOptions
-): { [key: string]: any } {
+): { [key: string]: unknown } {
   // eslint-disable-line @typescript-eslint/no-explicit-any
   const options: ArgParsingOptions = {
     ...DEFAULT_OPTIONS,

--- a/fs/README.md
+++ b/fs/README.md
@@ -31,7 +31,7 @@ ensureDir("./bar"); // returns a promise
 ensureDirSync("./ensureDirSync"); // void
 ```
 
-### ensure_file
+### ensureFile
 
 Ensures that the file exists.
 If the file that is requested to be created is in directories

--- a/prettier/main_test.ts
+++ b/prettier/main_test.ts
@@ -107,7 +107,8 @@ test(async function testPrettierOptions() {
   const file2 = join(testdata, "opts", "2.ts");
   const file3 = join(testdata, "opts", "3.md");
 
-  const getSourceCode = async f => decoder.decode(await Deno.readFile(f));
+  const getSourceCode = async (f: string): Promise<string> =>
+    decoder.decode(await Deno.readFile(f));
 
   await run([...cmd, "--no-semi", file0]);
   assertEquals(

--- a/testing/main.ts
+++ b/testing/main.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { runTests } from "./mod.ts";
 
-async function main() {
+async function main(): Promise<void> {
   // Testing entire test suite serially
   await runTests();
 }

--- a/toml/parser.ts
+++ b/toml/parser.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { existsSync } from "../fs/exists.ts";
+import { readFileStrSync } from "../fs/read_file_str.ts";
 import { deepAssign } from "../util/deep_assign.ts";
 import { pad } from "../strings/pad.ts";
 
@@ -542,7 +543,6 @@ export function parseFile(filePath: string): object {
   if (!existsSync(filePath)) {
     throw new Error("File not found");
   }
-  const decoder = new TextDecoder();
-  const strFile = decoder.decode(Deno.readFileSync(filePath));
+  const strFile = readFileStrSync(filePath);
   return parse(strFile);
 }


### PR DESCRIPTION
Just cleaned the typing which will make eslint not warn anymore in addition to https://github.com/denoland/deno_std/pull/326 .

Fixed a typo in the documentation.

Because https://github.com/denoland/deno_std/pull/276 has landed, little refactor in the TOML module.

**EDIT**: for the `flags/mod.ts` i have tried to fix it but can't really find a way. I'm not sure to add `eslint ignore` tag is a good solution. For the moment keeping it like this and we'll see if we find a solution after.