### PR TITLE
fix: pin eslint version for CI

### DIFF
--- a/.ci/template.linux.yml
+++ b/.ci/template.linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - bash: npm install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm install eslint@5.16.0 typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - template: ./template.unix.yml
   - bash: npx eslint **/*.ts --max-warnings=0
   - template: ./template.common.yml

--- a/.ci/template.linux.yml
+++ b/.ci/template.linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - bash: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - template: ./template.unix.yml
   - bash: npx eslint **/*.ts --max-warnings=0
   - template: ./template.common.yml

--- a/.ci/template.mac.yml
+++ b/.ci/template.mac.yml
@@ -1,6 +1,6 @@
 steps:
   - bash: npm install -g functional-red-black-tree
-  - bash: npm -g install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm -g install eslint@5.16.0 typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - template: ./template.unix.yml
   - bash: eslint **/*.ts --max-warnings=0
   - template: ./template.common.yml

--- a/.ci/template.mac.yml
+++ b/.ci/template.mac.yml
@@ -1,6 +1,6 @@
 steps:
   - bash: npm install -g functional-red-black-tree
-  - bash: npm -g install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm -g install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - template: ./template.unix.yml
   - bash: eslint **/*.ts --max-warnings=0
   - template: ./template.common.yml

--- a/.ci/template.windows.yml
+++ b/.ci/template.windows.yml
@@ -1,5 +1,5 @@
 steps:
-  - bash: npm install eslint typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - powershell: iwr https://deno.land/x/install/install.ps1 -out install.ps1; .\install.ps1 $(DENO_VERSION)
   - bash: echo "##vso[task.prependpath]C:\Users\VssAdministrator\.deno\\bin"
   - bash: npx eslint **/*.ts --max-warnings=0

--- a/.ci/template.windows.yml
+++ b/.ci/template.windows.yml
@@ -1,5 +1,5 @@
 steps:
-  - bash: npm install eslint typescript@$(TS_VERSION) eslint@5.16.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
+  - bash: npm install eslint@5.16.0 typescript@$(TS_VERSION) @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier
   - powershell: iwr https://deno.land/x/install/install.ps1 -out install.ps1; .\install.ps1 $(DENO_VERSION)
   - bash: echo "##vso[task.prependpath]C:\Users\VssAdministrator\.deno\\bin"
   - bash: npx eslint **/*.ts --max-warnings=0


### PR DESCRIPTION
CI broke today, seems like problem is in unpinned version of eslint, [reference](https://github.com/typescript-eslint/typescript-eslint/issues/637)

This PR temporarly pins version of ESlint