### PR TITLE
refactor: fix codes to pass `no-unused-vars` lint

### DIFF
--- a/encoding/_yaml/schema.ts
+++ b/encoding/_yaml/schema.ts
@@ -36,7 +36,7 @@ function compileList(
     result.push(currentType);
   }
 
-  return result.filter((type, index): unknown => !exclude.includes(index));
+  return result.filter((_type, index): unknown => !exclude.includes(index));
 }
 
 export type TypeMap = { [k in KindType | "fallback"]: ArrayObject<Type> };

--- a/examples/chat/server_test.ts
+++ b/examples/chat/server_test.ts
@@ -27,7 +27,7 @@ async function startServer(): Promise<
     const r = new TextProtoReader(new BufReader(server.stdout));
     const s = await r.readLine();
     assert(s !== null && s.includes("chat server starting"));
-  } catch (err) {
+  } catch {
     server.stdout.close();
     server.close();
   }

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -468,7 +468,7 @@ class Printf {
     let s = "";
     try {
       s = String.fromCodePoint(n);
-    } catch (RangeError) {
+    } catch {
       s = UNICODE_REPLACEMENT_CHARACTER;
     }
     return this.pad(s);

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -187,7 +187,7 @@ Deno.test({
         secure: true,
         maxAge: 0,
       });
-    } catch (e) {
+    } catch {
       error = true;
     }
     assert(error);

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -199,7 +199,7 @@ async function serveDir(
   return res;
 }
 
