### PR TITLE
fix(std/testing) : Handle Symbols correctly in deep equalities

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -151,7 +151,12 @@ export function equal(c: unknown, d: unknown): boolean {
         return unmatchedEntries === 0;
       }
       const merged = { ...a, ...b };
-      for (const key in merged) {
+      for (
+        const key of [
+          ...Object.getOwnPropertyNames(merged),
+          ...Object.getOwnPropertySymbols(merged),
+        ]
+      ) {
         type Key = keyof typeof merged;
         if (!compare(a && a[key as Key], b && b[key as Key])) {
           return false;

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -42,6 +42,18 @@ Deno.test("testingEqual", function (): void {
       { hello: "world", hi: { there: "everyone else" } },
     ),
   );
+  assert(
+    equal(
+      { [Symbol.for("foo")]: "bar" },
+      { [Symbol.for("foo")]: "bar" },
+    ),
+  );
+  assert(
+    !equal(
+      { [Symbol("foo")]: "bar" },
+      { [Symbol("foo")]: "bar" },
+    ),
+  );
   assert(equal(/deno/, /deno/));
   assert(!equal(/deno/, /node/));
   assert(equal(new Date(2019, 0, 3), new Date(2019, 0, 3)));


### PR DESCRIPTION
From https://github.com/denoland/deno/pull/8063

Currently symbols equalities are not properly handled in `std/testing/asserts` because of the way objects are iterated in equality function (symbols are ignored):
https://github.com/denoland/deno_std/blob/b2c25026537afab2d1e29569f3b72c08cf947fd3/testing/asserts.ts#L153-L155

**Example**
```typescript
import { assertEquals } from "https://deno.land/std/testing/asserts.ts"
const foo = Symbol("foo")
Deno.test("symbol1", () => assertEquals({[foo]:"bar"}, {[foo]:"bar"}))             //Same symbol
Deno.test("symbol2", () => assertEquals({[foo]:"bar"}, {[Symbol("foo")]:"bar"}))   //Different symbols (should fail)
```

**Expected**
```
running 2 tests
test symbol1 ... ok (3ms)
test symbol2 ... FAILED (2ms)

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out (5ms)
```
**Actual**
```
running 2 tests
test symbol1 ... ok (2ms)
test symbol2 ... ok (1ms)

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (4ms)
```
