### PR TITLE
fix: add file:// prefix for imports in test runner

### DIFF
--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -113,7 +113,7 @@ export async function main(root: string = cwd()): Promise<void> {
   console.log(`Found ${foundTestFiles.length} matching test files.`);
 
   for (const filename of foundTestFiles) {
-    await import(filename);
+    await import(`file://${filename}`);
   }
 
   await runTests({


### PR DESCRIPTION
Otherwise test runner is not working properly when requested from remote server:
```
// run in root of deno_std repo
$ deno -A https://deno.land/std/testing/runner.ts 
Download https://deno.land/Users/biwanczuk/dev/deno_std/strings/pad_test.ts
error: Uncaught TypeError: Import 'https://deno.land/Users/biwanczuk/dev/deno_std/strings/pad_test.ts' failed: 404 Not Found
```

It's caused because `base` for specifier is a remote script (`https://deno.land/std/testing/runner.ts`) and found test files are absolute paths (`/Users/biwanczuk/dev/deno_std/strings/pad_test.ts`).

I explicitly added `file://` prefix to import, that should resolve the problem.