### PR TITLE
chore(build): disable codecov status

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,7 @@
 comment: false
 codecov:
   require_ci_to_pass: true
+coverage:
+  status:
+    project: off
+    patch: off

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,5 +3,6 @@ codecov:
   require_ci_to_pass: true
 coverage:
   status:
-    project: off
-    patch: off
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
This PR disables the commit status from codecov.io.

Codecov sends failed commit status to the branch when the coverage rate is decreased. Higher coverage rate is generally a good thing, but marking the commit as `failure` because of the decreased coverage doesn't make sense to our use case.

ref: https://docs.codecov.io/docs/commit-status#disabling-a-status