### PR TITLE
fix(http/file_server): svg media type

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -67,6 +67,7 @@ const MEDIA_TYPES: Record<string, string> = {
   ".css": "text/css",
   ".wasm": "application/wasm",
   ".mjs": "application/javascript",
+  ".svg": "image/svg+xml",
 };
 
 /** Returns the content-type based on the extension of a path. */


### PR DESCRIPTION
If you use `file_server` to host a site with local svg files...
```html
<img src="./image.svg">
```
...then the image does not show...
<img width="76" alt="image" src="https://user-images.githubusercontent.com/6933510/107501394-9e008500-6b97-11eb-8660-0b6773c0f94b.png">
...because the browser assumes the XML media type, not the svg+xml type.

**This PR adds the correct `Content-Type` header to svg files, which fixes the problem.**

---

_(I also checked png and jpg, they work already because the browser can deduce the media type from the file headers)_