### PR TITLE
add "run" to file server alias

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -73,5 +73,5 @@ A small program for serving local files over HTTP.
 Add the following to your `.bash_profile`
 
 ```
-alias file_server="deno --allow-net https://deno.land/std/http/file_server.ts"
+alias file_server="deno run --allow-net https://deno.land/std/http/file_server.ts"
 ```


### PR DESCRIPTION
Hi 👋
I was just exploring deno and accidentally found a small mistake, this fixes a typo on the file server alias in README.