### PR TITLE
walk() should not use deprecated FileInfo.path

### DIFF
--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -1,32 +1,11 @@
-const { mkdir, open } = Deno;
+const { mkdir } = Deno;
 type FileInfo = Deno.FileInfo;
-import { test } from "../testing/mod.ts";
+import { test, runIfMain } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { glob } from "./glob.ts";
 import { join } from "./path.ts";
 import { testWalk } from "./walk_test.ts";
-import { walk, walkSync, WalkOptions } from "./walk.ts";
-
-async function touch(path: string): Promise<void> {
-  await open(path, "w");
-}
-
-async function walkArray(
-  dirname: string = ".",
-  options: WalkOptions = {}
-): Promise<string[]> {
-  const arr: string[] = [];
-  for await (const f of walk(dirname, { ...options })) {
-    arr.push(f.path.replace(/\\/g, "/"));
-  }
-  arr.sort();
-  const arrSync = Array.from(
-    walkSync(dirname, options),
-    (f: FileInfo): string => f.path.replace(/\\/g, "/")
-  ).sort();
-  assertEquals(arr, arrSync);
-  return arr;
-}
+import { touch, walkArray } from "./walk_test.ts";
 
 test({
   name: "glob: glob to regex",
@@ -77,7 +56,7 @@ testWalk(
   async function globInWalk(): Promise<void> {
     const arr = await walkArray(".", { match: [glob("*.ts")] });
     assertEquals(arr.length, 1);
-    assertEquals(arr[0], "./a/x.ts");
+    assertEquals(arr[0], "a/x.ts");
   }
 );
 
@@ -92,8 +71,8 @@ testWalk(
   async function globInWalkWildcardFiles(): Promise<void> {
     const arr = await walkArray(".", { match: [glob("*.ts")] });
     assertEquals(arr.length, 2);
-    assertEquals(arr[0], "./a/x.ts");
-    assertEquals(arr[1], "./b/z.ts");
+    assertEquals(arr[0], "a/x.ts");
+    assertEquals(arr[1], "b/z.ts");
   }
 );
 
@@ -113,7 +92,7 @@ testWalk(
       ]
     });
     assertEquals(arr.length, 1);
-    assertEquals(arr[0], "./a/yo/x.ts");
+    assertEquals(arr[0], "a/yo/x.ts");
   }
 );
 
@@ -137,8 +116,8 @@ testWalk(
       ]
     });
     assertEquals(arr.length, 2);
-    assertEquals(arr[0], "./a/deno/x.ts");
-    assertEquals(arr[1], "./a/raptor/x.ts");
+    assertEquals(arr[0], "a/deno/x.ts");
+    assertEquals(arr[1], "a/raptor/x.ts");
   }
 );
 
@@ -154,7 +133,9 @@ testWalk(
     });
     console.log(arr);
     assertEquals(arr.length, 2);
-    assertEquals(arr[0], "./x.js");
-    assertEquals(arr[1], "./x.ts");
+    assertEquals(arr[0], "x.js");
+    assertEquals(arr[1], "x.ts");
   }
 );
+
+runIfMain(import.meta);

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -12,7 +12,6 @@
 // This script formats the given source files. If the files are omitted, it
 // formats the all files in the repository.
 const { args, exit, readFile, writeFile } = Deno;
-type FileInfo = Deno.FileInfo;
 import { glob } from "../fs/glob.ts";
 import { walk, WalkInfo } from "../fs/walk.ts";
 import { parse } from "../flags/mod.ts";

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -14,7 +14,7 @@
 const { args, exit, readFile, writeFile } = Deno;
 type FileInfo = Deno.FileInfo;
 import { glob } from "../fs/glob.ts";
-import { walk } from "../fs/walk.ts";
+import { walk, WalkInfo } from "../fs/walk.ts";
 import { parse } from "../flags/mod.ts";
 import { prettier, prettierPlugins } from "./prettier.ts";
 
@@ -174,15 +174,15 @@ function selectParser(path: string): ParserLabel | null {
  * If paths are empty, then checks all the files.
  */
 async function checkSourceFiles(
-  files: AsyncIterableIterator<FileInfo>,
+  files: AsyncIterableIterator<WalkInfo>,
   prettierOpts: PrettierOptions
 ): Promise<void> {
   const checks: Array<Promise<boolean>> = [];
 
-  for await (const file of files) {
-    const parser = selectParser(file.path);
+  for await (const { filename } of files) {
+    const parser = selectParser(filename);
     if (parser) {
-      checks.push(checkFile(file.path, parser, prettierOpts));
+      checks.push(checkFile(filename, parser, prettierOpts));
     }
   }
 
@@ -202,15 +202,15 @@ async function checkSourceFiles(
  * If paths are empty, then formats all the files.
  */
 async function formatSourceFiles(
-  files: AsyncIterableIterator<FileInfo>,
+  files: AsyncIterableIterator<WalkInfo>,
   prettierOpts: PrettierOptions
 ): Promise<void> {
   const formats: Array<Promise<void>> = [];
 
-  for await (const file of files) {
-    const parser = selectParser(file.path);
+  for await (const { filename } of files) {
+    const parser = selectParser(filename);
     if (parser) {
-      formats.push(formatFile(file.path, parser, prettierOpts));
+      formats.push(formatFile(filename, parser, prettierOpts));
     }
   }
 

--- a/prettier/main_test.ts
+++ b/prettier/main_test.ts
@@ -63,8 +63,8 @@ test(async function testPrettierCheckAndFormatFiles(): Promise<void> {
   assertEquals(code, 0);
   assertEquals(
     normalizeOutput(stdout),
-    `Formatting ./prettier/testdata/0.ts
-Formatting ./prettier/testdata/1.js`
+    `Formatting prettier/testdata/0.ts
+Formatting prettier/testdata/1.js`
   );
 
   var { code, stdout } = await run([...cmd, "--check", ...files]);
@@ -87,10 +87,10 @@ test(async function testPrettierCheckAndFormatDirs(): Promise<void> {
   assertEquals(code, 0);
   assertEquals(
     normalizeOutput(stdout),
-    `Formatting ./prettier/testdata/bar/0.ts
-Formatting ./prettier/testdata/bar/1.js
-Formatting ./prettier/testdata/foo/0.ts
-Formatting ./prettier/testdata/foo/1.js`
+    `Formatting prettier/testdata/bar/0.ts
+Formatting prettier/testdata/bar/1.js
+Formatting prettier/testdata/foo/0.ts
+Formatting prettier/testdata/foo/1.js`
   );
 
   var { code, stdout } = await run([...cmd, "--check", ...dirs]);


### PR DESCRIPTION
walk() made extensive use of `FileInfo.path` which will be removed in future versions. 

cc @kt3k 

Note: this is necessary to bump CI to v0.5 https://github.com/denoland/deno_std/pull/393

Necessary for https://github.com/denoland/deno/pull/2313 too