### PR TITLE
[http] add rfc7230 handling

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -215,11 +215,11 @@ function fixLength(req: ServerRequest): void {
     if (req.method === "HEAD" && c && c !== "0") {
       throw Error("http: method cannot contain a Content-Length");
     }
-    if (c && req.headers.get("transfer-encoding")) {
-      // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
+    if (c && req.headers.has("transfer-encoding")) {
       // A sender MUST NOT send a Content-Length header field in any message
       // that contains a Transfer-Encoding header field.
-      throw Error(
+      // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
+      throw new Error(
         "http: Transfer-Encoding and Content-Length cannot be send together"
       );
     }

--- a/http/server.ts
+++ b/http/server.ts
@@ -215,6 +215,14 @@ function fixLength(req: ServerRequest): void {
     if (req.method === "HEAD" && c && c !== "0") {
       throw Error("http: method cannot contain a Content-Length");
     }
+    if (c && req.headers.get("transfer-encoding")) {
+      // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
+      // A sender MUST NOT send a Content-Length header field in any message
+      // that contains a Transfer-Encoding header field.
+      throw Error(
+        "http: Transfer-Encoding and Content-Length cannot be send together"
+      );
+    }
   }
 }
 
@@ -288,10 +296,6 @@ export async function readRequest(
   [req.protoMinor, req.protoMajor] = parseHTTPVersion(req.proto);
   req.headers = headers;
   fixLength(req);
-  // TODO(zekth) : add parsing of headers eg:
-  // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
-  // A sender MUST NOT send a Content-Length header field in any message
-  // that contains a Transfer-Encoding header field.
   return req;
 }
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -385,6 +385,12 @@ test(async function testReadRequestError(): Promise<void> {
     10: {
       in: "HEAD / HTTP/1.1\r\nContent-Length:0\r\nContent-Length: 0\r\n\r\n",
       headers: [{ key: "Content-Length", value: "0" }]
+    },
+    11: {
+      in:
+        "POST / HTTP/1.1\r\nContent-Length:0\r\ntransfer-encoding: chunked\r\n\r\n",
+      headers: [],
+      err: "http: Transfer-Encoding and Content-Length cannot be send together"
     }
   };
   for (const p in testCases) {


### PR DESCRIPTION
Add handling of RFC 7230:
https://tools.ietf.org/html/rfc7230#section-3.3.2

```
      A sender MUST NOT send a Content-Length header field in any message
      that contains a Transfer-Encoding header field.
```