### PR TITLE
Feat/add node truncate and truncate sync

### DIFF
--- a/node/_fs/_fs_truncate.ts
+++ b/node/_fs/_fs_truncate.ts
@@ -1,0 +1,27 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { CallbackWithError } from "./_fs_common.ts";
+import { fromFileUrl } from "../path.ts";
+
+export function truncate(
+  path: string | URL,
+  lenOrCallback: number | CallbackWithError,
+  maybeCallback?: CallbackWithError,
+) {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+  const len: number | undefined = typeof lenOrCallback === "number"
+    ? lenOrCallback
+    : undefined;
+  const callback: CallbackWithError = typeof lenOrCallback === "function"
+    ? lenOrCallback
+    : maybeCallback as CallbackWithError;
+
+  if (!callback) throw new Error("No callback function supplied");
+
+  Deno.truncate(path, len).then(() => callback(null), callback);
+}
+
+export function truncateSync(path: string | URL, len?: number) {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+
+  Deno.truncateSync(path, len);
+}

--- a/node/_fs/_fs_truncate_test.ts
+++ b/node/_fs/_fs_truncate_test.ts
@@ -1,0 +1,94 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assertEquals, assertThrows, fail } from "../../testing/asserts.ts";
+import { truncate, truncateSync } from "./_fs_truncate.ts";
+
+Deno.test({
+  name: "ASYNC: no callback function results in Error",
+  fn() {
+    assertThrows(
+      () => {
+        truncate("some/path", 0);
+      },
+      Error,
+      "No callback function supplied",
+    );
+  },
+});
+
+Deno.test({
+  name: "ASYNC: truncate entire file contents",
+  async fn() {
+    const file: string = Deno.makeTempFileSync();
+    await Deno.writeFile(file, new TextEncoder().encode("hello world"));
+
+    await new Promise<void>((resolve, reject) => {
+      truncate(file, (err: Error | null) => {
+        if (err !== null) reject();
+        else resolve();
+      });
+    })
+      .then(
+        () => {
+          const fileInfo: Deno.FileInfo = Deno.lstatSync(file);
+          assertEquals(fileInfo.size, 0);
+        },
+        () => {
+          fail("No error expected");
+        },
+      )
+      .finally(() => Deno.removeSync(file));
+  },
+});
+
+Deno.test({
+  name: "ASYNC: truncate file to a size of precisely len bytes",
+  async fn() {
+    const file: string = Deno.makeTempFileSync();
+    await Deno.writeFile(file, new TextEncoder().encode("hello world"));
+
+    await new Promise<void>((resolve, reject) => {
+      truncate(file, 3, (err: Error | null) => {
+        if (err !== null) reject();
+        else resolve();
+      });
+    })
+      .then(
+        () => {
+          const fileInfo: Deno.FileInfo = Deno.lstatSync(file);
+          assertEquals(fileInfo.size, 3);
+        },
+        () => {
+          fail("No error expected");
+        },
+      )
+      .finally(() => Deno.removeSync(file));
+  },
+});
+
+Deno.test({
+  name: "SYNC: truncate entire file contents",
+  fn() {
+    const file: string = Deno.makeTempFileSync();
+    try {
+      truncateSync(file);
+      const fileInfo: Deno.FileInfo = Deno.lstatSync(file);
+      assertEquals(fileInfo.size, 0);
+    } finally {
+      Deno.removeSync(file);
+    }
+  },
+});
+
+Deno.test({
+  name: "SYNC: truncate file to a size of precisely len bytes",
+  fn() {
+    const file: string = Deno.makeTempFileSync();
+    try {
+      truncateSync(file, 3);
+      const fileInfo: Deno.FileInfo = Deno.lstatSync(file);
+      assertEquals(fileInfo.size, 3);
+    } finally {
+      Deno.removeSync(file);
+    }
+  },
+});

--- a/node/fs.ts
+++ b/node/fs.ts
@@ -21,6 +21,7 @@ import { watch } from "./_fs/_fs_watch.ts";
 import { open, openSync } from "./_fs/_fs_open.ts";
 import { stat, statSync } from "./_fs/_fs_stat.ts";
 import { lstat, lstatSync } from "./_fs/_fs_lstat.ts";
+import { truncate, truncateSync } from "./_fs/_fs_truncate.ts";
 
 import * as promises from "./_fs/promises/mod.ts";
 
@@ -68,6 +69,8 @@ export default {
   watch,
   writeFile,
   writeFileSync,
+  truncate,
+  truncateSync,
 };
 
 export {
@@ -109,6 +112,8 @@ export {
   rmdirSync,
   stat,
   statSync,
+  truncate,
+  truncateSync,
   unlink,
   unlinkSync,
   watch,


### PR DESCRIPTION
Implemented `truncate` and `truncateSync` in `node/fs`. #648 

Ref to [node documents](https://nodejs.org/api/fs.html#fs_fs_truncate_path_len_callback):

> Passing a file descriptor is deprecated and may result in an error being thrown in the future

So I ignored handling file descriptors in implementation. let me know otherwise.
