### PR TITLE
build: remove matrix checks for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,10 @@ jobs:
           submodules: false
           persist-credentials: false
 
-      - name: Install Deno (Unix)
-        if: |
-          !startsWith(matrix.os, 'windows')
+      - name: Install Deno
         run: |-
           curl -fsSL https://deno.land/x/install/install.sh | sh
           echo "$HOME/.deno/bin" >> $GITHUB_PATH
-
-      - name: Install Deno (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |-
-          curl -fsSL https://deno.land/x/install/install.sh | sh
-          echo "$HOME/.deno/bin" >> $env:GITHUB_PATH
 
       - name: Upgrade to Deno canary
         run: deno upgrade --canary


### PR DESCRIPTION
This removes some dead branches in the lint job introduced in #681.
Lint doesn't actually run on matrix.os, only ubuntu-latest.