### PR TITLE
fix: add global test registry

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -69,8 +69,19 @@ function print(txt: string, newline: boolean = true): void {
   Deno.stdout.writeSync(encoder.encode(`${txt}`));
 }
 
+declare global {
+  interface Window {
+    __DENO_TEST_REGISTRY: TestDefinition[];
+  }
+}
+
+let candidates: TestDefinition[] = [];
+if (window["__DENO_TEST_REGISTRY"]) {
+  candidates = window.__DENO_TEST_REGISTRY as TestDefinition[];
+} else {
+  window["__DENO_TEST_REGISTRY"] = candidates;
+}
 let filterRegExp: RegExp | null;
-const candidates: TestDefinition[] = [];
 let filtered = 0;
 
 // Must be called before any test() that needs to be filtered.

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -71,6 +71,16 @@ function print(txt: string, newline: boolean = true): void {
 
 declare global {
   interface Window {
+    /**
+     * A global property to collect all registered test cases.
+     *
+     * It is required because user's code can import multiple versions
+     * of `testing` module.
+     *
+     * If test cases aren't registered in a globally shared
+     * object, then imports from different versions would register test cases
+     * to registry from it's respective version of `testing` module.
+     */
     __DENO_TEST_REGISTRY: TestDefinition[];
   }
 }


### PR DESCRIPTION
After adding `deno test` command a new problem appeared.

If you try running `deno test` inside this repo test runner will find 80 test files but won't run any tests! This is caused by fact that `deno test` uses tagged version of standard library which causes `test` function available inside to repo to be different function that `test` available in standard lib used by `deno test`.

```
~/src/deno_std> deno test -A
Found 79 matching test files.
Hello world!
running 0 tests

test result: OK. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (0.34ms)
```

A simple fix appears to be to add a global registry of all tests. It causes to register every test (even using `test` function from different version of standard lib) in the same global array that can be picked up by test runner.

That's just first iteration and we'll probably arrive at better solution before landing this PR.

CC @ry