### PR TITLE
Changed tests for HTTP versions to a Regex

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -229,8 +229,7 @@ function fixLength(req: ServerRequest): void {
 }
 
 // ParseHTTPVersion parses a HTTP version string.
-// "HTTP/1.0" returns (1, 0, true).
-// Ported from https://github.com/golang/go/blob/f5c43b9/src/net/http/request.go#L766-L792
+// "HTTP/1.0" returns (1, 0).
 export function parseHTTPVersion(vers: string): [number, number] {
   const httpReg = /^HTTP\/([0-9])\.([0-9])$/gm;
   const match = httpReg.exec(vers);

--- a/http/server.ts
+++ b/http/server.ts
@@ -231,7 +231,7 @@ function fixLength(req: ServerRequest): void {
 // ParseHTTPVersion parses a HTTP version string.
 // "HTTP/1.0" returns (1, 0).
 export function parseHTTPVersion(vers: string): [number, number] {
-  const httpReg = /^HTTP\/([0-9]{0,2})\.([0-9]{0,2})$/gm;
+  const httpReg = /^HTTP\/([0-9]+)\.([0-9]+)$/gm;
   const match = httpReg.exec(vers);
 
   if (match == null) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -232,55 +232,23 @@ function fixLength(req: ServerRequest): void {
 // "HTTP/1.0" returns (1, 0, true).
 // Ported from https://github.com/golang/go/blob/f5c43b9/src/net/http/request.go#L766-L792
 export function parseHTTPVersion(vers: string): [number, number] {
-  switch (vers) {
-    case "HTTP/1.1":
-      return [1, 1];
+  const httpReg = /^HTTP\/[0-9]\.[0-9]$/gm; // test if string is formatted as an HTTP version
+  let major: number;
+  let minor: number;
 
-    case "HTTP/1.0":
-      return [1, 0];
-
-    default: {
-      const Big = 1000000; // arbitrary upper bound
-      const digitReg = /^\d+$/; // test if string is only digit
-      let major: number;
-      let minor: number;
-
-      if (!vers.startsWith("HTTP/")) {
-        break;
-      }
-
-      const dot = vers.indexOf(".");
-      if (dot < 0) {
-        break;
-      }
-
-      let majorStr = vers.substring(vers.indexOf("/") + 1, dot);
-      major = parseInt(majorStr);
-      if (
-        !digitReg.test(majorStr) ||
-        isNaN(major) ||
-        major < 0 ||
-        major > Big
-      ) {
-        break;
-      }
-
-      let minorStr = vers.substring(dot + 1);
-      minor = parseInt(minorStr);
-      if (
-        !digitReg.test(minorStr) ||
-        isNaN(minor) ||
-        minor < 0 ||
-        minor > Big
-      ) {
-        break;
-      }
-
-      return [major, minor];
-    }
+  if (!httpReg.test(vers)) {
+    throw new Error(`malformed HTTP version ${vers}`);
   }
 
-  throw new Error(`malformed HTTP version ${vers}`);
+  const dot = vers.indexOf(".");
+
+  let majorStr = vers.substring(vers.indexOf("/") + 1, dot);
+  let minorStr = vers.substring(dot + 1);
+
+  major = parseInt(majorStr);
+  minor = parseInt(minorStr);
+
+  return [major, minor];
 }
 
 export async function readRequest(

--- a/http/server.ts
+++ b/http/server.ts
@@ -243,8 +243,8 @@ export function parseHTTPVersion(vers: string): [number, number] {
   const major = parseInt(majorStr);
   const minor = parseInt(minorStr);
   
-  /* Keep this condition unti we know
-    why golang is using this upper bound value. */
+  // Keep this condition unti we know
+  // why golang is using this upper bound value.
   if (major > 1000000 || minor > 1000000) {
     throw new Error(`malformed HTTP version ${vers}`);
   }

--- a/http/server.ts
+++ b/http/server.ts
@@ -231,7 +231,7 @@ function fixLength(req: ServerRequest): void {
 // ParseHTTPVersion parses a HTTP version string.
 // "HTTP/1.0" returns (1, 0).
 export function parseHTTPVersion(vers: string): [number, number] {
-  const httpReg = /^HTTP\/([0-9])\.([0-9])$/gm;
+  const httpReg = /^HTTP\/([0-9]{0,2})\.([0-9]{0,2})$/gm;
   const match = httpReg.exec(vers);
 
   if (match == null) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -232,21 +232,17 @@ function fixLength(req: ServerRequest): void {
 // "HTTP/1.0" returns (1, 0, true).
 // Ported from https://github.com/golang/go/blob/f5c43b9/src/net/http/request.go#L766-L792
 export function parseHTTPVersion(vers: string): [number, number] {
-  const httpReg = /^HTTP\/[0-9]\.[0-9]$/gm; // test if string is formatted as an HTTP version
-  let major: number;
-  let minor: number;
+  const httpReg = /^HTTP\/([0-9])\.([0-9])$/gm;
+  const match = httpReg.exec(vers);
 
-  if (!httpReg.test(vers)) {
+  if (match == null) {
     throw new Error(`malformed HTTP version ${vers}`);
   }
 
-  const dot = vers.indexOf(".");
+  const [, majorStr, minorStr] = match;
 
-  let majorStr = vers.substring(vers.indexOf("/") + 1, dot);
-  let minorStr = vers.substring(dot + 1);
-
-  major = parseInt(majorStr);
-  minor = parseInt(minorStr);
+  const major = parseInt(majorStr);
+  const minor = parseInt(minorStr);
 
   return [major, minor];
 }

--- a/http/server.ts
+++ b/http/server.ts
@@ -242,6 +242,12 @@ export function parseHTTPVersion(vers: string): [number, number] {
 
   const major = parseInt(majorStr);
   const minor = parseInt(minorStr);
+  
+  /* Keep this condition unti we know
+    why golang is using this upper bound value. */
+  if (major > 1000000 || minor > 1000000) {
+    throw new Error(`malformed HTTP version ${vers}`);
+  }
 
   return [major, minor];
 }

--- a/http/server.ts
+++ b/http/server.ts
@@ -242,9 +242,7 @@ export function parseHTTPVersion(vers: string): [number, number] {
 
   const major = parseInt(majorStr);
   const minor = parseInt(minorStr);
-  
-  // Keep this condition unti we know
-  // why golang is using this upper bound value.
+
   if (major > 1000000 || minor > 1000000) {
     throw new Error(`malformed HTTP version ${vers}`);
   }


### PR DESCRIPTION
I removed the `switch` and conditions there was inside of the `default` to one unique condition using regexp to test if `vers` is formatted as an http version. 