### PR TITLE
refactor(node/fs): update fs import

### DIFF
--- a/node/_fs/_fs_open.ts
+++ b/node/_fs/_fs_open.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "../../fs/mod.ts";
+import { existsSync } from "../../fs/exists.ts";
 import { fromFileUrl } from "../path.ts";
 import { getOpenOptions } from "./_fs_common.ts";
 

--- a/node/_fs/_fs_open_test.ts
+++ b/node/_fs/_fs_open_test.ts
@@ -7,7 +7,7 @@ import {
 import { assertCallbackErrorUncaught } from "../_utils.ts";
 import { open, openSync } from "./_fs_open.ts";
 import { join, parse } from "../../path/mod.ts";
-import { existsSync } from "../../fs/mod.ts";
+import { existsSync } from "../../fs/exists.ts";
 import { closeSync } from "./_fs_close.ts";
 
 const tempDir = parse(Deno.makeTempFileSync()).dir;

--- a/node/_fs/_fs_rename_test.ts
+++ b/node/_fs/_fs_rename_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, fail } from "../../testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_utils.ts";
 import { rename, renameSync } from "./_fs_rename.ts";
-import { existsSync } from "../../fs/mod.ts";
+import { existsSync } from "../../fs/exists.ts";
 import { join, parse } from "../../path/mod.ts";
 
 Deno.test({
@@ -42,7 +42,7 @@ Deno.test("[std/node/fs] rename callback isn't called twice if error is thrown",
   const importUrl = new URL("./_fs_rename.ts", import.meta.url);
   await assertCallbackErrorUncaught({
     prelude: `import { rename } from ${JSON.stringify(importUrl)}`,
-    invocation: `rename(${JSON.stringify(tempFile)}, 
+    invocation: `rename(${JSON.stringify(tempFile)},
                         ${JSON.stringify(`${tempFile}.newname`)}, `,
     async cleanup() {
       await Deno.remove(`${tempFile}.newname`);

--- a/node/_fs/_fs_rmdir_test.ts
+++ b/node/_fs/_fs_rmdir_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, fail } from "../../testing/asserts.ts";
 import { rmdir, rmdirSync } from "./_fs_rmdir.ts";
 import { closeSync } from "./_fs_close.ts";
-import { existsSync } from "../../fs/mod.ts";
+import { existsSync } from "../../fs/exists.ts";
 import { join } from "../../path/mod.ts";
 import { assertCallbackErrorUncaught } from "../_utils.ts";
 

--- a/node/_fs/_fs_unlink_test.ts
+++ b/node/_fs/_fs_unlink_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, fail } from "../../testing/asserts.ts";
-import { existsSync } from "../../fs/mod.ts";
+import { existsSync } from "../../fs/exists.ts";
 import { assertCallbackErrorUncaught } from "../_utils.ts";
 import { unlink, unlinkSync } from "./_fs_unlink.ts";
 


### PR DESCRIPTION
this pr is to avoid the `node/fs` to import unnecessary fs modules.