### PR TITLE
Ignore error of writing responses to aborted requests

### DIFF
--- a/http/racing_server.ts
+++ b/http/racing_server.ts
@@ -1,15 +1,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { serve, ServerRequest } from "./server.ts";
+import { sleep } from "./util.ts";
 
 const addr = Deno.args[1] || "127.0.0.1:4501";
 const server = serve(addr);
 
 const body = new TextEncoder().encode("Hello 1\n");
 const body4 = new TextEncoder().encode("World 4\n");
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((res): number => setTimeout(res, ms));
-}
 
 async function delayedRespond(request: ServerRequest): Promise<void> {
   await sleep(3000);

--- a/http/racing_server.ts
+++ b/http/racing_server.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { serve, ServerRequest } from "./server.ts";
-import { sleep } from "./util.ts";
+import { delay } from "../util/async.ts";
 
 const addr = Deno.args[1] || "127.0.0.1:4501";
 const server = serve(addr);
@@ -9,7 +9,7 @@ const body = new TextEncoder().encode("Hello 1\n");
 const body4 = new TextEncoder().encode("World 4\n");
 
 async function delayedRespond(request: ServerRequest): Promise<void> {
-  await sleep(3000);
+  await delay(3000);
   await request.respond({ status: 200, body });
 }
 

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -11,7 +11,7 @@ async function startServer(): Promise<void> {
     args: ["deno", "run", "-A", "http/racing_server.ts"],
     stdout: "piped"
   });
-  // Once fileServer is ready it will write to its stdout.
+  // Once racing server is ready it will write to its stdout.
   const r = new TextProtoReader(new BufReader(server.stdout!));
   const s = await r.readLine();
   assert(s !== Deno.EOF && s.includes("Racing server listening..."));

--- a/http/server.ts
+++ b/http/server.ts
@@ -342,10 +342,15 @@ export class Server implements AsyncIterable<ServerRequest> {
       // The connection was gracefully closed.
     } else if (err) {
       // An error was thrown while parsing request headers.
-      await writeResponse(req!.w, {
-        status: 400,
-        body: new TextEncoder().encode(`${err.message}\r\n\r\n`)
-      });
+      try {
+        await writeResponse(req!.w, {
+          status: 400,
+          body: new TextEncoder().encode(`${err.message}\r\n\r\n`)
+        });
+      } catch (_) {
+        // The connection is destroyed.
+        // Ignores the error.
+      }
     } else if (this.closing) {
       // There are more requests incoming but the server is closing.
       // TODO(ry): send a back a HTTP 503 Service Unavailable status.

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -496,7 +496,7 @@ test({
       assert(serverIsRunning);
     } finally {
       // Stops the sever.
-      p.kill(2); // SIGINT
+      p.kill(Deno.Signal.SIGINT);
     }
   }
 });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -6,6 +6,7 @@
 // https://github.com/golang/go/blob/master/src/net/http/responsewrite_test.go
 
 const { Buffer } = Deno;
