### PR TITLE
feat(http/file_server): show .. if it makes sense & make dir end with /

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -148,6 +148,19 @@ async function serveDir(
 ): Promise<Response> {
   const dirUrl = `/${posix.relative(target, dirPath)}`;
   const listEntry: EntryInfo[] = [];
+
+  // if ".." makes sense
+  if (dirUrl !== "/") {
+    const prevPath = posix.join(dirPath, "..");
+    const fileInfo = await Deno.stat(prevPath);
+    listEntry.push({
+      mode: modeToString(true, fileInfo.mode),
+      size: "",
+      name: "../",
+      url: posix.join(dirUrl, ".."),
+    });
+  }
+
   for await (const entry of Deno.readDir(dirPath)) {
     const filePath = posix.join(dirPath, entry.name);
     const fileUrl = posix.join(dirUrl, entry.name);
@@ -155,17 +168,11 @@ async function serveDir(
       // in case index.html as dir...
       return serveFile(req, filePath);
     }
-    // Yuck!
-    let fileInfo = null;
-    try {
-      fileInfo = await Deno.stat(filePath);
-    } catch (e) {
-      // Pass
-    }
+    const fileInfo = await Deno.stat(filePath);
     listEntry.push({
-      mode: modeToString(entry.isDirectory, fileInfo?.mode ?? null),
-      size: entry.isFile ? fileLenToString(fileInfo?.size ?? 0) : "",
-      name: entry.name,
+      mode: modeToString(entry.isDirectory, fileInfo.mode),
+      size: entry.isFile ? fileLenToString(fileInfo.size ?? 0) : "",
+      name: `${entry.name}${entry.isDirectory ? "/" : ""}`,
       url: fileUrl,
     });
   }

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -463,3 +463,19 @@ Deno.test("file_server disable dir listings", async function (): Promise<void> {
     await killFileServer();
   }
 });
+
+Deno.test("file_server should show .. if it makes sense", async function (): Promise<void> {
+  await startFileServer();
+  try {
+    let res = await fetch("http://localhost:4507/");
+    let page = await res.text();
+    assert(!page.includes("../"));
+    assert(page.includes("testdata/"));
+    
+    res = await fetch("http://localhost:4507/testdata/");
+    page = await res.text();
+    assert(page.includes("../"));
+  } finally {
+    await killFileServer();
+  }
+});

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -464,14 +464,16 @@ Deno.test("file_server disable dir listings", async function (): Promise<void> {
   }
 });
 
-Deno.test("file_server should show .. if it makes sense", async function (): Promise<void> {
+Deno.test("file_server should show .. if it makes sense", async function (): Promise<
+  void
+> {
   await startFileServer();
   try {
     let res = await fetch("http://localhost:4507/");
     let page = await res.text();
     assert(!page.includes("../"));
     assert(page.includes("testdata/"));
-    
+
     res = await fetch("http://localhost:4507/testdata/");
     page = await res.text();
     assert(page.includes("../"));


### PR DESCRIPTION
- If the current dir is not root, show "../".
- Make dir end with "/"
- `Deno.stat()` no longer needs to catch errors. (The "mode" prop may not exist before, see https://github.com/denoland/deno_std/pull/15/files#diff-106086daad2313990285a9c61085eeb5995d479127db151e613f84ea709450c8R118