### PR TITLE
Make uuid v4 rfc4122 compliant

### DIFF
--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -10,10 +10,24 @@ export function validate(id: string): boolean {
 }
 
 export default function generate(): string {
-  return "00000000-0000-4000-8000-000000000000".replace(
-    /[0]/g,
-    (): string =>
-      // random integer from 0 to 15 as a hex digit.
-      (crypto.getRandomValues(new Uint8Array(1))[0] % 16).toString(16)
-  );
+  const rnds = crypto.getRandomValues(new Uint8Array(16));
+
+  rnds[6] = (rnds[6] & 0x0f) | 0x40; // Version 4
+  rnds[8] = (rnds[8] & 0x3f) | 0x80; // Variant 10
+
+  const bits = [...rnds].map(bit => {
+    const s = bit.toString(16);
+    return bit < 0x10 ? "0" + s : s;
+  });
+  return [
+    ...bits.slice(0, 4),
+    "-",
+    ...bits.slice(4, 6),
+    "-",
+    ...bits.slice(6, 8),
+    "-",
+    ...bits.slice(8, 10),
+    "-",
+    ...bits.slice(10)
+  ].join("");
 }

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -15,10 +15,12 @@ export default function generate(): string {
   rnds[6] = (rnds[6] & 0x0f) | 0x40; // Version 4
   rnds[8] = (rnds[8] & 0x3f) | 0x80; // Variant 10
 
-  const bits: string[] = [...rnds].map((bit): string => {
-    const s: string = bit.toString(16);
-    return bit < 0x10 ? "0" + s : s;
-  });
+  const bits: string[] = [...rnds].map(
+    (bit): string => {
+      const s: string = bit.toString(16);
+      return bit < 0x10 ? "0" + s : s;
+    }
+  );
   return [
     ...bits.slice(0, 4),
     "-",

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -15,8 +15,8 @@ export default function generate(): string {
   rnds[6] = (rnds[6] & 0x0f) | 0x40; // Version 4
   rnds[8] = (rnds[8] & 0x3f) | 0x80; // Variant 10
 
-  const bits = [...rnds].map(bit => {
-    const s = bit.toString(16);
+  const bits: string[] = [...rnds].map((bit): string => {
+    const s: string = bit.toString(16);
     return bit < 0x10 ? "0" + s : s;
   });
   return [


### PR DESCRIPTION
UUID v4 is not currently RFC4122 compliant, the `8` is hard-coded

https://github.com/denoland/deno_std/blob/d36bff3fbe22a3585d23213e3f4c9f58756c032b/uuid/v4.ts#L13

Loosely based of https://github.com/google/uuid/blob/master/uuid.go

Went with the cleanest approach to convert Uint8Array to string, I could unwrap looping since the array contains 16 elements, if needed.
Let me know if any changes are required I'll make them.

Related to and fixes #559