### PR TITLE
Use Deno.execPath where possible

### DIFF
--- a/examples/test.ts
+++ b/examples/test.ts
@@ -15,7 +15,13 @@ test(function t2(): void {
 /** A more complicated test that runs a subprocess. */
 test(async function catSmoke(): Promise<void> {
   const p = run({
-    args: ["deno", "run", "--allow-read", "examples/cat.ts", "README.md"],
+    args: [
+      Deno.execPath,
+      "run",
+      "--allow-read",
+      "examples/cat.ts",
+      "README.md"
+    ],
     stdout: "piped"
   });
   const s = await p.status();

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -11,7 +11,7 @@ let fileServer: Deno.Process;
 async function startFileServer(): Promise<void> {
   fileServer = run({
     args: [
-      "deno",
+      Deno.execPath,
       "run",
       "--allow-read",
       "--allow-net",

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -8,7 +8,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 let server: Deno.Process;
 async function startServer(): Promise<void> {
   server = run({
-    args: ["deno", "run", "-A", "http/racing_server.ts"],
+    args: [Deno.execPath, "run", "-A", "http/racing_server.ts"],
     stdout: "piped"
   });
   // Once racing server is ready it will write to its stdout.

--- a/installer/mod.ts
+++ b/installer/mod.ts
@@ -227,7 +227,7 @@ export async function install(
 
   // ensure script that is being installed exists
   const ps = run({
-    args: ["deno", "fetch", "--reload", moduleUrl],
+    args: [Deno.execPath, "fetch", "--reload", moduleUrl],
     stdout: "inherit",
     stderr: "inherit"
   });

--- a/installer/test.ts
+++ b/installer/test.ts
@@ -16,7 +16,7 @@ const isWindows = Deno.platform.os === "win";
 async function startFileServer(): Promise<void> {
   fileServer = run({
     args: [
-      "deno",
+      Deno.execPath,
       "run",
       "--allow-read",
       "--allow-net",


### PR DESCRIPTION
This is convenient when you want to test deno_std with a special build of deno.