### PR TITLE
Make shebangs Linux compatible

### DIFF
--- a/examples/catj.ts
+++ b/examples/catj.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno --allow-read
+#!/usr/bin/env -S deno --allow-read
 // Ported from: https://github.com/soheilpro/catj
 // Copyright (c) 2014 Soheil Rashidi
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.

--- a/examples/gist.ts
+++ b/examples/gist.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno --allow-net --allow-env
+#!/usr/bin/env -S deno --allow-net --allow-env
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 const { args, env, exit, readFile } = Deno;

--- a/format.ts
+++ b/format.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --allow-run --allow-write --allow-read
+#!/usr/bin/env -S deno run --allow-run --allow-write --allow-read
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { exit, args, execPath } = Deno;
 import { parse } from "./flags/mod.ts";

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno --allow-net
+#!/usr/bin/env -S deno --allow-net
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 
 // This program serves files in the current directory over HTTP.

--- a/installer/mod.ts
+++ b/installer/mod.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno --allow-all
+#!/usr/bin/env -S deno --allow-all
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 const { env, stdin, args, exit, writeFile, chmod, run } = Deno;
 import { parse } from "../flags/mod.ts";
@@ -24,7 +24,7 @@ ARGS:
   SCRIPT_URL  Local or remote URL of script to install
   [FLAGS...]  List of flags for script, both Deno permission and script specific
               flag can be used.
-              
+
 OPTIONS:
   -d, --dir <PATH> Installation directory path (defaults to ~/.deno/bin)
 `);

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno --allow-run --allow-write
+#!/usr/bin/env -S deno --allow-run --allow-write
 /**
  * Copyright © James Long and contributors
  *

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run -A
+#!/usr/bin/env -S deno run -A
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import "./archive/tar_test.ts";
 import "./bytes/test.ts";

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -6,7 +6,7 @@ import {
   assertStrictEq,
   assertThrows,
   assertThrowsAsync
-} from "../testing/asserts.ts";
+} from "./asserts.ts";
 import "./format_test.ts";
 import "./diff_test.ts";
 import "./pretty_test.ts";

--- a/uuid/test.ts
+++ b/uuid/test.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run
+#!/usr/bin/env -S deno run
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { runIfMain } from "../testing/mod.ts";
 


### PR DESCRIPTION
Fixes #544

This makes the shebangs work with GNU coreutils 8.30+ where /usr/bin/env supports the '-S' option.

It should still work with macOS based on the manual pages I've read but can I get verification on this?