### PR TITLE
 refactor(md5): throw `TypeError` for wrong type

### DIFF
--- a/hash/md5.ts
+++ b/hash/md5.ts
@@ -158,10 +158,10 @@ export class Md5 {
       if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
         msg = new Uint8Array(data);
       } else {
-        throw new Error(TYPE_ERROR_MSG);
+        throw new TypeError(TYPE_ERROR_MSG);
       }
     } else {
-      throw new Error(TYPE_ERROR_MSG);
+      throw new TypeError(TYPE_ERROR_MSG);
     }
 
     let pos = this.#pos;


### PR DESCRIPTION
Use [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) is a good option for `a value is not of the expected type`