### PR TITLE
Revert "http: delete conn parameter in readRequest (#430)"

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -262,7 +262,7 @@ export class Server implements AsyncIterable<ServerRequest> {
 
     while (!this.closing) {
       try {
-        [req, bufStateErr] = await readRequest(bufr);
+        [req, bufStateErr] = await readRequest(conn, bufr);
       } catch (err) {
         bufStateErr = err;
       }

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -61,6 +61,21 @@ test(async function responseWrite(): Promise<void> {
     const request = new ServerRequest();
     request.w = bufw;
 
+    request.conn = {
+      localAddr: "",
+      remoteAddr: "",
+      rid: -1,
+      closeRead: (): void => {},
+      closeWrite: (): void => {},
+      read: async (): Promise<Deno.ReadResult> => {
+        return { eof: true, nread: 0 };
+      },
+      write: async (): Promise<number> => {
+        return -1;
+      },
+      close: (): void => {}
+    };
+
     await request.respond(testCase.response);
     assertEquals(buf.toString(), testCase.raw);
     await request.done;


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_std/issues/441

We'll have to wait to remove the conn parameter until ws is working.

This reverts commit 209183e24812095a40e48e60484f80a5a254b1c3.