### PR TITLE
fix(node): fix export items of events

### DIFF
--- a/node/_stream/readable_internal.ts
+++ b/node/_stream/readable_internal.ts
@@ -1,7 +1,7 @@
 // Copyright Node.js contributors. All rights reserved. MIT License.
 import { Buffer } from "../buffer.ts";
 import type Duplex from "./duplex.ts";
-import type EventEmitter from "../events.ts";
+import { EventEmitter } from "../events.ts";
 import type Readable from "./readable.ts";
 import type Writable from "./writable.ts";
 import type { ReadableState } from "./readable.ts";

--- a/node/events.ts
+++ b/node/events.ts
@@ -51,7 +51,7 @@ export let defaultMaxListeners = 10;
 /**
  * See also https://nodejs.org/api/events.html
  */
-export default class EventEmitter {
+export class EventEmitter {
   public static captureRejectionSymbol = Symbol.for("nodejs.rejection");
   public static errorMonitor = Symbol("events.errorMonitor");
   public static get defaultMaxListeners() {
@@ -558,7 +558,8 @@ export default class EventEmitter {
   }
 }
 
-export { EventEmitter };
+export default Object.assign(EventEmitter, { EventEmitter });
+
 export const captureRejectionSymbol = EventEmitter.captureRejectionSymbol;
 export const errorMonitor = EventEmitter.errorMonitor;
 export const listenerCount = EventEmitter.listenerCount;

--- a/node/module.ts
+++ b/node/module.ts
@@ -25,7 +25,7 @@ import nodeAssert from "./assert.ts";
 import nodeBuffer from "./buffer.ts";
 import nodeCrypto from "./crypto.ts";
 import nodeConstants from "./constants.ts";
-import EventEmitter from "./events.ts";
+import nodeEvents from "./events.ts";
 import nodeFS from "./fs.ts";
 import nodeOs from "./os.ts";
 import nodePath from "./path.ts";
@@ -610,7 +610,7 @@ nativeModulePolyfill.set(
 nativeModulePolyfill.set("crypto", createNativeModule("crypto", nodeCrypto));
 nativeModulePolyfill.set(
   "events",
-  createNativeModule("events", Object.assign(EventEmitter, { EventEmitter })),
+  createNativeModule("events", nodeEvents),
 );
 nativeModulePolyfill.set("fs", createNativeModule("fs", nodeFS));
 nativeModulePolyfill.set("os", createNativeModule("os", nodeOs));

--- a/node/module.ts
+++ b/node/module.ts
@@ -25,7 +25,7 @@ import nodeAssert from "./assert.ts";
 import nodeBuffer from "./buffer.ts";
 import nodeCrypto from "./crypto.ts";
 import nodeConstants from "./constants.ts";
-import nodeEvents from "./events.ts";
+import EventEmitter from "./events.ts";
 import nodeFS from "./fs.ts";
 import nodeOs from "./os.ts";
 import nodePath from "./path.ts";
@@ -608,7 +608,10 @@ nativeModulePolyfill.set(
   createNativeModule("constants", nodeConstants),
 );
 nativeModulePolyfill.set("crypto", createNativeModule("crypto", nodeCrypto));
-nativeModulePolyfill.set("events", createNativeModule("events", nodeEvents));
+nativeModulePolyfill.set(
+  "events",
+  createNativeModule("events", Object.assign(EventEmitter, { EventEmitter })),
+);
 nativeModulePolyfill.set("fs", createNativeModule("fs", nodeFS));
 nativeModulePolyfill.set("os", createNativeModule("os", nodeOs));
 nativeModulePolyfill.set("path", createNativeModule("path", nodePath));

--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -154,3 +154,8 @@ Deno.test("native modules are extensible", () => {
 Deno.test("Require file with shebang", () => {
   require("./testdata/shebang.js");
 });
+
+Deno.test("EventEmitter is exported correctly", () => {
+  const EventEmitter = require("events");
+  assertEquals(EventEmitter, EventEmitter.EventEmitter);
+});


### PR DESCRIPTION
In Node.js, EventEmitter is exported as both `require("events")` and `require("events").EventEmitter`, but latter is not exported in the current implementation. This PR fixes it.