### PR TITLE
remove url search params / "path traversal attack"

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -227,7 +227,10 @@ listenAndServe(
   addr,
   async (req): Promise<void> => {
     const fileName = req.url.replace(/\/$/, "");
+    fileName = fileName.replace(/\?.*/,'');
     const filePath = currentDir + fileName;
+    // Todo: possibly an "path traversal attack"?
+    // check if currentDir contains filePath (is there a function like "realpath")
 
     let response: Response;
 


### PR DESCRIPTION
At last if i have a directory, starting with a "?" i was able to trick the filserver to serve files not in the current directory.
http://srv.com/?x/../../