### PR TITLE
feat(node): add crypto.createHash

### DIFF
--- a/hash/mod.ts
+++ b/hash/mod.ts
@@ -4,26 +4,27 @@ import { Hash } from "./_wasm/hash.ts";
 import type { Hasher } from "./hasher.ts";
 
 export type { Hasher } from "./hasher.ts";
-export type SupportedAlgorithm =
-  | "md2"
-  | "md4"
-  | "md5"
-  | "ripemd160"
-  | "ripemd320"
-  | "sha1"
-  | "sha224"
-  | "sha256"
-  | "sha384"
-  | "sha512"
-  | "sha3-224"
-  | "sha3-256"
-  | "sha3-384"
-  | "sha3-512"
-  | "keccak224"
-  | "keccak256"
-  | "keccak384"
-  | "keccak512";
-
+export const supportedAlgorithms = [
+  "md2",
+  "md4",
+  "md5",
+  "ripemd160",
+  "ripemd320",
+  "sha1",
+  "sha224",
+  "sha256",
+  "sha384",
+  "sha512",
+  "sha3-224",
+  "sha3-256",
+  "sha3-384",
+  "sha3-512",
+  "keccak224",
+  "keccak256",
+  "keccak384",
+  "keccak512",
+] as const;
+export type SupportedAlgorithm = typeof supportedAlgorithms[number];
 /**
  * Creates a new `Hash` instance.
  *

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -1,6 +1,100 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
+import {
+  createHash as stdCreateHash,
+  Hasher,
+  SupportedAlgorithm,
+  supportedAlgorithms,
+} from "../hash/mod.ts";
 import { pbkdf2, pbkdf2Sync } from "./_crypto/pbkdf2.ts";
+import { Buffer } from "./buffer.ts";
+import { Transform } from "./stream.ts";
+import { TransformOptions } from "./_stream/transform.ts";
+import { encodeToString as encodeToHexString } from "../encoding/hex.ts";
 
-export default { randomBytes, pbkdf2, pbkdf2Sync };
+/**
+ * The Hash class is a utility for creating hash digests of data. It can be used in one of two ways:
+ *
+ * - As a stream that is both readable and writable, where data is written to produce a computed hash digest on the readable side, or
+ * - Using the hash.update() and hash.digest() methods to produce the computed hash.
+ *
+ * The crypto.createHash() method is used to create Hash instances. Hash objects are not to be created directly using the new keyword.
+ */
+export class Hash extends Transform {
+  public hash: Hasher;
+  constructor(algorithm: SupportedAlgorithm, opts?: TransformOptions) {
+    super({
+      transform(chunk: string, _encoding: string, callback: () => void): void {
+        hash.update(chunk);
+        callback();
+      },
+      flush(callback: () => void): void {
+        // deno-lint-ignore no-this-before-super
+        this.push(hash.digest());
+        callback();
+      },
+    });
+    const hash = this.hash = stdCreateHash(algorithm);
+  }
+
+  // TODO(kt3k): Implement copy method
+  // copy(options) { ... }
+
+  /**
+   * Updates the hash content with the given data.
+   */
+  update(data: string | ArrayBuffer, _encoding?: string): this {
+    if (typeof data === "string") {
+      data = new TextEncoder().encode(data);
+      this.hash.update(data);
+    } else {
+      this.hash.update(data);
+    }
+    return this;
+  }
+
+  /**
+   * Calculates the digest of all of the data.
+   *
+   * If encoding is provided a string will be returned; otherwise a Buffer is returned.
+   *
+   * Supported encoding is currently 'hex' only. 'binary', 'base64' will be supported in the future versions.
+   */
+  digest(encoding?: string): Buffer | string {
+    const digest = this.hash.digest();
+    if (encoding === undefined) {
+      return Buffer.from(digest);
+    }
+
+    switch (encoding) {
+      case "hex": {
+        return encodeToHexString(new Uint8Array(digest));
+      }
+      // TODO(kt3k): Support more output encodings such as base64, binary, etc
+      default: {
+        throw new Error(
+          `The output encoding for hash digest is not impelemented: ${encoding}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Creates and returns a Hash object that can be used to generate hash digests
+ * using the given `algorithm`. Optional `options` argument controls stream behavior.
+ */
+export function createHash(algorithm: SupportedAlgorithm, opts?: TransformOptions) {
+  return new Hash(algorithm, opts);
+}
+
+/**
+ * Returns an array of the names of the supported hash algorithms, such as 'sha1'.
+ */
+export function getHashes(): SupportedAlgorithm[] {
+  return supportedAlgorithms.slice();
+}
+
+export default { Hash, createHash, getHashes, pbkdf2, pbkdf2Sync, randomBytes };
 export { pbkdf2, pbkdf2Sync, randomBytes };

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -85,7 +85,10 @@ export class Hash extends Transform {
  * Creates and returns a Hash object that can be used to generate hash digests
  * using the given `algorithm`. Optional `options` argument controls stream behavior.
  */
-export function createHash(algorithm: SupportedAlgorithm, opts?: TransformOptions) {
+export function createHash(
+  algorithm: SupportedAlgorithm,
+  opts?: TransformOptions,
+) {
   return new Hash(algorithm, opts);
 }
 

--- a/node/crypto_test.ts
+++ b/node/crypto_test.ts
@@ -1,0 +1,87 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assert, assertEquals } from "../testing/asserts.ts";
+import { Buffer } from "./buffer.ts";
+import { createHash, getHashes } from "./crypto.ts";
+import { Readable } from "./stream.ts";
+
+Deno.test("[node/crypto.Hash] basic usage - buffer output", () => {
+  const d = createHash("sha1").update("abc").update("def").digest();
+  assertEquals(
+    d,
+    Buffer.from([
+      0x1f,
+      0x8a,
+      0xc1,
+      0xf,
+      0x23,
+      0xc5,
+      0xb5,
+      0xbc,
+      0x11,
+      0x67,
+      0xbd,
+      0xa8,
+      0x4b,
+      0x83,
+      0x3e,
+      0x5c,
+      0x5,
+      0x7a,
+      0x77,
+      0xd2,
+    ]),
+  );
+});
+
+Deno.test("[node/crypto.Hash] basic usage - hex output", () => {
+  const d = createHash("sha1").update("abc").update("def").digest("hex");
+  assertEquals(d, "1f8ac10f23c5b5bc1167bda84b833e5c057a77d2");
+});
+
+Deno.test("[node/crypto.Hash] streaming usage", async () => {
+  const source = Readable.from(["abc", "def"]);
+  const hash = createHash("sha1");
+  const dest = source.pipe(hash);
+  const result = await new Promise((resolve, _) => {
+    let buffer = Buffer.from([]);
+    dest.on("data", (data) => {
+      buffer = Buffer.concat([buffer, data]);
+    });
+    dest.on("end", () => {
+      resolve(buffer);
+    });
+  });
+  assertEquals(
+    result,
+    Buffer.from([
+      0x1f,
+      0x8a,
+      0xc1,
+      0xf,
+      0x23,
+      0xc5,
+      0xb5,
+      0xbc,
+      0x11,
+      0x67,
+      0xbd,
+      0xa8,
+      0x4b,
+      0x83,
+      0x3e,
+      0x5c,
+      0x5,
+      0x7a,
+      0x77,
+      0xd2,
+    ]),
+  );
+});
+
+Deno.test("[node/crypto.getHashes]", () => {
+  for (const algorithm of getHashes()) {
+    const d = createHash(algorithm).update("abc").digest();
+    assert(d instanceof Buffer);
+    assert(d.length > 0);
+  }
+});


### PR DESCRIPTION
This PR adds crypto.createHash() method and related functions.

Many items are still missing, but this partial implementation covers the use case of [object-hash](https://www.npmjs.com/package/object-hash) npm module. object-hash is heavily depended by many modules, which include eslint-loader, nestjs, tailwindcss, [etc](https://www.npmjs.com/browse/depended/object-hash).