+import { TextProtoReader } from "../textproto/mod.ts";
 import { test, runIfMain } from "../testing/mod.ts";
 import { assert, assertEquals, assertNotEquals } from "../testing/asserts.ts";
 import {
@@ -15,6 +16,7 @@ import {
   readRequest,
   parseHTTPVersion
 } from "./server.ts";
+import { sleep } from "./util.ts";
 import {
   BufReader,
   BufWriter,
@@ -452,6 +454,49 @@ test({
         assertEquals(err, undefined);
         assertEquals(r, t.want, t.in);
       }
+    }
+  }
+});
+
+test({
+  name: "[http] destroyed connection",
+  async fn(): Promise<void> {
+    // TODO: don't skip on windows when process.kill is implemented on windows.
+    if (Deno.build.os === "win") {
+      return;
+    }
+    // Runs a simple server as another process
+    const p = Deno.run({
+      args: [Deno.execPath, "http/testdata/simple_server.ts", "--allow-net"],
+      stdout: "piped"
+    });
+
+    try {
+      const r = new TextProtoReader(new BufReader(p.stdout!));
+      const s = await r.readLine();
+      assert(s !== Deno.EOF && s.includes("server listening"));
+
+      let serverIsRunning = true;
+      p.status().then(
+        (): void => {
+          serverIsRunning = false;
+        }
+      );
+
+      await sleep(100);
+
+      // Reqeusts to the server and immediately closes the connection
+      const conn = await Deno.dial("tcp", "127.0.0.1:4502");
+      await conn.write(new TextEncoder().encode("GET / HTTP/1.0\n\n"));
+      conn.close();
+
+      // Waits for the server to handle the above (broken) request
+      await sleep(100);
+
+      assert(serverIsRunning);
+    } finally {
+      // Stops the sever.
+      p.kill(2); // SIGINT
     }
   }
 });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -16,7 +16,7 @@ import {
   readRequest,
   parseHTTPVersion
 } from "./server.ts";
-import { sleep } from "./util.ts";
+import { delay } from "../util/async.ts";
 import {
   BufReader,
   BufWriter,
@@ -483,7 +483,7 @@ test({
         }
       );
 
-      await sleep(100);
+      await delay(100);
 
       // Reqeusts to the server and immediately closes the connection
       const conn = await Deno.dial("tcp", "127.0.0.1:4502");
@@ -491,7 +491,7 @@ test({
       conn.close();
 
       // Waits for the server to handle the above (broken) request
-      await sleep(100);
+      await delay(100);
 
       assert(serverIsRunning);
     } finally {

--- a/http/testdata/simple_server.ts
+++ b/http/testdata/simple_server.ts
@@ -1,0 +1,9 @@
+import { serve } from "../server.ts";
+
+window.onload = async function main() {
+  const addr = "0.0.0.0:4502";
+  console.log(`Simple server listening on ${addr}`);
+  for await (let req of serve(addr)) {
+    req.respond({});
+  }
+}

--- a/http/testdata/simple_server.ts
+++ b/http/testdata/simple_server.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// This is an example of a server that responds with an empty body
 import { serve } from "../server.ts";
 
 window.onload = async function main() {

--- a/http/util.ts
+++ b/http/util.ts
@@ -1,0 +1,9 @@
+// Sleeps the given milliseconds and resolves.
+export function sleep(ms: number): Promise<void> {
+  return new Promise(
+    (res): number =>
+      setTimeout((): void => {
+        res();
+      }, ms)
+  );
+}

--- a/http/util.ts
+++ b/http/util.ts
@@ -1,9 +1,0 @@
-// Sleeps the given milliseconds and resolves.
-export function sleep(ms: number): Promise<void> {
-  return new Promise(
-    (res): number =>
-      setTimeout((): void => {
-        res();
-      }, ms)
-  );
-}

--- a/util/async.ts
+++ b/util/async.ts
@@ -108,3 +108,13 @@ export async function collectUint8Arrays(
   }
   return collected;
 }
+
+// Delays the given milliseconds and resolves.
+export function delay(ms: number): Promise<void> {
+  return new Promise(
+    (res): number =>
+      setTimeout((): void => {
+        res();
+      }, ms)
+  );
+}


### PR DESCRIPTION
This PR fixes the case described in #442. The test case reproduces the case given by @MarkTiedemann in the comment ( https://github.com/denoland/deno_std/issues/442#issuecomment-495557424 ).

This change simply ignore the error when the writing failed.

I believe the corresponding part of go's std library is [here](https://github.com/golang/go/blob/1962dc88eb89cd37d3f9f85e8e4b7ad4915db089/src/net/http/server.go#L1858).
```go
fmt.Fprintf(c.rwc, "HTTP/1.1 "+publicErr+errorHeaders+publicErr)
```
This doesn't handle the error returned by `fmt.Fprintf`. So this patch follows the above.

closes #442 