### PR TITLE
[http] add handling of bad request

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -194,7 +194,7 @@ export class ServerRequest {
     // we rewrite it
     if (this.err) {
       r.status = 400;
-      r.body = new TextEncoder().encode("Unable to proceed request");
+      r.body = new TextEncoder().encode("Unable to proceed request\r\n\r\n");
     }
 
     // Write our response!

--- a/http/server.ts
+++ b/http/server.ts
@@ -107,7 +107,7 @@ export class ServerRequest {
   r: BufReader;
   w: BufWriter;
   done: Deferred<void> = deferred();
-  err?: any; // error in the request
+  err?: Error; // error in the request
 
   public async *bodyStream(): AsyncIterableIterator<Uint8Array> {
     if (this.headers.has("content-length")) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -216,7 +216,6 @@ export async function readRequest(
   // we proceed the request but we force a 400
   try {
     [req.method, req.url, req.proto] = firstLine.split(" ", 3);
-
     [req.headers, err] = await tp.readMIMEHeader();
   } catch (e) {
     return [req, new Error("Unable to proceed request")];

--- a/http/server.ts
+++ b/http/server.ts
@@ -190,10 +190,13 @@ export class ServerRequest {
   }
 
   async respond(r: Response): Promise<void> {
+    // if an error in the request occurs
+    // we rewrite it
     if (this.err) {
       r.status = 400;
       r.body = new TextEncoder().encode("Unable to proceed request");
     }
+
     // Write our response!
     await writeResponse(this.w, r);
     // Signal that this request has been processed and the next pipelined

--- a/http/server.ts
+++ b/http/server.ts
@@ -197,9 +197,10 @@ export class ServerRequest {
   }
 }
 
+// TODO(#427) readRequest should not depend on conn.
 export async function readRequest(
   bufr: BufReader
-): Promise<[ServerRequest, BufState | Error]> {
+): Promise<[ServerRequest, BufState]> {
   const req = new ServerRequest();
   req.r = bufr;
   const tp = new TextProtoReader(bufr);
@@ -210,11 +211,12 @@ export async function readRequest(
   if (err) {
     return [null, err];
   }
-  [req.method, req.url, req.proto] = firstLine.split(" ", 3);
 
   // if there is an error in the request header
   // we proceed the request but we force a 400
   try {
+    [req.method, req.url, req.proto] = firstLine.split(" ", 3);
+
     [req.headers, err] = await tp.readMIMEHeader();
   } catch (e) {
     return [req, new Error("Unable to proceed request")];

--- a/http/server.ts
+++ b/http/server.ts
@@ -197,7 +197,7 @@ export class ServerRequest {
   }
 }
 
-async function readRequest(
+export async function readRequest(
   bufr: BufReader
 ): Promise<[ServerRequest, BufState]> {
   const req = new ServerRequest();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -12,8 +12,7 @@ import {
   Response,
   ServerRequest,
   writeResponse,
-  readRequest,
-  HttpError
+  readRequest
 } from "./server.ts";
 import { BufReader, BufWriter } from "../io/bufio.ts";
 import { StringReader } from "../io/readers.ts";
@@ -315,8 +314,7 @@ malformedHeader
   const conn = createConnMock();
   const [_, err] = await readRequest(conn, reader);
   const e: any = err; // eslint-disable-line @typescript-eslint/no-explicit-any
-  assert(e instanceof HttpError);
-  assertEquals(e.status, 400);
+  assert(e instanceof Error);
   assertEquals(e.message, "Unable to proceed request");
 });
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -317,8 +317,8 @@ malformedHeader
   assertEquals(e.message, "Unable to proceed request");
 });
 
-// Port from Go
-// https://github.com/golang/go/blob/master/src/net/http/request_test.go#L380-L446
+// Ported from Go
+// https://github.com/golang/go/blob/go1.12.5/src/net/http/request_test.go#L377-L443
 test(async function testReadRequestError(): Promise<void> {
   const testCases = {
     0: {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -55,39 +55,6 @@ test(async function responseWrite(): Promise<void> {
   }
 });
 
-test(async function responseWriteInCaseOfError(): Promise<void> {
-  const buf = new Buffer();
-  const bufw = new BufWriter(buf);
-  const request = new ServerRequest();
-  request.w = bufw;
-  request.err = new Error("Unable to parse request");
-  request.conn = {
-    localAddr: "",
-    remoteAddr: "",
-    rid: -1,
-    closeRead: (): void => {},
-    closeWrite: (): void => {},
-    read: async (): Promise<Deno.ReadResult> => {
-      return { eof: true, nread: 0 };
-    },
-    write: async (): Promise<number> => {
-      return -1;
-    },
-    close: (): void => {}
-  };
-  const response = {
-    status: 200
-  };
-  await request.respond(response);
-  console.log(buf.toString());
-  const expected =
-    "HTTP/1.1 400 Bad Request\r\n" +
-    "content-length: 29\r\n\r\n" +
-    "Unable to proceed request\r\n\r\n";
-  assertEquals(buf.toString(), expected);
-  await request.done;
-});
-
 test(async function requestBodyWithContentLength(): Promise<void> {
   {
     const req = new ServerRequest();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -339,7 +339,7 @@ test(async function testReadRequestError(): Promise<void> {
       in: "HEAD / HTTP/1.1\r\n\r\n",
       headers: [],
       err: null
-    },
+    }
     // Multiple Content-Length values should either be
     // deduplicated if same or reject otherwise
     // See Issue 16490.

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -55,6 +55,39 @@ test(async function responseWrite(): Promise<void> {
   }
 });
 
+test(async function responseWriteInCaseOfError(): Promise<void> {
+  const buf = new Buffer();
+  const bufw = new BufWriter(buf);
+  const request = new ServerRequest();
+  request.w = bufw;
+  request.err = new Error("Unable to parse request");
+  request.conn = {
+    localAddr: "",
+    remoteAddr: "",
+    rid: -1,
+    closeRead: (): void => {},
+    closeWrite: (): void => {},
+    read: async (): Promise<Deno.ReadResult> => {
+      return { eof: true, nread: 0 };
+    },
+    write: async (): Promise<number> => {
+      return -1;
+    },
+    close: (): void => {}
+  };
+  const response = {
+    status: 200
+  };
+  await request.respond(response);
+  console.log(buf.toString());
+  const expected =
+    "HTTP/1.1 400 Bad Request\r\n" +
+    "content-length: 29\r\n\r\n" +
+    "Unable to proceed request\r\n\r\n";
+  assertEquals(buf.toString(), expected);
+  await request.done;
+});
+
 test(async function requestBodyWithContentLength(): Promise<void> {
   {
     const req = new ServerRequest();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -367,11 +367,11 @@ test(async function testReadRequestError(): Promise<void> {
     //   in: "POST / HTTP/1.1\r\nContent-Length:\r\nContent-Length: 3\r\n\r\n",
     //   err: "cannot contain multiple Content-Length headers"
     // },
-    10: {
-      in: "HEAD / HTTP/1.1\r\nContent-Length:0\r\nContent-Length: 0\r\n\r\n",
-      headers: [{ key: "Content-Length", value: "0" }],
-      err: null
-    }
+    // 10: {
+    //   in: "HEAD / HTTP/1.1\r\nContent-Length:0\r\nContent-Length: 0\r\n\r\n",
+    //   headers: [{ key: "Content-Length", value: "0" }],
+    //   err: null
+    // }
   };
   for (const p in testCases) {
     const test = testCases[p];

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -319,6 +319,7 @@ malformedHeader
 
 // Ported from Go
 // https://github.com/golang/go/blob/go1.12.5/src/net/http/request_test.go#L377-L443
+// TODO(zekth) fix tests
 test(async function testReadRequestError(): Promise<void> {
   const testCases = {
     0: {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -309,8 +309,7 @@ test(async function readRequestError(): Promise<void> {
   let input = `GET / HTTP/1.1
 malformedHeader
 `;
-  const buf = new Buffer(enc.encode(input));
-  const reader = new BufReader(buf);
+  const reader = new BufReader(new StringReader(input));
   const conn = createConnMock();
   const [_, err] = await readRequest(conn, reader);
   const e: any = err; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -319,7 +318,7 @@ malformedHeader
 });
 
 // Port from Go
-// https://github.com/golang/go/blob/master/src/net/http/request_test.go
+// https://github.com/golang/go/blob/master/src/net/http/request_test.go#L380-L446
 test(async function testReadRequestError(): Promise<void> {
   const testCases = {
     0: {
@@ -373,8 +372,7 @@ test(async function testReadRequestError(): Promise<void> {
   };
   for (const p in testCases) {
     const test = testCases[p];
-    const buf = new Buffer(enc.encode(test.in).buffer);
-    const reader = new BufReader(buf);
+    const reader = new BufReader(new StringReader(test.in));
     const conn = createConnMock();
     const [req, err] = await readRequest(conn, reader);
     assertEquals(test.err, err);


### PR DESCRIPTION
This is meant to fix : https://github.com/denoland/deno/issues/2346

It's not that pretty but ATM i haven't found any other way to do it.

So if, there is an issue in the request with malformed headers or encrypted due to HTTPS, an error is attached to the server request, if there is a respond of it the ServerResponse is automaticaly rewritten.

This fixes bad headers and wrong protocol (somehow). The problem with https is we got : `ssl3_get_record:wrong version number` because the client is trying to do the handshake.

**Note**: i've noticed we have multiple set of `new TextEncoder()`. Would it be better to have it as a const in the module?