### PR TITLE
feat(testing): Adding `assertTruthy` to ensure a value is true in a boolean context

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -72,7 +72,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push(
     `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(bold("Expected"))
+      green(
+        bold("Expected"),
+      )
     }`,
   );
   messages.push("");
@@ -302,7 +304,9 @@ export function assertStrictEquals(
         .join("\n");
       message =
         `Values have the same structure but are not reference-equal:\n\n${
-          red(withOffset)
+          red(
+            withOffset,
+          )
         }\n`;
     } else {
       try {
@@ -353,13 +357,24 @@ export function assertNotStrictEquals(
 }
 
 /**
+ * Make an asserion that actual is truthy. If not then thrown.
+ */
+export function assertTruthy(actual: unknown, msg?: string) {
+  const pass = !!actual;
+  if (pass) {
+    return true;
+  }
+
+  throw new AssertionError(
+    msg ?? `Expected "actual" to be true in a boolean context`,
+  );
+}
+
+/**
  * Make an assertion that actual is not null or undefined. If not
  * then thrown.
  */
-export function assertExists(
-  actual: unknown,
-  msg?: string,
-): void {
+export function assertExists(actual: unknown, msg?: string): void {
   if (actual === undefined || actual === null) {
     if (!msg) {
       msg =
@@ -429,7 +444,9 @@ export function assertArrayIncludes(
   }
   if (!msg) {
     msg = `actual: "${_format(actual)}" expected to include: "${
-      _format(expected)
+      _format(
+        expected,
+      )
     }"\nmissing: ${_format(missing)}`;
   }
   throw new AssertionError(msg);
@@ -482,7 +499,7 @@ export function assertObjectMatch(
   return assertEquals(
     (function filter(a: loose, b: loose): loose {
       // Prevent infinite loop with circular references with same filter
-      if ((seen.has(a)) && (seen.get(a) === b)) {
+      if (seen.has(a) && seen.get(a) === b) {
         return a;
       }
       seen.set(a, b);
@@ -498,7 +515,7 @@ export function assertObjectMatch(
       for (const [key, value] of entries) {
         if (typeof value === "object") {
           const subset = (b as loose)[key];
-          if ((typeof subset === "object") && (subset)) {
+          if (typeof subset === "object" && subset) {
             filtered[key] = filter(value as loose, subset as loose);
             continue;
           }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -15,6 +15,7 @@ import {
   assertStringIncludes,
   assertThrows,
   assertThrowsAsync,
+  assertTruthy,
   equal,
   fail,
   unimplemented,
@@ -42,18 +43,8 @@ Deno.test("testingEqual", function (): void {
       { hello: "world", hi: { there: "everyone else" } },
     ),
   );
-  assert(
-    equal(
-      { [Symbol.for("foo")]: "bar" },
-      { [Symbol.for("foo")]: "bar" },
-    ),
-  );
-  assert(
-    !equal(
-      { [Symbol("foo")]: "bar" },
-      { [Symbol("foo")]: "bar" },
-    ),
-  );
+  assert(equal({ [Symbol.for("foo")]: "bar" }, { [Symbol.for("foo")]: "bar" }));
+  assert(!equal({ [Symbol("foo")]: "bar" }, { [Symbol("foo")]: "bar" }));
   assert(equal(/deno/, /deno/));
   assert(!equal(/deno/, /node/));
   assert(equal(new Date(2019, 0, 3), new Date(2019, 0, 3)));
@@ -158,10 +149,7 @@ Deno.test("testingNotEquals", function (): void {
     new Date(2019, 0, 3, 4, 20, 1, 10),
     new Date(2019, 0, 3, 4, 20, 1, 20),
   );
-  assertNotEquals(
-    new Date("invalid"),
-    new Date(2019, 0, 3, 4, 20, 1, 20),
-  );
+  assertNotEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20));
   let didThrow;
   try {
     assertNotEquals("Raptor", "Raptor");
@@ -208,6 +196,24 @@ Deno.test("testingAssertStringContains", function (): void {
   let didThrow;
   try {
     assertStringIncludes("Denosaurus", "Raptor");
+    didThrow = false;
+  } catch (e) {
+    assert(e instanceof AssertionError);
+    didThrow = true;
+  }
+  assertEquals(didThrow, true);
+});
+
+Deno.test("testingAssertTruthy", function (): void {
+  assertTruthy(true);
+  let didThrow;
+  try {
+    assertTruthy(false);
+    assertTruthy(0);
+    assertTruthy("");
+    assertTruthy(null);
+    assertTruthy(undefined);
+    assertTruthy(NaN);
     didThrow = false;
   } catch (e) {
     assert(e instanceof AssertionError);
@@ -357,12 +363,15 @@ Deno.test("testingAssertObjectMatching", function (): void {
   {
     let didThrow;
     try {
-      assertObjectMatch({
-        foo: true,
-      }, {
-        foo: true,
-        bar: false,
-      });
+      assertObjectMatch(
+        {
+          foo: true,
+        },
+        {
+          foo: true,
+          bar: false,
+        },
+      );
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);
@@ -659,10 +668,7 @@ Deno.test({
     );
     assertThrows(
       (): void =>
-        assertEquals(
-          new Date("invalid"),
-          new Date(2019, 0, 3, 4, 20, 1, 20),
-        ),
+        assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
       AssertionError,
       [
         "Values are not equal:",


### PR DESCRIPTION
Use `assertTruthy` when  you don't care what a value is and you want to ensure a value is true in a boolean context.
In Javascript The following values are **always falsy**:

- `false`
- `0`(zero)
- `''` or `""` (empty string)
- `null`
- `undefined`
- `NaN`
