### PR TITLE
Replace Deno.platform usages

### DIFF
--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -16,7 +16,7 @@ import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 const testdataDir = path.resolve("fs", "testdata");
 
 // TODO(axetroy): Add test for Windows once symlink is implemented for Windows.
-const isWindows = Deno.platform.os === "win";
+const isWindows = Deno.build.os === "win";
 
 async function testCopy(
   name: string,

--- a/fs/ensure_symlink_test.ts
+++ b/fs/ensure_symlink_test.ts
@@ -10,7 +10,7 @@ import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 import * as path from "./path/mod.ts";
 
 const testdataDir = path.resolve("fs", "testdata");
-const isWindows = Deno.platform.os === "win";
+const isWindows = Deno.build.os === "win";
 
 test(async function ensureSymlinkIfItNotExist(): Promise<void> {
   const testDir = path.join(testdataDir, "link_file_1");

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -61,9 +61,9 @@ test(async function serveDirectory(): Promise<void> {
     // `Deno.FileInfo` is not completely compatible with Windows yet
     // TODO: `mode` should work correctly in the future.
     // Correct this test case accordingly.
-    Deno.platform.os !== "win" &&
+    Deno.build.os !== "win" &&
       assert(/<td class="mode">\([a-zA-Z-]{10}\)<\/td>/.test(page));
-    Deno.platform.os === "win" &&
+    Deno.build.os === "win" &&
       assert(/<td class="mode">\(unknown mode\)<\/td>/.test(page));
     assert(
       page.includes(

--- a/installer/mod.ts
+++ b/installer/mod.ts
@@ -10,7 +10,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder("utf-8");
 // Regular expression to test disk driver letter. eg "C:\\User\username\path\to"
 const driverLetterReg = /^[c-z]:/i;
-const isWindows = Deno.platform.os === "win";
+const isWindows = Deno.build.os === "win";
 
 function showHelp(): void {
   console.log(`deno installer

--- a/installer/test.ts
+++ b/installer/test.ts
@@ -10,7 +10,7 @@ import * as fs from "../fs/mod.ts";
 import { install, isRemoteUrl } from "./mod.ts";
 
 let fileServer: Deno.Process;
-const isWindows = Deno.platform.os === "win";
+const isWindows = Deno.build.os === "win";
 
 // copied from `http/file_server_test.ts`
 async function startFileServer(): Promise<void> {


### PR DESCRIPTION
Deno.platform was deprecated and it was reorganized into Deno.build at https://github.com/denoland/deno/pull/1879 . This PR replaces Deno.platform usages with Deno.build.