### PR TITLE
[bytes] fix bytesFindIndex and bytesFindLastIndex

### DIFF
--- a/bytes/bytes.ts
+++ b/bytes/bytes.ts
@@ -6,7 +6,8 @@ export function bytesFindIndex(a: Uint8Array, pat: Uint8Array): number {
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== s) continue;
     const pin = i;
-    let matched = 1, j = i;
+    let matched = 1,
+      j = i;
     while (matched < pat.length) {
       j++;
       if (a[j] !== pat[j - pin]) {
@@ -27,7 +28,8 @@ export function bytesFindLastIndex(a: Uint8Array, pat: Uint8Array): number {
   for (let i = a.length - 1; i >= 0; i--) {
     if (a[i] !== e) continue;
     const pin = i;
-    let matched = 1, j = i;
+    let matched = 1,
+      j = i;
     while (matched < pat.length) {
       j--;
       if (a[j] !== pat[pat.length - 1 - (pin - j)]) {

--- a/bytes/bytes.ts
+++ b/bytes/bytes.ts
@@ -6,10 +6,10 @@ export function bytesFindIndex(a: Uint8Array, pat: Uint8Array): number {
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== s) continue;
     const pin = i;
-    let matched = 1;
+    let matched = 1, j = i;
     while (matched < pat.length) {
-      i++;
-      if (a[i] !== pat[i - pin]) {
+      j++;
+      if (a[j] !== pat[j - pin]) {
         break;
       }
       matched++;
@@ -27,10 +27,10 @@ export function bytesFindLastIndex(a: Uint8Array, pat: Uint8Array): number {
   for (let i = a.length - 1; i >= 0; i--) {
     if (a[i] !== e) continue;
     const pin = i;
-    let matched = 1;
+    let matched = 1, j = i;
     while (matched < pat.length) {
-      i--;
-      if (a[i] !== pat[pat.length - 1 - (pin - i)]) {
+      j--;
+      if (a[j] !== pat[pat.length - 1 - (pin - j)]) {
         break;
       }
       matched++;

--- a/bytes/bytes_test.ts
+++ b/bytes/bytes_test.ts
@@ -9,7 +9,7 @@ import { assertEquals } from "../testing/asserts.ts";
 
 test(function bytesBytesFindIndex(): void {
   const i = bytesFindIndex(
-    new Uint8Array([1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 3]),
+    new Uint8Array([0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 3]),
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 2);
@@ -17,7 +17,7 @@ test(function bytesBytesFindIndex(): void {
 
 test(function bytesBytesFindLastIndex1(): void {
   const i = bytesFindLastIndex(
-    new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 3]),
+    new Uint8Array([0, 1, 2, 0, 1, 2, 1, 2]),
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 3);

--- a/bytes/bytes_test.ts
+++ b/bytes/bytes_test.ts
@@ -9,7 +9,7 @@ import { assertEquals } from "../testing/asserts.ts";
 
 test(function bytesBytesFindIndex(): void {
   const i = bytesFindIndex(
-    new Uint8Array([0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 3]),
+    new Uint8Array([1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 3]),
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 2);
@@ -17,7 +17,7 @@ test(function bytesBytesFindIndex(): void {
 
 test(function bytesBytesFindLastIndex1(): void {
   const i = bytesFindLastIndex(
-    new Uint8Array([0, 1, 2, 0, 1, 2, 1, 2]),
+    new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 3]),
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 3);

--- a/bytes/bytes_test.ts
+++ b/bytes/bytes_test.ts
@@ -7,12 +7,17 @@ import {
 import { test } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 
-test(function bytesBytesFindIndex(): void {
+test(function bytesBytesFindIndex1(): void {
   const i = bytesFindIndex(
     new Uint8Array([1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 3]),
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 2);
+});
+
+test(function bytesBytesFindIndex2(): void {
+  const i = bytesFindIndex(new Uint8Array([0, 0, 1]), new Uint8Array([0, 1]));
+  assertEquals(i, 1);
 });
 
 test(function bytesBytesFindLastIndex1(): void {
@@ -21,6 +26,14 @@ test(function bytesBytesFindLastIndex1(): void {
     new Uint8Array([0, 1, 2])
   );
   assertEquals(i, 3);
+});
+
+test(function bytesBytesFindLastIndex2(): void {
+  const i = bytesFindLastIndex(
+    new Uint8Array([0, 1, 1]),
+    new Uint8Array([0, 1])
+  );
+  assertEquals(i, 0);
 });
 
 test(function bytesBytesBytesEqual(): void {


### PR DESCRIPTION
### Bug
`bytesFindIndex` and `bytesFindLastIndex` in `deno_std/bytes` cannot find the binary pattern when its occurrence has an overlap with a partly (but not completely) matching sequence.

- target: `001`
- pattern: `01`
- expected `bytesFindIndex` result: `1`
- current `bytesFindIndex` result: `-1`

### Reproduction
Existing test cases are edited to reproduce the bug: https://github.com/arcatdmz/deno_std/commit/fe9d5b47ccb89c1244c54bf04dfbb941f65ac657

Two corresponding tests fail accordingly: https://gist.github.com/arcatdmz/08ae107dd5e29e2aaebf18e1d8b76d43

### Fix
This pull request contains a commit that fixes the bug: https://github.com/arcatdmz/deno_std/commit/1251423f5b18bc12e2821862825f0a95a99edee7

### Context
- I am writing a web server that accepts `multipart/form-data` posted by a web browser client.
- The server crashes mysteriously, and I first suspected a bug of `deno_std/multipart`.
- Indeed, [deno_std/multipart/multipart_test.ts](https://github.com/arcatdmz/deno_std/blob/bd0d2c31609b81d2a63c5b8cacc7369708e9c0c6/multipart/multipart_test.ts) fails as shown in this gist: 
https://gist.github.com/arcatdmz/307800328cd7aaa35e027cebab4a611a
- When I update `sample.txt` as shown in https://github.com/arcatdmz/deno_std/commit/c3ed68f35aaa83b1a3890bd37b6d01c0ca367214, test failures are gone, and I notice it's a bug not in `deno_std/multipart` but in `deno_std/bytes`.
