### PR TITLE
test(node): Prevent fixture from being run as a test

### DIFF
--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -101,7 +101,7 @@ Deno.test({
       cmd: [
         Deno.execPath(),
         "run",
-        "./process_exit_test.ts",
+        "./testdata/process_exit.ts",
       ],
       cwd,
       stdout: "piped",

--- a/node/testdata/process_exit.ts
+++ b/node/testdata/process_exit.ts
@@ -1,4 +1,4 @@
-import "./global.ts";
+import "../global.ts";
 
 //deno-lint-ignore no-undef
 process.on("exit", () => {


### PR DESCRIPTION
The process exit test fixture is being run as a test, it uses console.log which adds to the noise produced by running deno test.

This moves it into testdata folder and drops the test suffix so that it doesn't run as a test.