### PR TITLE
Bench: replace Date.now with Performance.now

### DIFF
--- a/testing/bench.ts
+++ b/testing/bench.ts
@@ -61,10 +61,10 @@ function assertTiming(clock: BenchmarkClock): void {
 function createBenchmarkTimer(clock: BenchmarkClock): BenchmarkTimer {
   return {
     start(): void {
-      clock.start = Date.now();
+      clock.start = performance.now();
     },
     stop(): void {
-      clock.stop = Date.now();
+      clock.stop = performance.now();
     }
   };
 }


### PR DESCRIPTION
Due to inactivity of https://github.com/denoland/deno_std/pull/253

Pushing this as it's revelant to have it now.