### PR TITLE
Implement expandGlob()

### DIFF
--- a/format.ts
+++ b/format.ts
@@ -14,9 +14,9 @@ async function main(opts): Promise<void> {
     "--ignore",
     "node_modules",
     "--ignore",
-    "testdata",
+    "**/testdata",
     "--ignore",
-    "vendor",
+    "**/vendor",
     "--write"
   ];
 

--- a/fs/README.md
+++ b/fs/README.md
@@ -160,7 +160,7 @@ Iterate all files in a directory recursively.
 ```ts
 import { walk, walkSync } from "https://deno.land/std/fs/mod.ts";
 
-for (const fileInfo of walkSync()) {
+for (const fileInfo of walkSync(".")) {
   console.log(fileInfo.filename);
 }
 

--- a/fs/README.md
+++ b/fs/README.md
@@ -100,16 +100,16 @@ exists("./foo"); // returns a Promise<boolean>
 existsSync("./foo"); // returns boolean
 ```
 
-### glob
+### globToRegExp
 
 Generate a regex based on glob pattern and options
 This was meant to be using the the `fs.walk` function
 but can be used anywhere else.
 
 ```ts
-import { glob } from "https://deno.land/std/fs/mod.ts";
+import { globToRegExp } from "https://deno.land/std/fs/mod.ts";
 
-glob("foo/**/*.json", {
+globToRegExp("foo/**/*.json", {
   flags: "g",
   extended: true,
   globstar: true

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -94,12 +94,13 @@ interface SplitPath {
 
 // TODO: Maybe make this public somewhere if it can be fixed for Windows.
 function split(path: string): SplitPath {
+  const s = SEP_PATTERN.source;
   return {
     segments: path
-      .replace(new RegExp(`^${SEP_PATTERN.source}|${SEP_PATTERN.source}$`), "")
+      .replace(new RegExp(`^${s}|${s}$`, "g"), "")
       .split(SEP_PATTERN),
     isAbsolute: isAbsolute(path),
-    hasTrailingSep: !!path.match(new RegExp(`${SEP_PATTERN.source}$`))
+    hasTrailingSep: !!path.match(new RegExp(`${s}$`))
   };
 }
 

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -8,7 +8,6 @@ type FileInfo = Deno.FileInfo;
 export interface GlobOptions {
   extended?: boolean;
   globstar?: boolean;
-  strict?: boolean;
 }
 
 export interface GlobToRegExpOptions extends GlobOptions {
@@ -43,7 +42,7 @@ export function globToRegExp(
   glob: string,
   options: GlobToRegExpOptions = {}
 ): RegExp {
-  const result = globrex(glob, { ...options, filepath: true });
+  const result = globrex(glob, { ...options, strict: false, filepath: true });
   return result.path!.regex;
 }
 
@@ -118,13 +117,12 @@ export async function* expandGlob(
     exclude = [],
     includeDirs = true,
     extended = false,
-    globstar = false,
-    strict = false
+    globstar = false
   }: ExpandGlobOptions = {}
 ): AsyncIterableIterator<WalkInfo> {
   const resolveFromRoot = (path: string): string =>
     isAbsolute(path) ? normalize(path) : join(root, path);
-  const globOptions: GlobOptions = { extended, globstar, strict };
+  const globOptions: GlobOptions = { extended, globstar };
   const excludePatterns = exclude
     .map(resolveFromRoot)
     .map((s: string): RegExp => globToRegExp(s, globOptions));
@@ -213,13 +211,12 @@ export function* expandGlobSync(
     exclude = [],
     includeDirs = true,
     extended = false,
-    globstar = false,
-    strict = false
+    globstar = false
   }: ExpandGlobOptions = {}
 ): IterableIterator<WalkInfo> {
   const resolveFromRoot = (path: string): string =>
     isAbsolute(path) ? normalize(path) : join(root, path);
-  const globOptions: GlobOptions = { extended, globstar, strict };
+  const globOptions: GlobOptions = { extended, globstar };
   const excludePatterns = exclude
     .map(resolveFromRoot)
     .map((s: string): RegExp => globToRegExp(s, globOptions));

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -1,5 +1,5 @@
 import { globrex } from "./globrex.ts";
-import { isWindows } from "./path/constants.ts";
+import { SEP_PATTERN, isWindows } from "./path/constants.ts";
 import { isAbsolute, join, normalize } from "./path/mod.ts";
 import { WalkInfo, walk, walkSync } from "./walk.ts";
 const { cwd, stat, statSync } = Deno;
@@ -85,8 +85,6 @@ export interface ExpandGlobOptions extends GlobOptions {
   exclude?: string[];
   includeDirs?: boolean;
 }
-
-const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;
 
 interface SplitPath {
   segments: string[];

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -213,13 +213,11 @@ export async function* expandGlob(
     } else if (globSegment == "**") {
       return yield* walk(walkInfo.filename, {
         includeFiles: false,
-        includeDirs: true,
         skip: excludePatterns
       });
     }
     yield* walk(walkInfo.filename, {
       maxDepth: 1,
-      includeDirs: true,
       match: [
         globToRegExp(
           joinGlobs([walkInfo.filename, globSegment], globOptions),
@@ -317,13 +315,11 @@ export function* expandGlobSync(
     } else if (globSegment == "**") {
       return yield* walkSync(walkInfo.filename, {
         includeFiles: false,
-        includeDirs: true,
         skip: excludePatterns
       });
     }
     yield* walkSync(walkInfo.filename, {
       maxDepth: 1,
-      includeDirs: true,
       match: [
         globToRegExp(
           joinGlobs([walkInfo.filename, globSegment], globOptions),

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -169,8 +169,13 @@ export async function* expandGlob(
   }: ExpandGlobOptions = {}
 ): AsyncIterableIterator<WalkInfo> {
   const globOptions: GlobOptions = { extended, globstar };
+  const absRoot = isAbsolute(root)
+    ? normalize(root)
+    : joinGlobs([cwd(), root], globOptions);
   const resolveFromRoot = (path: string): string =>
-    isAbsolute(path) ? normalize(path) : joinGlobs([root, path], globOptions);
+    isAbsolute(path)
+      ? normalize(path)
+      : joinGlobs([absRoot, path], globOptions);
   const excludePatterns = exclude
     .map(resolveFromRoot)
     .map((s: string): RegExp => globToRegExp(s, globOptions));
@@ -268,8 +273,13 @@ export function* expandGlobSync(
   }: ExpandGlobOptions = {}
 ): IterableIterator<WalkInfo> {
   const globOptions: GlobOptions = { extended, globstar };
+  const absRoot = isAbsolute(root)
+    ? normalize(root)
+    : joinGlobs([cwd(), root], globOptions);
   const resolveFromRoot = (path: string): string =>
-    isAbsolute(path) ? normalize(path) : joinGlobs([root, path], globOptions);
+    isAbsolute(path)
+      ? normalize(path)
+      : joinGlobs([absRoot, path], globOptions);
   const excludePatterns = exclude
     .map(resolveFromRoot)
     .map((s: string): RegExp => globToRegExp(s, globOptions));

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -111,8 +111,8 @@ export function joinGlobs(
   }
   if (globs.length === 0) return ".";
   let joined: string | undefined;
-  for (let i = 0, len = globs.length; i < len; ++i) {
-    let path = globs[i];
+  for (const glob of globs) {
+    let path = glob;
     if (path.length > 0) {
       if (!joined) joined = path;
       else joined += `${SEP}${path}`;

--- a/fs/glob.ts
+++ b/fs/glob.ts
@@ -109,9 +109,7 @@ export async function* expandGlob(
   const globOptions: GlobOptions = { extended, globstar, strict };
   yield* walk(root, {
     match: [globToRegExp(absGlob, globOptions)],
-    skip: absExclude.map(
-      (s: string): RegExp => globToRegExp(s, { ...globOptions, flags: "g" })
-    ),
+    skip: absExclude.map((s: string): RegExp => globToRegExp(s, globOptions)),
     includeDirs
   });
 }
@@ -136,9 +134,7 @@ export function* expandGlobSync(
   const globOptions: GlobOptions = { extended, globstar, strict };
   yield* walkSync(root, {
     match: [globToRegExp(absGlob, globOptions)],
-    skip: absExclude.map(
-      (s: string): RegExp => globToRegExp(s, { ...globOptions, flags: "g" })
-    ),
+    skip: absExclude.map((s: string): RegExp => globToRegExp(s, globOptions)),
     includeDirs
   });
 }

--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -1,13 +1,15 @@
 const { cwd, mkdir } = Deno;
 import { test, runIfMain } from "../testing/mod.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
-import { isWindows } from "./path/constants.ts";
+import { SEP, isWindows } from "./path/constants.ts";
 import {
   ExpandGlobOptions,
   expandGlob,
+  expandGlobSync,
   globToRegExp,
   isGlob,
-  expandGlobSync
+  joinGlobs,
+  normalizeGlob
 } from "./glob.ts";
 import { join, normalize, relative } from "./path.ts";
 import { testWalk } from "./walk_test.ts";
@@ -256,6 +258,14 @@ test({
     assert(!isGlob("abc/\\(aaa|bbb).js"));
     assert(!isGlob("abc/\\?.js"));
   }
+});
+
+test(function normalizeGlobGlobstar(): void {
+  assertEquals(normalizeGlob(`**${SEP}..`, { globstar: true }), `**${SEP}..`);
+});
+
+test(function joinGlobsGlobstar(): void {
+  assertEquals(joinGlobs(["**", ".."], { globstar: true }), `**${SEP}..`);
 });
 
 async function expandGlobArray(

--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -292,8 +292,7 @@ const EG_OPTIONS: ExpandGlobOptions = {
   root: urlToFilePath(new URL(join("testdata", "glob"), import.meta.url)),
   includeDirs: true,
   extended: false,
-  globstar: false,
-  strict: false
+  globstar: false
 };
 
 test(async function expandGlobWildcard(): Promise<void> {

--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -286,8 +286,8 @@ async function expandGlobArray(
   for (const path of paths) {
     assert(path.startsWith(root));
   }
-  const relativePaths = paths.map((path: string): string =>
-    relative(root, path)
+  const relativePaths = paths.map(
+    (path: string): string => relative(root, path) || "."
   );
   relativePaths.sort();
   return relativePaths;
@@ -352,10 +352,18 @@ test(async function expandGlobExt(): Promise<void> {
 
 test(async function expandGlobGlobstar(): Promise<void> {
   const options = { ...EG_OPTIONS, globstar: true };
-  assertEquals(await expandGlobArray(join("**", "abc"), options), [
-    "abc",
-    join("subdir", "abc")
-  ]);
+  assertEquals(
+    await expandGlobArray(joinGlobs(["**", "abc"], options), options),
+    ["abc", join("subdir", "abc")]
+  );
+});
+
+test(async function expandGlobGlobstarParent(): Promise<void> {
+  const options = { ...EG_OPTIONS, globstar: true };
+  assertEquals(
+    await expandGlobArray(joinGlobs(["subdir", "**", ".."], options), options),
+    ["."]
+  );
 });
 
 test(async function expandGlobIncludeDirs(): Promise<void> {

--- a/fs/glob_test.ts
+++ b/fs/glob_test.ts
@@ -5,7 +5,7 @@ import { isWindows } from "./path/constants.ts";
 import {
   ExpandGlobOptions,
   expandGlob,
-  glob,
+  globToRegExp,
   isGlob,
   expandGlobSync
 } from "./glob.ts";
@@ -17,37 +17,37 @@ import { touch, walkArray } from "./walk_test.ts";
 test({
   name: "glob: glob to regex",
   fn(): void {
-    assertEquals(glob("unicorn.*") instanceof RegExp, true);
-    assertEquals(glob("unicorn.*").test("poney.ts"), false);
-    assertEquals(glob("unicorn.*").test("unicorn.py"), true);
-    assertEquals(glob("*.ts").test("poney.ts"), true);
-    assertEquals(glob("*.ts").test("unicorn.js"), false);
+    assertEquals(globToRegExp("unicorn.*") instanceof RegExp, true);
+    assertEquals(globToRegExp("unicorn.*").test("poney.ts"), false);
+    assertEquals(globToRegExp("unicorn.*").test("unicorn.py"), true);
+    assertEquals(globToRegExp("*.ts").test("poney.ts"), true);
+    assertEquals(globToRegExp("*.ts").test("unicorn.js"), false);
     assertEquals(
-      glob(join("unicorn", "**", "cathedral.ts")).test(
+      globToRegExp(join("unicorn", "**", "cathedral.ts")).test(
         join("unicorn", "in", "the", "cathedral.ts")
       ),
       true
     );
     assertEquals(
-      glob(join("unicorn", "**", "cathedral.ts")).test(
+      globToRegExp(join("unicorn", "**", "cathedral.ts")).test(
         join("unicorn", "in", "the", "kitchen.ts")
       ),
       false
     );
     assertEquals(
-      glob(join("unicorn", "**", "bathroom.*")).test(
+      globToRegExp(join("unicorn", "**", "bathroom.*")).test(
         join("unicorn", "sleeping", "in", "bathroom.py")
       ),
       true
     );
     assertEquals(
-      glob(join("unicorn", "!(sleeping)", "bathroom.ts"), {
+      globToRegExp(join("unicorn", "!(sleeping)", "bathroom.ts"), {
         extended: true
       }).test(join("unicorn", "flying", "bathroom.ts")),
       true
     );
     assertEquals(
-      glob(join("unicorn", "(!sleeping)", "bathroom.ts"), {
+      globToRegExp(join("unicorn", "(!sleeping)", "bathroom.ts"), {
         extended: true
       }).test(join("unicorn", "sleeping", "bathroom.ts")),
       false
@@ -61,7 +61,7 @@ testWalk(
     await touch(d + "/a/x.ts");
   },
   async function globInWalk(): Promise<void> {
-    const arr = await walkArray(".", { match: [glob("*.ts")] });
+    const arr = await walkArray(".", { match: [globToRegExp("*.ts")] });
     assertEquals(arr.length, 1);
     assertEquals(arr[0], "a/x.ts");
   }
@@ -76,7 +76,7 @@ testWalk(
     await touch(d + "/b/z.js");
   },
   async function globInWalkWildcardFiles(): Promise<void> {
-    const arr = await walkArray(".", { match: [glob("*.ts")] });
+    const arr = await walkArray(".", { match: [globToRegExp("*.ts")] });
     assertEquals(arr.length, 2);
     assertEquals(arr[0], "a/x.ts");
     assertEquals(arr[1], "b/z.ts");
@@ -92,7 +92,7 @@ testWalk(
   async function globInWalkFolderWildcard(): Promise<void> {
     const arr = await walkArray(".", {
       match: [
-        glob(join("a", "**", "*.ts"), {
+        globToRegExp(join("a", "**", "*.ts"), {
           flags: "g",
           globstar: true
         })
@@ -116,7 +116,7 @@ testWalk(
   async function globInWalkFolderExtended(): Promise<void> {
     const arr = await walkArray(".", {
       match: [
-        glob(join("a", "+(raptor|deno)", "*.ts"), {
+        globToRegExp(join("a", "+(raptor|deno)", "*.ts"), {
           flags: "g",
           extended: true
         })
@@ -136,7 +136,7 @@ testWalk(
   },
   async function globInWalkWildcardExtension(): Promise<void> {
     const arr = await walkArray(".", {
-      match: [glob("x.*", { flags: "g", globstar: true })]
+      match: [globToRegExp("x.*", { flags: "g", globstar: true })]
     });
     assertEquals(arr.length, 2);
     assertEquals(arr[0], "x.js");
@@ -288,14 +288,12 @@ function urlToFilePath(url: URL): string {
   return url.pathname.slice(url.protocol == "file:" && isWindows ? 1 : 0);
 }
 
-const EG_OPTIONS = {
+const EG_OPTIONS: ExpandGlobOptions = {
   root: urlToFilePath(new URL(join("testdata", "glob"), import.meta.url)),
   includeDirs: true,
   extended: false,
   globstar: false,
-  strict: false,
-  filepath: false,
-  flags: ""
+  strict: false
 };
 
 test(async function expandGlobExt(): Promise<void> {

--- a/fs/globrex.ts
+++ b/fs/globrex.ts
@@ -2,8 +2,6 @@
 // MIT License
 // Copyright (c) 2018 Terkel Gjervig Nielsen
 
-import { GlobOptions } from "./glob.ts";
-
 const isWin = Deno.build.os === "win";
 const SEP = isWin ? `(\\\\+|\\/)` : `\\/`;
 const SEP_ESC = isWin ? `\\\\` : `/`;
@@ -12,6 +10,22 @@ const GLOBSTAR = `((?:[^${SEP_ESC}/]*(?:${SEP_ESC}|\/|$))*)`;
 const WILDCARD = `([^${SEP_ESC}/]*)`;
 const GLOBSTAR_SEGMENT = `((?:[^${SEP_ESC}/]*(?:${SEP_ESC}|\/|$))*)`;
 const WILDCARD_SEGMENT = `([^${SEP_ESC}/]*)`;
+
+export interface GlobrexOptions {
+  // Allow ExtGlob features
+  extended?: boolean;
+  // When globstar is true, '/foo/**' is equivelant
+  // to '/foo/*' when globstar is false.
+  // Having globstar set to true is the same usage as
+  // using wildcards in bash
+  globstar?: boolean;
+  // be laissez faire about mutiple slashes
+  strict?: boolean;
+  // Parse as filepath for extra path related features
+  filepath?: boolean;
+  // Flag to use in the generated RegExp
+  flags?: string;
+}
 
 export interface GlobrexResult {
   regex: RegExp;
@@ -41,7 +55,7 @@ export function globrex(
     strict = false,
     filepath = false,
     flags = ""
-  }: GlobOptions = {}
+  }: GlobrexOptions = {}
 ): GlobrexResult {
   let regex = "";
   let segment = "";

--- a/fs/path/constants.ts
+++ b/fs/path/constants.ts
@@ -51,3 +51,4 @@ export const CHAR_9 = 57; /* 9 */
 export const isWindows = build.os === "win";
 export const EOL = isWindows ? "\r\n" : "\n";
 export const SEP = isWindows ? "\\" : "/";
+export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -71,11 +71,15 @@ export async function* walk(
   root: string,
   options: WalkOptions = {}
 ): AsyncIterableIterator<WalkInfo> {
-  options.maxDepth! -= 1;
+  const maxDepth = options.maxDepth != undefined ? options.maxDepth! : Infinity;
+  if (maxDepth < 0) {
+    return;
+  }
   if (options.includeDirs && include(root, options)) {
     const rootInfo = await stat(root);
     yield { filename: root, info: rootInfo };
-  } else if (patternTest(options.skip || [], root)) {
+  }
+  if (maxDepth < 1 || patternTest(options.skip || [], root)) {
     return;
   }
   let ls: FileInfo[] = [];
@@ -103,9 +107,7 @@ export async function* walk(
         yield { filename, info };
       }
     } else {
-      if (!(options.maxDepth! < 0)) {
-        yield* walk(filename, options);
-      }
+      yield* walk(filename, { ...options, maxDepth: maxDepth - 1 });
     }
   }
 }
@@ -115,11 +117,15 @@ export function* walkSync(
   root: string = ".",
   options: WalkOptions = {}
 ): IterableIterator<WalkInfo> {
-  options.maxDepth! -= 1;
+  const maxDepth = options.maxDepth != undefined ? options.maxDepth! : Infinity;
+  if (maxDepth < 0) {
+    return;
+  }
   if (options.includeDirs && include(root, options)) {
     const rootInfo = statSync(root);
     yield { filename: root, info: rootInfo };
-  } else if (patternTest(options.skip || [], root)) {
+  }
+  if (maxDepth < 1 || patternTest(options.skip || [], root)) {
     return;
   }
   let ls: FileInfo[] = [];
@@ -146,9 +152,7 @@ export function* walkSync(
         yield { filename, info };
       }
     } else {
-      if (!(options.maxDepth! < 0)) {
-        yield* walkSync(filename, options);
-      }
+      yield* walkSync(filename, { ...options, maxDepth: maxDepth - 1 });
     }
   }
 }

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -8,6 +8,7 @@ import { join } from "./path/mod.ts";
 
 export interface WalkOptions {
   maxDepth?: number;
+  includeFiles?: boolean;
   includeDirs?: boolean;
   exts?: string[];
   match?: RegExp[];
@@ -55,6 +56,7 @@ export interface WalkInfo {
  *
  * Options:
  * - maxDepth?: number;
+ * - includeFiles?: boolean;
  * - includeDirs?: boolean;
  * - exts?: string[];
  * - match?: RegExp[];
@@ -103,7 +105,7 @@ export async function* walk(
     const filename = join(root, info.name!);
 
     if (info.isFile()) {
-      if (include(filename, options)) {
+      if (options.includeFiles != false && include(filename, options)) {
         yield { filename, info };
       }
     } else {
@@ -148,7 +150,7 @@ export function* walkSync(
     const filename = join(root, info.name!);
 
     if (info.isFile()) {
-      if (include(filename, options)) {
+      if (options.includeFiles != false && include(filename, options)) {
         yield { filename, info };
       }
     } else {

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -116,7 +116,7 @@ export async function* walk(
 
 /** Same as walk() but uses synchronous ops */
 export function* walkSync(
-  root: string = ".",
+  root: string,
   options: WalkOptions = {}
 ): IterableIterator<WalkInfo> {
   const maxDepth = options.maxDepth != undefined ? options.maxDepth! : Infinity;

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -75,6 +75,8 @@ export async function* walk(
   if (options.includeDirs && include(root, options)) {
     const rootInfo = await stat(root);
     yield { filename: root, info: rootInfo };
+  } else if (patternTest(options.skip || [], root)) {
+    return;
   }
   let ls: FileInfo[] = [];
   try {
@@ -117,6 +119,8 @@ export function* walkSync(
   if (options.includeDirs && include(root, options)) {
     const rootInfo = statSync(root);
     yield { filename: root, info: rootInfo };
+  } else if (patternTest(options.skip || [], root)) {
+    return;
   }
   let ls: FileInfo[] = [];
   try {

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,5 +1,4 @@
 const { cwd, chdir, makeTempDir, mkdir, open, remove } = Deno;
-type FileInfo = Deno.FileInfo;
 import { walk, walkSync, WalkOptions, WalkInfo } from "./walk.ts";
 import { test, TestFunction, runIfMain } from "../testing/mod.ts";
 import { assertEquals } from "../testing/asserts.ts";
@@ -29,7 +28,7 @@ function normalize({ filename }: WalkInfo): string {
 }
 
 export async function walkArray(
-  root: string = ".",
+  root: string,
   options: WalkOptions = {}
 ): Promise<string[]> {
   const arr: string[] = [];
@@ -48,7 +47,7 @@ export async function touch(path: string): Promise<void> {
 }
 
 function assertReady(expectedLength: number): void {
-  const arr = Array.from(walkSync(), normalize);
+  const arr = Array.from(walkSync("."), normalize);
 
   assertEquals(arr.length, expectedLength);
 }
@@ -58,7 +57,7 @@ testWalk(
     await mkdir(d + "/empty");
   },
   async function emptyDir(): Promise<void> {
-    const arr = await walkArray();
+    const arr = await walkArray(".");
     assertEquals(arr.length, 0);
   }
 );
@@ -68,7 +67,7 @@ testWalk(
     await touch(d + "/x");
   },
   async function singleFile(): Promise<void> {
-    const arr = await walkArray();
+    const arr = await walkArray(".");
     assertEquals(arr.length, 1);
     assertEquals(arr[0], "x");
   }
@@ -97,7 +96,7 @@ testWalk(
     await touch(d + "/a/x");
   },
   async function nestedSingleFile(): Promise<void> {
-    const arr = await walkArray();
+    const arr = await walkArray(".");
     assertEquals(arr.length, 1);
     assertEquals(arr[0], "a/x");
   }

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -133,6 +133,23 @@ testWalk(
 
 testWalk(
   async (d: string): Promise<void> => {
+    await touch(d + "/a");
+    await mkdir(d + "/b");
+    await touch(d + "/b/c");
+  },
+  async function includeFiles(): Promise<void> {
+    assertReady(2);
+    const arr = await walkArray(".", {
+      includeDirs: true,
+      includeFiles: false
+    });
+    assertEquals(arr.length, 2);
+    assertEquals(arr, [".", "b"]);
+  }
+);
+
+testWalk(
+  async (d: string): Promise<void> => {
     await touch(d + "/x.ts");
     await touch(d + "/y.rs");
   },

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -307,8 +307,7 @@ async function* getTargetFiles(
     exclude,
     includeDirs: true,
     extended: true,
-    globstar: true,
-    strict: false
+    globstar: true
   };
 
   async function* expandDirectory(d: string): AsyncIterableIterator<WalkInfo> {

--- a/prettier/main.ts
+++ b/prettier/main.ts
@@ -23,11 +23,12 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 // This script formats the given source files. If the files are omitted, it
 // formats the all files in the repository.
-const { args, exit, readFile, writeFile, stdout, stdin, readAll } = Deno;
-import { glob, isGlob, GlobOptions } from "../fs/glob.ts";
-import { walk, WalkInfo } from "../fs/walk.ts";
+import { ExpandGlobOptions, expandGlob, glob } from "../fs/glob.ts";
+import { isAbsolute, join } from "../fs/path/mod.ts";
+import { WalkInfo } from "../fs/walk.ts";
 import { parse } from "../flags/mod.ts";
 import { prettier, prettierPlugins } from "./prettier.ts";
+const { args, cwd, exit, readAll, readFile, stdin, stdout, writeFile } = Deno;
 
 const HELP_MESSAGE = `
 Formats the given files. If no arg is passed, then formats the all files.
