### PR TITLE
fix(node): fix node/cli.ts

### DIFF
--- a/node/cli.ts
+++ b/node/cli.ts
@@ -59,7 +59,7 @@ Object.defineProperty(process.argv, "0", {
     return Deno.execPath();
   },
 });
-const require = createRequire(import.meta.url);
+const require = createRequire(Deno.cwd());
 const path = require("path");
 const resolved = path.resolve(script);
 require(resolved);


### PR DESCRIPTION
This PR fixes an error of node/cli.ts. The first argument of createRequire needs to be a local path. In testing `import.meta.url` becomes a local file url, but when the user use [the released version](https://deno.land/std@0.90.0/node/cli.ts), that path becomes `https://...` url, and it doesn't work.

You can reproduce this error with the following command:

example.js
```
console.log(1);
```

```shellsession
$ deno run --unstable https://deno.land/std@0.90.0/node/cli.ts example.js
error: Uncaught InvalidData: invalid url scheme
    throw new Deno.errors.InvalidData("invalid url scheme");
          ^
    at fileURLToPath (https://deno.land/std@0.90.0/node/url.ts:53:11)
    at createRequire (https://deno.land/std@0.90.0/node/module.ts:535:18)
    at https://deno.land/std@0.90.0/node/cli.ts:62:17
```