### PR TITLE
[http] delete conn parameter in readRequest

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -104,7 +104,6 @@ export class ServerRequest {
   method: string;
   proto: string;
   headers: Headers;
-  conn: Conn;
   r: BufReader;
   w: BufWriter;
   done: Deferred<void> = deferred();
@@ -237,8 +236,8 @@ export class Server implements AsyncIterable<ServerRequest> {
 
     while (!this.closing) {
       [req, bufStateErr] = await readRequest(bufr);
-      req.w = w;
       if (bufStateErr) break;
+      req.w = w;
       yield req;
       // Wait for the request to be processed before we accept a new request on
       // this connection.

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -49,21 +49,6 @@ test(async function responseWrite(): Promise<void> {
     const request = new ServerRequest();
     request.w = bufw;
 
-    request.conn = {
-      localAddr: "",
-      remoteAddr: "",
-      rid: -1,
-      closeRead: (): void => {},
-      closeWrite: (): void => {},
-      read: async (): Promise<Deno.ReadResult> => {
-        return { eof: true, nread: 0 };
-      },
-      write: async (): Promise<number> => {
-        return -1;
-      },
-      close: (): void => {}
-    };
-
     await request.respond(testCase.response);
     assertEquals(buf.toString(), testCase.raw);
     await request.done;


### PR DESCRIPTION
fix: https://github.com/denoland/deno_std/issues/427

Also deleted `conn` property of `ServerRequest` because it's not used anymore and it's not in the request struct of golang:
https://github.com/golang/go/blob/1d1ba85d9986bb56226046c06dec4ce63ef9fe48/src/net/http/request.go#L107
