### PR TITLE
feat: [ws] wss support with dialTLS

### DIFF
--- a/ws/test.ts
+++ b/ws/test.ts
@@ -1,9 +1,15 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { BufReader } from "../io/bufio.ts";
-import { assert, assertEquals } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync
+} from "../testing/asserts.ts";
 import { runIfMain, test } from "../testing/mod.ts";
 import {
   acceptable,
+  connectWebSocket,
   createSecAccept,
   OpCode,
   readFrame,
@@ -46,7 +52,6 @@ test(async function wsReadMaskedTextFrame(): Promise<void> {
     )
   );
   const frame = await readFrame(buf);
-  console.dir(frame);
   assertEquals(frame.opcode, OpCode.TextFrame);
   unmask(frame.payload, frame.mask);
   assertEquals(new Buffer(frame.payload).toString(), "Hello");
@@ -190,6 +195,12 @@ test(function wsAcceptableInvalid(): void {
     }),
     false
   );
+});
+
+test("connectWebSocket should throw invalid scheme of url", async () => {
+  await assertThrowsAsync(async () => {
+    await connectWebSocket("file://hoge/hoge");
+  });
 });
 
 test(async function wsWriteReadMaskedFrame(): Promise<void> {

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -1,11 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { BufReader } from "../io/bufio.ts";
-import {
-  assert,
-  assertEquals,
-  assertThrows,
-  assertThrowsAsync
-} from "../testing/asserts.ts";
+import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
 import { runIfMain, test } from "../testing/mod.ts";
 import {
   acceptable,
@@ -197,10 +192,14 @@ test(function wsAcceptableInvalid(): void {
   );
 });
 
-test("connectWebSocket should throw invalid scheme of url", async () => {
-  await assertThrowsAsync(async () => {
-    await connectWebSocket("file://hoge/hoge");
-  });
+test("connectWebSocket should throw invalid scheme of url", async (): Promise<
+  void
+> => {
+  await assertThrowsAsync(
+    async (): Promise<void> => {
+      await connectWebSocket("file://hoge/hoge");
+    }
+  );
 });
 
 test(async function wsWriteReadMaskedFrame(): Promise<void> {


### PR DESCRIPTION
- feat: `wss` support with dialTLS
- fixed: Default port check by url.protocol was not working