### PR TITLE
[WebSocket] Add sec-websocket-version to handshake header

### DIFF
--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -423,6 +423,7 @@ async function handshake(
   headers.set("upgrade", "websocket");
   headers.set("connection", "upgrade");
   headers.set("sec-websocket-key", key);
+  headers.set("sec-websocket-version", "13");
 
   let headerStr = `GET ${pathname}?${searchParams || ""} HTTP/1.1\r\n`;
   for (const [key, value] of headers) {


### PR DESCRIPTION
I tried to communicate with deno_std WebSocket Client and a WebSocket Endpoint of Chrome DevTools, but handshake was rejected by Chrome.

I had to add a `sec-websocket-version` field to the request header to fix this.

According to the RFC, `sec-websocket-version` is required for the WebSocket Client implementation.

> The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.

https://tools.ietf.org/html/rfc6455#page-60

cc: @keroxp 