### PR TITLE
feat(log): Added ability to configure a fallback configuration

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -350,5 +350,5 @@ await setup({
 const configuredLogger = getLogger("configured");
 configuredLogger.info("foo"); // will log "foo"
 const notConfiguredLogger = getLogger("NotConfigured");
-logger.info("bar"); // will log "bar" instead of nothing
+notConfiguredLogger.info("bar"); // will log "bar" instead of nothing
 ```

--- a/log/README.md
+++ b/log/README.md
@@ -314,3 +314,41 @@ await log.setup({
 const data: string | undefined = logger.debug(() => someExpenseFn(5, true));
 console.log(data); // undefined
 ```
+
+### Configuring a fallback logger
+
+If you call `getLogger()` without any argument then you will get the default
+logger. If you call `getLogger("bar")` with a logger name that has not been
+configured then you will get a logger without any handlers (nothing will be
+logged). By configuring a fallback logger you can specify handlers and a log
+level that should be used if `getLogger` is called with a logger name that has
+not been configured explitly in the `setup` call.
+
+```ts
+import {
+  ConsoleHandler,
+  getLogger,
+  setup,
+} from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+
+await setup({
+  handlers: {
+    console: new ConsoleHandler("DEBUG"),
+  },
+  loggers: {
+    configured: {
+      level: "DEBUG",
+      handlers: ["console"],
+    },
+  },
+  fallbackLogger: {
+    level: "INFO",
+    handlers: ["console"],
+  },
+});
+
+const configuredLogger = getLogger("configured");
+configuredLogger.info("foo"); // will log "foo"
+const notConfiguredLogger = getLogger("NotConfigured");
+logger.info("bar"); // will log "bar" instead of nothing
+```

--- a/log/mod_test.ts
+++ b/log/mod_test.ts
@@ -220,3 +220,66 @@ Deno.test({
     assertEquals(testHandlerB.messages.length, 2);
   },
 });
+
+Deno.test({
+  name: "Not configured logger should log nothing",
+  async fn() {
+    const testHandler = new TestHandler("DEBUG");
+    await setup({
+      handlers: {
+        test: testHandler,
+      },
+      loggers: {
+        configured: {
+          level: "DEBUG",
+          handlers: ["test"],
+        },
+      },
+    });
+    const configuredLogger = getLogger("configured");
+    const notConfiguredLogger = getLogger("notconfigured");
+
+    configuredLogger.info("Log something from configured logger");
+    notConfiguredLogger.info("Log something from a not configured logger");
+
+    assertEquals(testHandler.messages, [
+      "INFO Log something from configured logger",
+    ]);
+  },
+});
+
+Deno.test({
+  name:
+    "Not configured logger should log something if fallback handler has been set",
+  async fn() {
+    const testHandler = new TestHandler("DEBUG");
+    await setup({
+      handlers: {
+        test: testHandler,
+      },
+      loggers: {
+        configured: {
+          level: "DEBUG",
+          handlers: ["test"],
+        },
+      },
+      fallbackLogger: {
+        level: "INFO",
+        handlers: ["test"],
+      },
+    });
+    const configuredLogger = getLogger("configured");
+    const notConfiguredLogger = getLogger("notconfigured");
+
+    configuredLogger.info("Log something from configured logger");
+    notConfiguredLogger.info("Log something from a not configured logger");
+    notConfiguredLogger.debug(
+      "Log something from a not configured logger with debug",
+    );
+
+    assertEquals(testHandler.messages, [
+      "INFO Log something from configured logger",
+      "INFO Log something from a not configured logger",
+    ]);
+  },
+});


### PR DESCRIPTION
You can specify a configuration for a `default` logger but this just adds a logging configuration for unnamed loggers.
I added the ability to add a `fallback` logger to be able to configure loggers that have a name but no configuration.