### PR TITLE
refactor(node): remove unused variable `msg`

### DIFF
--- a/node/assert.ts
+++ b/node/assert.ts
@@ -223,7 +223,6 @@ function throws(
     }
     throw new Error(`Invalid expectation: ${error}`);
   }
-  let msg;
   if (message) {
     let msg = `Missing expected exception: ${message}`;
     if (typeof error === "function" && error?.name) {


### PR DESCRIPTION
This PR removes `msg` because this variable looks to be unused at all. 
This has been detected by `no-unused-vars` rule of deno_lint, which is going to be enabled soon.

ref: https://github.com/denoland/deno_lint/pull/625