### PR TITLE
print out the failed tests after the summary

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -171,9 +171,7 @@ function printFailedSummary(results: TestResults): void {
     (v): void => {
       if (!v.ok) {
         console.error(`${RED_BG_FAIL} ${red(v.name)}`);
-        if (Deno.args.includes("--verbose")) {
-          console.error(v.error);
-        }
+        console.error(v.error);
       }
     }
   );

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -104,8 +104,6 @@ const RED_FAILED = red("FAILED");
 const GREEN_OK = green("OK");
 const RED_BG_FAIL = bgRed(" FAIL ");
 
-const VERBOSE = true;
-
 interface TestStats {
   filtered: number;
   ignored: number;
@@ -168,12 +166,12 @@ function report(result: TestResult): void {
   result.printed = true;
 }
 
-function printFailedSummary(results: TestResults, verbose: boolean): void {
+function printFailedSummary(results: TestResults): void {
   results.cases.forEach(
     (v): void => {
       if (!v.ok) {
         console.error(`${RED_BG_FAIL} ${red(v.name)}`);
-        if (verbose) {
+        if (Deno.args.includes("--verbose")) {
           console.error(v.error);
         }
       }
@@ -375,7 +373,7 @@ export async function runTests({
     // promise rejections being swallowed.
     setTimeout((): void => {
       console.error(`There were ${stats.failed} test failures.`);
-      printFailedSummary(results, VERBOSE);
+      printFailedSummary(results);
       Deno.exit(1);
     }, 0);
   }

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -346,8 +346,10 @@ export async function runTests({
     // promise rejections being swallowed.
     setTimeout((): void => {
       console.error(`There were ${stats.failed} test failures.`);
-      failedTests.forEach(failedTest =>
-        console.error(`${RED_BG_FAIL} ${red(failedTest)}`)
+      failedTests.forEach(
+        (failedTest): void => {
+          console.error(`${RED_BG_FAIL} ${red(failedTest)}`);
+        }
       );
       Deno.exit(1);
     }, 0);

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -287,7 +287,8 @@ async function runTestsSerial(
         break;
       }
     }
-  } return failed;
+  }
+  return failed;
 }
 
 /** Defines options for controlling execution details of a test suite. */
@@ -345,7 +346,9 @@ export async function runTests({
     // promise rejections being swallowed.
     setTimeout((): void => {
       console.error(`There were ${stats.failed} test failures.`);
-      failedTests.forEach(failedTest => console.error(`${RED_BG_FAIL} ${red(failedTest)}`));
+      failedTests.forEach(failedTest =>
+        console.error(`${RED_BG_FAIL} ${red(failedTest)}`)
+      );
       Deno.exit(1);
     }, 0);
   }


### PR DESCRIPTION
We have 575 tests and it is a problem to scroll up the terminal to see which tests failed.
So I added a summary of all the failed tests down under with a red label next to them.

These changes will only affect cases when we have failed tests (If all tests pass, it will look like before.) 

Also some refactoring to use existing `TestResult` model and populate it with the test results. We only initialized it before when going Serial testing and could not extract the details from each test afterwards.

proposed look :
![deno-test-runner2](https://user-images.githubusercontent.com/32613393/62791171-ee8fb180-bacc-11e9-8391-490dd58d3d7c.png)
