### PR TITLE
[textproto] test porting

### DIFF
--- a/textproto/mod.ts
+++ b/textproto/mod.ts
@@ -119,7 +119,11 @@ export class TextProtoReader {
       }
       let value = str(kv.subarray(i));
 
-      m.append(key, value);
+      // In case of invalid header we swallow the error
+      // example: "Audio Mode" => invalid due to space in the key
+      try {
+        m.append(key, value);
+      } catch {}
 
       if (err != null) {
         throw err;

--- a/textproto/reader_test.ts
+++ b/textproto/reader_test.ts
@@ -20,7 +20,6 @@ function reader(s: string): TextProtoReader {
 //   }
 // });
 
-
 test(async function textprotoReadEmpty(): Promise<void> {
   let r = reader("");
   let [, err] = await r.readMIMEHeader();
@@ -88,7 +87,7 @@ test({
     }
     const sdata = data.join("");
     const r = reader(`Cookie: ${sdata}`);
-    let [m, err] = await r.readMIMEHeader();
+    let [m, _] = await r.readMIMEHeader();
     assertEquals(m.get("Cookie"), sdata);
     // TODO re-enable, here err === "EOF" is has to be null
     // assert(!err);

--- a/textproto/reader_test.ts
+++ b/textproto/reader_test.ts
@@ -82,7 +82,7 @@ test({
   async fn(): Promise<void> {
     const data = [];
     // Go test is 16*1024. But seems it can't handle more
-    for (let i = 0; i < 256; i++) {
+    for (let i = 0; i < 1024; i++) {
       data.push("x");
     }
     const sdata = data.join("");

--- a/textproto/reader_test.ts
+++ b/textproto/reader_test.ts
@@ -1,0 +1,163 @@
+// Based on https://github.com/golang/go/blob/master/src/net/textproto/reader_test.go
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import { BufReader } from "../io/bufio.ts";
+import { TextProtoReader, ProtocolError } from "./mod.ts";
+import { stringsReader } from "../io/util.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
+import { test } from "../testing/mod.ts";
+
+function reader(s: string): TextProtoReader {
+  return new TextProtoReader(new BufReader(stringsReader(s)));
+}
+// test({
+//   name: "[textproto] Reader : DotBytes",
+//   async fn(): Promise<void> {
+//     const input =
+//       "dotlines\r\n.foo\r\n..bar\n...baz\nquux\r\n\r\n.\r\nanot.her\r\n";
+//   }
+// });
+
+
+test(async function textprotoReadEmpty(): Promise<void> {
+  let r = reader("");
+  let [, err] = await r.readMIMEHeader();
+  // Should not crash!
+  assertEquals(err, "EOF");
+});
+
+test(async function textprotoReader(): Promise<void> {
+  let r = reader("line1\nline2\n");
+  let [s, err] = await r.readLine();
+  assertEquals(s, "line1");
+  assert(err == null);
+
+  [s, err] = await r.readLine();
+  assertEquals(s, "line2");
+  assert(err == null);
+
+  [s, err] = await r.readLine();
+  assertEquals(s, "");
+  assert(err == "EOF");
+});
+
+test({
+  name: "[textproto] Reader : MIME Header",
+  async fn(): Promise<void> {
+    const input =
+      "my-key: Value 1  \r\nLong-key: Even \n Longer Value\r\nmy-Key: Value 2\r\n\n";
+    const r = reader(input);
+    const [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("My-Key"), ["Value 1", "Value 2"]);
+    assertEquals(m.get("Long-key"), "Even Longer Value");
+    assert(!err);
+  }
+});
+
+test({
+  name: "[textproto] Reader : MIME Header Single",
+  async fn(): Promise<void> {
+    const input = "Foo: bar\n\n";
+    const r = reader(input);
+    let [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("Foo"), "bar");
+    assert(!err);
+  }
+});
+
+test({
+  name: "[textproto] Reader : MIME Header No Key",
+  async fn(): Promise<void> {
+    const input = ": bar\ntest-1: 1\n\n";
+    const r = reader(input);
+    let [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("Test-1"), "1");
+    assert(!err);
+  }
+});
+
+test({
+  name: "[textproto] Reader : Large MIME Header",
+  async fn(): Promise<void> {
+    const data = [];
+    // Go test is 16*1024. But seems it can't handle more
+    for (let i = 0; i < 1024; i++) {
+      data.push("x");
+    }
+    const sdata = data.join("");
+    const r = reader(`Cookie: ${sdata}`);
+    let [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("Cookie"), sdata);
+    // TODO re-enable, here err === "EOF" is has to be null
+    // assert(!err);
+  }
+});
+
+// Test that we read slightly-bogus MIME headers seen in the wild,
+// with spaces before colons, and spaces in keys.
+// TODO Re-enable With Audio Mode
+// TypeError: audio mode is not a legal HTTP header name
+// due to Headers()
+test({
+  name: "[textproto] Reader : MIME Header Non compliant",
+  async fn(): Promise<void> {
+    const input =
+      "Foo: bar\r\n" +
+      "Content-Language: en\r\n" +
+      "SID : 0\r\n" +
+      // "Audio Mode : None\r\n" +
+      "Privilege : 127\r\n\r\n";
+    const r = reader(input);
+    let [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("Foo"), "bar");
+    assertEquals(m.get("Content-Language"), "en");
+    assertEquals(m.get("SID"), "0");
+    // assertEquals(m.get("Audio Mode"), "None");
+    assertEquals(m.get("Privilege"), "127");
+    assert(!err);
+  }
+});
+
+test({
+  name: "[textproto] Reader : MIME Header Malformed",
+  async fn(): Promise<void> {
+    const input = [
+      "No colon first line\r\nFoo: foo\r\n\r\n",
+      " No colon first line with leading space\r\nFoo: foo\r\n\r\n",
+      "\tNo colon first line with leading tab\r\nFoo: foo\r\n\r\n",
+      " First: line with leading space\r\nFoo: foo\r\n\r\n",
+      "\tFirst: line with leading tab\r\nFoo: foo\r\n\r\n",
+      "Foo: foo\r\nNo colon second line\r\n\r\n"
+    ];
+    const r = reader(input.join(""));
+
+    let err;
+    try {
+      await r.readMIMEHeader();
+    } catch (e) {
+      err = e;
+    }
+    assert(err instanceof ProtocolError);
+  }
+});
+test({
+  name: "[textproto] Reader : MIME Header Trim Continued",
+  async fn(): Promise<void> {
+    const input =
+      "" + // for code formatting purpose.
+      "a:\n" +
+      " 0 \r\n" +
+      "b:1 \t\r\n" +
+      "c: 2\r\n" +
+      " 3\t\n" +
+      "  \t 4  \r\n\n";
+    const r = reader(input);
+    let [m, err] = await r.readMIMEHeader();
+    assertEquals(m.get("A"), "0");
+    assertEquals(m.get("B"), "1");
+    assertEquals(m.get("C"), "2 3 4");
+    assert(!err);
+  }
+});

--- a/textproto/test.ts
+++ b/textproto/test.ts
@@ -3,84 +3,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { BufReader } from "../io/bufio.ts";
-import { TextProtoReader, append } from "./mod.ts";
-import { stringsReader } from "../io/util.ts";
-import { assert, assertEquals } from "../testing/asserts.ts";
+import { append } from "./mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
 import { test } from "../testing/mod.ts";
-
-function reader(s: string): TextProtoReader {
-  return new TextProtoReader(new BufReader(stringsReader(s)));
-}
-
-test(async function textprotoReader(): Promise<void> {
-  let r = reader("line1\nline2\n");
-  let [s, err] = await r.readLine();
-  assertEquals(s, "line1");
-  assert(err == null);
-
-  [s, err] = await r.readLine();
-  assertEquals(s, "line2");
-  assert(err == null);
-
-  [s, err] = await r.readLine();
-  assertEquals(s, "");
-  assert(err == "EOF");
-});
-
-/*
-test(async function textprotoReadMIMEHeader() {
-	let r = reader("my-key: Value 1  \r\nLong-key: Even \n Longer Value\r\nmy-Key: Value 2\r\n\n");
-	let [m, err] = await r.readMIMEHeader();
-
-  console.log("Got headers", m.toString());
-	want := MIMEHeader{
-		"My-Key":   {"Value 1", "Value 2"},
-		"Long-Key": {"Even Longer Value"},
-	}
-	if !reflect.DeepEqual(m, want) || err != nil {
-		t.Fatalf("ReadMIMEHeader: %v, %v; want %v", m, err, want)
-	}
-});
-*/
-
-test(async function textprotoReadMIMEHeaderSingle(): Promise<void> {
-  let r = reader("Foo: bar\n\n");
-  let [m, err] = await r.readMIMEHeader();
-  assertEquals(m.get("Foo"), "bar");
-  assert(!err);
-});
-
-// Test that we read slightly-bogus MIME headers seen in the wild,
-// with spaces before colons, and spaces in keys.
-test(async function textprotoReadMIMEHeaderNonCompliant(): Promise<void> {
-  // Invalid HTTP response header as sent by an Axis security
-  // camera: (this is handled by IE, Firefox, Chrome, curl, etc.)
-  let r = reader(
-    "Foo: bar\r\n" +
-      "Content-Language: en\r\n" +
-      "SID : 0\r\n" +
-      // TODO Re-enable Currently fails with:
-      // "TypeError: audio mode is not a legal HTTP header name"
-      // "Audio Mode : None\r\n" +
-      "Privilege : 127\r\n\r\n"
-  );
-  let [m, err] = await r.readMIMEHeader();
-  console.log(m.toString());
-  assert(!err);
-  /*
-	let want = MIMEHeader{
-		"Foo":              {"bar"},
-		"Content-Language": {"en"},
-		"Sid":              {"0"},
-		"Audio Mode":       {"None"},
-		"Privilege":        {"127"},
-	}
-	if !reflect.DeepEqual(m, want) || err != nil {
-		t.Fatalf("ReadMIMEHeader =\n%v, %v; want:\n%v", m, err, want)
-	}
-  */
-});
+import "./reader_test.ts";
 
 test(async function textprotoAppend(): Promise<void> {
   const enc = new TextEncoder();
@@ -89,11 +15,4 @@ test(async function textprotoAppend(): Promise<void> {
   const u2 = enc.encode("World");
   const joined = append(u1, u2);
   assertEquals(dec.decode(joined), "Hello World");
-});
-
-test(async function textprotoReadEmpty(): Promise<void> {
-  let r = reader("");
-  let [, err] = await r.readMIMEHeader();
-  // Should not crash!
-  assertEquals(err, "EOF");
 });


### PR DESCRIPTION
Porting the test from https://github.com/golang/go/blob/master/src/net/textproto/reader_test.go as @ry suggested.

ref: https://github.com/denoland/deno_std/issues/363

Also there is 3 problems atm:

First one is the HTTP header line break. If we check in the RFC2616 ( https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.3 ) the standard line terminator is `CRLF`. It also says: 
```
The line terminator for message-header fields is the sequence CRLF. However, we recommend that applications, when parsing such headers, recognize a single LF as a line terminator and ignore the leading CR.
```
Problem is in `bufio` we `readLine` using charCode('\n') which is not standard for HTTP headers.
https://github.com/denoland/deno_std/blob/master/io/bufio.ts#L238

In the golang tests, as i read it the `LF` is not considered as a line terminator. So we have the choice of using the golang way or the RFC way. Thoughts?

Second one is for the invalid headers. For example in the tests 'audio mode' is commented because pushing it into 'Headers()' throw a `TypeError`:
```
TypeError: audio mode is not a legal HTTP header name
```
Do we use a try catch on the header addition and swallow those kind of invalid headers or we consider it's an error?

Last one is here:
https://github.com/denoland/deno_std/compare/master...zekth:text_proto?expand=1#diff-0aa76ba8307ddc7f2285b0f2a6f68256R93
Problem is mimeReader returns a "EOF" which is not normal as i see in golang tests. Also we cannot set a  header value up to 1024 chars at the moment. In golang test there is 16*1024 chars.