### PR TITLE
feat(node): add tty module

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -35,7 +35,7 @@ deno standard library as it's a compatibility module.
 - [ ] sys
 - [x] timers
 - [ ] tls
-- [ ] tty
+- [x] tty _partly_
 - [x] url
 - [x] util _partly_
 - ~~v8~~ _can't implement_

--- a/node/module.ts
+++ b/node/module.ts
@@ -619,9 +619,9 @@ nativeModulePolyfill.set(
   createNativeModule("string_decoder", nodeStringDecoder),
 );
 nativeModulePolyfill.set("timers", createNativeModule("timers", nodeTimers));
+nativeModulePolyfill.set("tty", createNativeModule("tty", nodeTty));
 nativeModulePolyfill.set("url", createNativeModule("url", nodeUrl));
 nativeModulePolyfill.set("util", createNativeModule("util", nodeUtil));
-nativeModulePolyfill.set("tty", createNativeModule("tty", nodeTty));
 
 function loadNativeModule(
   _filename: string,

--- a/node/module.ts
+++ b/node/module.ts
@@ -32,6 +32,7 @@ import * as nodeQueryString from "./querystring.ts";
 import * as nodeStream from "./stream.ts";
 import * as nodeStringDecoder from "./string_decoder.ts";
 import * as nodeTimers from "./timers.ts";
+import * as nodeTty from "./tty.ts";
 import * as nodeUrl from "./url.ts";
 import * as nodeUtil from "./util.ts";
 
@@ -620,6 +621,7 @@ nativeModulePolyfill.set(
 nativeModulePolyfill.set("timers", createNativeModule("timers", nodeTimers));
 nativeModulePolyfill.set("url", createNativeModule("url", nodeUrl));
 nativeModulePolyfill.set("util", createNativeModule("util", nodeUtil));
+nativeModulePolyfill.set("tty", createNativeModule("tty", nodeTty));
 
 function loadNativeModule(
   _filename: string,

--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -96,6 +96,7 @@ Deno.test("requireNodeJsNativeModules", () => {
   require("stream");
   require("string_decoder");
   require("timers");
+  require("tty");
   require("url");
   require("util");
 
@@ -114,7 +115,6 @@ Deno.test("requireNodeJsNativeModules", () => {
   // require("repl");
   // require("sys");
   // require("tls");
-  // require("tty");
   // require("vm");
   // require("worker_threads");
   // require("zlib");

--- a/node/tty.ts
+++ b/node/tty.ts
@@ -4,7 +4,7 @@
 // ref: https://nodejs.org/api/tty.html
 
 // Returns true when the given numeric fd is associated with a TTY and false otherwise.
-function isatty(fd: unknown) {
+function isatty(fd: number) {
   if (typeof fd !== "number") {
     return false;
   }

--- a/node/tty.ts
+++ b/node/tty.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// This module implements 'tty' module of Node.JS API.
+// ref: https://nodejs.org/api/tty.html
+
+// Returns true when the given numeric fd is associated with a TTY and false otherwise.
+function isatty(fd: unknown) {
+  if (typeof fd !== "number") {
+    return false;
+  }
+  try {
+    return Deno.isatty(fd);
+  } catch (_) {
+    return false;
+  }
+}
+
+// TODO(kt3k): Implement tty.ReadStream class
+// TODO(kt3k): Implement tty.WriteStream class
+
+export { isatty };
+export default { isatty };

--- a/node/tty_test.ts
+++ b/node/tty_test.ts
@@ -1,0 +1,25 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assert } from "../testing/asserts.ts";
+import { isatty } from "./tty.ts";
+
+Deno.test("[node/tty isatty] returns true when fd is a tty, false otherwise", () => {
+  assert(Deno.isatty(Deno.stdin.rid) === isatty(Deno.stdin.rid));
+  assert(Deno.isatty(Deno.stdout.rid) === isatty(Deno.stdout.rid));
+  assert(Deno.isatty(Deno.stderr.rid) === isatty(Deno.stderr.rid));
+
+  const file = Deno.openSync("README.md");
+  assert(!isatty(file.rid));
+  Deno.close(file.rid);
+});
+
+Deno.test("[node/tty isatty] returns false for irrelevant values", () => {
+  // invalid numeric fd
+  assert(!isatty(1234567));
+
+  // invalid type fd
+  assert(!isatty("abc"));
+  assert(!isatty({}));
+  assert(!isatty([]));
+  assert(!isatty(null));
+  assert(!isatty(undefined));
+});

--- a/node/tty_test.ts
+++ b/node/tty_test.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-explicit-any
 import { assert } from "../testing/asserts.ts";
 import { isatty } from "./tty.ts";
 
@@ -15,11 +16,12 @@ Deno.test("[node/tty isatty] returns true when fd is a tty, false otherwise", ()
 Deno.test("[node/tty isatty] returns false for irrelevant values", () => {
   // invalid numeric fd
   assert(!isatty(1234567));
+  assert(!isatty(-1));
 
   // invalid type fd
-  assert(!isatty("abc"));
-  assert(!isatty({}));
-  assert(!isatty([]));
-  assert(!isatty(null));
-  assert(!isatty(undefined));
+  assert(!isatty("abc" as any));
+  assert(!isatty({} as any));
+  assert(!isatty([] as any));
+  assert(!isatty(null as any));
+  assert(!isatty(undefined as any));
 });


### PR DESCRIPTION
This PR implements `isatty` function of [tty](https://nodejs.org/api/tty.html) module of Node.js API.

A heavily dependent npm module [supports-color](https://www.npmjs.com/package/supports-color) uses this method. (ref: https://github.com/chalk/supports-color/blob/main/index.js#L150). This PR enables requiring `supports-color` in deno.