### PR TITLE
Fix "deno test" on windows

### DIFF
--- a/.ci/check_source_file_changes.ts
+++ b/.ci/check_source_file_changes.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { xrun } from "../prettier/util.ts";
 import { red, green } from "../fmt/colors.ts";
-import { EOL } from "../fs/path/constants.ts";
 
 /**
  * Checks whether any source file is changed since the given start time.

--- a/.ci/check_source_file_changes.ts
+++ b/.ci/check_source_file_changes.ts
@@ -12,7 +12,7 @@ async function main(startTime: number): Promise<void> {
   const changed = new TextDecoder()
     .decode(await xrun({ args: ["git", "ls-files"], stdout: "piped" }).output())
     .trim()
-    .split(EOL)
+    .split("\n")
     .filter(file => {
       const stat = Deno.lstatSync(file);
       if (stat != null) {

--- a/.ci/check_source_file_changes.ts
+++ b/.ci/check_source_file_changes.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { xrun } from "../prettier/util.ts";
 import { red, green } from "../fmt/colors.ts";
+import { EOL } from "../fs/path/constants.ts";
 
 /**
  * Checks whether any source file is changed since the given start time.
@@ -11,7 +12,7 @@ async function main(startTime: number): Promise<void> {
   const changed = new TextDecoder()
     .decode(await xrun({ args: ["git", "ls-files"], stdout: "piped" }).output())
     .trim()
-    .split("\n")
+    .split(EOL)
     .filter(file => {
       const stat = Deno.lstatSync(file);
       if (stat != null) {

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -5,12 +5,18 @@ import { glob, isGlob, walk } from "../fs/mod.ts";
 import { runTests } from "./mod.ts";
 const { args, cwd } = Deno;
 
-const DEFAULT_GLOBS = [
+const DEFAULT_GLOBS = Deno.build.os == "win" ? [
+  "**\\*_test.ts",
+  "**\\*_test.js",
+  "**\\test.ts",
+  "**\\test.js"
+] : [
   "**/*_test.ts",
   "**/*_test.js",
   "**/test.ts",
   "**/test.js"
 ];
+
 
 /* eslint-disable max-len */
 function showHelp(): void {

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -3,18 +3,14 @@
 import { parse } from "../flags/mod.ts";
 import { glob, isGlob, walk } from "../fs/mod.ts";
 import { runTests } from "./mod.ts";
+import { join } from "../fs/path/mod.ts";
 const { args, cwd } = Deno;
 
-const DEFAULT_GLOBS = Deno.build.os == "win" ? [
-  "**\\*_test.ts",
-  "**\\*_test.js",
-  "**\\test.ts",
-  "**\\test.js"
-] : [
-  "**/*_test.ts",
-  "**/*_test.js",
-  "**/test.ts",
-  "**/test.js"
+const DEFAULT_GLOBS = [
+  join("**","*_test.ts" ),
+  join("**","*_test.js" ),
+  join("**","test.ts" ),
+  join("**","test.ts" ),
 ];
 
 

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -10,7 +10,7 @@ const DEFAULT_GLOBS = [
   join("**", "*_test.ts"),
   join("**", "*_test.js"),
   join("**", "test.ts"),
-  join("**", "test.ts")
+  join("**", "test.js")
 ];
 
 /* eslint-disable max-len */

--- a/testing/runner_test.ts
+++ b/testing/runner_test.ts
@@ -22,7 +22,7 @@ test(async function getMatchingUrlsRemote(): Promise<void> {
 
 test(async function getMatchingUrlsLocal(): Promise<void> {
   const urls = await getMatchingUrls(
-    ["fmt/*_test.ts"],
+    [join("fmt", "*_test.ts")],
     ["colors*"],
     TEST_ROOT_PATH
   );

--- a/testing/runner_test.ts
+++ b/testing/runner_test.ts
@@ -22,7 +22,7 @@ test(async function getMatchingUrlsRemote(): Promise<void> {
 
 test(async function getMatchingUrlsLocal(): Promise<void> {
   const urls = await getMatchingUrls(
-    [join("fmt", "*_test.ts")],
+    ["*_test.ts"],
     ["colors*"],
     TEST_ROOT_PATH
   );

--- a/xeval/test.ts
+++ b/xeval/test.ts
@@ -1,6 +1,7 @@
 import { xeval } from "./mod.ts";
 import { stringsReader } from "../io/util.ts";
 import { decode, encode } from "../strings/mod.ts";
+import { EOL } from "../fs/path/constants.ts";
 import { assertEquals, assertStrContains } from "../testing/asserts.ts";
 import { test } from "../testing/mod.ts";
 const { execPath, run } = Deno;
@@ -33,7 +34,7 @@ test(async function xevalCliReplvar(): Promise<void> {
   await p.stdin!.write(encode("hello"));
   await p.stdin!.close();
   assertEquals(await p.status(), { code: 0, success: true });
-  assertEquals(decode(await p.output()), "hello\n");
+  assertEquals(decode(await p.output()), "hello"+EOL);
 });
 
 test(async function xevalCliSyntaxError(): Promise<void> {

--- a/xeval/test.ts
+++ b/xeval/test.ts
@@ -34,7 +34,7 @@ test(async function xevalCliReplvar(): Promise<void> {
   await p.stdin!.write(encode("hello"));
   await p.stdin!.close();
   assertEquals(await p.status(), { code: 0, success: true });
-  assertEquals(decode(await p.output()), "hello"+EOL);
+  assertEquals(decode(await p.output()), "hello" + EOL);
 });
 
 test(async function xevalCliSyntaxError(): Promise<void> {


### PR DESCRIPTION
Fixes #593 

Use backslashes on windows for the default matcher globs.

Some tests don't run correctly on windows because they expect `\n` to result in a line break or `/` to be the file separator. These should probably be fixed in different PRs to keep this one simple.