### PR TITLE
Bump deno version to 0.14.0 and update execPath usages

### DIFF
--- a/.ci/template.common.yml
+++ b/.ci/template.common.yml
@@ -2,5 +2,5 @@ parameters:
   exe_suffix: ""
 
 steps:
-  - bash: deno${{ parameters.exe_suffix }} run --allow-run --allow-write --allow-read format.ts --check
+  - bash: deno${{ parameters.exe_suffix }} run --allow-run --allow-write --allow-read --allow-env format.ts --check
   - bash: deno${{ parameters.exe_suffix }} run --allow-run --allow-net --allow-write --allow-read --allow-env --config=tsconfig.test.json test.ts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DENO_VERSION: "v0.12.0"
+  DENO_VERSION: "v0.14.0"
   TS_VERSION: "3.4.5"
 
 # TODO Try to get eslint to run under Deno, like prettier

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -16,7 +16,7 @@ test(function t2(): void {
 test(async function catSmoke(): Promise<void> {
   const p = run({
     args: [
-      Deno.execPath,
+      Deno.execPath(),
       "run",
       "--allow-read",
       "examples/cat.ts",

--- a/format.ts
+++ b/format.ts
@@ -6,7 +6,7 @@ import { xrun } from "./prettier/util.ts";
 
 async function main(opts): Promise<void> {
   const args = [
-    execPath,
+    execPath(),
     "run",
     "--allow-write",
     "--allow-read",

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -11,7 +11,7 @@ let fileServer: Deno.Process;
 async function startFileServer(): Promise<void> {
   fileServer = run({
     args: [
-      Deno.execPath,
+      Deno.execPath(),
       "run",
       "--allow-read",
       "--allow-net",

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -8,7 +8,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 let server: Deno.Process;
 async function startServer(): Promise<void> {
   server = run({
-    args: [Deno.execPath, "run", "-A", "http/racing_server.ts"],
+    args: [Deno.execPath(), "run", "-A", "http/racing_server.ts"],
     stdout: "piped"
   });
   // Once racing server is ready it will write to its stdout.

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -493,7 +493,7 @@ test({
   async fn(): Promise<void> {
     // Runs a simple server as another process
     const p = Deno.run({
-      args: [Deno.execPath, "http/testdata/simple_server.ts", "--allow-net"],
+      args: [Deno.execPath(), "http/testdata/simple_server.ts", "--allow-net"],
       stdout: "piped"
     });
 

--- a/installer/mod.ts
+++ b/installer/mod.ts
@@ -227,7 +227,7 @@ export async function install(
 
   // ensure script that is being installed exists
   const ps = run({
-    args: [Deno.execPath, "fetch", "--reload", moduleUrl],
+    args: [Deno.execPath(), "fetch", "--reload", moduleUrl],
     stdout: "inherit",
     stderr: "inherit"
   });

--- a/installer/test.ts
+++ b/installer/test.ts
@@ -16,7 +16,7 @@ const isWindows = Deno.platform.os === "win";
 async function startFileServer(): Promise<void> {
   fileServer = run({
     args: [
-      Deno.execPath,
+      Deno.execPath(),
       "run",
       "--allow-read",
       "--allow-net",

--- a/prettier/main_test.ts
+++ b/prettier/main_test.ts
@@ -21,7 +21,7 @@ async function run(
 }
 
 const cmd = [
-  execPath,
+  execPath(),
   "run",
   "--allow-run",
   "--allow-write",
@@ -254,13 +254,13 @@ test(async function testPrettierReadFromStdin(): Promise<void> {
   ): Promise<void> {
     const inputCode = stdin;
     const p1 = Deno.run({
-      args: [execPath, "./prettier/testdata/echox.ts", `${inputCode}`],
+      args: [execPath(), "./prettier/testdata/echox.ts", `${inputCode}`],
       stdout: "piped"
     });
 
     const p2 = Deno.run({
       args: [
-        execPath,
+        execPath(),
         "run",
         "./prettier/main.ts",
         "--stdin",


### PR DESCRIPTION
`execPath` is now a function and requires `--allow-env`