### PR TITLE
feat(encoding/yaml): Add support for JS types and user types

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -463,6 +463,44 @@ console.log(data);
 // => [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" } ]
 ```
 
+To handle `function`, `regexp`, and `undefined` types, use the
+`EXTENDED_SCHEMA`.
+
+```ts
+import {
+  EXTENDED_SCHEMA,
+  parse,
+} from "https://deno.land/std@$STD_VERSION/encoding/yaml.ts";
+
+const data = parse(
+  `
+  regexp:
+    simple: !!js/regexp foobar
+    modifiers: !!js/regexp /foobar/mi
+  undefined: !!js/undefined ~
+  function: !!js/function >
+    function foobar() {
+      return 'hello world!';
+    }
+`,
+  { schema: EXTENDED_SCHEMA },
+);
+```
+
+You can also use custom types by extending schemas.
+
+```ts
+import {
+  parse,
+  Type,
+} from "https://deno.land/std@$STD_VERSION/encoding/yaml.ts";
+
+const MyYamlType = new Type("!myYamlType", {/* your type definition here*/});
+const MY_SCHEMA = DEFAULT_SCHEMA.extend({ explicit: [MyYamlType] });
+
+parse(yaml, { schema: MY_SCHEMA });
+```
+
 ### API
 
 #### `parse(str: string, opts?: ParserOption): unknown`
@@ -481,11 +519,10 @@ Serializes `object` as a YAML document.
 ### :warning: Limitations
 
 - `binary` type is currently not stable.
-- `function`, `regexp`, and `undefined` type are currently not supported.
 
 ### More example
 
-See: https://github.com/nodeca/js-yaml
+See: https://github.com/nodeca/js-yaml/tree/master/examples
 
 ## base32
 

--- a/encoding/_yaml/example/sample_document.yml
+++ b/encoding/_yaml/example/sample_document.yml
@@ -181,17 +181,17 @@ timestamp:
 
 # https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/RegExp
 
-# regexp:
-#   simple: !!js/regexp      foobar
-#   modifiers: !!js/regexp   /foobar/mi
+regexp:
+  simple: !!js/regexp      foobar
+  modifiers: !!js/regexp   /foobar/mi
 
 # https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/undefined
 
-# undefined: !!js/undefined ~
+undefined: !!js/undefined ~
 
 # https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function
 
-# function: !!js/function >
-#   function foobar() {
-#     return 'Wow! JS-YAML Rocks!';
-#   }
+function: !!js/function >
+  function foobar() {
+    return 'Wow! JS-YAML Rocks!';
+  }

--- a/encoding/_yaml/parse_test.ts
+++ b/encoding/_yaml/parse_test.ts
@@ -4,7 +4,10 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 import { parse, parseAll } from "./parse.ts";
-import { assertEquals } from "../../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+import { DEFAULT_SCHEMA, EXTENDED_SCHEMA } from "./schema/mod.ts";
+import { YAMLError } from "./error.ts";
+import { Type } from "./type.ts";
 
 Deno.test({
   name: "`parse` parses single document yaml string",
@@ -52,5 +55,84 @@ name: Eve
       },
     ];
     assertEquals(parseAll(yaml), expected);
+  },
+});
+
+Deno.test({
+  name: "`!!js/*` yaml types are not handled in default schemas",
+  fn(): void {
+    const yaml = `undefined: !!js/undefined ~`;
+    assertThrows(() => parse(yaml), YAMLError, "unknown tag !");
+  },
+});
+
+Deno.test({
+  name: "`!!js/*` yaml types are correctly handled with extended schema",
+  fn(): void {
+    const yaml = `
+      regexp:
+        simple: !!js/regexp foobar
+        modifiers: !!js/regexp /foobar/mi
+      undefined: !!js/undefined ~
+    `;
+
+    const expected = {
+      regexp: {
+        simple: /foobar/,
+        modifiers: /foobar/mi,
+      },
+      undefined: undefined,
+    };
+
+    assertEquals(parse(yaml, { schema: EXTENDED_SCHEMA }), expected);
+  },
+});
+
+Deno.test({
+  name: "`!!js/function` yaml type is correctly handled with extended schema",
+  fn(): void {
+    const func = function foobar() {
+      return "hello world!";
+    };
+
+    const yaml = `
+function: !!js/function >
+${func.toString().split("\n").map((line) => `  ${line}`).join("\n")}
+`;
+
+    const parsed = parse(yaml, { schema: EXTENDED_SCHEMA }) as {
+      [key: string]: unknown;
+    };
+
+    assertEquals(Object.keys(parsed).length, 1);
+    assertEquals((parsed?.function as typeof func).toString(), func.toString());
+  },
+});
+
+Deno.test({
+  name: "`!*` yaml user defined types are supported",
+  fn(): void {
+    const PointYamlType = new Type("!point", {
+      kind: "sequence",
+      resolve(data) {
+        return data !== null && data?.length === 3;
+      },
+      construct(data) {
+        const [x, y, z] = data;
+        return { x, y, z };
+      },
+      represent(point) {
+        return JSON.stringify(point);
+      },
+    });
+    const SPACE_SCHEMA = DEFAULT_SCHEMA.extend({ explicit: [PointYamlType] });
+
+    const yaml = `
+      point: !point [1, 2, 3]
+    `;
+
+    assertEquals(parse(yaml, { schema: SPACE_SCHEMA }), {
+      point: { x: 1, y: 2, z: 3 },
+    });
   },
 });

--- a/encoding/_yaml/parse_test.ts
+++ b/encoding/_yaml/parse_test.ts
@@ -59,7 +59,7 @@ name: Eve
 });
 
 Deno.test({
-  name: "`!!js/*` yaml types are not handled in default schemas",
+  name: "`!!js/*` yaml types are not handled in default schemas while parsing",
   fn(): void {
     const yaml = `undefined: !!js/undefined ~`;
     assertThrows(() => parse(yaml), YAMLError, "unknown tag !");
@@ -67,7 +67,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "`!!js/*` yaml types are correctly handled with extended schema",
+  name:
+    "`!!js/*` yaml types are correctly handled with extended schema while parsing",
   fn(): void {
     const yaml = `
       regexp:
@@ -89,7 +90,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "`!!js/function` yaml type is correctly handled with extended schema",
+  name:
+    "`!!js/function` yaml type is correctly handled with extended schema while parsing",
   fn(): void {
     const func = function foobar() {
       return "hello world!";
@@ -110,7 +112,7 @@ ${func.toString().split("\n").map((line) => `  ${line}`).join("\n")}
 });
 
 Deno.test({
-  name: "`!*` yaml user defined types are supported",
+  name: "`!*` yaml user defined types are supported while parsing",
   fn(): void {
     const PointYamlType = new Type("!point", {
       kind: "sequence",
@@ -120,9 +122,6 @@ Deno.test({
       construct(data) {
         const [x, y, z] = data;
         return { x, y, z };
-      },
-      represent(point) {
-        return JSON.stringify(point);
       },
     });
     const SPACE_SCHEMA = DEFAULT_SCHEMA.extend({ explicit: [PointYamlType] });

--- a/encoding/_yaml/schema.ts
+++ b/encoding/_yaml/schema.ts
@@ -91,6 +91,19 @@ export class Schema implements SchemaDefinition {
     );
   }
 
+  /* Returns a new extended schema from current schema */
+  public extend(definition: SchemaDefinition) {
+    return new Schema({
+      implicit: [
+        ...new Set([...this.implicit, ...(definition?.implicit ?? [])]),
+      ],
+      explicit: [
+        ...new Set([...this.explicit, ...(definition?.explicit ?? [])]),
+      ],
+      include: [...new Set([...this.include, ...(definition?.include ?? [])])],
+    });
+  }
+
   public static create(): void {}
 }
 