@@ -289,65 +290,57 @@ async function formatFromStdin(
 
 /**
  * Get the files to format.
- * @param selectors The glob patterns to select the files.
- *                  eg `cmd/*.ts` to select all the typescript files in cmd
+ * @param include The glob patterns to select the files.
+ *                  eg `"cmd/*.ts"` to select all the typescript files in cmd
  *                  directory.
- *                  eg `cmd/run.ts` to select `cmd/run.ts` file as only.
- * @param ignore The glob patterns to ignore files.
- *                  eg `*_test.ts` to ignore all the test file.
- * @param options options to pass to `glob(selector, options)`
+ *                  eg `"cmd/run.ts"` to select `cmd/run.ts` file as only.
+ * @param exclude The glob patterns to ignore files.
+ *                  eg `"*_test.ts"` to ignore all the test file.
+ * @param root    The directory from which to apply default globs.
  * @returns returns an async iterable object
  */
-function getTargetFiles(
-  selectors: string[],
-  ignore: string[] = [],
-  options: GlobOptions = {}
+async function* getTargetFiles(
+  include: string[],
+  exclude: string[],
+  root: string = cwd()
 ): AsyncIterableIterator<WalkInfo> {
-  const matchers: Array<string | RegExp> = [];
+  const expandGlobOpts: ExpandGlobOptions = {
+    root,
+    extended: true,
+    globstar: true,
+    filepath: true
+  };
 
-  const selectorMap: { [k: string]: boolean } = {};
+  // TODO: We use the `g` flag here to support path prefixes when specifying
+  // excludes. Replace with a solution that does this more correctly.
+  const excludePathPatterns = exclude.map(
+    (s: string): RegExp =>
+      glob(isAbsolute(s) ? s : join(root, s), { ...expandGlobOpts, flags: "g" })
+  );
+  const shouldInclude = ({ filename }: WalkInfo): boolean =>
+    !excludePathPatterns.some((p: RegExp): boolean => !!filename.match(p));
 
-  for (const selector of selectors) {
-    // If the selector already exists then ignore it.
-    if (selectorMap[selector]) continue;
-    selectorMap[selector] = true;
-    if (isGlob(selector) || selector === ".") {
-      matchers.push(glob(selector, options));
-    } else {
-      matchers.push(selector);
+  async function* expandDirectory(d: string): AsyncIterableIterator<WalkInfo> {
+    for await (const walkInfo of expandGlob("**/*", {
+      ...expandGlobOpts,
+      root: d,
+      includeDirs: false
+    })) {
+      if (shouldInclude(walkInfo)) {
+        yield walkInfo;
+      }
     }
   }
 
-  const skip = ignore.map((i: string): RegExp => glob(i, options));
-
-  return (async function*(): AsyncIterableIterator<WalkInfo> {
-    for (const match of matchers) {
-      if (typeof match === "string") {
-        const fileInfo = await Deno.stat(match);
-
-        if (fileInfo.isDirectory()) {
-          const files = walk(match, { skip });
-
-          for await (const info of files) {
-            yield info;
-          }
-        } else {
-          const info: WalkInfo = {
-            filename: match,
-            info: fileInfo
-          };
-
-          yield info;
-        }
-      } else {
-        const files = walk(".", { match: [match], skip });
-
-        for await (const info of files) {
-          yield info;
-        }
+  for (const globString of include) {
+    for await (const walkInfo of expandGlob(globString, expandGlobOpts)) {
+      if (walkInfo.info.isDirectory()) {
+        yield* expandDirectory(walkInfo.filename);
+      } else if (shouldInclude(walkInfo)) {
+        yield walkInfo;
       }
     }
-  })();
+  }
 }
 
 async function main(opts): Promise<void> {
@@ -371,12 +364,10 @@ async function main(opts): Promise<void> {
     console.log(HELP_MESSAGE);
     exit(0);
   }
-  const options: GlobOptions = { flags: "g" };
 
   const files = getTargetFiles(
     args.length ? args : ["."],
-    Array.isArray(ignore) ? ignore : [ignore],
-    options
+    Array.isArray(ignore) ? ignore : [ignore]
   );
 
   const tty = Deno.isTTY();

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -77,8 +77,7 @@ export async function* findTestModules(
     exclude: excludePaths,
     includeDirs: true,
     extended: true,
-    globstar: true,
-    strict: false
+    globstar: true
   };
 
   async function* expandDirectory(d: string): AsyncIterableIterator<string> {

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env -S deno -A
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import { parse } from "../flags/mod.ts";
-import { WalkInfo, expandGlob, glob, ExpandGlobOptions } from "../fs/mod.ts";
+import {
+  ExpandGlobOptions,
+  WalkInfo,
+  expandGlob,
+  globToRegExp
+} from "../fs/mod.ts";
 import { isWindows } from "../fs/path/constants.ts";
 import { isAbsolute, join } from "../fs/path/mod.ts";
 import { RunTestsOptions, runTests } from "./mod.ts";
@@ -76,14 +81,17 @@ export async function* findTestModules(
     root,
     extended: true,
     globstar: true,
-    filepath: true
+    strict: false
   };
 
   // TODO: We use the `g` flag here to support path prefixes when specifying
   // excludes. Replace with a solution that does this more correctly.
   const excludePathPatterns = excludePaths.map(
     (s: string): RegExp =>
-      glob(isAbsolute(s) ? s : join(root, s), { ...expandGlobOpts, flags: "g" })
+      globToRegExp(isAbsolute(s) ? s : join(root, s), {
+        ...expandGlobOpts,
+        flags: "g"
+      })
   );
   const excludeUrlPatterns = excludeUrls.map(
     (url: string): RegExp => RegExp(url)

--- a/testing/runner_test.ts
+++ b/testing/runner_test.ts
@@ -3,17 +3,30 @@ import { test } from "./mod.ts";
 import { findTestModules } from "./runner.ts";
 import { isWindows } from "../fs/path/constants.ts";
 import { assertEquals } from "../testing/asserts.ts";
+const { cwd } = Deno;
 
 function urlToFilePath(url: URL): string {
   // Since `new URL('file:///C:/a').pathname` is `/C:/a`, remove leading slash.
   return url.pathname.slice(url.protocol == "file:" && isWindows ? 1 : 0);
 }
 
+async function findTestModulesArray(
+  include: string[],
+  exclude: string[],
+  root: string = cwd()
+): Promise<string[]> {
+  const result = [];
+  for await (const testModule of findTestModules(include, exclude, root)) {
+    result.push(testModule);
+  }
+  return result;
+}
+
 const TEST_DATA_URL = new URL("testdata", import.meta.url);
 const TEST_DATA_PATH = urlToFilePath(TEST_DATA_URL);
 
 test(async function findTestModulesDir1(): Promise<void> {
-  const urls = await findTestModules(["."], [], TEST_DATA_PATH);
+  const urls = await findTestModulesArray(["."], [], TEST_DATA_PATH);
   assertEquals(urls.sort(), [
     `${TEST_DATA_URL}/bar_test.js`,
     `${TEST_DATA_URL}/foo_test.ts`,
@@ -27,7 +40,7 @@ test(async function findTestModulesDir1(): Promise<void> {
 });
 
 test(async function findTestModulesDir2(): Promise<void> {
-  const urls = await findTestModules(["subdir"], [], TEST_DATA_PATH);
+  const urls = await findTestModulesArray(["subdir"], [], TEST_DATA_PATH);
   assertEquals(urls.sort(), [
     `${TEST_DATA_URL}/subdir/bar_test.js`,
     `${TEST_DATA_URL}/subdir/foo_test.ts`,
@@ -37,7 +50,11 @@ test(async function findTestModulesDir2(): Promise<void> {
 });
 
 test(async function findTestModulesGlob(): Promise<void> {
-  const urls = await findTestModules(["**/*_test.{js,ts}"], [], TEST_DATA_PATH);
+  const urls = await findTestModulesArray(
+    ["**/*_test.{js,ts}"],
+    [],
+    TEST_DATA_PATH
+  );
   assertEquals(urls.sort(), [
     `${TEST_DATA_URL}/bar_test.js`,
     `${TEST_DATA_URL}/foo_test.ts`,
@@ -47,7 +64,7 @@ test(async function findTestModulesGlob(): Promise<void> {
 });
 
 test(async function findTestModulesExcludeDir(): Promise<void> {
-  const urls = await findTestModules(["."], ["subdir"], TEST_DATA_PATH);
+  const urls = await findTestModulesArray(["."], ["subdir"], TEST_DATA_PATH);
   assertEquals(urls.sort(), [
     `${TEST_DATA_URL}/bar_test.js`,
     `${TEST_DATA_URL}/foo_test.ts`,
@@ -57,7 +74,7 @@ test(async function findTestModulesExcludeDir(): Promise<void> {
 });
 
 test(async function findTestModulesExcludeGlob(): Promise<void> {
-  const urls = await findTestModules(["."], ["**/foo*"], TEST_DATA_PATH);
+  const urls = await findTestModulesArray(["."], ["**/foo*"], TEST_DATA_PATH);
   assertEquals(urls.sort(), [
     `${TEST_DATA_URL}/bar_test.js`,
     `${TEST_DATA_URL}/subdir/bar_test.js`,
@@ -73,6 +90,6 @@ test(async function findTestModulesRemote(): Promise<void> {
     "https://example.com/colors_test.ts",
     "http://example.com/printf_test.ts"
   ];
-  const matches = await findTestModules(urls, []);
+  const matches = await findTestModulesArray(urls, []);
   assertEquals(matches, urls);
 });


### PR DESCRIPTION
...properly. Fixes #576.

This had to be done from scratch unless we could utilise `globrex` somehow but I think it can be done by splitting paths and flat-mapping on each segment, applying `globrex` on individual segments. I also want to give it an `exclude` option so excluded directories won't be traversed - callers all want to exclude by path prefix anyway, this is currently done with a hacky `g` flag.