### PR TITLE
[chore] add require-jsdoc

### DIFF
--- a/.eslintrc.jsdoc.json
+++ b/.eslintrc.jsdoc.json
@@ -1,0 +1,8 @@
+{
+    "plugins": [
+      "jsdoc"
+    ],
+    "rules": {
+      "jsdoc/require-jsdoc": 1
+    }
+  }

--- a/.eslintrc.jsdoc.json
+++ b/.eslintrc.jsdoc.json
@@ -1,8 +1,8 @@
 {
     "plugins": [
-      "jsdoc"
+        "jsdoc"
     ],
     "rules": {
-      "jsdoc/require-jsdoc": 1
+        "jsdoc/require-jsdoc": 1
     }
-  }
+}

--- a/.eslintrc.jsdoc.json
+++ b/.eslintrc.jsdoc.json
@@ -1,8 +1,6 @@
 {
-    "plugins": [
-        "jsdoc"
-    ],
-    "rules": {
-        "jsdoc/require-jsdoc": 1
-    }
+  "plugins": ["jsdoc"],
+  "rules": {
+    "jsdoc/require-jsdoc": 1
+  }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,11 @@ jobs:
     pool:
       vmImage: "Ubuntu-16.04"
     steps:
-      - script: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - script: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-jsdoc eslint-config-prettier
       - script: curl -L https://deno.land/x/install/install.sh | sh -s $(DENO_VERSION)
       - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
       - script: npx eslint **/*.ts --max-warnings=0
+      - script: npx eslint -c ./.eslintrc.jsdoc.json **/*.ts --ignore-pattern '**/*_test.ts'
       - script: deno run --allow-run --allow-write --allow-read format.ts --check
       - script: deno run --allow-run --allow-net --allow-write --allow-read test.ts
 
@@ -21,10 +22,11 @@ jobs:
       vmImage: "macOS-10.13"
     steps:
       - script: npm install -g functional-red-black-tree
-      - script: npm install -g eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - script: npm install -g eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-jsdoc eslint-config-prettier
       - script: curl -L https://deno.land/x/install/install.sh | sh -s $(DENO_VERSION)
       - script: echo '##vso[task.prependpath]$(HOME)/.deno/bin/'
       - script: eslint **/*.ts --max-warnings=0
+      - script: eslint -c ./.eslintrc.jsdoc.json **/*.ts --ignore-pattern '**/*_test.ts'
       - script: deno run --allow-run --allow-write --allow-read format.ts --check
       - script: deno run --allow-run --allow-net --allow-write --allow-read test.ts
 
@@ -32,9 +34,10 @@ jobs:
     pool:
       vmImage: "vs2017-win2016"
     steps:
-      - bash: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+      - bash: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-jsdoc eslint-config-prettier
       - powershell: iwr https://deno.land/x/install/install.ps1 -out install.ps1; .\install.ps1 $(DENO_VERSION)
       - bash: echo "##vso[task.prependpath]C:\Users\VssAdministrator\.deno\\bin"
       - bash: npx eslint **/*.ts --max-warnings=0
+      - script: npx eslint -c ./.eslintrc.jsdoc.json **/*.ts --ignore-pattern '**/*_test.ts'
       - bash: deno.exe run --allow-run --allow-write --allow-read format.ts --check
       - bash: deno.exe run --allow-run --allow-net --allow-write --allow-read test.ts

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -118,6 +118,7 @@ export function currentDayOfYear(): number {
  * @return IMF date formated string
  */
 export function toIMF(date: Date): string {
+  /** @private */
   function dtPad(v: string, lPad: number = 2): string {
     return pad(v, lPad, { char: "0" });
   }

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -25,6 +25,7 @@ export interface ParseOptions {
   fieldsPerRecord?: number;
 }
 
+/** @private */
 function chkOptions(opt: ParseOptions): Error | null {
   if (
     INVALID_RUNE.includes(opt.comma) ||
@@ -36,6 +37,7 @@ function chkOptions(opt: ParseOptions): Error | null {
   return null;
 }
 
+/** Read and parse the next csv line of the BufReader */
 export async function read(
   Startline: number,
   reader: BufReader,
@@ -100,6 +102,7 @@ export async function read(
   return [result, err];
 }
 
+/** Read and parse the BufReader as CSV content */
 export async function readAll(
   reader: BufReader,
   opt: ParseOptions = {

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -40,15 +40,18 @@ class Parser {
   }
 
   _mergeMultilines(): void {
+    /** @private */
     function arrayStart(line: string): boolean {
       const reg = /.*=\s*\[/g;
       return reg.test(line) && !(line[line.length - 1] === "]");
     }
 
+    /** @private */
     function arrayEnd(line: string): boolean {
       return line[line.length - 1] === "]";
     }
 
+    /** @private */
     function stringStart(line: string): boolean {
       const m = line.match(/.*=\s*(?:\"\"\"|''')/);
       if (!m) {
@@ -57,10 +60,12 @@ class Parser {
       return !line.endsWith(`"""`) || !line.endsWith(`'''`);
     }
 
+    /** @private */
     function stringEnd(line: string): boolean {
       return line.endsWith(`'''`) || line.endsWith(`"""`);
     }
 
+    /** @private */
     function isLiteralString(line: string): boolean {
       return line.match(/'''/) ? true : false;
     }
@@ -479,6 +484,7 @@ class Dumper {
     }
   }
   _dateDeclaration(title: string, value: Date): string {
+    /** @private */
     function dtPad(v: string, lPad: number = 2): string {
       return pad(v, lPad, { char: "0" });
     }
@@ -525,12 +531,14 @@ class Dumper {
   }
 }
 
+/** Stringify the input object in a TOML string */
 export function stringify(srcObj: object): string {
   let out: string[] = [];
   out = new Dumper(srcObj).dump();
   return out.join("\n");
 }
 
+/** Parse the TOML string in an object */
 export function parse(tomlString: string): object {
   // File is potentially using EOL CRLF
   tomlString = tomlString.replace(/\r\n/g, "\n").replace(/\\\n/g, "\n");

--- a/fs/globrex.ts
+++ b/fs/globrex.ts
@@ -64,7 +64,10 @@ export function globrex(
     only?: string;
   }
 
-  // Helper function to build string and segments
+  /**
+   * Helper function to build string and segments
+   * @private
+   */
   function add(
     str,
     options: AddOptions = { split: false, last: false, only: "" }

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -24,6 +24,7 @@ export interface Cookie {
 
 export type SameSite = "Strict" | "Lax";
 
+/** Stringify the Cooki in the proper format */
 function toString(cookie: Cookie): string {
   const out: string[] = [];
   out.push(`${cookie.name}=${cookie.value}`);
@@ -45,8 +46,8 @@ function toString(cookie: Cookie): string {
   if (cookie.httpOnly) {
     out.push("HttpOnly");
   }
-  if (Number.isInteger(cookie.maxAge)) {
-    assert(cookie.maxAge > 0, "Max-Age must be an integer superior to 0");
+  if (Number.isInteger(cookie.maxAge!)) {
+    assert(cookie.maxAge! > 0, "Max-Age must be an integer superior to 0");
     out.push(`Max-Age=${cookie.maxAge}`);
   }
   if (cookie.domain) {

--- a/util/deep_assign.ts
+++ b/util/deep_assign.ts
@@ -1,4 +1,11 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Do a deep assign of objects
+ * Object.assign() only do shallow assign
+ * @param target Object receiving the assign
+ * @param sources array of objects to be merged in
+ */
 export function deepAssign(target: object, ...sources: object[]): object {
   for (let i = 0; i < sources.length; i++) {
     const source = sources[i];


### PR DESCRIPTION
As we want to make a robust API, we also need to have a robust documentation. Adding JsDoc check in the pipeline is necessary i think. We sometimes (me the first) forget about adding JsDoc. Then it would help for the PR review process.

I've added another eslint line for the pipeline because i don't want to flood the main one with all the warnings. Once the repo will be cleaned i think we can merge the two commands in one. Also there is some warning about `_test` files ignored because we don't need documentation for it. Note: only wait to disable those warns is to `--quiet` the eslint command.

To ignore private methods you have to do like this:
https://github.com/denoland/deno_std/compare/master...zekth:jsdo_proposal?expand=1#diff-3dabb7bf52bbca9c45474fe23c1d029bR122

For the moment only the rule of missing jsdoc is applied. Feel free to give you thoughts about adding rules.
Here is the doc: https://eslint.org/docs/rules/require-jsdoc