### PR TITLE
Prettier: support for specified files and glob mode

### DIFF
--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -228,15 +228,16 @@ async function formatSourceFiles(
 }
 
 /**
- * Select a specific file based on glob, then return an async iterable object.
+ * Get the files to format.
  * @param selectors The glob patterns to select the files.
  *                  eg `cmd/*.ts` to select all the typescript files in cmd directory.
  *                  eg `cmd/run.ts` to select `cmd/run.ts` file as only.
  * @param ignore The glob patterns to ignore files.
  *                  eg `*_test.ts` to ignore all the test file.
  * @param options options to pass to `glob(selector, options)`
+ * @returns returns an async iterable object
  */
-function filesSelector(
+function getTargetFiles(
   selectors: string[],
   ignore: string[] = [],
   options: GlobOptions = {}
@@ -311,7 +312,7 @@ async function main(opts): Promise<void> {
   }
   const options: GlobOptions = { flags: "g" };
 
-  const files = filesSelector(
+  const files = getTargetFiles(
     args.length ? args : ["."],
     Array.isArray(ignore) ? ignore : [ignore],
     options

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -233,7 +233,7 @@ function filesSelector(
   ignore: string[] = [],
   options: GlobOptions = {}
 ): AsyncIterableIterator<WalkInfo> {
-  const matchers: (string | RegExp)[] = [];
+  const matchers: Array<string | RegExp> = [];
 
   const selectorMap: { [k: string]: boolean } = {};
 
@@ -250,7 +250,7 @@ function filesSelector(
 
   const skip = ignore.map((i: string): RegExp => glob(i, options));
 
-  return (async function*() {
+  return (async function*(): AsyncIterableIterator<WalkInfo> {
     for (const match of matchers) {
       if (typeof match === "string") {
         const fileInfo = await Deno.stat(match);

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -14,7 +14,6 @@
 const { args, exit, readFile, writeFile, stdout } = Deno;
 import { glob, isGlob, GlobOptions } from "../fs/glob.ts";
 import { walk, WalkInfo } from "../fs/walk.ts";
-import { sep } from "../fs/path.ts";
 import { parse } from "../flags/mod.ts";
 import { prettier, prettierPlugins } from "./prettier.ts";
 

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -229,7 +229,7 @@ async function formatSourceFiles(
 }
 
 /**
- * Select a specific file based on the selector selected, then return an async iterable object.
+ * Select a specific file based on glob, then return an async iterable object.
  * @param selectors The glob patterns to select the files.
  *                  eg `cmd/*.ts` to select all the typescript files in cmd directory.
  *                  eg `cmd/run.ts` to select `cmd/run.ts` file as only.


### PR DESCRIPTION
close #424

Thanks to @dshubhadeep for #433

support `specified files` mix with `glob`

```bash
> deno run prettier/main.ts script1.ts script2.ts **/**/test.ts
```

This allows to directly specify a file to be formatted.

### Before

```bash
> deno run prettier/main.ts test.ts
Formatting test.ts
Formatting fs/test.ts
Formatting fs/copy_test.ts
Formatting fs/empty_test.ts
...
```

### After

> only format the `test.ts`

```bash
> deno run prettier/main.ts test.ts
Formatting test.ts
```

/cc @kt3k 