--- a/encoding/_yaml/schema/extended.ts
+++ b/encoding/_yaml/schema/extended.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { Schema } from "../schema.ts";
+import { func, regexp, undefinedType } from "../type/mod.ts";
+import { def } from "./default.ts";
+
+// Extends JS-YAML default schema with additional JavaScript types
+// It is not described in the YAML specification.
+export const extended = new Schema({
+  explicit: [func, regexp, undefinedType],
+  include: [def],
+});

--- a/encoding/_yaml/schema/mod.ts
+++ b/encoding/_yaml/schema/mod.ts
@@ -5,5 +5,6 @@
 
 export { core as CORE_SCHEMA } from "./core.ts";
 export { def as DEFAULT_SCHEMA } from "./default.ts";
+export { extended as EXTENDED_SCHEMA } from "./extended.ts";
 export { failsafe as FAILSAFE_SCHEMA } from "./failsafe.ts";
 export { json as JSON_SCHEMA } from "./json.ts";

--- a/encoding/_yaml/type/function.ts
+++ b/encoding/_yaml/type/function.ts
@@ -7,11 +7,11 @@ import { Type } from "../type.ts";
 import type { Any } from "../utils.ts";
 
 // Note: original implementation used Esprima to handle functions
-// To avoid depencies, we'll just try to check if we can construct a function from given string
+// To avoid dependencies, we'll just try to check if we can construct a function from given string
 function reconstructFunction(code: string) {
   const func = new Function(`return ${code}`)();
   if (!(func instanceof Function)) {
-    throw new TypeError(`Expected function but got ${typeof func}`);
+    throw new TypeError(`Expected function but got ${typeof func}: ${code}`);
   }
   return func;
 }

