### PR TITLE
chore(codecov): ignore coverage of examples

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,5 @@ coverage:
     project:
       default:
         informational: true
+ignore:
+  - examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Deno Standard Modules
 
+[![codecov](https://codecov.io/gh/denoland/deno_std/branch/main/graph/badge.svg?token=w6s3ODtULz)](https://codecov.io/gh/denoland/deno_std)
+
 These modules do not have external dependencies and they are reviewed by the
 Deno core team. The intention is to have a standard set of high quality code
 that all Deno projects can use fearlessly.


### PR DESCRIPTION
This PR configures codecov to ignore the coverage of `examples`. This PR also adds the badge of codecov in README.

ref: Ignoring Paths - https://docs.codecov.io/docs/ignoring-paths