### PR TITLE
Http

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -200,6 +200,12 @@ export class ServerRequest {
 
 function fixLength(req: ServerRequest): void {
   const contentLength = req.headers.get("Content-Length");
+  const transferEncoding = req.headers.get("Transfer-Encoding");
+  if (contentLength && transferEncoding) {
+    throw Error(
+      "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
+    );
+  }
   if (contentLength) {
     const arrClen = contentLength.split(",");
     if (arrClen.length > 1) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -285,10 +285,6 @@ export async function readRequest(
 
   [req.headers, err] = await tp.readMIMEHeader();
   fixLength(req);
-  // TODO(zekth) : add parsing of headers eg:
-  // rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
-  // A sender MUST NOT send a Content-Length header field in any message
-  // that contains a Transfer-Encoding header field.
   return [req, err];
 }
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -365,6 +365,24 @@ test(async function testReadRequestError(): Promise<void> {
       in: "HEAD / HTTP/1.1\r\nContent-Length:0\r\nContent-Length: 0\r\n\r\n",
       headers: [{ key: "Content-Length", value: "0" }],
       err: null
+    },
+    11: {
+      in:
+        "POST / HTTP/1.1\r\nContent-Length: 6 \r\nTransfer-Encoding: chunked\r\n\r\nGopher\r\n",
+      err:
+        "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
+    },
+    12: {
+      in:
+        "PUT / HTTP/1.1\r\nContent-Length: 6 \r\nTransfer-Encoding: chunked\r\n\r\nGopher\r\n",
+      err:
+        "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
+    },
+    13: {
+      in:
+        "HEAD / HTTP/1.1\r\nContent-Length:0\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n\r\n",
+      err:
+        "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
     }
   };
   for (const p in testCases) {


### PR DESCRIPTION
add parsing of headers eg:
rfc: https://tools.ietf.org/html/rfc7230#section-3.3.2
A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
