### PR TITLE
fix(node): fix type errors in canary test

### DIFF
--- a/node/_stream/readable.ts
+++ b/node/_stream/readable.ts
@@ -284,7 +284,7 @@ class Readable extends Stream {
       dest.end();
     }
 
-    let ondrain: () => void;
+    let ondrain: (() => void) | undefined;
 
     let cleanedUp = false;
     function cleanup() {

--- a/node/process.ts
+++ b/node/process.ts
@@ -56,7 +56,7 @@ export const argv: Record<string, string> = new Proxy(_argv, {
     if (prop === Deno.customInspect) {
       return target[Deno.customInspect];
     }
-    return getArguments()[prop as number];
+    return getArguments()[prop as unknown as number];
   },
   ownKeys() {
     return Reflect.ownKeys(getArguments());


### PR DESCRIPTION
This PR fixes type errors in canary test in main branch. TypeScript was updated in https://github.com/denoland/deno/pull/9341 yesterday, and probably that causes these errors.