### PR TITLE
feat(http/file_server): support do not show dotfiles

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -33,6 +33,7 @@ export interface FileServerArgs {
   cors?: boolean;
   // --no-dir-listing
   "dir-listing"?: boolean;
+  dotfiles?: boolean;
   // --host
   host?: string;
   // -c --cert
@@ -146,9 +147,13 @@ async function serveDir(
   req: ServerRequest,
   dirPath: string,
 ): Promise<Response> {
+  const showDotfiles = serverArgs.dotfiles ?? true;
   const dirUrl = `/${posix.relative(target, dirPath)}`;
   const listEntry: EntryInfo[] = [];
   for await (const entry of Deno.readDir(dirPath)) {
+    if (!showDotfiles && entry.name[0] === ".") {
+      continue;
+    }
     const filePath = posix.join(dirPath, entry.name);
     const fileUrl = posix.join(dirUrl, entry.name);
     if (entry.name === "index.html" && entry.isFile) {
@@ -397,6 +402,7 @@ function main(): void {
     -c, --cert <FILE>   TLS certificate file (enables TLS)
     -k, --key  <FILE>   TLS key file (enables TLS)
     --no-dir-listing    Disable directory listing
+    --no-dotfiles       Do not show dotfiles
 
     All TLS options are required when one is provided.`);
     Deno.exit();

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -470,7 +470,7 @@ Deno.test("file_server do not show dotfiles", async function (): Promise<void> {
   await startFileServer({ target: "./testdata", dotfiles: false });
   try {
     let res = await fetch("http://localhost:4507/");
-    assertEquals((await res.text()).includes(".dotfile"), false);
+    assert(!(await res.text()).includes(".dotfile"));
 
     res = await fetch("http://localhost:4507/.dotfile");
     assertEquals((await res.text()), "dotfile");

--- a/http/testdata/.dotfile
+++ b/http/testdata/.dotfile
@@ -1,0 +1,1 @@
+dotfile


### PR DESCRIPTION
default:
<img src="https://user-images.githubusercontent.com/24505451/106568644-852c1a00-656e-11eb-8c3e-58df61f6e4c5.png" width=400 />

with `--no-dotfiles`:
<img src="https://user-images.githubusercontent.com/24505451/106568686-92e19f80-656e-11eb-9e50-32d2035b5030.png" width=400>
