### PR TITLE
http: Cookie extend

### DIFF
--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import { pad } from "../strings/pad.ts";
+
 export type DateFormat = "mm-dd-yyyy" | "dd-mm-yyyy" | "yyyy-mm-dd";
 
 /**
@@ -104,4 +106,38 @@ export function dayOfYear(date: Date): number {
  */
 export function currentDayOfYear(): number {
   return dayOfYear(new Date());
+}
+
+/**
+ * Parse a date to return a IMF formated string date
+ * RFC: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+ * @param date Date to parse
+ * @return IMF date formated string
+ */
+export function toIMF(date: Date): string {
+  function dtPad(v: string, lPad: number = 2): string {
+    return pad(v, lPad, { char: "0" });
+  }
+  const d = dtPad(date.getUTCDate().toString());
+  const h = dtPad(date.getUTCHours().toString());
+  const min = dtPad(date.getUTCMinutes().toString());
+  const s = dtPad(date.getUTCSeconds().toString());
+  const y = date.getUTCFullYear();
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thus", "Fri", "Sat"];
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ];
+  return `${days[date.getDay()]}, ${d} ${
+    months[date.getUTCMonth()]
+  } ${y} ${h}:${min}:${s} GMT`;
 }

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -111,6 +111,9 @@ export function currentDayOfYear(): number {
 /**
  * Parse a date to return a IMF formated string date
  * RFC: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+ * IMF is the time format to use when generating times in HTTP
+ * headers. The time being formatted must be in UTC for Format to
+ * generate the correct format.
  * @param date Date to parse
  * @return IMF date formated string
  */

--- a/datetime/test.ts
+++ b/datetime/test.ts
@@ -74,3 +74,12 @@ test(function DayOfYear(): void {
 test(function currentDayOfYear(): void {
   assertEquals(datetime.currentDayOfYear(), datetime.dayOfYear(new Date()));
 });
+
+test({
+  name: "[DateTime] to IMF",
+  fn(): void {
+    const actual = datetime.toIMF(new Date(Date.UTC(1994, 3, 5, 15, 32)));
+    const expected = "Tue, 05 May 1994 15:32:00 GMT";
+    assertEquals(actual, expected);
+  }
+});

--- a/http/README.md
+++ b/http/README.md
@@ -2,6 +2,45 @@
 
 A framework for creating HTTP/HTTPS server.
 
+## Cookie
+
+Helper to manipulate `Cookie` throught `ServerRequest` and `Response`.
+
+```ts
+import { getCookie } from "https://deno.land/std/http/cookie.ts";
+
+let req = new ServerRequest();
+req.headers = new Headers();
+req.headers.set("Cookie", "full=of; tasty=chocolate");
+
+const c = getCookie(request);
+// c = { full: "of", tasty: "chocolate" }
+```
+
+To set a `Cookie` you can add `CookieOptions` to properly set your `Cookie`
+
+```ts
+import { setCookie } from "https://deno.land/std/http/cookie.ts";
+
+let res: Response = {};
+res.headers = new Headers();
+setCookie(res, { name: "Space", value: "Cat" });
+```
+
+Deleting a `Cookie` will set its expiration date before now.
+Forcing the browser to delete it.
+
+```ts
+import { delCookie } from "https://deno.land/std/http/cookie.ts";
+
+let res = new Response();
+delCookie(res, "deno");
+// Will append this header in the response
+// "Set-Cookie: deno=; Expires=Thus, 01 Jan 1970 00:00:00 GMT"
+```
+
+**Note**: At the moment multiple `Set-Cookie` in a `Response` is not handled.
+
 ## Example
 
 ```typescript

--- a/http/README.md
+++ b/http/README.md
@@ -7,13 +7,13 @@ A framework for creating HTTP/HTTPS server.
 Helper to manipulate `Cookie` throught `ServerRequest` and `Response`.
 
 ```ts
-import { getCookie } from "https://deno.land/std/http/cookie.ts";
+import { getCookies } from "https://deno.land/std/http/cookie.ts";
 
 let req = new ServerRequest();
 req.headers = new Headers();
 req.headers.set("Cookie", "full=of; tasty=chocolate");
 
-const c = getCookie(request);
+const c = getCookies(request);
 // c = { full: "of", tasty: "chocolate" }
 ```
 

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -1,15 +1,37 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { ServerRequest } from "./server.ts";
+import { ServerRequest, Response } from "./server.ts";
+import { assert } from "../testing/asserts.ts";
+import { pad } from "../strings/pad.ts";
+
+const SETCOOKIE = "Set-Cookie";
+const COOKIE = "Cookie";
 
 export interface Cookie {
   [key: string]: string;
 }
 
+export interface CookieValue {
+  name: string;
+  value: string;
+}
+
+export interface CookieOptions {
+  Expires?: Date;
+  MaxAge?: number;
+  Domain?: string;
+  Path?: string;
+  Secure?: boolean;
+  HttpOnly?: boolean;
+  SameSite?: SameSite;
+}
+
+export type SameSite = "Strict" | "Lax";
+
 /* Parse the cookie of the Server Request */
 export function getCookie(rq: ServerRequest): Cookie {
-  if (rq.headers.has("Cookie")) {
+  if (rq.headers.has(COOKIE)) {
     const out: Cookie = {};
-    const c = rq.headers.get("Cookie").split(";");
+    const c = rq.headers.get(COOKIE).split(";");
     for (const kv of c) {
       const cookieVal = kv.split("=");
       const key = cookieVal.shift().trim();
@@ -18,4 +40,99 @@ export function getCookie(rq: ServerRequest): Cookie {
     return out;
   }
   return {};
+}
+
+/* Set the cookie header properly in the Response */
+export function setCookie(
+  res: Response,
+  cookie: CookieValue,
+  opt: CookieOptions = {}
+): void {
+  if (!res.headers) {
+    res.headers = new Headers();
+  }
+  // TODO (zekth) : Add proper parsing of Set-Cookie headers
+  // Parsing cookie headers to make consistent set-cookie header
+  // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
+  res.headers.set(SETCOOKIE, cookieStringFormat(cookie, opt));
+}
+
+/* Set the cookie header properly in the Response to delete it */
+export function delCookie(res: Response, CookieName: string): void {
+  if (!res.headers) {
+    res.headers = new Headers();
+  }
+  const c: CookieValue = {
+    name: CookieName,
+    value: ""
+  };
+  res.headers.set(SETCOOKIE, cookieStringFormat(c, { Expires: new Date(0) }));
+}
+
+function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
+  function dtPad(v: string, lPad: number = 2): string {
+    return pad(v, lPad, { char: "0" });
+  }
+
+  const out: string[] = [];
+  out.push(`${cookie.name}=${cookie.value}`);
+
+  // Fallback for invalid Set-Cookie
+  // ref: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00#section-3.1
+  if (cookie.name.startsWith("__Secure")) {
+    opt.Secure = true;
+  }
+  if (cookie.name.startsWith("__Host")) {
+    opt.Path = "/";
+    opt.Secure = true;
+    delete opt.Domain;
+  }
+
+  if (opt.Secure) {
+    out.push("Secure");
+  }
+  if (opt.HttpOnly) {
+    out.push("HttpOnly");
+  }
+  if (Number.isInteger(opt.MaxAge)) {
+    assert(opt.MaxAge > 0, "Max-Age must be an integer superior to 0");
+    out.push(`Max-Age=${opt.MaxAge}`);
+  }
+  if (opt.Domain) {
+    out.push(`Domain=${opt.Domain}`);
+  }
+  if (opt.SameSite) {
+    out.push(`SameSite=${opt.SameSite}`);
+  }
+  if (opt.Path) {
+    out.push(`Path=${opt.Path}`);
+  }
+  if (opt.Expires) {
+    let dateString = "";
+    let d = dtPad(opt.Expires.getUTCDate().toString());
+    const h = dtPad(opt.Expires.getUTCHours().toString());
+    const min = dtPad(opt.Expires.getUTCMinutes().toString());
+    const s = dtPad(opt.Expires.getUTCSeconds().toString());
+    const y = opt.Expires.getUTCFullYear();
+    // See Date format: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thus", "Fri", "Sat"];
+    const months = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec"
+    ];
+    dateString += `${days[opt.Expires.getDay()]}, ${d} ${
+      months[opt.Expires.getUTCMonth()]
+    } ${y} ${h}:${min}:${s} GMT`;
+    out.push(`Expires=${dateString}`);
+  }
+  return out.join("; ");
 }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -24,7 +24,10 @@ export interface CookieOptions {
 
 export type SameSite = "Strict" | "Lax";
 
-function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
+export function cookieStringFormat(
+  cookie: CookieValue,
+  opt: CookieOptions
+): string {
   function dtPad(v: string, lPad: number = 2): string {
     return pad(v, lPad, { char: "0" });
   }
@@ -92,7 +95,10 @@ function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
   return out.join("; ");
 }
 
-/* Parse the cookie of the Server Request */
+/**
+ * Parse the cookie of the Server Request
+ * @param rq Server Request
+ */
 export function getCookie(rq: ServerRequest): Cookie {
   if (rq.headers.has("Cookie")) {
     const out: Cookie = {};
@@ -107,7 +113,24 @@ export function getCookie(rq: ServerRequest): Cookie {
   return {};
 }
 
-/* Set the cookie header properly in the Response */
+/**
+ * Set the cookie header properly in the Response
+ * @param res Server Response
+ * @param cookie Cookie to set
+ * @param opt Cookie options
+ * @param [opt.Expires] Expiration Date of the cookie
+ * @param [opt.MaxAge] Max-Age of the Cookie. Must be integer superior to 0
+ * @param [opt.Domain] Specifies those hosts to which the cookie will be sent
+ * @param [opt.Path] Indicates a URL path that must exist in the request.
+ * @param [opt.Secure] Indicates if the cookie is made using SSL & HTTPS.
+ * @param [opt.HttpOnly] Indicates that cookie is not accessible via Javascript
+ * @param [opt.SameSite] Allows servers to assert that a cookie ought not to be
+ *  sent along with cross-site requests
+ * Example:
+ *
+ *     setCookie(response, { name: 'deno', value: 'runtime' },
+ *        { HttpOnly: true, Secure: true, MaxAge: 2, Domain: "deno.land" });
+ */
 export function setCookie(
   res: Response,
   cookie: CookieValue,
@@ -122,7 +145,14 @@ export function setCookie(
   res.headers.set("Set-Cookie", cookieStringFormat(cookie, opt));
 }
 
-/* Set the cookie header properly in the Response to delete it */
+/**
+ *  Set the cookie header properly in the Response to delete it
+ * @param res Server Response
+ * @param CookieName Name of the cookie to Delete
+ * Example:
+ *
+ *     delCookie(res,'foo');
+ */
 export function delCookie(res: Response, CookieName: string): void {
   if (!res.headers) {
     res.headers = new Headers();

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -3,9 +3,6 @@ import { ServerRequest, Response } from "./server.ts";
 import { assert } from "../testing/asserts.ts";
 import { pad } from "../strings/pad.ts";
 
-const SETCOOKIE = "Set-Cookie";
-const COOKIE = "Cookie";
-
 export interface Cookie {
   [key: string]: string;
 }
@@ -97,9 +94,9 @@ function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
 
 /* Parse the cookie of the Server Request */
 export function getCookie(rq: ServerRequest): Cookie {
-  if (rq.headers.has(COOKIE)) {
+  if (rq.headers.has("Cookie")) {
     const out: Cookie = {};
-    const c = rq.headers.get(COOKIE).split(";");
+    const c = rq.headers.get("Cookie").split(";");
     for (const kv of c) {
       const cookieVal = kv.split("=");
       const key = cookieVal.shift().trim();
@@ -122,7 +119,7 @@ export function setCookie(
   // TODO (zekth) : Add proper parsing of Set-Cookie headers
   // Parsing cookie headers to make consistent set-cookie header
   // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
-  res.headers.set(SETCOOKIE, cookieStringFormat(cookie, opt));
+  res.headers.set("Set-Cookie", cookieStringFormat(cookie, opt));
 }
 
 /* Set the cookie header properly in the Response to delete it */
@@ -134,5 +131,8 @@ export function delCookie(res: Response, CookieName: string): void {
     name: CookieName,
     value: ""
   };
-  res.headers.set(SETCOOKIE, cookieStringFormat(c, { Expires: new Date(0) }));
+  res.headers.set(
+    "Set-Cookie",
+    cookieStringFormat(c, { Expires: new Date(0) })
+  );
 }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -124,10 +124,9 @@ export function setCookie(res: Response, cookie: Cookie): void {
  *     delCookie(res,'foo');
  */
 export function delCookie(res: Response, name: string): void {
-  const c: Cookie = {
+  setCookie(res, {
     name: name,
     value: "",
     expires: new Date(0)
-  };
-  setCookie(res, c);
+  });
 }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -124,9 +124,6 @@ export function setCookie(res: Response, cookie: Cookie): void {
  *     delCookie(res,'foo');
  */
 export function delCookie(res: Response, name: string): void {
-  if (!res.headers) {
-    res.headers = new Headers();
-  }
   const c: Cookie = {
     name: name,
     value: "",

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -24,14 +24,36 @@ export interface CookieOptions {
 
 export type SameSite = "Strict" | "Lax";
 
-export function cookieStringFormat(
-  cookie: CookieValue,
-  opt: CookieOptions
-): string {
+export function cookieDateFormat(date: Date): string {
   function dtPad(v: string, lPad: number = 2): string {
     return pad(v, lPad, { char: "0" });
   }
+  const d = dtPad(date.getUTCDate().toString());
+  const h = dtPad(date.getUTCHours().toString());
+  const min = dtPad(date.getUTCMinutes().toString());
+  const s = dtPad(date.getUTCSeconds().toString());
+  const y = date.getUTCFullYear();
+  // See Date format: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thus", "Fri", "Sat"];
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ];
+  return `${days[date.getDay()]}, ${d} ${
+    months[date.getUTCMonth()]
+  } ${y} ${h}:${min}:${s} GMT`;
+}
 
+function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
   const out: string[] = [];
   out.push(`${cookie.name}=${cookie.value}`);
 
@@ -66,30 +88,7 @@ export function cookieStringFormat(
     out.push(`Path=${opt.Path}`);
   }
   if (opt.Expires) {
-    let dateString = "";
-    let d = dtPad(opt.Expires.getUTCDate().toString());
-    const h = dtPad(opt.Expires.getUTCHours().toString());
-    const min = dtPad(opt.Expires.getUTCMinutes().toString());
-    const s = dtPad(opt.Expires.getUTCSeconds().toString());
-    const y = opt.Expires.getUTCFullYear();
-    // See Date format: https://tools.ietf.org/html/rfc7231#section-7.1.1.1
-    const days = ["Sun", "Mon", "Tue", "Wed", "Thus", "Fri", "Sat"];
-    const months = [
-      "Jan",
-      "Feb",
-      "Mar",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec"
-    ];
-    dateString += `${days[opt.Expires.getDay()]}, ${d} ${
-      months[opt.Expires.getUTCMonth()]
-    } ${y} ${h}:${min}:${s} GMT`;
+    let dateString = cookieDateFormat(opt.Expires);
     out.push(`Expires=${dateString}`);
   }
   return out.join("; ");

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -24,7 +24,7 @@ export interface Cookie {
 
 export type SameSite = "Strict" | "Lax";
 
-function cookieStringFormat(cookie: Cookie): string {
+function toString(cookie: Cookie): string {
   const out: string[] = [];
   out.push(`${cookie.name}=${cookie.value}`);
 
@@ -70,12 +70,12 @@ function cookieStringFormat(cookie: Cookie): string {
 
 /**
  * Parse the cookies of the Server Request
- * @param rq Server Request
+ * @param req Server Request
  */
-export function getCookies(rq: ServerRequest): Cookies {
-  if (rq.headers.has("Cookie")) {
+export function getCookies(req: ServerRequest): Cookies {
+  if (req.headers.has("Cookie")) {
     const out: Cookies = {};
-    const c = rq.headers.get("Cookie").split(";");
+    const c = req.headers.get("Cookie").split(";");
     for (const kv of c) {
       const cookieVal = kv.split("=");
       const key = cookieVal.shift().trim();
@@ -112,25 +112,25 @@ export function setCookie(res: Response, cookie: Cookie): void {
   // TODO (zekth) : Add proper parsing of Set-Cookie headers
   // Parsing cookie headers to make consistent set-cookie header
   // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
-  res.headers.set("Set-Cookie", cookieStringFormat(cookie));
+  res.headers.set("Set-Cookie", toString(cookie));
 }
 
 /**
  *  Set the cookie header properly in the Response to delete it
  * @param res Server Response
- * @param CookieName Name of the cookie to Delete
+ * @param name Name of the cookie to Delete
  * Example:
  *
  *     delCookie(res,'foo');
  */
-export function delCookie(res: Response, CookieName: string): void {
+export function delCookie(res: Response, name: string): void {
   if (!res.headers) {
     res.headers = new Headers();
   }
   const c: Cookie = {
-    name: CookieName,
+    name: name,
     value: "",
     expires: new Date(0)
   };
-  res.headers.set("Set-Cookie", cookieStringFormat(c));
+  setCookie(res, c);
 }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -27,48 +27,6 @@ export interface CookieOptions {
 
 export type SameSite = "Strict" | "Lax";
 
-/* Parse the cookie of the Server Request */
-export function getCookie(rq: ServerRequest): Cookie {
-  if (rq.headers.has(COOKIE)) {
-    const out: Cookie = {};
-    const c = rq.headers.get(COOKIE).split(";");
-    for (const kv of c) {
-      const cookieVal = kv.split("=");
-      const key = cookieVal.shift().trim();
-      out[key] = cookieVal.join("");
-    }
-    return out;
-  }
-  return {};
-}
-
-/* Set the cookie header properly in the Response */
-export function setCookie(
-  res: Response,
-  cookie: CookieValue,
-  opt: CookieOptions = {}
-): void {
-  if (!res.headers) {
-    res.headers = new Headers();
-  }
-  // TODO (zekth) : Add proper parsing of Set-Cookie headers
-  // Parsing cookie headers to make consistent set-cookie header
-  // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
-  res.headers.set(SETCOOKIE, cookieStringFormat(cookie, opt));
-}
-
-/* Set the cookie header properly in the Response to delete it */
-export function delCookie(res: Response, CookieName: string): void {
-  if (!res.headers) {
-    res.headers = new Headers();
-  }
-  const c: CookieValue = {
-    name: CookieName,
-    value: ""
-  };
-  res.headers.set(SETCOOKIE, cookieStringFormat(c, { Expires: new Date(0) }));
-}
-
 function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
   function dtPad(v: string, lPad: number = 2): string {
     return pad(v, lPad, { char: "0" });
@@ -135,4 +93,46 @@ function cookieStringFormat(cookie: CookieValue, opt: CookieOptions): string {
     out.push(`Expires=${dateString}`);
   }
   return out.join("; ");
+}
+
+/* Parse the cookie of the Server Request */
+export function getCookie(rq: ServerRequest): Cookie {
+  if (rq.headers.has(COOKIE)) {
+    const out: Cookie = {};
+    const c = rq.headers.get(COOKIE).split(";");
+    for (const kv of c) {
+      const cookieVal = kv.split("=");
+      const key = cookieVal.shift().trim();
+      out[key] = cookieVal.join("");
+    }
+    return out;
+  }
+  return {};
+}
+
+/* Set the cookie header properly in the Response */
+export function setCookie(
+  res: Response,
+  cookie: CookieValue,
+  opt: CookieOptions = {}
+): void {
+  if (!res.headers) {
+    res.headers = new Headers();
+  }
+  // TODO (zekth) : Add proper parsing of Set-Cookie headers
+  // Parsing cookie headers to make consistent set-cookie header
+  // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
+  res.headers.set(SETCOOKIE, cookieStringFormat(cookie, opt));
+}
+
+/* Set the cookie header properly in the Response to delete it */
+export function delCookie(res: Response, CookieName: string): void {
+  if (!res.headers) {
+    res.headers = new Headers();
+  }
+  const c: CookieValue = {
+    name: CookieName,
+    value: ""
+  };
+  res.headers.set(SETCOOKIE, cookieStringFormat(c, { Expires: new Date(0) }));
 }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Structured similarly to Go's cookie.go
+// https://github.com/golang/go/blob/master/src/net/http/cookie.go
 import { ServerRequest, Response } from "./server.ts";
 import { assert } from "../testing/asserts.ts";
 import { toIMF } from "../datetime/mod.ts";

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -1,35 +1,26 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { ServerRequest, Response } from "./server.ts";
-import { getCookie, delCookie, setCookie, cookieDateFormat } from "./cookie.ts";
+import { getCookies, delCookie, setCookie } from "./cookie.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { test } from "../testing/mod.ts";
-
-test({
-  name: "[HTTP] Cookie Date Format",
-  fn(): void {
-    const actual = cookieDateFormat(new Date(Date.UTC(1994, 3, 5, 15, 32)));
-    const expected = "Tue, 05 May 1994 15:32:00 GMT";
-    assertEquals(actual, expected);
-  }
-});
 
 test({
   name: "[HTTP] Cookie parser",
   fn(): void {
     let req = new ServerRequest();
     req.headers = new Headers();
-    assertEquals(getCookie(req), {});
+    assertEquals(getCookies(req), {});
     req.headers = new Headers();
     req.headers.set("Cookie", "foo=bar");
-    assertEquals(getCookie(req), { foo: "bar" });
+    assertEquals(getCookies(req), { foo: "bar" });
 
     req.headers = new Headers();
     req.headers.set("Cookie", "full=of  ; tasty=chocolate");
-    assertEquals(getCookie(req), { full: "of  ", tasty: "chocolate" });
+    assertEquals(getCookies(req), { full: "of  ", tasty: "chocolate" });
 
     req.headers = new Headers();
     req.headers.set("Cookie", "igot=99; problems=but...");
-    assertEquals(getCookie(req), { igot: "99", problems: "but..." });
+    assertEquals(getCookies(req), { igot: "99", problems: "but..." });
   }
 });
 
@@ -55,27 +46,30 @@ test({
     assertEquals(res.headers.get("Set-Cookie"), "Space=Cat");
 
     res.headers = new Headers();
-    setCookie(res, { name: "Space", value: "Cat" }, { Secure: true });
+    setCookie(res, { name: "Space", value: "Cat", secure: true });
     assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; Secure");
 
     res.headers = new Headers();
-    setCookie(res, { name: "Space", value: "Cat" }, { HttpOnly: true });
+    setCookie(res, { name: "Space", value: "Cat", httpOnly: true });
     assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; HttpOnly");
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      { HttpOnly: true, Secure: true }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true
+    });
     assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; Secure; HttpOnly");
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      { HttpOnly: true, Secure: true, MaxAge: 2 }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2"
@@ -84,91 +78,104 @@ test({
     let error = false;
     res.headers = new Headers();
     try {
-      setCookie(
-        res,
-        { name: "Space", value: "Cat" },
-        { HttpOnly: true, Secure: true, MaxAge: 0 }
-      );
+      setCookie(res, {
+        name: "Space",
+        value: "Cat",
+        httpOnly: true,
+        secure: true,
+        maxAge: 0
+      });
     } catch (e) {
       error = true;
     }
     assert(error);
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      { HttpOnly: true, Secure: true, MaxAge: 2, Domain: "deno.land" }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land"
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land"
     );
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      {
-        HttpOnly: true,
-        Secure: true,
-        MaxAge: 2,
-        Domain: "deno.land",
-        SameSite: "Strict"
-      }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land",
+      sameSite: "Strict"
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; SameSite=Strict"
     );
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      {
-        HttpOnly: true,
-        Secure: true,
-        MaxAge: 2,
-        Domain: "deno.land",
-        SameSite: "Lax"
-      }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land",
+      sameSite: "Lax"
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; SameSite=Lax"
     );
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      {
-        HttpOnly: true,
-        Secure: true,
-        MaxAge: 2,
-        Domain: "deno.land",
-        Path: "/"
-      }
-    );
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land",
+      path: "/"
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; Path=/"
     );
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "Space", value: "Cat" },
-      {
-        HttpOnly: true,
-        Secure: true,
-        MaxAge: 2,
-        Domain: "deno.land",
-        Path: "/",
-        Expires: new Date(Date.UTC(1983, 0, 7, 15, 32))
-      }
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land",
+      path: "/",
+      unparsed: ["unparsed=keyvalue", "batman=Bruce"]
+    });
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; Path=/; unparsed=keyvalue; batman=Bruce"
     );
+
+    res.headers = new Headers();
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 2,
+      domain: "deno.land",
+      path: "/",
+      expires: new Date(Date.UTC(1983, 0, 7, 15, 32))
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; Path=/; Expires=Fri, 07 Jan 1983 15:32:00 GMT"
@@ -179,11 +186,11 @@ test({
     assertEquals(res.headers.get("Set-Cookie"), "__Secure-Kitty=Meow; Secure");
 
     res.headers = new Headers();
-    setCookie(
-      res,
-      { name: "__Host-Kitty", value: "Meow" },
-      { Domain: "deno.land" }
-    );
+    setCookie(res, {
+      name: "__Host-Kitty",
+      value: "Meow",
+      domain: "deno.land"
+    });
     assertEquals(
       res.headers.get("Set-Cookie"),
       "__Host-Kitty=Meow; Secure; Path=/"

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -14,18 +14,6 @@ test({
 });
 
 test({
-  name: "[HTTP] Cookie Delete",
-  fn(): void {
-    let res: Response = {};
-    delCookie(res, "deno");
-    assertEquals(
-      res.headers.get("Set-Cookie"),
-      "deno=; Expires=Thus, 01 Jan 1970 00:00:00 GMT"
-    );
-  }
-});
-
-test({
   name: "[HTTP] Cookie parser",
   fn(): void {
     let req = new ServerRequest();

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -157,7 +157,7 @@ test({
         MaxAge: 2,
         Domain: "deno.land",
         Path: "/",
-        Expires: new Date(1983, 0, 7, 16, 32)
+        Expires: new Date(Date.UTC(1983, 0, 7, 15, 32))
       }
     );
     assertEquals(

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -1,8 +1,29 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { ServerRequest, Response } from "./server.ts";
-import { getCookie, delCookie, setCookie } from "./cookie.ts";
+import { getCookie, delCookie, setCookie, cookieDateFormat } from "./cookie.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { test } from "../testing/mod.ts";
+
+test({
+  name: "[HTTP] Cookie Date Format",
+  fn(): void {
+    const actual = cookieDateFormat(new Date(Date.UTC(1994, 3, 5, 15, 32)));
+    const expected = "Tue, 05 May 1994 15:32:00 GMT";
+    assertEquals(actual, expected);
+  }
+});
+
+test({
+  name: "[HTTP] Cookie Delete",
+  fn(): void {
+    let res: Response = {};
+    delCookie(res, "deno");
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "deno=; Expires=Thus, 01 Jan 1970 00:00:00 GMT"
+    );
+  }
+});
 
 test({
   name: "[HTTP] Cookie parser",

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
-import { ServerRequest } from "./server.ts";
-import { getCookie } from "./cookie.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { ServerRequest, Response } from "./server.ts";
+import { getCookie, delCookie, setCookie } from "./cookie.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 import { test } from "../testing/mod.ts";
 
 test({
@@ -21,5 +21,163 @@ test({
     req.headers = new Headers();
     req.headers.set("Cookie", "igot=99; problems=but...");
     assertEquals(getCookie(req), { igot: "99", problems: "but..." });
+  }
+});
+
+test({
+  name: "[HTTP] Cookie Delete",
+  fn(): void {
+    let res: Response = {};
+    delCookie(res, "deno");
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "deno=; Expires=Thus, 01 Jan 1970 00:00:00 GMT"
+    );
+  }
+});
+
+test({
+  name: "[HTTP] Cookie Set",
+  fn(): void {
+    let res: Response = {};
+
+    res.headers = new Headers();
+    setCookie(res, { name: "Space", value: "Cat" });
+    assertEquals(res.headers.get("Set-Cookie"), "Space=Cat");
+
+    res.headers = new Headers();
+    setCookie(res, { name: "Space", value: "Cat" }, { Secure: true });
+    assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; Secure");
+
+    res.headers = new Headers();
+    setCookie(res, { name: "Space", value: "Cat" }, { HttpOnly: true });
+    assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; HttpOnly");
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      { HttpOnly: true, Secure: true }
+    );
+    assertEquals(res.headers.get("Set-Cookie"), "Space=Cat; Secure; HttpOnly");
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      { HttpOnly: true, Secure: true, MaxAge: 2 }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2"
+    );
+
+    let error = false;
+    res.headers = new Headers();
+    try {
+      setCookie(
+        res,
+        { name: "Space", value: "Cat" },
+        { HttpOnly: true, Secure: true, MaxAge: 0 }
+      );
+    } catch (e) {
+      error = true;
+    }
+    assert(error);
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      { HttpOnly: true, Secure: true, MaxAge: 2, Domain: "deno.land" }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land"
+    );
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      {
+        HttpOnly: true,
+        Secure: true,
+        MaxAge: 2,
+        Domain: "deno.land",
+        SameSite: "Strict"
+      }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; SameSite=Strict"
+    );
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      {
+        HttpOnly: true,
+        Secure: true,
+        MaxAge: 2,
+        Domain: "deno.land",
+        SameSite: "Lax"
+      }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; SameSite=Lax"
+    );
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      {
+        HttpOnly: true,
+        Secure: true,
+        MaxAge: 2,
+        Domain: "deno.land",
+        Path: "/"
+      }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; Path=/"
+    );
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "Space", value: "Cat" },
+      {
+        HttpOnly: true,
+        Secure: true,
+        MaxAge: 2,
+        Domain: "deno.land",
+        Path: "/",
+        Expires: new Date(1983, 0, 7, 16, 32)
+      }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land; Path=/; Expires=Fri, 07 Jan 1983 15:32:00 GMT"
+    );
+
+    res.headers = new Headers();
+    setCookie(res, { name: "__Secure-Kitty", value: "Meow" });
+    assertEquals(res.headers.get("Set-Cookie"), "__Secure-Kitty=Meow; Secure");
+
+    res.headers = new Headers();
+    setCookie(
+      res,
+      { name: "__Host-Kitty", value: "Meow" },
+      { Domain: "deno.land" }
+    );
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "__Host-Kitty=Meow; Secure; Path=/"
+    );
   }
 });


### PR DESCRIPTION
Add `delCookie` and `setCookie`.

I have a concern about the multiple `Set-Cookie` header. It's common to use BUT `Headers` does not give us the possibility to do this. Do you think any workaround is possible? I think we can keep it like this for the moment and work on multiple `Set-Cookie` headers handling in a future PR.

Also Days / Months format are hardcoded in the module because ATM there is some discussions about embedding or not the ICU in Deno which may break this module. Ref: https://github.com/denoland/deno/issues/1968