### PR TITLE
fix(node/process): make process.argv an array

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -27,9 +27,21 @@ const notImplementedEvents = [
 /** https://nodejs.org/api/process.html#process_process_arch */
 export const arch = Deno.build.arch;
 
-// TODO(kt3k): The first item should be the entrypoint of
-// node compatibility library.
-const argv = [Deno.execPath(), fromFileUrl(Deno.mainModule), ...Deno.args];
+// The first 2 items are placeholders.
+// They will be overwritten by the below Object.defineProperty calls.
+const argv = ["", "", ...Deno.args];
+// Overwrites the 1st item with getter.
+Object.defineProperty(argv, "0", {
+  get() {
+    return Deno.execPath();
+  },
+});
+// Overwrites the 2nd item with getter.
+Object.defineProperty(argv, "1", {
+  get() {
+    return fromFileUrl(Deno.mainModule);
+  },
+});
 
 /** https://nodejs.org/api/process.html#process_process_chdir_directory */
 export const chdir = Deno.chdir;

--- a/node/process.ts
+++ b/node/process.ts
@@ -27,40 +27,9 @@ const notImplementedEvents = [
 /** https://nodejs.org/api/process.html#process_process_arch */
 export const arch = Deno.build.arch;
 
-function getArguments() {
-  return [Deno.execPath(), fromFileUrl(Deno.mainModule), ...Deno.args];
-}
-
-//deno-lint-ignore ban-ts-comment
-//@ts-ignore
-const _argv: {
-  [Deno.customInspect]: () => string;
-  [key: number]: string;
-} = [];
-
-Object.defineProperty(_argv, Deno.customInspect, {
-  enumerable: false,
-  configurable: false,
-  get: function () {
-    return getArguments();
-  },
-});
-
-/**
- * https://nodejs.org/api/process.html#process_process_argv
- * Read permissions are required in order to get the executable route
- * */
-export const argv: Record<string, string> = new Proxy(_argv, {
-  get(target, prop) {
-    if (prop === Deno.customInspect) {
-      return target[Deno.customInspect];
-    }
-    return getArguments()[prop as number];
-  },
-  ownKeys() {
-    return Reflect.ownKeys(getArguments());
-  },
-});
+// TODO(kt3k): The first item should be the entrypoint of
+// node compatibility library.
+const argv = [Deno.execPath(), fromFileUrl(Deno.mainModule), ...Deno.args];
 
 /** https://nodejs.org/api/process.html#process_process_chdir_directory */
 export const chdir = Deno.chdir;

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -102,6 +102,7 @@ Deno.test({
         Deno.execPath(),
         "run",
         "--quiet",
+        "--allow-read",
         "./testdata/process_exit.ts",
       ],
       cwd,
@@ -130,6 +131,7 @@ Deno.test({
       process.argv[1],
       path.fromFileUrl(Deno.mainModule),
     );
+    assert(Array.isArray(process.argv.slice(2)));
   },
 });
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -102,7 +102,6 @@ Deno.test({
         Deno.execPath(),
         "run",
         "--quiet",
-        "--allow-read",
         "./testdata/process_exit.ts",
       ],
       cwd,

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -130,7 +130,10 @@ Deno.test({
       process.argv[1],
       path.fromFileUrl(Deno.mainModule),
     );
+    // argv supports array methods.
     assert(Array.isArray(process.argv.slice(2)));
+    assertEquals(process.argv.indexOf(Deno.execPath()), 0);
+    assertEquals(process.argv.indexOf(path.fromFileUrl(Deno.mainModule)), 1);
   },
 });
 


### PR DESCRIPTION
This PR makes process.argv simply an array.

The current implementation simulates an array by using Proxy, but it doesn't support array methods and it causes problem in executing cli tools in npm.

In node.js, process.argv is just an array (ref 1: https://github.com/nodejs/node/blob/eed3c72/src/node_process_object.cc#L158, ref 2: https://github.com/nodejs/node/blob/eed3c72/src/env-inl.h#L601). So this PR change it to an array.