### PR TITLE
feat(std/http): add HTTP server "error" event

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -9,9 +9,9 @@
 import { extname, posix } from "../path/mod.ts";
 import {
   HTTPSOptions,
+  Response,
   serve,
   Server,
-  Response,
   ServerRequest,
   serveTLS,
 } from "./server.ts";

--- a/http/server.ts
+++ b/http/server.ts
@@ -117,11 +117,57 @@ export class ServerRequest {
   }
 }
 
-export class Server implements AsyncIterable<ServerRequest> {
+export type ServerErrorEventListenerOrEventListenerObject =
+  | ServerErrorListener
+  | ServerErrorListenerObject;
+
+export interface ServerErrorListener {
+  (evt: ServerErrorEvent): void | Promise<void>;
+}
+
+export interface ServerErrorListenerObject {
+  handleEvent(evt: ServerErrorEvent): void | Promise<void>;
+}
+
+export interface ServerErrorEventInit extends ErrorEventInit {
+  server: Server;
+  origin: ServerErrorEvent["origin"];
+  connection?: Deno.Conn;
+}
+
+export class ServerErrorEvent extends ErrorEvent {
+  server: Server;
+  origin: "listener" | "request";
+  connection?: Deno.Conn;
+  constructor(init: ServerErrorEventInit) {
+    super("error", init);
+    this.server = init.server;
+    this.origin = init.origin;
+    this.connection = init.connection;
+  }
+}
+
+export class Server extends EventTarget implements AsyncIterable<ServerRequest> {
   #closing = false;
   #connections: Deno.Conn[] = [];
 
-  constructor(public listener: Deno.Listener) {}
+  constructor(public listener: Deno.Listener) {
+    super();
+  }
+
+  addEventListener(
+    type: "error",
+    listener: ServerErrorEventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+
+  addEventListener(
+    type: "error",
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    super.addEventListener(type, listener, options);
+  }
 
   close(): void {
     this.#closing = true;
@@ -144,15 +190,27 @@ export class Server implements AsyncIterable<ServerRequest> {
   ): AsyncIterableIterator<ServerRequest> {
     const reader = new BufReader(conn);
     const writer = new BufWriter(conn);
+    let preventClosing = false;
 
     while (!this.#closing) {
       let request: ServerRequest | null;
       try {
         request = await readRequest(conn, reader);
       } catch (error) {
+        const eventDefault = this.dispatchEvent(
+          new ServerErrorEvent({
+            error,
+            origin: "request",
+            server: this,
+            connection: conn,
+            cancelable: true,
+          }),
+        );
         if (
-          error instanceof Deno.errors.InvalidData ||
-          error instanceof Deno.errors.UnexpectedEof
+          eventDefault && (
+            error instanceof Deno.errors.InvalidData ||
+            error instanceof Deno.errors.UnexpectedEof
+          )
         ) {
           // An error was thrown while parsing request headers.
           // Try to send the "400 Bad Request" before closing the connection.
@@ -164,6 +222,9 @@ export class Server implements AsyncIterable<ServerRequest> {
           } catch (error) {
             // The connection is broken.
           }
+        }
+        if (!eventDefault) {
+          preventClosing = true;
         }
         break;
       }
@@ -195,10 +256,12 @@ export class Server implements AsyncIterable<ServerRequest> {
     }
 
     this.untrackConnection(conn);
-    try {
-      conn.close();
-    } catch (e) {
-      // might have been already closed
+    if (!preventClosing) {
+      try {
+        conn.close();
+      } catch (e) {
+        // might have been already closed
+      }
     }
   }
 
@@ -226,17 +289,21 @@ export class Server implements AsyncIterable<ServerRequest> {
     try {
       conn = await this.listener.accept();
     } catch (error) {
-      if (
-        // The listener is closed:
-        error instanceof Deno.errors.BadResource ||
-        // TLS handshake errors:
-        error instanceof Deno.errors.InvalidData ||
-        error instanceof Deno.errors.UnexpectedEof ||
-        error instanceof Deno.errors.ConnectionReset
-      ) {
-        return mux.add(this.acceptConnAndIterateHttpRequests(mux));
+      if (this.#closing && error instanceof Deno.errors.BadResource) {
+        return;
       }
-      throw error;
+      const eventDefault = this.dispatchEvent(
+        new ServerErrorEvent({
+          error,
+          origin: "listener",
+          server: this,
+          cancelable: true,
+        }),
+      );
+      if (eventDefault) {
+        mux.add(this.acceptConnAndIterateHttpRequests(mux));
+      }
+      return;
     }
     this.trackConnection(conn);
     // Try to accept another connection and add it to the multiplexer.

--- a/http/server.ts
+++ b/http/server.ts
@@ -147,7 +147,8 @@ export class ServerErrorEvent extends ErrorEvent {
   }
 }
 
-export class Server extends EventTarget implements AsyncIterable<ServerRequest> {
+export class Server extends EventTarget
+  implements AsyncIterable<ServerRequest> {
   #closing = false;
   #connections: Deno.Conn[] = [];
 


### PR DESCRIPTION
This PR allows the user to handle/log the error from the listener and the request reader.
(Moved from denoland/deno#8554)

Before:
The HTTP server rethrows the error from the listener if the error type is unknown, and causes an uncaught error. Also, it ignores all errors while reading requests.

After:
The `Server` class is now inherited from `EventTarget`. It will pass the error to the `error` event. The user can handle it after adding an event listener to the server. By default, the server keeps running after encountering an error.

Related issue: denoland/deno#8499 (not closing it because I don't know where did the ENOTCONN come from)

Usage:
```ts
const server = serve({ port: 8000 });
server.addEventListener('error', (evt) => {
  if (evt.origin == "request") {
    console.warn("Error reading request", evt.connection, evt.error);
    // The server will send "400 Bad Request" and close the connection
    // unless `evt.preventDefault()` is called.
  } else if (evt.origin == "listener") {
    console.warn("Error accepting connection", evt.error);
    // The server will continue to accept connections
    // unless `evt.preventDefault()` is called.
  }
})
for await (const req of server) {
  req.respond({ body: "Hello World\n" });
}
```

This PR also make `file_server` print errors from the http server.

Something to discuss:
1. Is it okay to have `Server extends EventTarget` to implement events? Should we implement it in another way? While I am guessing it will hardly break something, should it be considered a BREAKING change?
2. `server.addEventListener("error", (evt) => { ... })` then check `evt.origin == "request"`, or just `server.addEventListener("request-error", ...)`?