### PR TITLE
Add installer

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,47 @@
+# deno_install
+
+- This command installs executable deno script.
+
+## Features
+
+- Install executable script into ~/.deno/bin
+
+## Usage
+
+```sh
+deno_install https://deno.land/std/http/file_server.ts
+# now you can use installed command!
+file_server
+```
+
+## Requirements
+
+- wget #TODO: Remove
+
+## Installing
+
+### 1. Install deno_install
+
+deno_install can be installed by using itself.
+
+```sh
+deno -A https://deno.land/std/install/deno_install.ts https://deno.land/std/install/deno_install.ts
+```
+
+### 2. Add `~/.deno/bin` to PATH
+
+```
+echo 'export PATH="$HOME/.deno/bin:$PATH"' >> ~/.bashrc # change this to your shell
+```
+
+## Create Executable Script
+
+- Add shebang to top of your deno script.
+  - This defines what permissions are needed.
+
+```sh
+#!/usr/bin/env deno --allow-read --allow-write --allow-env --allow-run
+```
+
+- Host script on the web.
+- Install script using deno_install.

--- a/installer/README.md
+++ b/installer/README.md
@@ -9,9 +9,11 @@
 ## Usage
 
 ```sh
-deno_install https://deno.land/std/http/file_server.ts
-# now you can use installed command!
-file_server
+$ deno_install https://deno.land/std/http/file_server.ts
+> file_server requests network access. Grant permanently? [yN] # Grant the permissions to use command.
+> y
+> Successfully installed file_server.
+$ file_server # now you can use installed command!
 ```
 
 ## Requirements

--- a/installer/deno_install.ts
+++ b/installer/deno_install.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env deno --allow-all
+// This file was added to install `installer/mod.ts` with the name `deno_install`.
+import './mod.ts';

--- a/installer/mod.ts
+++ b/installer/mod.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env deno --allow-all
+
+const {
+  args,
+  env,
+  readDirSync,
+  mkdirSync,
+  writeFileSync,
+  exit,
+  stdin,
+  run,
+} = Deno;
+import * as path from '../fs/path.ts';
+import { parse } from './shebang.ts';
+
+enum Permission {
+  Unknown,
+  Read,
+  Write,
+  Net,
+  Env,
+  Run,
+  All,
+}
+
+function getPermissionFromFlag(flag: string): Permission {
+  switch (flag) {
+    case '--allow-read':
+      return Permission.Read;
+    case '--allow-write':
+      return Permission.Write;
+    case '--allow-net':
+      return Permission.Net;
+    case '--allow-env':
+      return Permission.Env;
+    case '--allow-run':
+      return Permission.Run;
+    case '--allow-all':
+      return Permission.All;
+    case '-A':
+      return Permission.All;
+  }
+  return Permission.Unknown;
+}
+
+function getFlagFromPermission(perm: Permission): string {
+  switch (perm) {
+    case Permission.Read:
+      return '--allow-read';
+    case Permission.Write:
+      return '--allow-write';
+    case Permission.Net:
+      return '--allow-net';
+    case Permission.Env:
+      return '--allow-env';
+    case Permission.Run:
+      return '--allow-run';
+    case Permission.All:
+      return '--allow-all';
+  }
+  return '';
+}
+
+async function readCharacter(): Promise<string> {
+  const decoder = new TextDecoder('utf-8');
+  const byteArray = new Uint8Array(1024);
+  await stdin.read(byteArray);
+  const line = decoder.decode(byteArray);
+  return line[0];
+}
+
+async function grantPermission(
+  perm: Permission,
+  moduleName: string = 'Deno'
+): Promise<boolean> {
+  let msg = `${moduleName} requests `;
+  switch (perm) {
+    case Permission.Read:
+      msg += 'read access to file system. ';
+      break;
+    case Permission.Write:
+      msg += 'write access to file system. ';
+      break;
+    case Permission.Net:
+      msg += 'network access. ';
+      break;
+    case Permission.Env:
+      msg += 'access to environment variable. ';
+      break;
+    case Permission.Run:
+      msg += 'access to run a subprocess. ';
+      break;
+    case Permission.All:
+      msg += 'all available access. ';
+      break;
+    default:
+      return false;
+  }
+  msg += 'Grant permanently? [yN]';
+  console.log(msg);
+
+  const input = await readCharacter();
+  if (input !== 'y' && input !== 'Y') {
+    return false;
+  }
+  return true;
+}
+
+function createDirIfNotExists(path: string) {
+  try {
+    readDirSync(path);
+  } catch (e) {
+    mkdirSync(path);
+  }
+}
+
+function getInstallerHome(): string {
+  const { DENO_DIR, HOME } = env();
+  if (!HOME && !DENO_DIR) {
+    throw new Error('$DENO_DIR and $HOME are not defined.');
+  }
+  if (DENO_DIR) {
+    return path.join(DENO_DIR, 'bin');
+  }
+  return path.join(HOME, '.deno', 'bin');
+}
+
+async function main() {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder('utf-8');
+
+  const INSTALLER_HOME = getInstallerHome();
+
+  const modulePath: string = args[args.length - 1];
+  if (!modulePath.startsWith('http')) {
+    throw new Error('module path is not correct.');
+  }
+  const moduleName = path.basename(modulePath, '.ts');
+
+  const wget = run({
+    args: ['wget', '--quiet', '-O', '-', modulePath],
+    stdout: 'piped',
+  });
+  const moduleText = decoder.decode(await wget.output());
+  const status = await wget.status();
+  wget.close();
+  if (status.code !== 0) {
+    throw new Error(`Failed to get remote script: ${modulePath}`);
+  }
+  console.log('Completed loading remote script.');
+
+  createDirIfNotExists(INSTALLER_HOME);
+  const FILE_PATH = path.join(INSTALLER_HOME, moduleName);
+
+  const shebang = parse(moduleText.split('\n')[0]);
+
+  const grantedPermissions: Array<Permission> = [];
+  for (const flag of shebang.args) {
+    const permission = getPermissionFromFlag(flag);
+    if (permission === Permission.Unknown) {
+      continue;
+    }
+    if (!(await grantPermission(permission, moduleName))) {
+      continue;
+    }
+    grantedPermissions.push(permission);
+  }
+  const commands = [
+    'deno',
+    ...grantedPermissions.map(getFlagFromPermission),
+    modulePath,
+    '$@',
+  ];
+
+  writeFileSync(FILE_PATH, encoder.encode('#/bin/sh\n'));
+  writeFileSync(FILE_PATH, encoder.encode(commands.join(' ')));
+
+  const makeExecutable = run({ args: ['chmod', '+x', FILE_PATH] });
+  await makeExecutable.status();
+  makeExecutable.close();
+
+  console.log(`Successfully installed ${moduleName}.`);
+}
+
+try {
+  main();
+} catch (e) {
+  const err = e as Error;
+  if (err.message) {
+    console.log(err.message);
+    exit(1);
+  }
+  console.log(e);
+  exit(1);
+}

