### PR TITLE
[encoding] add csv parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Here are the dedicated documentations of modules:
 
 - [colors](colors/README.md)
 - [datetime](datetime/README.md)
+- [encoding](encoding/README.md)
 - [examples](examples/README.md)
 - [flags](flags/README.md)
 - [fs](fs/README.md)
@@ -33,7 +34,6 @@ Here are the dedicated documentations of modules:
 - [prettier](prettier/README.md)
 - [strings](strings/README.md)
 - [testing](testing/README.md)
-- [toml](encoding/toml/README.md)
 - [ws](ws/README.md)
 
 ## Contributing

--- a/encoding/README.md
+++ b/encoding/README.md
@@ -1,11 +1,112 @@
-# TOML
+# Encoding
+
+## CSV
+
+- **`readAll(reader: BufReader, opt: ParseOptions = { comma: ",", trimLeadingSpace: false, lazyQuotes: false } ): Promise<[string[][], BufState]>`**:
+  Read the whole buffer and output the structured CSV datas
+- **`parse(csvString: string, opt: ParseOption): Promise<unknown[]>`**:
+  See [parse](###Parse)
+
+### Parse
+
+Parse the CSV string with the options provided.
+
+#### Options
+
+##### ParseOption
+
+- **`header: boolean | string[] | HeaderOption[];`**: If a boolean is provided,
+  the first line will be used as Header definitions. If `string[]` or
+  `HeaderOption[]`
+  those names will be used for header definition.
+- **`parse?: (input: unknown) => unknown;`**: Parse function for the row, which
+  will be executed after parsing of all columns. Therefore if you don't provide
+  header and parse function with headers, input will be `string[]`.
+
+##### HeaderOption
+
+- **`name: string;`**: Name of the header to be used as property.
+- **`parse?: (input: string) => unknown;`**: Parse function for the column.
+  This is executed on each entry of the header. This can be combined with the
+  Parse function of the rows.
+
+#### Usage
+
+```ts
+// input:
+// a,b,c
+// e,f,g
+
+const r = await parseFile(filepath, {
+  header: false
+});
+// output:
+// [["a", "b", "c"], ["e", "f", "g"]]
+
+const r = await parseFile(filepath, {
+  header: true
+});
+// output:
+// [{ a: "e", b: "f", c: "g" }]
+
+const r = await parseFile(filepath, {
+  header: ["this", "is", "sparta"]
+});
+// output:
+// [
+//   { this: "a", is: "b", sparta: "c" },
+//   { this: "e", is: "f", sparta: "g" }
+// ]
+
+const r = await parseFile(filepath, {
+  header: [
+    {
+      name: "this",
+      parse: (e: string): string => {
+        return `b${e}$$`;
+      }
+    },
+    {
+      name: "is",
+      parse: (e: string): number => {
+        return e.length;
+      }
+    },
+    {
+      name: "sparta",
+      parse: (e: string): unknown => {
+        return { bim: `boom-${e}` };
+      }
+    }
+  ]
+});
+// output:
+// [
+//    { this: "ba$$", is: 1, sparta: { bim: `boom-c` } },
+//    { this: "be$$", is: 1, sparta: { bim: `boom-g` } }
+// ]
+
+const r = await parseFile(filepath, {
+  header: ["this", "is", "sparta"],
+  parse: (e: Record<string, unknown>) => {
+    return { super: e.this, street: e.is, fighter: e.sparta };
+  }
+});
+// output:
+// [
+//   { super: "a", street: "b", fighter: "c" },
+//   { super: "e", street: "f", fighter: "g" }
+// ]
+```
+
+## TOML
 
 This module parse TOML files. It follows as much as possible the
 [TOML specs](https://github.com/toml-lang/toml). Be sure to read the supported
 types as not every specs is supported at the moment and the handling in
 TypeScript side is a bit different.
 
-## Supported types and handling
+### Supported types and handling
 
 - :heavy_check_mark: [Keys](https://github.com/toml-lang/toml#string)
 - :exclamation: [String](https://github.com/toml-lang/toml#string)
@@ -27,39 +128,39 @@ TypeScript side is a bit different.
 
 :exclamation: _Supported with warnings see [Warning](#Warning)._
 
-### :warning: Warning
+#### :warning: Warning
 
-#### String
+##### String
 
 - Regex : Due to the spec, there is no flag to detect regex properly
   in a TOML declaration. So the regex is stored as string.
 
-#### Integer
+##### Integer
 
 For **Binary** / **Octal** / **Hexadecimal** numbers,
 they are stored as string to be not interpreted as Decimal.
 
-#### Local Time
+##### Local Time
 
 Because local time does not exist in JavaScript, the local time is stored as a string.
 
-#### Inline Table
+##### Inline Table
 
 Inline tables are supported. See below:
 
 ```toml
 animal = { type = { name = "pug" } }
-# Output
+## Output
 animal = { type.name = "pug" }
-# Output { animal : { type : { name : "pug" } }
+## Output { animal : { type : { name : "pug" } }
 animal.as.leaders = "tosin"
-# Output { animal: { as: { leaders: "tosin" } } }
+## Output { animal: { as: { leaders: "tosin" } } }
 "tosin.abasi" = "guitarist"
-# Output
+## Output
 "tosin.abasi" : "guitarist"
 ```
 
-#### Array of Tables
+##### Array of Tables
 
 At the moment only simple declarations like below are supported:
 
@@ -89,9 +190,9 @@ will output:
 }
 ```
 
-## Usage
+### Usage
 
-### Parse
+#### Parse
 
 ```ts
 import { parse } from "./parser.ts";
@@ -103,7 +204,7 @@ const tomlString = 'foo.bar = "Deno"';
 const tomlObject22 = parse(tomlString);
 ```
 
-### Stringify
+#### Stringify
 
 ```ts
 import { stringify } from "./parser.ts";

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -29,7 +29,7 @@ export interface ParseOptions {
 function chkOptions(opt: ParseOptions): void {
   if (
     INVALID_RUNE.includes(opt.comma) ||
-    (opt.comment && INVALID_RUNE.includes(opt.comment)) ||
+    INVALID_RUNE.includes(opt.comment!) ||
     opt.comma === opt.comment
   ) {
     throw new Error("Invalid Delimiter");
@@ -150,7 +150,7 @@ export interface HeaderOption {
   parse?: (input: string) => unknown;
 }
 
-export interface ParseOption {
+export interface ExtendedParseOptions extends ParseOptions {
   header: boolean | string[] | HeaderOption[];
   parse?: (input: unknown) => unknown;
 }
@@ -178,14 +178,18 @@ export interface ParseOption {
  */
 export async function parse(
   input: string | BufReader,
-  opt: ParseOption = { header: false }
+  opt: ExtendedParseOptions = {
+    header: false,
+    comma: ",",
+    trimLeadingSpace: false
+  }
 ): Promise<unknown[]> {
   let r: string[][];
   let err: BufState;
   if (input instanceof BufReader) {
-    [r, err] = await readAll(input);
+    [r, err] = await readAll(input, opt);
   } else {
-    [r, err] = await readAll(new BufReader(new StringReader(input)));
+    [r, err] = await readAll(new BufReader(new StringReader(input)), opt);
   }
   if (err) throw err;
   if (opt.header) {

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -36,6 +36,8 @@ export interface ParseOptions {
 }
 
 function chkOptions(opt: ParseOptions): void {
+  if (!opt.comma) opt.comma = ",";
+  if (!opt.trimLeadingSpace) opt.trimLeadingSpace = false;
   if (
     INVALID_RUNE.includes(opt.comma!) ||
     INVALID_RUNE.includes(opt.comment!) ||
@@ -48,7 +50,7 @@ function chkOptions(opt: ParseOptions): void {
 async function read(
   Startline: number,
   reader: BufReader,
-  opt: ParseOptions = { comma: ",", comment: "#", trimLeadingSpace: false }
+  opt: ParseOptions = { comma: ",", trimLeadingSpace: false }
 ): Promise<string[] | EOF> {
   const tp = new TextProtoReader(reader);
   let line: string;
@@ -192,13 +194,11 @@ export async function parse(
   }
 ): Promise<unknown[]> {
   let r: string[][];
-  let err: BufState;
   if (input instanceof BufReader) {
-    [r, err] = await readAll(input, opt);
+    r = await readAll(input, opt);
   } else {
-    [r, err] = await readAll(new BufReader(new StringReader(input)), opt);
+    r = await readAll(new BufReader(new StringReader(input)), opt);
   }
-  if (err) throw err;
   if (opt.header) {
     let headers: HeaderOption[] = [];
     let i = 0;

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -19,16 +19,16 @@ export class ParseError extends Error {
 }
 
 export interface ParseOptions {
-  comma: string;
+  comma?: string;
   comment?: string;
-  trimLeadingSpace: boolean;
+  trimLeadingSpace?: boolean;
   lazyQuotes?: boolean;
   fieldsPerRecord?: number;
 }
 
 function chkOptions(opt: ParseOptions): void {
   if (
-    INVALID_RUNE.includes(opt.comma) ||
+    INVALID_RUNE.includes(opt.comma!) ||
     INVALID_RUNE.includes(opt.comment!) ||
     opt.comma === opt.comment
   ) {
@@ -69,7 +69,7 @@ export async function read(
     return [];
   }
 
-  result = line.split(opt.comma);
+  result = line.split(opt.comma!);
 
   let quoteError = false;
   result = result.map(
@@ -179,9 +179,7 @@ export interface ExtendedParseOptions extends ParseOptions {
 export async function parse(
   input: string | BufReader,
   opt: ExtendedParseOptions = {
-    header: false,
-    comma: ",",
-    trimLeadingSpace: false
+    header: false
   }
 ): Promise<unknown[]> {
   let r: string[][];

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -18,6 +18,15 @@ export class ParseError extends Error {
   }
 }
 
+/**
+ * @property comma - Character which separates values. Default: ','
+ * @property comment - Character to start a comment. Default: '#'
+ * @property trimLeadingSpace - Flag to trim the leading space of the value. Default: 'false'
+ * @property lazyQuotes - Allow unquoted quote in a quoted field or non double
+ *  quoted quotes in quoted field Default: 'false'
+ * @property fieldsPerRecord - Enabling the check of fields for each row. If == 0
+ * first row is used as referal for the number of fields.
+ */
 export interface ParseOptions {
   comma?: string;
   comment?: string;

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -45,7 +45,7 @@ function chkOptions(opt: ParseOptions): void {
   }
 }
 
-export async function read(
+async function read(
   Startline: number,
   reader: BufReader,
   opt: ParseOptions = { comma: ",", comment: "#", trimLeadingSpace: false }

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -2,7 +2,7 @@
 // https://github.com/golang/go/blob/2cc15b1/src/encoding/csv/reader_test.go
 import { test, runIfMain } from "../testing/mod.ts";
 import { assertEquals, assert } from "../testing/asserts.ts";
-import { readAll } from "./csv.ts";
+import { readAll, parse } from "./csv.ts";
 import { StringReader } from "../io/readers.ts";
 import { BufReader } from "../io/bufio.ts";
 
@@ -464,6 +464,116 @@ for (const t of testCases) {
         const expected = t.Output;
         assertEquals(actual, expected);
       }
+    }
+  });
+}
+
+const parseTestCases = [
+  {
+    name: "simple",
+    in: "a,b,c",
+    header: false,
+    result: [["a", "b", "c"]]
+  },
+  {
+    name: "simple Bufreader",
+    in: new BufReader(new StringReader("a,b,c")),
+    header: false,
+    result: [["a", "b", "c"]]
+  },
+  {
+    name: "multiline",
+    in: "a,b,c\ne,f,g\n",
+    header: false,
+    result: [["a", "b", "c"], ["e", "f", "g"]]
+  },
+  {
+    name: "header mapping boolean",
+    in: "a,b,c\ne,f,g\n",
+    header: true,
+    result: [{ a: "e", b: "f", c: "g" }]
+  },
+  {
+    name: "header mapping array",
+    in: "a,b,c\ne,f,g\n",
+    header: ["this", "is", "sparta"],
+    result: [
+      { this: "a", is: "b", sparta: "c" },
+      { this: "e", is: "f", sparta: "g" }
+    ]
+  },
+  {
+    name: "header mapping object",
+    in: "a,b,c\ne,f,g\n",
+    header: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
+    result: [
+      { this: "a", is: "b", sparta: "c" },
+      { this: "e", is: "f", sparta: "g" }
+    ]
+  },
+  {
+    name: "header mapping parse entry",
+    in: "a,b,c\ne,f,g\n",
+    header: [
+      {
+        name: "this",
+        parse: (e: string): string => {
+          return `b${e}$$`;
+        }
+      },
+      {
+        name: "is",
+        parse: (e: string): number => {
+          return e.length;
+        }
+      },
+      {
+        name: "sparta",
+        parse: (e: string): unknown => {
+          return { bim: `boom-${e}` };
+        }
+      }
+    ],
+    result: [
+      { this: "ba$$", is: 1, sparta: { bim: `boom-c` } },
+      { this: "be$$", is: 1, sparta: { bim: `boom-g` } }
+    ]
+  },
+  {
+    name: "multiline parse",
+    in: "a,b,c\ne,f,g\n",
+    parse: (e: string[]): unknown => {
+      return { super: e[0], street: e[1], fighter: e[2] };
+    },
+    header: false,
+    result: [
+      { super: "a", street: "b", fighter: "c" },
+      { super: "e", street: "f", fighter: "g" }
+    ]
+  },
+  {
+    name: "header mapping object parseline",
+    in: "a,b,c\ne,f,g\n",
+    header: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
+    parse: (e: Record<string, unknown>): unknown => {
+      return { super: e.this, street: e.is, fighter: e.sparta };
+    },
+    result: [
+      { super: "a", street: "b", fighter: "c" },
+      { super: "e", street: "f", fighter: "g" }
+    ]
+  }
+];
+
+for (const testCase of parseTestCases) {
+  test({
+    name: `[CSV] Parse ${testCase.name}`,
+    async fn(): Promise<void> {
+      const r = await parse(testCase.in, {
+        header: testCase.header,
+        parse: testCase.parse
+      });
+      assertEquals(r, testCase.result);
     }
   });
 }

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -571,7 +571,9 @@ for (const testCase of parseTestCases) {
     async fn(): Promise<void> {
       const r = await parse(testCase.in, {
         header: testCase.header,
-        parse: testCase.parse
+        parse: testCase.parse,
+        comma: ",",
+        trimLeadingSpace: false
       });
       assertEquals(r, testCase.result);
     }

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -571,9 +571,7 @@ for (const testCase of parseTestCases) {
     async fn(): Promise<void> {
       const r = await parse(testCase.in, {
         header: testCase.header,
-        parse: testCase.parse,
-        comma: ",",
-        trimLeadingSpace: false
+        parse: testCase.parse
       });
       assertEquals(r, testCase.result);
     }

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -571,7 +571,7 @@ for (const testCase of parseTestCases) {
     async fn(): Promise<void> {
       const r = await parse(testCase.in, {
         header: testCase.header,
-        parse: testCase.parse
+        parse: testCase.parse as (input: unknown) => unknown
       });
       assertEquals(r, testCase.result);
     }

--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -346,8 +346,10 @@ testCopySync(
 
     assert(typeof destStatInfo.accessed === "number");
     assert(typeof destStatInfo.modified === "number");
-    assertEquals(destStatInfo.accessed, srcStatInfo.accessed);
-    assertEquals(destStatInfo.modified, srcStatInfo.modified);
+    // TODO: Activate test when https://github.com/denoland/deno/issues/2411
+    // is fixed
+    // assertEquals(destStatInfo.accessed, srcStatInfo.accessed);
+    // assertEquals(destStatInfo.modified, srcStatInfo.modified);
   }
 );
 

--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -346,10 +346,8 @@ testCopySync(
 
     assert(typeof destStatInfo.accessed === "number");
     assert(typeof destStatInfo.modified === "number");
-    // TODO: Activate test when https://github.com/denoland/deno/issues/2411
-    // is fixed
-    // assertEquals(destStatInfo.accessed, srcStatInfo.accessed);
-    // assertEquals(destStatInfo.modified, srcStatInfo.modified);
+    assertEquals(destStatInfo.accessed, srcStatInfo.accessed);
+    assertEquals(destStatInfo.modified, srcStatInfo.modified);
   }
 );
 


### PR DESCRIPTION
Ported https://github.com/zekth/deno_easyCSV to encoding/csv.
Also added the possibility to use `BufReader` as input and not only `string`.

ref: https://github.com/denoland/deno_std/issues/455