-function serveFallback(req: ServerRequest, e: Error): Promise<Response> {
+function serveFallback(_req: ServerRequest, e: Error): Promise<Response> {
   if (e instanceof URIError) {
     return Promise.resolve({
       status: 400,

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -2,7 +2,6 @@
 import {
   assert,
   assertEquals,
-  assertNotEquals,
   assertStringIncludes,
 } from "../testing/asserts.ts";
 import { BufReader } from "../io/bufio.ts";

--- a/http/server.ts
+++ b/http/server.ts
@@ -160,7 +160,7 @@ export class Server implements AsyncIterable<ServerRequest> {
               status: 400,
               body: new TextEncoder().encode(`${error.message}\r\n\r\n`),
             });
-          } catch (error) {
+          } catch {
             // The connection is broken.
           }
         }
@@ -187,7 +187,7 @@ export class Server implements AsyncIterable<ServerRequest> {
       try {
         // Consume unread body and trailers if receiver didn't consume those data
         await request.finalize();
-      } catch (error) {
+      } catch {
         // Invalid data was received or the connection was closed.
         break;
       }
@@ -196,7 +196,7 @@ export class Server implements AsyncIterable<ServerRequest> {
     this.untrackConnection(conn);
     try {
       conn.close();
-    } catch (e) {
+    } catch {
       // might have been already closed
     }
   }

--- a/node/_crypto/pbkdf2_test.ts
+++ b/node/_crypto/pbkdf2_test.ts
@@ -3,11 +3,7 @@ import {
   pbkdf2,
   pbkdf2Sync,
 } from "./pbkdf2.ts";
-import {
-  assert,
-  assertEquals,
-  assertStringIncludes,
-} from "../../testing/asserts.ts";
+import { assert, assertEquals } from "../../testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_utils.ts";
 
 type Pbkdf2Fixture = {

--- a/node/_crypto/randomBytes_test.ts
+++ b/node/_crypto/randomBytes_test.ts
@@ -1,7 +1,6 @@
 import {
   assert,
   assertEquals,
-  assertStringIncludes,
   assertThrows,
   assertThrowsAsync,
 } from "../../testing/asserts.ts";

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -17,6 +17,6 @@ export function access(
 // TODO(bartlomieju) 'path' can also be a Buffer.  Neither of these polyfills
 // is available yet.  See https://github.com/denoland/deno/issues/3403
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function accessSync(path: string | URL, mode?: number): void {
+export function accessSync(_path: string | URL, _mode?: number): void {
   notImplemented("Not yet available");
 }

--- a/node/_fs/_fs_dir_test.ts
+++ b/node/_fs/_fs_dir_test.ts
@@ -83,7 +83,7 @@ Deno.test({
       const firstRead: Dirent | null = await dir.read();
       const secondRead: Dirent | null = await dir.read(
         // deno-lint-ignore no-explicit-any
-        (err: any, secondResult: Dirent) => {
+        (_err: any, secondResult: Dirent) => {
           assert(
             secondResult.name === "bar.txt" ||
               secondResult.name === "foo.txt",

--- a/node/_fs/_fs_mkdtemp.ts
+++ b/node/_fs/_fs_mkdtemp.ts
@@ -64,7 +64,7 @@ function parseEncoding(
   if (encoding) {
     try {
       new TextDecoder(encoding);
-    } catch (error) {
+    } catch {
       throw new ERR_INVALID_OPT_VALUE_ENCODING(encoding);
     }
   }

--- a/node/_fs/_fs_readdir.ts
+++ b/node/_fs/_fs_readdir.ts
@@ -50,7 +50,7 @@ export function readdir(
   if (options?.encoding) {
     try {
       new TextDecoder(options.encoding);
-    } catch (error) {
+    } catch {
       throw new Error(
         `TypeError [ERR_INVALID_OPT_VALUE_ENCODING]: The value "${options.encoding}" is invalid for option "encoding"`,
       );
@@ -100,7 +100,7 @@ export function readdirSync(
   if (options?.encoding) {
     try {
       new TextDecoder(options.encoding);
-    } catch (error) {
+    } catch {
       throw new Error(
         `TypeError [ERR_INVALID_OPT_VALUE_ENCODING]: The value "${options.encoding}" is invalid for option "encoding"`,
       );

--- a/node/_fs/_fs_watch_test.ts
+++ b/node/_fs/_fs_watch_test.ts
@@ -1,5 +1,5 @@
 import { watch } from "./_fs_watch.ts";
-import { assertEquals, fail } from "../../testing/asserts.ts";
+import { assertEquals } from "../../testing/asserts.ts";
 
 function wait(time: number) {
   return new Promise((resolve) => {

--- a/node/_stream/duplex_internal.ts
+++ b/node/_stream/duplex_internal.ts
@@ -59,7 +59,7 @@ function endReadableNT(state: ReadableState, stream: Duplex) {
   }
 }
 
-function endWritableNT(state: ReadableState, stream: Duplex) {
+function endWritableNT(_state: ReadableState, stream: Duplex) {
   const writable = stream.writable &&
     !stream.writableEnded &&
     !stream.destroyed;

--- a/node/_util/_util_callbackify_test.ts
+++ b/node/_util/_util_callbackify_test.ts
@@ -204,7 +204,7 @@ Deno.test(
 
       const thenableFn = (): PromiseLike<never> => {
         return {
-          then(onfulfilled, onrejected): PromiseLike<never> {
+          then(_onfulfilled, onrejected): PromiseLike<never> {
             assert(onrejected);
             onrejected(value);
             return this;

--- a/node/assert_test.ts
+++ b/node/assert_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import {
-  assert as denoAssert,
   assertEquals,
   assertMatch,
   assertNotEquals,

--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -537,7 +537,7 @@ export class AssertionError extends Error {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 
-  [inspect.custom](recurseTimes: number, ctx: Record<string, unknown>) {
+  [inspect.custom](_recurseTimes: number, ctx: Record<string, unknown>) {
     // Long strings should not be fully inspected.
     const tmpActual = this.actual;
     const tmpExpected = this.expected;

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -23,7 +23,7 @@ import { encodeToString as encodeToHexString } from "../encoding/hex.ts";
  */
 export class Hash extends Transform {
   public hash: Hasher;
-  constructor(algorithm: SupportedAlgorithm, opts?: TransformOptions) {
+  constructor(algorithm: SupportedAlgorithm, _opts?: TransformOptions) {
     super({
       transform(chunk: string, _encoding: string, callback: () => void): void {
         hash.update(chunk);

--- a/node/events_test.ts
+++ b/node/events_test.ts
@@ -681,7 +681,7 @@ Deno.test("Elements that extend EventEmitter listener alias don't end up in a de
   const x = new X();
   try {
     x.on("x", () => {});
-  } catch (e) {
+  } catch {
     fail();
   }
 });

--- a/node/os.ts
+++ b/node/os.ts
@@ -211,6 +211,7 @@ export function uptime(): number {
 
 /** Not yet implemented */
 export function userInfo(
+  // deno-lint-ignore no-unused-vars
   options: UserInfoOptions = { encoding: "utf-8" },
 ): UserInfo {
   notImplemented(SEE_GITHUB_ISSUE);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -210,7 +210,7 @@ export function assertEquals(
     );
     const diffMsg = buildMessage(diffResult).join("\n");
     message = `Values are not equal:\n${diffMsg}`;
-  } catch (e) {
+  } catch {
     message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
   }
   if (msg) {
@@ -247,12 +247,12 @@ export function assertNotEquals(
   let expectedString: string;
   try {
     actualString = String(actual);
-  } catch (e) {
+  } catch {
     actualString = "[Cannot display]";
   }
   try {
     expectedString = String(expected);
-  } catch (e) {
+  } catch {
     expectedString = "[Cannot display]";
   }
   if (!msg) {
@@ -312,7 +312,7 @@ export function assertStrictEquals(
         );
         const diffMsg = buildMessage(diffResult).join("\n");
         message = `Values are not strictly equal:\n${diffMsg}`;
-      } catch (e) {
+      } catch {
         message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
       }
     }

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-unused-vars
 
 import { relative, resolve } from "../path/mod.ts";
 

--- a/wasi/snapshot_preview1_test.ts
+++ b/wasi/snapshot_preview1_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import Context from "./snapshot_preview1.ts";
-import { assert, assertEquals, assertThrows } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
 

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -228,7 +228,7 @@ class WebSocketImpl implements WebSocket {
       let frame: WebSocketFrame;
       try {
         frame = await readFrame(this.bufReader);
-      } catch (e) {
+      } catch {
         this.ensureSocketClosed();
         break;
       }


### PR DESCRIPTION
The `no-unused-vars` rule is going to be enabled by default in deno_lint: https://github.com/denoland/deno_lint/pull/625
Once it's enabled, lots of errors will be flagged in deno_std. So in this PR, I address them beforehand.