--- a/encoding/_yaml/type/function.ts
+++ b/encoding/_yaml/type/function.ts
@@ -1,0 +1,41 @@
+// Ported and adapted from js-yaml-js-types v1.0.0:
+// https://github.com/nodeca/js-yaml-js-types/tree/ac537e7bbdd3c2cbbd9882ca3919c520c2dc022b
+// Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { Type } from "../type.ts";
+import type { Any } from "../utils.ts";
+
+// Note: original implementation used Esprima to handle functions
+// To avoid depencies, we'll just try to check if we can construct a function from given string
+function reconstructFunction(code: string) {
+  const func = new Function(`return ${code}`)();
+  if (!(func instanceof Function)) {
+    throw new TypeError(`Expected function but got ${typeof func}`);
+  }
+  return func;
+}
+
+export const func = new Type("tag:yaml.org,2002:js/function", {
+  kind: "scalar",
+  resolve(data: Any) {
+    if (data === null) {
+      return false;
+    }
+    try {
+      reconstructFunction(`${data}`);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  },
+  construct(data: string) {
+    return reconstructFunction(data);
+  },
+  predicate(object: unknown) {
+    return object instanceof Function;
+  },
+  represent(object: (...args: Any[]) => Any) {
+    return object.toString();
+  },
+});

--- a/encoding/_yaml/type/mod.ts
+++ b/encoding/_yaml/type/mod.ts
@@ -6,13 +6,16 @@
 export { binary } from "./binary.ts";
 export { bool } from "./bool.ts";
 export { float } from "./float.ts";
+export { func } from "./function.ts";
 export { int } from "./int.ts";
 export { map } from "./map.ts";
 export { merge } from "./merge.ts";
 export { nil } from "./nil.ts";
 export { omap } from "./omap.ts";
 export { pairs } from "./pairs.ts";
+export { regexp } from "./regexp.ts";
 export { seq } from "./seq.ts";
 export { set } from "./set.ts";
 export { str } from "./str.ts";
 export { timestamp } from "./timestamp.ts";
+export { undefinedType } from "./undefined.ts";

--- a/encoding/_yaml/type/regexp.ts
+++ b/encoding/_yaml/type/regexp.ts
@@ -1,0 +1,44 @@
+// Ported and adapted from js-yaml-js-types v1.0.0:
+// https://github.com/nodeca/js-yaml-js-types/tree/ac537e7bbdd3c2cbbd9882ca3919c520c2dc022b
+// Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { Type } from "../type.ts";
+import type { Any } from "../utils.ts";
+
+const REGEXP = /^\/(?<regexp>[\s\S]+)\/(?<modifiers>[gismuy]*)$/;
+
+export const regexp = new Type("tag:yaml.org,2002:js/regexp", {
+  kind: "scalar",
+  resolve(data: Any) {
+    if ((data === null) || (!data.length)) {
+      return false;
+    }
+
+    const regexp = `${data}`;
+    if (regexp.charAt(0) === "/") {
+      // Ensure regex is properly terminated
+      if (!REGEXP.test(data)) {
+        return false;
+      }
+      // Check no duplicate modifiers
+      const modifiers = [...(regexp.match(REGEXP)?.groups?.modifiers ?? "")];
+      if (new Set(modifiers).size < modifiers.length) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+  construct(data: string) {
+    const { regexp = `${data}`, modifiers = "" } =
+      `${data}`.match(REGEXP)?.groups ?? {};
+    return new RegExp(regexp, modifiers);
+  },
+  predicate(object: unknown) {
+    return object instanceof RegExp;
+  },
+  represent(object: RegExp) {
+    return object.toString();
+  },
+});

--- a/encoding/_yaml/type/undefined.ts
+++ b/encoding/_yaml/type/undefined.ts
@@ -1,0 +1,22 @@
+// Ported and adapted from js-yaml-js-types v1.0.0:
+// https://github.com/nodeca/js-yaml-js-types/tree/ac537e7bbdd3c2cbbd9882ca3919c520c2dc022b
+// Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { Type } from "../type.ts";
+
+export const undefinedType = new Type("tag:yaml.org,2002:js/undefined", {
+  kind: "scalar",
+  resolve() {
+    return true;
+  },
+  construct() {
+    return undefined;
+  },
+  predicate(object) {
+    return typeof object === "undefined";
+  },
+  represent() {
+    return "";
+  },
+});

--- a/encoding/yaml.ts
+++ b/encoding/yaml.ts
@@ -8,10 +8,11 @@ export { parse, parseAll } from "./_yaml/parse.ts";
 export type { DumpOptions as StringifyOptions } from "./_yaml/stringify.ts";
 export { stringify } from "./_yaml/stringify.ts";
 export type { SchemaDefinition } from "./_yaml/schema.ts";
-export type { StyleVariant } from "./_yaml/type.ts";
+export type { StyleVariant, Type } from "./_yaml/type.ts";
 export {
   CORE_SCHEMA,
   DEFAULT_SCHEMA,
+  EXTENDED_SCHEMA,
   FAILSAFE_SCHEMA,
   JSON_SCHEMA,
 } from "./_yaml/schema/mod.ts";


### PR DESCRIPTION
This extends current YAML support with an `EXTENDED_SCHEMA` which supports `!!js/regexp`, `!!js/function` and `!!js/undefined` to remove current [Deno limitation](https://github.com/denoland/deno_std/tree/main/encoding#warning-limitations) (heavily based on [nodeca/js-yaml-js-types](https://github.com/nodeca/js-yaml-js-types) but reworked a bit to be more succint).

This also exposes the `Type` function (which is already implemented but not available to end-users) to allow the creation of custom types with `!tags` as defined in [YAML spec](https://yaml.org/spec/1.2/spec.html#tag/).