### PR TITLE
fix(testing): Function signature of assertObjectEquals() does not accept interfaces #741

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -477,6 +477,7 @@ export function assertNotMatch(
  * If not, then throw.
  */
 export function assertObjectMatch(
+  // deno-lint-ignore no-explicit-any
   actual: Record<PropertyKey, any>,
   expected: Record<PropertyKey, unknown>,
 ): void {

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -72,7 +72,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push(
     `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(bold("Expected"))
+      green(
+        bold("Expected"),
+      )
     }`,
   );
   messages.push("");
@@ -302,7 +304,9 @@ export function assertStrictEquals(
         .join("\n");
       message =
         `Values have the same structure but are not reference-equal:\n\n${
-          red(withOffset)
+          red(
+            withOffset,
+          )
         }\n`;
     } else {
       try {
@@ -356,10 +360,7 @@ export function assertNotStrictEquals(
  * Make an assertion that actual is not null or undefined. If not
  * then thrown.
  */
-export function assertExists(
-  actual: unknown,
-  msg?: string,
-): void {
+export function assertExists(actual: unknown, msg?: string): void {
   if (actual === undefined || actual === null) {
     if (!msg) {
       msg =
@@ -429,7 +430,9 @@ export function assertArrayIncludes(
   }
   if (!msg) {
     msg = `actual: "${_format(actual)}" expected to include: "${
-      _format(expected)
+      _format(
+        expected,
+      )
     }"\nmissing: ${_format(missing)}`;
   }
   throw new AssertionError(msg);
@@ -474,7 +477,7 @@ export function assertNotMatch(
  * If not, then throw.
  */
 export function assertObjectMatch(
-  actual: Record<PropertyKey, unknown>,
+  actual: Record<PropertyKey, any>,
   expected: Record<PropertyKey, unknown>,
 ): void {
   type loose = Record<PropertyKey, unknown>;
@@ -482,7 +485,7 @@ export function assertObjectMatch(
   return assertEquals(
     (function filter(a: loose, b: loose): loose {
       // Prevent infinite loop with circular references with same filter
-      if ((seen.has(a)) && (seen.get(a) === b)) {
+      if (seen.has(a) && seen.get(a) === b) {
         return a;
       }
       seen.set(a, b);
@@ -498,7 +501,7 @@ export function assertObjectMatch(
       for (const [key, value] of entries) {
         if (typeof value === "object") {
           const subset = (b as loose)[key];
-          if ((typeof subset === "object") && (subset)) {
+          if (typeof subset === "object" && subset) {
             filtered[key] = filter(value as loose, subset as loose);
             continue;
           }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -304,9 +304,7 @@ export function assertStrictEquals(
         .join("\n");
       message =
         `Values have the same structure but are not reference-equal:\n\n${
-          red(
-            withOffset,
-          )
+          red(withOffset)
         }\n`;
     } else {
       try {
@@ -360,7 +358,10 @@ export function assertNotStrictEquals(
  * Make an assertion that actual is not null or undefined. If not
  * then thrown.
  */
-export function assertExists(actual: unknown, msg?: string): void {
+export function assertExists(
+  actual: unknown,
+  msg?: string,
+): void {
   if (actual === undefined || actual === null) {
     if (!msg) {
       msg =
@@ -430,9 +431,7 @@ export function assertArrayIncludes(
   }
   if (!msg) {
     msg = `actual: "${_format(actual)}" expected to include: "${
-      _format(
-        expected,
-      )
+      _format(expected)
     }"\nmissing: ${_format(missing)}`;
   }
   throw new AssertionError(msg);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -72,9 +72,7 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push(
     `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(
-        bold("Expected"),
-      )
+      green(bold("Expected"))
     }`,
   );
   messages.push("");
@@ -485,7 +483,7 @@ export function assertObjectMatch(
   return assertEquals(
     (function filter(a: loose, b: loose): loose {
       // Prevent infinite loop with circular references with same filter
-      if (seen.has(a) && seen.get(a) === b) {
+      if ((seen.has(a)) && (seen.get(a) === b)) {
         return a;
       }
       seen.set(a, b);
@@ -501,7 +499,7 @@ export function assertObjectMatch(
       for (const [key, value] of entries) {
         if (typeof value === "object") {
           const subset = (b as loose)[key];
-          if (typeof subset === "object" && subset) {
+          if ((typeof subset === "object") && (subset)) {
             filtered[key] = filter(value as loose, subset as loose);
             continue;
           }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -365,15 +365,12 @@ Deno.test("testingAssertObjectMatching", function (): void {
   {
     let didThrow;
     try {
-      assertObjectMatch(
-        {
-          foo: true,
-        },
-        {
-          foo: true,
-          bar: false,
-        },
-      );
+      assertObjectMatch({
+        foo: true,
+      }, {
+        foo: true,
+        bar: false,
+      });
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -158,10 +158,7 @@ Deno.test("testingNotEquals", function (): void {
     new Date(2019, 0, 3, 4, 20, 1, 10),
     new Date(2019, 0, 3, 4, 20, 1, 20),
   );
-  assertNotEquals(
-    new Date("invalid"),
-    new Date(2019, 0, 3, 4, 20, 1, 20),
-  );
+  assertNotEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20));
   let didThrow;
   try {
     assertNotEquals("Raptor", "Raptor");
@@ -310,6 +307,12 @@ Deno.test("testingAssertObjectMatching", function (): void {
   const e = { foo: true } as { [key: string]: unknown };
   e.bar = e;
   const f = { [sym]: true, bar: false };
+  interface r {
+    foo: boolean;
+    bar: boolean;
+  }
+  const g: r = { foo: true, bar: false };
+
   // Simple subset
   assertObjectMatch(a, {
     foo: true,
@@ -349,6 +352,8 @@ Deno.test("testingAssertObjectMatching", function (): void {
       },
     },
   });
+  // Subset with interface
+  assertObjectMatch(g, { bar: false });
   // Subset with same symbol
   assertObjectMatch(f, {
     [sym]: true,
@@ -357,12 +362,15 @@ Deno.test("testingAssertObjectMatching", function (): void {
   {
     let didThrow;
     try {
-      assertObjectMatch({
-        foo: true,
-      }, {
-        foo: true,
-        bar: false,
-      });
+      assertObjectMatch(
+        {
+          foo: true,
+        },
+        {
+          foo: true,
+          bar: false,
+        },
+      );
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);
@@ -659,10 +667,7 @@ Deno.test({
     );
     assertThrows(
       (): void =>
-        assertEquals(
-          new Date("invalid"),
-          new Date(2019, 0, 3, 4, 20, 1, 20),
-        ),
+        assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
       AssertionError,
       [
         "Values are not equal:",

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -158,7 +158,10 @@ Deno.test("testingNotEquals", function (): void {
     new Date(2019, 0, 3, 4, 20, 1, 10),
     new Date(2019, 0, 3, 4, 20, 1, 20),
   );
-  assertNotEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20));
+  assertNotEquals(
+    new Date("invalid"),
+    new Date(2019, 0, 3, 4, 20, 1, 20),
+  );
   let didThrow;
   try {
     assertNotEquals("Raptor", "Raptor");
@@ -667,7 +670,10 @@ Deno.test({
     );
     assertThrows(
       (): void =>
-        assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
+        assertEquals(
+          new Date("invalid"),
+          new Date(2019, 0, 3, 4, 20, 1, 20),
+        ),
       AssertionError,
       [
         "Values are not equal:",


### PR DESCRIPTION
The type `Record<PropertyKey, unknown>` used in `assertObjectEquals()` does not accept interface types as an argument.

```ts
import { assertObjectMatch } from "https://deno.land/std@0.87.0/testing/asserts.ts";

interface NumberToken {
    type: "number";
    value: number;
}

const token: NumberToken = {
    type: "number",
    value: 15
};

assertObjectMatch(token, { type: "number" }); // doesn't work

type TNumberToken = {
    type: "number";
    value: number;
};

const typeToken: TNumberToken = {
    type: "number",
    value: 15
};

assertObjectMatch(typeToken, { type: "number" }); // works
```
The solution is to change `assertObjectMatch` first param from `unknown` to `any`.
