### PR TITLE
chore: fix typo in duplex_test.ts

### DIFF
--- a/node/_stream/duplex_test.ts
+++ b/node/_stream/duplex_test.ts
@@ -86,7 +86,7 @@ Deno.test("Duplex stream can be paused", () => {
   assert(!readable.isPaused());
 });
 
-Deno.test("Duplex stream sets enconding correctly", () => {
+Deno.test("Duplex stream sets encoding correctly", () => {
   const readable = new Duplex({
     read() {},
   });


### PR DESCRIPTION
enconding -> encoding