### PR TITLE
http file_server support for ? or # in url #503

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -226,7 +226,7 @@ function setCORS(res: Response): void {
 listenAndServe(
   addr,
   async (req): Promise<void> => {
-    const fileName = req.url.replace(/\/$/, "");
+    const fileName = req.url.split(/[?#]/)[0].replace(/\/$/, "");
     const filePath = currentDir + fileName;
 
     let response: Response;


### PR DESCRIPTION
Fixes #503 

My instinct was to use `window.URL` to parse the incoming url but it requires a `baseUrl` so instead I used regex to split out anything after `?` or `#`.

This code will see a lot of traffic though so `substr` or `indexOf` might be more performant?