--- a/installer/shebang.ts
+++ b/installer/shebang.ts
@@ -1,0 +1,29 @@
+export interface Shebang {
+  path: string;
+  args: Array<string>;
+}
+
+class ShebangImpl implements Shebang {
+  public readonly path: string;
+  public readonly args: Array<string>;
+  constructor(shebang: string) {
+    const line = shebang.split('\n')[0];
+    const parts = line.split(' ').map(s => s.trim());
+    const pathBase = parts.shift();
+    if (pathBase.startsWith('#!')) {
+      this.path = pathBase.slice(2);
+      this.args = [...parts];
+    } else {
+      this.path = '';
+      this.args = [];
+    }
+  }
+
+  toString(): string {
+    return [`#!${this.path}`, ...this.args].join(' ');
+  }
+}
+
+export function parse(shebang: string): Shebang {
+  return new ShebangImpl(shebang);
+}


### PR DESCRIPTION
Related to https://github.com/denoland/deno_std/issues/471 .

## What this does

* Add command `deno_install`.
* This enables installing executable deno script in a easy way.

## Usage

```sh
# Install deno script
deno_install https://deno.land/std/http/file_server.ts
# Now, you can run installed command
file_server
```

* For the details, please read the README.
* If you want to try behavior of this command, run the command below.

```sh
deno -A \
https://raw.githubusercontent.com/syumai/deno_std/add-installer/installer/deno_install.ts \
https://raw.githubusercontent.com/syumai/deno_std/add-installer/installer/deno_install.ts
```

## TODO

* [ ] Remove `wget`.
  - This is necessary for parsing target script's shebang.
  - If deno's `fetch` supports redirect, this can be removed.
* [ ] Add tests.

## Why I needed wget?

* deno's fetch can't get data from scripts using redirect server like `deno.land`. (e.g. `https://deno.land/std/http/file_server.ts`)
* fetch returns blank data.
* redirect destination script's body is needed to parse shebang.