### PR TITLE
feat: add io/buffer and io/util module

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -4,11 +4,12 @@
 
 ```ts
 import { Tar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
+import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
 
 const tar = new Tar();
 const content = new TextEncoder().encode("Deno.land");
 await tar.append("deno.txt", {
-  reader: new Deno.Buffer(content),
+  reader: new Buffer(content),
   contentSize: content.byteLength,
 });
 

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -29,6 +29,8 @@
 import { MultiReader } from "../io/readers.ts";
 import { PartialReadError } from "../io/bufio.ts";
 import { assert } from "../_util/assert.ts";
+import { Buffer } from "../io/buffer.ts";
+import { readAll } from "../io/util.ts";
 
 type Reader = Deno.Reader;
 type Seeker = Deno.Seeker;
@@ -355,7 +357,7 @@ export class Tar {
       info = await Deno.stat(opts.filePath);
       if (info.isDirectory) {
         info.size = 0;
-        opts.reader = new Deno.Buffer();
+        opts.reader = new Buffer();
       }
     }
 
@@ -424,7 +426,7 @@ export class Tar {
       let { reader } = tarData;
       const { filePath } = tarData;
       const headerArr = formatHeader(tarData);
-      readers.push(new Deno.Buffer(headerArr));
+      readers.push(new Buffer(headerArr));
       if (!reader) {
         assert(filePath != null);
         reader = new FileReader(filePath);
@@ -434,7 +436,7 @@ export class Tar {
       // to the nearest multiple of recordSize
       assert(tarData.fileSize != null, "fileSize must be set");
       readers.push(
-        new Deno.Buffer(
+        new Buffer(
           clean(
             recordSize -
               (parseInt(tarData.fileSize, 8) % recordSize || recordSize),
@@ -444,7 +446,7 @@ export class Tar {
     });
 
     // append 2 empty records
-    readers.push(new Deno.Buffer(clean(recordSize * 2)));
+    readers.push(new Buffer(clean(recordSize * 2)));
     return new MultiReader(...readers);
   }
 }
@@ -519,7 +521,7 @@ class TarEntry implements Reader {
       );
       this.#read = this.#entrySize;
     } else {
-      await Deno.readAll(this);
+      await readAll(this);
     }
   }
 }

--- a/archive/tar_test.ts
+++ b/archive/tar_test.ts
@@ -13,6 +13,8 @@ import { assert, assertEquals } from "../testing/asserts.ts";
 
 import { dirname, fromFileUrl, resolve } from "../path/mod.ts";
 import { Tar, Untar } from "./tar.ts";
+import { Buffer } from "../io/buffer.ts";
+import { readAll } from "../io/util.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 const testdataDir = resolve(moduleDir, "testdata");
@@ -32,7 +34,7 @@ async function createTar(entries: TestEntry[]): Promise<Tar> {
 
     if (file.content) {
       options = {
-        reader: new Deno.Buffer(file.content),
+        reader: new Buffer(file.content),
         contentSize: file.content.byteLength,
       };
     } else {
@@ -52,7 +54,7 @@ Deno.test("createTarArchive", async function (): Promise<void> {
   // put data on memory
   const content = new TextEncoder().encode("hello tar world!");
   await tar.append("output.txt", {
-    reader: new Deno.Buffer(content),
+    reader: new Buffer(content),
     contentSize: content.byteLength,
   });
 
@@ -60,7 +62,7 @@ Deno.test("createTarArchive", async function (): Promise<void> {
   await tar.append("dir/tar.ts", { filePath });
 
   // write tar data to a buffer
-  const writer = new Deno.Buffer();
+  const writer = new Buffer();
   const wrote = await Deno.copy(tar.getReader(), writer);
 
   /**
@@ -78,7 +80,7 @@ Deno.test("deflateTarArchive", async function (): Promise<void> {
   const tar = new Tar();
   const content = new TextEncoder().encode(text);
   await tar.append(fileName, {
-    reader: new Deno.Buffer(content),
+    reader: new Buffer(content),
     contentSize: content.byteLength,
   });
 
@@ -86,7 +88,7 @@ Deno.test("deflateTarArchive", async function (): Promise<void> {
   const untar = new Untar(tar.getReader());
   const result = await untar.extract();
   assert(result !== null);
-  const untarText = new TextDecoder("utf-8").decode(await Deno.readAll(result));
+  const untarText = new TextDecoder("utf-8").decode(await readAll(result));
 
   assertEquals(await untar.extract(), null); // EOF
   // tests
@@ -105,7 +107,7 @@ Deno.test("appendFileWithLongNameToTarArchive", async function (): Promise<
   const tar = new Tar();
   const content = new TextEncoder().encode(text);
   await tar.append(fileName, {
-    reader: new Deno.Buffer(content),
+    reader: new Buffer(content),
     contentSize: content.byteLength,
   });
 
@@ -114,7 +116,7 @@ Deno.test("appendFileWithLongNameToTarArchive", async function (): Promise<
   const result = await untar.extract();
   assert(result !== null);
   assert(!result.consumed);
-  const untarText = new TextDecoder("utf-8").decode(await Deno.readAll(result));
+  const untarText = new TextDecoder("utf-8").decode(await readAll(result));
   assert(result.consumed);
 
   // tests
@@ -148,7 +150,7 @@ Deno.test("untarAsyncIterator", async function (): Promise<void> {
     if (expected.filePath) {
       content = await Deno.readFile(expected.filePath);
     }
-    assertEquals(content, await Deno.readAll(entry));
+    assertEquals(content, await readAll(entry));
     assertEquals(expected.name, entry.fileName);
 
     if (lastEntry) assert(lastEntry.consumed);
@@ -256,7 +258,7 @@ Deno.test("untarAsyncIteratorFromFileReader", async function (): Promise<void> {
       content = await Deno.readFile(expected.filePath);
     }
 
-    assertEquals(content, await Deno.readAll(entry));
+    assertEquals(content, await readAll(entry));
     assertEquals(expected.name, entry.fileName);
   }
 
@@ -295,7 +297,7 @@ Deno.test(
         assert(expected);
         assertEquals(expected.name, entry.fileName);
 
-        const writer = new Deno.Buffer();
+        const writer = new Buffer();
         while (true) {
           const buf = new Uint8Array(bufSize);
           const n = await entry.read(buf);
@@ -398,7 +400,7 @@ Deno.test("untarLinuxGeneratedTar", async function (): Promise<void> {
     assertEquals(entry, expected);
 
     if (content) {
-      assertEquals(content, await Deno.readAll(entry));
+      assertEquals(content, await readAll(entry));
     }
   }
 
@@ -409,7 +411,7 @@ Deno.test("directoryEntryType", async function (): Promise<void> {
   const tar = new Tar();
 
   tar.append("directory/", {
-    reader: new Deno.Buffer(),
+    reader: new Buffer(),
     contentSize: 0,
     type: "directory",
   });

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -4,6 +4,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { Type } from "../type.ts";
 import type { Any } from "../utils.ts";
+import { Buffer } from "../../../io/buffer.ts";
 
 // [ 64, 65, 66 ] -> [ padding, CR, LF ]
 const BASE64_MAP =
@@ -34,7 +35,7 @@ function resolveYamlBinary(data: Any): boolean {
   return bitlen % 8 === 0;
 }
 
-function constructYamlBinary(data: string): Deno.Buffer {
+function constructYamlBinary(data: string): Buffer {
   // remove CR/LF & padding to simplify scan
   const input = data.replace(/[\r\n=]/g, "");
   const max = input.length;
@@ -69,7 +70,7 @@ function constructYamlBinary(data: string): Deno.Buffer {
     result.push((bits >> 4) & 0xff);
   }
 
-  return new Deno.Buffer(new Uint8Array(result));
+  return new Buffer(new Uint8Array(result));
 }
 
 function representYamlBinary(object: Uint8Array): string {
@@ -115,10 +116,10 @@ function representYamlBinary(object: Uint8Array): string {
   return result;
 }
 
-function isBinary(obj: Any): obj is Deno.Buffer {
-  const buf = new Deno.Buffer();
+function isBinary(obj: Any): obj is Buffer {
+  const buf = new Buffer();
   try {
-    if (0 > buf.readFromSync(obj as Deno.Buffer)) return true;
+    if (0 > buf.readFromSync(obj as Buffer)) return true;
     return false;
   } catch {
     return false;

--- a/encoding/binary_test.ts
+++ b/encoding/binary_test.ts
@@ -15,17 +15,18 @@ import {
   writeVarbig,
   writeVarnum,
 } from "./binary.ts";
+import { Buffer } from "../io/buffer.ts";
 
 Deno.test("testGetNBytes", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   const rslt = await getNBytes(buff, 8);
   assertEquals(rslt, data);
 });
 
 Deno.test("testGetNBytesThrows", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   await assertThrowsAsync(async () => {
     await getNBytes(buff, 8);
   }, Deno.errors.UnexpectedEof);
@@ -63,28 +64,28 @@ Deno.test("testPutVarnumLittleEndian", function (): void {
 
 Deno.test("testReadVarbig", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   const rslt = await readVarbig(buff);
   assertEquals(rslt, 0x0102030405060708n);
 });
 
 Deno.test("testReadVarbigLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   const rslt = await readVarbig(buff, { endian: "little" });
   assertEquals(rslt, 0x0807060504030201n);
 });
 
 Deno.test("testReadVarnum", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   const rslt = await readVarnum(buff);
   assertEquals(rslt, 0x01020304);
 });
 
 Deno.test("testReadVarnumLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array([1, 2, 3, 4]);
-  const buff = new Deno.Buffer(data.buffer);
+  const buff = new Buffer(data.buffer);
   const rslt = await readVarnum(buff, { endian: "little" });
   assertEquals(rslt, 0x04030201);
 });
@@ -127,7 +128,7 @@ Deno.test("testVarnumLittleEndian", function (): void {
 
 Deno.test("testWriteVarbig", async function (): Promise<void> {
   const data = new Uint8Array(8);
-  const buff = new Deno.Buffer();
+  const buff = new Buffer();
   await writeVarbig(buff, 0x0102030405060708n);
   await buff.read(data);
   assertEquals(
@@ -138,7 +139,7 @@ Deno.test("testWriteVarbig", async function (): Promise<void> {
 
 Deno.test("testWriteVarbigLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array(8);
-  const buff = new Deno.Buffer();
+  const buff = new Buffer();
   await writeVarbig(buff, 0x0807060504030201n, { endian: "little" });
   await buff.read(data);
   assertEquals(
@@ -149,7 +150,7 @@ Deno.test("testWriteVarbigLittleEndian", async function (): Promise<void> {
 
 Deno.test("testWriteVarnum", async function (): Promise<void> {
   const data = new Uint8Array(4);
-  const buff = new Deno.Buffer();
+  const buff = new Buffer();
   await writeVarnum(buff, 0x01020304);
   await buff.read(data);
   assertEquals(data, new Uint8Array([0x01, 0x02, 0x03, 0x04]));
@@ -157,7 +158,7 @@ Deno.test("testWriteVarnum", async function (): Promise<void> {
 
 Deno.test("testWriteVarnumLittleEndian", async function (): Promise<void> {
   const data = new Uint8Array(4);
-  const buff = new Deno.Buffer();
+  const buff = new Buffer();
   await writeVarnum(buff, 0x04030201, { endian: "little" });
   await buff.read(data);
   assertEquals(data, new Uint8Array([0x01, 0x02, 0x03, 0x04]));

--- a/examples/catj.ts
+++ b/examples/catj.ts
@@ -8,6 +8,7 @@
 
 import { parse } from "../flags/mod.ts";
 import * as colors from "../fmt/colors.ts";
+import { readAll } from "../io/util.ts";
 
 const decoder = new TextDecoder();
 
@@ -96,7 +97,7 @@ if (import.meta.main) {
   }
 
   if (parsedArgs._[0] === "-") {
-    const contents = await Deno.readAll(Deno.stdin);
+    const contents = await readAll(Deno.stdin);
     const json = JSON.parse(decoder.decode(contents));
     print(json);
   } else {

--- a/http/_io_test.ts
+++ b/http/_io_test.ts
@@ -18,14 +18,16 @@ import { BufReader, ReadLineResult } from "../io/bufio.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { StringReader } from "../io/readers.ts";
 import { mockConn } from "./_mock_conn.ts";
+import { Buffer } from "../io/buffer.ts";
+import { readAll } from "../io/util.ts";
 
 Deno.test("bodyReader", async () => {
   const text = "Hello, Deno";
   const r = bodyReader(
     text.length,
-    new BufReader(new Deno.Buffer(new TextEncoder().encode(text))),
+    new BufReader(new Buffer(new TextEncoder().encode(text))),
   );
-  assertEquals(new TextDecoder().decode(await Deno.readAll(r)), text);
+  assertEquals(new TextDecoder().decode(await readAll(r)), text);
 });
 
 function chunkify(n: number, char: string): string {
@@ -46,12 +48,12 @@ Deno.test("chunkedBodyReader", async () => {
   const h = new Headers();
   const r = chunkedBodyReader(
     h,
-    new BufReader(new Deno.Buffer(new TextEncoder().encode(body))),
+    new BufReader(new Buffer(new TextEncoder().encode(body))),
   );
   let result: number | null;
   // Use small buffer as some chunks exceed buffer size
   const buf = new Uint8Array(5);
-  const dest = new Deno.Buffer();
+  const dest = new Buffer();
   while ((result = await r.read(buf)) !== null) {
     const len = Math.min(buf.byteLength, result);
     await dest.write(buf.subarray(0, len));
@@ -76,12 +78,12 @@ Deno.test("chunkedBodyReader with trailers", async () => {
   });
   const r = chunkedBodyReader(
     h,
-    new BufReader(new Deno.Buffer(new TextEncoder().encode(body))),
+    new BufReader(new Buffer(new TextEncoder().encode(body))),
   );
   assertEquals(h.has("trailer"), true);
   assertEquals(h.has("deno"), false);
   assertEquals(h.has("node"), false);
-  const act = new TextDecoder().decode(await Deno.readAll(r));
+  const act = new TextDecoder().decode(await readAll(r));
   const exp = "aaabbbbbcccccccccccdddddddddddddddddddddd";
   assertEquals(act, exp);
   assertEquals(h.has("trailer"), false);
@@ -96,7 +98,7 @@ Deno.test("readTrailers", async () => {
   const trailer = ["deno: land", "node: js", "", ""].join("\r\n");
   await readTrailers(
     h,
-    new BufReader(new Deno.Buffer(new TextEncoder().encode(trailer))),
+    new BufReader(new Buffer(new TextEncoder().encode(trailer))),
   );
   assertEquals(h.has("trailer"), false);
   assertEquals(h.get("deno"), "land");
@@ -119,7 +121,7 @@ Deno.test(
         async () => {
           await readTrailers(
             h,
-            new BufReader(new Deno.Buffer(new TextEncoder().encode(trailer))),
+            new BufReader(new Buffer(new TextEncoder().encode(trailer))),
           );
         },
         Deno.errors.InvalidData,
@@ -138,7 +140,7 @@ Deno.test(
       });
       await assertThrowsAsync(
         async () => {
-          await readTrailers(h, new BufReader(new Deno.Buffer()));
+          await readTrailers(h, new BufReader(new Buffer()));
         },
         Deno.errors.InvalidData,
         `Prohibited trailer names: [ "`,
@@ -148,7 +150,7 @@ Deno.test(
 );
 
 Deno.test("writeTrailer", async () => {
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   await writeTrailers(
     w,
     new Headers({ "transfer-encoding": "chunked", trailer: "deno,node" }),
@@ -161,7 +163,7 @@ Deno.test("writeTrailer", async () => {
 });
 
 Deno.test("writeTrailer should throw", async () => {
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   await assertThrowsAsync(
     () => {
       return writeTrailers(w, new Headers(), new Headers());
@@ -240,7 +242,7 @@ Deno.test("writeUint8ArrayResponse", async function (): Promise<void> {
   const body = new TextEncoder().encode(shortText);
   const res: Response = { body };
 
-  const buf = new Deno.Buffer();
+  const buf = new Buffer();
   await writeResponse(buf, res);
 
   const decoder = new TextDecoder("utf-8");
@@ -275,7 +277,7 @@ Deno.test("writeStringResponse", async function (): Promise<void> {
 
   const res: Response = { body };
 
-  const buf = new Deno.Buffer();
+  const buf = new Buffer();
   await writeResponse(buf, res);
 
   const decoder = new TextDecoder("utf-8");
@@ -311,7 +313,7 @@ Deno.test("writeStringReaderResponse", async function (): Promise<void> {
   const body = new StringReader(shortText);
   const res: Response = { body };
 
-  const buf = new Deno.Buffer();
+  const buf = new Buffer();
   await writeResponse(buf, res);
 
   const decoder = new TextDecoder("utf-8");
@@ -349,7 +351,7 @@ Deno.test("writeStringReaderResponse", async function (): Promise<void> {
 });
 
 Deno.test("writeResponse with trailer", async () => {
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   const body = new StringReader("Hello");
   await writeResponse(w, {
     status: 200,
@@ -380,14 +382,14 @@ Deno.test("writeResponse with trailer", async () => {
 
 Deno.test("writeResponseShouldNotModifyOriginHeaders", async () => {
   const headers = new Headers();
-  const buf = new Deno.Buffer();
+  const buf = new Buffer();
   const decoder = new TextDecoder();
 
   await writeResponse(buf, { body: "foo", headers });
-  assert(decoder.decode(await Deno.readAll(buf)).includes("content-length: 3"));
+  assert(decoder.decode(await readAll(buf)).includes("content-length: 3"));
 
   await writeResponse(buf, { body: "hello", headers });
-  assert(decoder.decode(await Deno.readAll(buf)).includes("content-length: 5"));
+  assert(decoder.decode(await readAll(buf)).includes("content-length: 5"));
 });
 
 Deno.test("readRequestError", async function (): Promise<void> {

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -9,6 +9,8 @@ import { TextProtoReader } from "../textproto/mod.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { FileServerArgs, serveFile } from "./file_server.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
+import { readAll, writeAll } from "../io/util.ts";
+
 let fileServer: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 
 type FileServerCfg = Omit<FileServerArgs, "_"> & { target?: string };
@@ -76,7 +78,7 @@ async function killFileServer(): Promise<void> {
   // exited. As a workaround, wait for its stdout to close instead.
   // TODO(piscisaureus): when `Process.kill()` is stable and works on Windows,
   // switch to calling `kill()` followed by `await fileServer.status()`.
-  await Deno.readAll(fileServer.stdout!);
+  await readAll(fileServer.stdout!);
   fileServer.stdout!.close();
 }
 
@@ -98,7 +100,7 @@ async function fetchExactPath(
     conn = await Deno.connect(
       { hostname: hostname, port: port, transport: "tcp" },
     );
-    await Deno.writeAll(conn, request);
+    await writeAll(conn, request);
     let currentResult = "";
     let contentLength = -1;
     let startOfBody = -1;
@@ -403,7 +405,7 @@ Deno.test("serveDirectory TLS", async function (): Promise<void> {
       certFile: join(testdataDir, "tls/RootCA.pem"),
     });
 
-    await Deno.writeAll(
+    await writeAll(
       conn,
       new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n"),
     );

--- a/http/server.ts
+++ b/http/server.ts
@@ -9,6 +9,7 @@ import {
   readRequest,
   writeResponse,
 } from "./_io.ts";
+import { readAll } from "../io/util.ts";
 
 export class ServerRequest {
   url!: string;
@@ -55,7 +56,7 @@ export class ServerRequest {
   /**
    * Body of the request.  The easiest way to consume the body is:
    *
-   *     const buf: Uint8Array = await Deno.readAll(req.body);
+   *     const buf: Uint8Array = await readAll(req.body);
    */
   get body(): Deno.Reader {
     if (!this.#body) {

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -1,0 +1,260 @@
+import { assert } from "../_util/assert.ts";
+
+// MIN_READ is the minimum ArrayBuffer size passed to a read call by
+// buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
+// what is required to hold the contents of r, readFrom() will not grow the
+// underlying buffer.
+const MIN_READ = 32 * 1024;
+const MAX_SIZE = 2 ** 32 - 2;
+
+// `off` is the offset into `dst` where it will at which to begin writing values
+// from `src`.
+// Returns the number of bytes copied.
+function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0) {
+  const r = dst.byteLength - off;
+  if (src.byteLength > r) {
+    src = src.subarray(0, r);
+  }
+  dst.set(src, off);
+  return src.byteLength;
+}
+
+/** A variable-sized buffer of bytes with `read()` and `write()` methods.
+ *
+ * Buffer is almost always used with some I/O like files and sockets. It allows
+ * one to buffer up a download from a socket. Buffer grows and shrinks as
+ * necessary.
+ *
+ * Buffer is NOT the same thing as Node's Buffer. Node's Buffer was created in
+ * 2009 before JavaScript had the concept of ArrayBuffers. It's simply a
+ * non-standard ArrayBuffer.
+ *
+ * ArrayBuffer is a fixed memory allocation. Buffer is implemented on top of
+ * ArrayBuffer.
+ *
+ * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
+
+export class Buffer {
+  #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
+  #off = 0; // read at buf[off], write at buf[buf.byteLength]
+
+  constructor(ab?: ArrayBuffer) {
+    if (ab === undefined) {
+      this.#buf = new Uint8Array(0);
+      return;
+    }
+    this.#buf = new Uint8Array(ab);
+  }
+
+  /** Returns a slice holding the unread portion of the buffer.
+   *
+   * The slice is valid for use only until the next buffer modification (that
+   * is, only until the next call to a method like `read()`, `write()`,
+   * `reset()`, or `truncate()`). If `options.copy` is false the slice aliases the buffer content at
+   * least until the next buffer modification, so immediate changes to the
+   * slice will affect the result of future reads.
+   * @param options Defaults to `{ copy: true }`
+   */
+  bytes(options = { copy: true }): Uint8Array {
+    if (options.copy === false) return this.#buf.subarray(this.#off);
+    return this.#buf.slice(this.#off);
+  }
+
+  /** Returns whether the unread portion of the buffer is empty. */
+  empty(): boolean {
+    return this.#buf.byteLength <= this.#off;
+  }
+
+  /** A read only number of bytes of the unread portion of the buffer. */
+  get length(): number {
+    return this.#buf.byteLength - this.#off;
+  }
+
+  /** The read only capacity of the buffer's underlying byte slice, that is,
+   * the total space allocated for the buffer's data. */
+  get capacity(): number {
+    return this.#buf.buffer.byteLength;
+  }
+
+  /** Discards all but the first `n` unread bytes from the buffer but
+   * continues to use the same allocated storage. It throws if `n` is
+   * negative or greater than the length of the buffer. */
+  truncate(n: number): void {
+    if (n === 0) {
+      this.reset();
+      return;
+    }
+    if (n < 0 || n > this.length) {
+      throw Error("bytes.Buffer: truncation out of range");
+    }
+    this.#reslice(this.#off + n);
+  }
+
+  reset(): void {
+    this.#reslice(0);
+    this.#off = 0;
+  }
+
+  #tryGrowByReslice = (n: number) => {
+    const l = this.#buf.byteLength;
+    if (n <= this.capacity - l) {
+      this.#reslice(l + n);
+      return l;
+    }
+    return -1;
+  };
+
+  #reslice = (len: number) => {
+    assert(len <= this.#buf.buffer.byteLength);
+    this.#buf = new Uint8Array(this.#buf.buffer, 0, len);
+  };
+
+  /** Reads the next `p.length` bytes from the buffer or until the buffer is
+   * drained. Returns the number of bytes read. If the buffer has no data to
+   * return, the return is EOF (`null`). */
+  readSync(p: Uint8Array): number | null {
+    if (this.empty()) {
+      // Buffer is empty, reset to recover space.
+      this.reset();
+      if (p.byteLength === 0) {
+        // this edge case is tested in 'bufferReadEmptyAtEOF' test
+        return 0;
+      }
+      return null;
+    }
+    const nread = copyBytes(this.#buf.subarray(this.#off), p);
+    this.#off += nread;
+    return nread;
+  }
+
+  /** Reads the next `p.length` bytes from the buffer or until the buffer is
+   * drained. Resolves to the number of bytes read. If the buffer has no
+   * data to return, resolves to EOF (`null`).
+   *
+   * NOTE: This methods reads bytes synchronously; it's provided for
+   * compatibility with `Reader` interfaces.
+   */
+  read(p: Uint8Array): Promise<number | null> {
+    const rr = this.readSync(p);
+    return Promise.resolve(rr);
+  }
+
+  writeSync(p: Uint8Array): number {
+    const m = this.#grow(p.byteLength);
+    return copyBytes(p, this.#buf, m);
+  }
+
+  /** NOTE: This methods writes bytes synchronously; it's provided for
+   * compatibility with `Writer` interface. */
+  write(p: Uint8Array): Promise<number> {
+    const n = this.writeSync(p);
+    return Promise.resolve(n);
+  }
+
+  #grow = (n: number) => {
+    const m = this.length;
+    // If buffer is empty, reset to recover space.
+    if (m === 0 && this.#off !== 0) {
+      this.reset();
+    }
+    // Fast: Try to grow by means of a reslice.
+    const i = this.#tryGrowByReslice(n);
+    if (i >= 0) {
+      return i;
+    }
+    const c = this.capacity;
+    if (n <= Math.floor(c / 2) - m) {
+      // We can slide things down instead of allocating a new
+      // ArrayBuffer. We only need m+n <= c to slide, but
+      // we instead let capacity get twice as large so we
+      // don't spend all our time copying.
+      copyBytes(this.#buf.subarray(this.#off), this.#buf);
+    } else if (c + n > MAX_SIZE) {
+      throw new Error("The buffer cannot be grown beyond the maximum size.");
+    } else {
+      // Not enough space anywhere, we need to allocate.
+      const buf = new Uint8Array(Math.min(2 * c + n, MAX_SIZE));
+      copyBytes(this.#buf.subarray(this.#off), buf);
+      this.#buf = buf;
+    }
+    // Restore this.#off and len(this.#buf).
+    this.#off = 0;
+    this.#reslice(Math.min(m + n, MAX_SIZE));
+    return m;
+  };
+
+  /** Grows the buffer's capacity, if necessary, to guarantee space for
+   * another `n` bytes. After `.grow(n)`, at least `n` bytes can be written to
+   * the buffer without another allocation. If `n` is negative, `.grow()` will
+   * throw. If the buffer can't grow it will throw an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.Grow](https://golang.org/pkg/bytes/#Buffer.Grow). */
+  grow(n: number): void {
+    if (n < 0) {
+      throw Error("Buffer.grow: negative count");
+    }
+    const m = this.#grow(n);
+    this.#reslice(m);
+  }
+
+  /** Reads data from `r` until EOF (`null`) and appends it to the buffer,
+   * growing the buffer as needed. It resolves to the number of bytes read.
+   * If the buffer becomes too large, `.readFrom()` will reject with an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
+  async readFrom(r: Deno.Reader): Promise<number> {
+    let n = 0;
+    const tmp = new Uint8Array(MIN_READ);
+    while (true) {
+      const shouldGrow = this.capacity - this.length < MIN_READ;
+      // read into tmp buffer if there's not enough room
+      // otherwise read directly into the internal buffer
+      const buf = shouldGrow
+        ? tmp
+        : new Uint8Array(this.#buf.buffer, this.length);
+
+      const nread = await r.read(buf);
+      if (nread === null) {
+        return n;
+      }
+
+      // write will grow if needed
+      if (shouldGrow) this.writeSync(buf.subarray(0, nread));
+      else this.#reslice(this.length + nread);
+
+      n += nread;
+    }
+  }
+
+  /** Reads data from `r` until EOF (`null`) and appends it to the buffer,
+   * growing the buffer as needed. It returns the number of bytes read. If the
+   * buffer becomes too large, `.readFromSync()` will throw an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
+  readFromSync(r: Deno.ReaderSync): number {
+    let n = 0;
+    const tmp = new Uint8Array(MIN_READ);
+    while (true) {
+      const shouldGrow = this.capacity - this.length < MIN_READ;
+      // read into tmp buffer if there's not enough room
+      // otherwise read directly into the internal buffer
+      const buf = shouldGrow
+        ? tmp
+        : new Uint8Array(this.#buf.buffer, this.length);
+
+      const nread = r.readSync(buf);
+      if (nread === null) {
+        return n;
+      }
+
+      // write will grow if needed
+      if (shouldGrow) this.writeSync(buf.subarray(0, nread));
+      else this.#reslice(this.length + nread);
+
+      n += nread;
+    }
+  }
+}

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -1,0 +1,407 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// This code has been ported almost directly from Go's src/bytes/buffer_test.go
+// Copyright 2009 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "../testing/asserts.ts";
+import { Buffer } from "./buffer.ts";
+import { writeAllSync } from "./util.ts";
+
+const MAX_SIZE = 2 ** 32 - 2;
+// N controls how many iterations of certain checks are performed.
+const N = 100;
+let testBytes: Uint8Array | null;
+let testString: string | null;
+
+const ignoreMaxSizeTests = true;
+
+function init(): void {
+  if (testBytes == null) {
+    testBytes = new Uint8Array(N);
+    for (let i = 0; i < N; i++) {
+      testBytes[i] = "a".charCodeAt(0) + (i % 26);
+    }
+    const decoder = new TextDecoder();
+    testString = decoder.decode(testBytes);
+  }
+}
+
+function check(buf: Buffer, s: string): void {
+  const bytes = buf.bytes();
+  assertEquals(buf.length, bytes.byteLength);
+  const decoder = new TextDecoder();
+  const bytesStr = decoder.decode(bytes);
+  assertEquals(bytesStr, s);
+  assertEquals(buf.length, s.length);
+}
+
+// Fill buf through n writes of byte slice fub.
+// The initial contents of buf corresponds to the string s;
+// the result is the final contents of buf returned as a string.
+async function fillBytes(
+  buf: Buffer,
+  s: string,
+  n: number,
+  fub: Uint8Array,
+): Promise<string> {
+  check(buf, s);
+  for (; n > 0; n--) {
+    const m = await buf.write(fub);
+    assertEquals(m, fub.byteLength);
+    const decoder = new TextDecoder();
+    s += decoder.decode(fub);
+    check(buf, s);
+  }
+  return s;
+}
+
+// Empty buf through repeated reads into fub.
+// The initial contents of buf corresponds to the string s.
+async function empty(
+  buf: Buffer,
+  s: string,
+  fub: Uint8Array,
+): Promise<void> {
+  check(buf, s);
+  while (true) {
+    const r = await buf.read(fub);
+    if (r === null) {
+      break;
+    }
+    s = s.slice(r);
+    check(buf, s);
+  }
+  check(buf, "");
+}
+
+function repeat(c: string, bytes: number): Uint8Array {
+  assertEquals(c.length, 1);
+  const ui8 = new Uint8Array(bytes);
+  ui8.fill(c.charCodeAt(0));
+  return ui8;
+}
+
+Deno.test("bufferNewBuffer", () => {
+  init();
+  assert(testBytes);
+  assert(testString);
+  const buf = new Buffer(testBytes.buffer as ArrayBuffer);
+  check(buf, testString);
+});
+
+Deno.test("bufferBasicOperations", async () => {
+  assert(testBytes);
+  assert(testString);
+  const buf = new Buffer();
+  for (let i = 0; i < 5; i++) {
+    check(buf, "");
+
+    buf.reset();
+    check(buf, "");
+
+    buf.truncate(0);
+    check(buf, "");
+
+    let n = await buf.write(testBytes.subarray(0, 1));
+    assertEquals(n, 1);
+    check(buf, "a");
+
+    n = await buf.write(testBytes.subarray(1, 2));
+    assertEquals(n, 1);
+    check(buf, "ab");
+
+    n = await buf.write(testBytes.subarray(2, 26));
+    assertEquals(n, 24);
+    check(buf, testString.slice(0, 26));
+
+    buf.truncate(26);
+    check(buf, testString.slice(0, 26));
+
+    buf.truncate(20);
+    check(buf, testString.slice(0, 20));
+
+    await empty(buf, testString.slice(0, 20), new Uint8Array(5));
+    await empty(buf, "", new Uint8Array(100));
+
+    // TODO(bartlomieju): buf.writeByte()
+    // TODO(bartlomieju): buf.readByte()
+  }
+});
+
+Deno.test("bufferReadEmptyAtEOF", async () => {
+  // check that EOF of 'buf' is not reached (even though it's empty) if
+  // results are written to buffer that has 0 length (ie. it can't store any data)
+  const buf = new Buffer();
+  const zeroLengthTmp = new Uint8Array(0);
+  const result = await buf.read(zeroLengthTmp);
+  assertEquals(result, 0);
+});
+
+Deno.test("bufferLargeByteWrites", async () => {
+  init();
+  const buf = new Buffer();
+  const limit = 9;
+  for (let i = 3; i < limit; i += 3) {
+    const s = await fillBytes(buf, "", 5, testBytes!);
+    await empty(buf, s, new Uint8Array(Math.floor(testString!.length / i)));
+  }
+  check(buf, "");
+});
+
+Deno.test("bufferTooLargeByteWrites", async () => {
+  init();
+  const tmp = new Uint8Array(72);
+  const growLen = Number.MAX_VALUE;
+  const xBytes = repeat("x", 0);
+  const buf = new Buffer(xBytes.buffer as ArrayBuffer);
+  await buf.read(tmp);
+
+  assertThrows(
+    () => {
+      buf.grow(growLen);
+    },
+    Error,
+    "grown beyond the maximum size",
+  );
+});
+
+Deno.test({
+  name: "bufferGrowWriteMaxBuffer",
+  ignore: ignoreMaxSizeTests,
+  fn() {
+    const bufSize = 16 * 1024;
+    const capacities = [MAX_SIZE, MAX_SIZE - 1];
+    for (const capacity of capacities) {
+      let written = 0;
+      const buf = new Buffer();
+      const writes = Math.floor(capacity / bufSize);
+      for (let i = 0; i < writes; i++) {
+        written += buf.writeSync(repeat("x", bufSize));
+      }
+
+      if (written < capacity) {
+        written += buf.writeSync(repeat("x", capacity - written));
+      }
+
+      assertEquals(written, capacity);
+    }
+  },
+});
+
+Deno.test({
+  name: "bufferGrowReadCloseMaxBufferPlus1",
+  ignore: ignoreMaxSizeTests,
+  async fn() {
+    const reader = new Buffer(new ArrayBuffer(MAX_SIZE + 1));
+    const buf = new Buffer();
+
+    await assertThrowsAsync(
+      async () => {
+        await buf.readFrom(reader);
+      },
+      Error,
+      "grown beyond the maximum size",
+    );
+  },
+});
+
+Deno.test({
+  name: "bufferGrowReadSyncCloseMaxBufferPlus1",
+  ignore: ignoreMaxSizeTests,
+  fn() {
+    const reader = new Buffer(new ArrayBuffer(MAX_SIZE + 1));
+    const buf = new Buffer();
+
+    assertThrows(
+      () => {
+        buf.readFromSync(reader);
+      },
+      Error,
+      "grown beyond the maximum size",
+    );
+  },
+});
+
+Deno.test({
+  name: "bufferGrowReadSyncCloseToMaxBuffer",
+  ignore: ignoreMaxSizeTests,
+  fn() {
+    const capacities = [MAX_SIZE, MAX_SIZE - 1];
+    for (const capacity of capacities) {
+      const reader = new Buffer(new ArrayBuffer(capacity));
+      const buf = new Buffer();
+      buf.readFromSync(reader);
+
+      assertEquals(buf.length, capacity);
+    }
+  },
+});
+
+Deno.test({
+  name: "bufferGrowReadCloseToMaxBuffer",
+  ignore: ignoreMaxSizeTests,
+  async fn() {
+    const capacities = [MAX_SIZE, MAX_SIZE - 1];
+    for (const capacity of capacities) {
+      const reader = new Buffer(new ArrayBuffer(capacity));
+      const buf = new Buffer();
+      await buf.readFrom(reader);
+      assertEquals(buf.length, capacity);
+    }
+  },
+});
+
+Deno.test({
+  name: "bufferReadCloseToMaxBufferWithInitialGrow",
+  ignore: ignoreMaxSizeTests,
+  async fn() {
+    const capacities = [MAX_SIZE, MAX_SIZE - 1, MAX_SIZE - 512];
+    for (const capacity of capacities) {
+      const reader = new Buffer(new ArrayBuffer(capacity));
+      const buf = new Buffer();
+      buf.grow(MAX_SIZE);
+      await buf.readFrom(reader);
+      assertEquals(buf.length, capacity);
+    }
+  },
+});
+
+Deno.test("bufferLargeByteReads", async () => {
+  init();
+  assert(testBytes);
+  assert(testString);
+  const buf = new Buffer();
+  for (let i = 3; i < 30; i += 3) {
+    const n = Math.floor(testBytes.byteLength / i);
+    const s = await fillBytes(buf, "", 5, testBytes.subarray(0, n));
+    await empty(buf, s, new Uint8Array(testString.length));
+  }
+  check(buf, "");
+});
+
+Deno.test("bufferCapWithPreallocatedSlice", () => {
+  const buf = new Buffer(new ArrayBuffer(10));
+  assertEquals(buf.capacity, 10);
+});
+
+Deno.test("bufferReadFrom", async () => {
+  init();
+  assert(testBytes);
+  assert(testString);
+  const buf = new Buffer();
+  for (let i = 3; i < 30; i += 3) {
+    const s = await fillBytes(
+      buf,
+      "",
+      5,
+      testBytes.subarray(0, Math.floor(testBytes.byteLength / i)),
+    );
+    const b = new Buffer();
+    await b.readFrom(buf);
+    const fub = new Uint8Array(testString.length);
+    await empty(b, s, fub);
+  }
+  assertThrowsAsync(async function () {
+    await new Buffer().readFrom(null!);
+  });
+});
+
+Deno.test("bufferReadFromSync", async () => {
+  init();
+  assert(testBytes);
+  assert(testString);
+  const buf = new Buffer();
+  for (let i = 3; i < 30; i += 3) {
+    const s = await fillBytes(
+      buf,
+      "",
+      5,
+      testBytes.subarray(0, Math.floor(testBytes.byteLength / i)),
+    );
+    const b = new Buffer();
+    b.readFromSync(buf);
+    const fub = new Uint8Array(testString.length);
+    await empty(b, s, fub);
+  }
+  assertThrows(function () {
+    new Buffer().readFromSync(null!);
+  });
+});
+
+Deno.test("bufferTestGrow", async () => {
+  const tmp = new Uint8Array(72);
+  for (const startLen of [0, 100, 1000, 10000]) {
+    const xBytes = repeat("x", startLen);
+    for (const growLen of [0, 100, 1000, 10000]) {
+      const buf = new Buffer(xBytes.buffer as ArrayBuffer);
+      // If we read, this affects buf.off, which is good to test.
+      const nread = (await buf.read(tmp)) ?? 0;
+      buf.grow(growLen);
+      const yBytes = repeat("y", growLen);
+      await buf.write(yBytes);
+      // Check that buffer has correct data.
+      assertEquals(
+        buf.bytes().subarray(0, startLen - nread),
+        xBytes.subarray(nread),
+      );
+      assertEquals(
+        buf.bytes().subarray(startLen - nread, startLen - nread + growLen),
+        yBytes,
+      );
+    }
+  }
+});
+
+Deno.test("testBufferBytesArrayBufferLength", () => {
+  // defaults to copy
+  const args = [undefined, { copy: true }] as const;
+  for (const arg of args) {
+    const bufSize = 64 * 1024;
+    const bytes = new TextEncoder().encode("a".repeat(bufSize));
+    const reader = new Buffer();
+    writeAllSync(reader, bytes);
+
+    const writer = new Buffer();
+    writer.readFromSync(reader);
+    const actualBytes = writer.bytes(arg);
+
+    assertEquals(actualBytes.byteLength, bufSize);
+    assert(actualBytes.buffer !== writer.bytes(arg).buffer);
+    assertEquals(actualBytes.byteLength, actualBytes.buffer.byteLength);
+  }
+});
+
+Deno.test("testBufferBytesCopyFalse", () => {
+  const bufSize = 64 * 1024;
+  const bytes = new TextEncoder().encode("a".repeat(bufSize));
+  const reader = new Buffer();
+  writeAllSync(reader, bytes);
+
+  const writer = new Buffer();
+  writer.readFromSync(reader);
+  const actualBytes = writer.bytes({ copy: false });
+
+  assertEquals(actualBytes.byteLength, bufSize);
+  assertEquals(actualBytes.buffer, writer.bytes({ copy: false }).buffer);
+  assert(actualBytes.buffer.byteLength > actualBytes.byteLength);
+});
+
+Deno.test("testBufferBytesCopyFalseGrowExactBytes", () => {
+  const bufSize = 64 * 1024;
+  const bytes = new TextEncoder().encode("a".repeat(bufSize));
+  const reader = new Buffer();
+  writeAllSync(reader, bytes);
+
+  const writer = new Buffer();
+  writer.grow(bufSize);
+  writer.readFromSync(reader);
+  const actualBytes = writer.bytes({ copy: false });
+
+  assertEquals(actualBytes.byteLength, bufSize);
+  assertEquals(actualBytes.buffer.byteLength, actualBytes.byteLength);
+});

--- a/io/bufio.ts
+++ b/io/bufio.ts
@@ -9,6 +9,8 @@ type Writer = Deno.Writer;
 type WriterSync = Deno.WriterSync;
 import { copy } from "../bytes/mod.ts";
 import { assert } from "../_util/assert.ts";
+import { Buffer } from "./buffer.ts";
+import { writeAll, writeAllSync } from "./util.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 const MIN_BUF_SIZE = 16;
@@ -465,7 +467,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
     if (this.usedBufferBytes === 0) return;
 
     try {
-      await Deno.writeAll(
+      await writeAll(
         this.writer,
         this.buf.subarray(0, this.usedBufferBytes),
       );
@@ -558,7 +560,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
     if (this.usedBufferBytes === 0) return;
 
     try {
-      Deno.writeAllSync(
+      writeAllSync(
         this.writer,
         this.buf.subarray(0, this.usedBufferBytes),
       );
@@ -640,7 +642,7 @@ export async function* readDelim(
   const delimLen = delim.length;
   const delimLPS = createLPS(delim);
 
-  let inputBuffer = new Deno.Buffer();
+  let inputBuffer = new Buffer();
   const inspectArr = new Uint8Array(Math.max(1024, delimLen + 1));
 
   // Modified KMP
@@ -658,7 +660,7 @@ export async function* readDelim(
       return;
     }
     const sliceRead = inspectArr.subarray(0, result as number);
-    await Deno.writeAll(inputBuffer, sliceRead);
+    await writeAll(inputBuffer, sliceRead);
 
     let sliceToProcess = inputBuffer.bytes();
     while (inspectIndex < sliceToProcess.length) {
@@ -686,7 +688,7 @@ export async function* readDelim(
       }
     }
     // Keep inspectIndex and matchIndex.
-    inputBuffer = new Deno.Buffer(sliceToProcess);
+    inputBuffer = new Buffer(sliceToProcess);
   }
 }
 

--- a/io/bufio_test.ts
+++ b/io/bufio_test.ts
@@ -18,6 +18,7 @@ import * as iotest from "./_iotest.ts";
 import { StringReader } from "./readers.ts";
 import { StringWriter } from "./writers.ts";
 import { copy } from "../bytes/mod.ts";
+import { Buffer } from "../io/buffer.ts";
 
 const encoder = new TextEncoder();
 
@@ -334,7 +335,7 @@ Deno.test("bufioWriter", async function (): Promise<void> {
     data[i] = " ".charCodeAt(0) + (i % ("~".charCodeAt(0) - " ".charCodeAt(0)));
   }
 
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   for (const nwrite of bufsizes) {
     for (const bs of bufsizes) {
       // Write nwrite bytes using buffer size bs.
@@ -368,7 +369,7 @@ Deno.test("bufioWriterSync", function (): void {
     data[i] = " ".charCodeAt(0) + (i % ("~".charCodeAt(0) - " ".charCodeAt(0)));
   }
 
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   for (const nwrite of bufsizes) {
     for (const bs of bufsizes) {
       // Write nwrite bytes using buffer size bs.
@@ -398,7 +399,7 @@ Deno.test("bufReaderReadFull", async function (): Promise<void> {
   const enc = new TextEncoder();
   const dec = new TextDecoder();
   const text = "Hello World";
-  const data = new Deno.Buffer(enc.encode(text));
+  const data = new Buffer(enc.encode(text));
   const bufr = new BufReader(data, 3);
   {
     const buf = new Uint8Array(6);
@@ -423,7 +424,7 @@ Deno.test("bufReaderReadFull", async function (): Promise<void> {
 
 Deno.test("readStringDelimAndLines", async function (): Promise<void> {
   const enc = new TextEncoder();
-  const data = new Deno.Buffer(
+  const data = new Buffer(
     enc.encode("Hello World\tHello World 2\tHello World 3"),
   );
   const chunks_ = [];
@@ -435,9 +436,9 @@ Deno.test("readStringDelimAndLines", async function (): Promise<void> {
   assertEquals(chunks_.length, 3);
   assertEquals(chunks_, ["Hello World", "Hello World 2", "Hello World 3"]);
 
-  const linesData = new Deno.Buffer(enc.encode("0\n1\n2\n3\n4\n5\n6\n7\n8\n9"));
+  const linesData = new Buffer(enc.encode("0\n1\n2\n3\n4\n5\n6\n7\n8\n9"));
   // consider data with windows newlines too
-  const linesDataWindows = new Deno.Buffer(
+  const linesDataWindows = new Buffer(
     enc.encode("0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9"),
   );
   const lines_ = [];

--- a/io/ioutil_test.ts
+++ b/io/ioutil_test.ts
@@ -9,6 +9,7 @@ import {
 } from "./ioutil.ts";
 import { StringReader } from "./readers.ts";
 import { BufReader } from "./bufio.ts";
+import { Buffer } from "./buffer.ts";
 
 class BinaryReader implements Deno.Reader {
   index = 0;
@@ -69,7 +70,7 @@ Deno.test("testSliceLongToBytes2", function (): void {
 });
 
 Deno.test("testCopyN1", async function (): Promise<void> {
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   const r = new StringReader("abcdefghij");
   const n = await copyN(r, w, 3);
   assertEquals(n, 3);
@@ -77,7 +78,7 @@ Deno.test("testCopyN1", async function (): Promise<void> {
 });
 
 Deno.test("testCopyN2", async function (): Promise<void> {
-  const w = new Deno.Buffer();
+  const w = new Buffer();
   const r = new StringReader("abcdefghij");
   const n = await copyN(r, w, 11);
   assertEquals(n, 10);

--- a/io/mod.ts
+++ b/io/mod.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+export * from "./buffer.ts";
 export * from "./bufio.ts";
 export * from "./ioutil.ts";
 export * from "./readers.ts";
-export * from "./writers.ts";
 export * from "./streams.ts";
+export * from "./util.ts";
+export * from "./writers.ts";

--- a/io/readers.ts
+++ b/io/readers.ts
@@ -4,8 +4,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import { Buffer } from "./buffer.ts";
+
 /** Reader utility for strings */
-export class StringReader extends Deno.Buffer {
+export class StringReader extends Buffer {
   constructor(s: string) {
     super(new TextEncoder().encode(s).buffer);
   }

--- a/io/readers_test.ts
+++ b/io/readers_test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "../testing/asserts.ts";
 import { LimitedReader, MultiReader, StringReader } from "./readers.ts";
 import { StringWriter } from "./writers.ts";
 import { copyN } from "./ioutil.ts";
+import { readAll } from "../io/util.ts";
 
 Deno.test("ioStringReader", async function (): Promise<void> {
   const r = new StringReader("abcdef");
@@ -41,19 +42,19 @@ Deno.test("ioLimitedReader", async function (): Promise<void> {
   const decoder = new TextDecoder();
   let sr = new StringReader("abc");
   let r = new LimitedReader(sr, 2);
-  let buffer = await Deno.readAll(r);
+  let buffer = await readAll(r);
   assertEquals(decoder.decode(buffer), "ab");
-  assertEquals(decoder.decode(await Deno.readAll(sr)), "c");
+  assertEquals(decoder.decode(await readAll(sr)), "c");
   sr = new StringReader("abc");
   r = new LimitedReader(sr, 3);
-  buffer = await Deno.readAll(r);
+  buffer = await readAll(r);
   assertEquals(decoder.decode(buffer), "abc");
-  assertEquals((await Deno.readAll(r)).length, 0);
+  assertEquals((await readAll(r)).length, 0);
   sr = new StringReader("abc");
   r = new LimitedReader(sr, 4);
-  buffer = await Deno.readAll(r);
+  buffer = await readAll(r);
   assertEquals(decoder.decode(buffer), "abc");
-  assertEquals((await Deno.readAll(r)).length, 0);
+  assertEquals((await readAll(r)).length, 0);
 });
 
 Deno.test("ioLimitedReader", async function (): Promise<void> {

--- a/io/streams.ts
+++ b/io/streams.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import { Buffer } from "./buffer.ts";
+import { writeAll } from "./util.ts";
+
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
  *      // Server-sent events: Send runtime metrics to the client every second.
@@ -20,7 +23,7 @@ export function readerFromIterable(
   const iterator: Iterator<Uint8Array> | AsyncIterator<Uint8Array> =
     (iterable as AsyncIterable<Uint8Array>)[Symbol.asyncIterator]?.() ??
       (iterable as Iterable<Uint8Array>)[Symbol.iterator]?.();
-  const buffer: Deno.Buffer = new Deno.Buffer();
+  const buffer = new Buffer();
   return {
     async read(p: Uint8Array): Promise<number | null> {
       if (buffer.length == 0) {
@@ -33,7 +36,7 @@ export function readerFromIterable(
             return result.value.byteLength;
           }
           p.set(result.value.subarray(0, p.byteLength));
-          await Deno.writeAll(buffer, result.value.subarray(p.byteLength));
+          await writeAll(buffer, result.value.subarray(p.byteLength));
           return p.byteLength;
         }
       } else {
@@ -64,7 +67,7 @@ export function writerFromStreamWriter(
 export function readerFromStreamReader(
   streamReader: ReadableStreamDefaultReader<Uint8Array>,
 ): Deno.Reader {
-  const buffer = new Deno.Buffer();
+  const buffer = new Buffer();
 
   return {
     async read(p: Uint8Array): Promise<number | null> {
@@ -74,7 +77,7 @@ export function readerFromStreamReader(
           return null; // EOF
         }
 
-        await Deno.writeAll(buffer, res.value);
+        await writeAll(buffer, res.value);
       }
 
       return buffer.read(p);
@@ -88,7 +91,7 @@ export function writableStreamFromWriter(
 ): WritableStream<Uint8Array> {
   return new WritableStream({
     async write(chunk) {
-      await Deno.writeAll(writer, chunk);
+      await writeAll(writer, chunk);
     },
   });
 }

--- a/io/streams_test.ts
+++ b/io/streams_test.ts
@@ -8,6 +8,7 @@ import {
   writableStreamFromWriter,
   writerFromStreamWriter,
 } from "./streams.ts";
+import { Buffer } from "./buffer.ts";
 
 function repeat(c: string, bytes: number): Uint8Array {
   assertEquals(c.length, 1);
@@ -98,7 +99,7 @@ Deno.test("[io] readerFromStreamReader()", async function () {
 Deno.test("[io] readerFromStreamReader() big chunks", async function () {
   const bufSize = 1024;
   const chunkSize = 3 * bufSize;
-  const writer = new Deno.Buffer();
+  const writer = new Buffer();
 
   // A readable stream can enqueue chunks bigger than Copy bufSize
   // Reader returned by toReader should enqueue exceeding bytes
@@ -129,7 +130,7 @@ Deno.test("[io] readerFromStreamReader() big chunks", async function () {
 Deno.test("[io] readerFromStreamReader() irregular chunks", async function () {
   const bufSize = 1024;
   const chunkSize = 3 * bufSize;
-  const writer = new Deno.Buffer();
+  const writer = new Buffer();
 
   // A readable stream can enqueue chunks bigger than Copy bufSize
   // Reader returned by toReader should enqueue exceeding bytes

--- a/io/util.ts
+++ b/io/util.ts
@@ -1,0 +1,107 @@
+import { Buffer } from "./buffer.ts";
+
+/** Read Reader `r` until EOF (`null`) and resolve to the content as
+ * Uint8Array`.
+ *
+ * ```ts
+ * 
+ * // Example from stdin
+ * const stdinContent = await readAll(Deno.stdin);
+ *
+ * // Example from file
+ * const file = await Deno.open("my_file.txt", {read: true});
+ * const myFileContent = await readAll(file);
+ * Deno.close(file.rid);
+ *
+ * // Example from buffer
+ * const myData = new Uint8Array(100);
+ * // ... fill myData array with data
+ * const reader = new Buffer(myData.buffer as ArrayBuffer);
+ * const bufferContent = await readAll(reader);
+ * ```
+ */
+export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
+  const buf = new Buffer();
+  await buf.readFrom(r);
+  return buf.bytes();
+}
+
+/** Synchronously reads Reader `r` until EOF (`null`) and returns the content
+ * as `Uint8Array`.
+ *
+ * ```ts
+ * // Example from stdin
+ * const stdinContent = readAllSync(Deno.stdin);
+ *
+ * // Example from file
+ * const file = Deno.openSync("my_file.txt", {read: true});
+ * const myFileContent = readAllSync(file);
+ * Deno.close(file.rid);
+ *
+ * // Example from buffer
+ * const myData = new Uint8Array(100);
+ * // ... fill myData array with data
+ * const reader = new Buffer(myData.buffer as ArrayBuffer);
+ * const bufferContent = readAllSync(reader);
+ * ```
+ */
+export function readAllSync(r: Deno.ReaderSync): Uint8Array {
+  const buf = new Buffer();
+  buf.readFromSync(r);
+  return buf.bytes();
+}
+
+/** Write all the content of the array buffer (`arr`) to the writer (`w`).
+ *
+ * ```ts
+ * // Example writing to stdout
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * await writeAll(Deno.stdout, contentBytes);
+ *
+ * // Example writing to file
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const file = await Deno.open('test.file', {write: true});
+ * await writeAll(file, contentBytes);
+ * Deno.close(file.rid);
+ *
+ * // Example writing to buffer
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const writer = new Buffer();
+ * await writeAll(writer, contentBytes);
+ * console.log(writer.bytes().length);  // 11
+ * ```
+ */
+export async function writeAll(w: Deno.Writer, arr: Uint8Array): Promise<void> {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += await w.write(arr.subarray(nwritten));
+  }
+}
+
+/** Synchronously write all the content of the array buffer (`arr`) to the
+ * writer (`w`).
+ *
+ * ```ts
+ * // Example writing to stdout
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * writeAllSync(Deno.stdout, contentBytes);
+ *
+ * // Example writing to file
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const file = Deno.openSync('test.file', {write: true});
+ * writeAllSync(file, contentBytes);
+ * Deno.close(file.rid);
+ *
+ * // Example writing to buffer
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const writer = new Buffer();
+ * writeAllSync(writer, contentBytes);
+ * console.log(writer.bytes().length);  // 11
+ * ```
+ */
+export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += w.writeSync(arr.subarray(nwritten));
+  }
+}

--- a/io/util_test.ts
+++ b/io/util_test.ts
@@ -1,0 +1,67 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// This code has been ported almost directly from Go's src/bytes/buffer_test.go
+// Copyright 2009 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+import { assert, assertEquals } from "../testing/asserts.ts";
+import { Buffer } from "./buffer.ts";
+import { readAll, readAllSync, writeAll, writeAllSync } from "./util.ts";
+
+// N controls how many iterations of certain checks are performed.
+const N = 100;
+let testBytes: Uint8Array | null;
+
+export function init(): void {
+  if (testBytes == null) {
+    testBytes = new Uint8Array(N);
+    for (let i = 0; i < N; i++) {
+      testBytes[i] = "a".charCodeAt(0) + (i % 26);
+    }
+  }
+}
+
+Deno.test("testReadAll", async () => {
+  init();
+  assert(testBytes);
+  const reader = new Buffer(testBytes.buffer as ArrayBuffer);
+  const actualBytes = await readAll(reader);
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});
+
+Deno.test("testReadAllSync", () => {
+  init();
+  assert(testBytes);
+  const reader = new Buffer(testBytes.buffer as ArrayBuffer);
+  const actualBytes = readAllSync(reader);
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});
+
+Deno.test("testwriteAll", async () => {
+  init();
+  assert(testBytes);
+  const writer = new Buffer();
+  await writeAll(writer, testBytes);
+  const actualBytes = writer.bytes();
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});
+
+Deno.test("testWriteAllSync", () => {
+  init();
+  assert(testBytes);
+  const writer = new Buffer();
+  writeAllSync(writer, testBytes);
+  const actualBytes = writer.bytes();
+  assertEquals(testBytes.byteLength, actualBytes.byteLength);
+  for (let i = 0; i < testBytes.length; ++i) {
+    assertEquals(testBytes[i], actualBytes[i]);
+  }
+});

--- a/mime/multipart.ts
+++ b/mime/multipart.ts
@@ -7,6 +7,7 @@ import { BufReader, BufWriter } from "../io/bufio.ts";
 import { assert } from "../_util/assert.ts";
 import { TextProtoReader } from "../textproto/mod.ts";
 import { hasOwnProperty } from "../_util/has_own_property.ts";
+import { Buffer } from "../io/buffer.ts";
 
 /** FormFile object */
 export interface FormFile {
@@ -285,7 +286,7 @@ export class MultipartReader {
     const fileMap = new Map<string, FormFile | FormFile[]>();
     const valueMap = new Map<string, string>();
     let maxValueBytes = maxMemory + (10 << 20);
-    const buf = new Deno.Buffer(new Uint8Array(maxValueBytes));
+    const buf = new Buffer(new Uint8Array(maxValueBytes));
     for (;;) {
       const p = await this.nextPart();
       if (p === null) {

--- a/mime/multipart_test.ts
+++ b/mime/multipart_test.ts
@@ -14,6 +14,7 @@ import {
   scanUntilBoundary,
 } from "./multipart.ts";
 import { StringWriter } from "../io/writers.ts";
+import { Buffer } from "../io/buffer.ts";
 
 const e = new TextEncoder();
 const boundary = "--abcde";
@@ -90,7 +91,7 @@ Deno.test("multipartMatchAfterPrefix3", function (): void {
 });
 
 Deno.test("multipartMultipartWriter", async function (): Promise<void> {
-  const buf = new Deno.Buffer();
+  const buf = new Buffer();
   const mw = new MultipartWriter(buf);
   await mw.writeField("foo", "foo");
   await mw.writeField("bar", "bar");

--- a/node/_fs/_fs_exists_test.ts
+++ b/node/_fs/_fs_exists_test.ts
@@ -5,6 +5,7 @@ import {
   assertStringIncludes,
 } from "../../testing/asserts.ts";
 import { exists, existsSync } from "./_fs_exists.ts";
+import { readAll } from "../../io/util.ts";
 
 Deno.test("existsFile", async function () {
   const availableFile = await new Promise((resolve) => {
@@ -49,7 +50,7 @@ Deno.test("[std/node/fs] exists callback isn't called twice if error is thrown",
     stderr: "piped",
   });
   const status = await p.status();
-  const stderr = new TextDecoder().decode(await Deno.readAll(p.stderr));
+  const stderr = new TextDecoder().decode(await readAll(p.stderr));
   p.close();
   p.stderr.close();
   await Deno.remove(tempFile);

--- a/node/_fs/_fs_writeFile.ts
+++ b/node/_fs/_fs_writeFile.ts
@@ -2,6 +2,7 @@
 import { Encodings, notImplemented } from "../_utils.ts";
 import { fromFileUrl } from "../path.ts";
 import { Buffer } from "../buffer.ts";
+import { writeAll, writeAllSync } from "../../io/util.ts";
 import {
   CallbackWithError,
   checkEncoding,
@@ -56,7 +57,7 @@ export function writeFile(
         await Deno.chmod(pathOrRid as string, mode);
       }
 
-      await Deno.writeAll(file, data as Uint8Array);
+      await writeAll(file, data as Uint8Array);
     } catch (e) {
       error = e;
     } finally {
@@ -101,7 +102,7 @@ export function writeFileSync(
       Deno.chmodSync(pathOrRid as string, mode);
     }
 
-    Deno.writeAllSync(file, data as Uint8Array);
+    writeAllSync(file, data as Uint8Array);
   } catch (e) {
     error = e;
   } finally {

--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -4,6 +4,8 @@ import { walk } from "../../fs/walk.ts";
 import { basename, fromFileUrl, join, resolve } from "../../path/mod.ts";
 import { ensureFile } from "../../fs/ensure_file.ts";
 import { config, ignoreList } from "./common.ts";
+import { Buffer } from "../../io/buffer.ts";
+import { readAll, writeAll } from "../../io/util.ts";
 
 /**
  * This script will download and extract the test files specified in the
@@ -111,7 +113,7 @@ async function decompressTests(filePath: string) {
     { read: true },
   );
 
-  const buffer = new Deno.Buffer(gunzip(await Deno.readAll(compressedFile)));
+  const buffer = new Buffer(gunzip(await readAll(compressedFile)));
   Deno.close(compressedFile.rid);
 
   const tar = new Untar(buffer);
@@ -133,7 +135,7 @@ async function decompressTests(filePath: string) {
     });
     // This will allow CI to pass without checking linting and formatting
     // on the test suite files, removing the need to mantain that as well
-    await Deno.writeAll(
+    await writeAll(
       file,
       new TextEncoder().encode(
         "// deno-fmt-ignore-file\n// deno-lint-ignore-file\n" +

--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { deferred } from "../async/mod.ts";
 import { assert, assertStringIncludes, fail } from "../testing/asserts.ts";
+import { readAll } from "../io/util.ts";
 
 export type BinaryEncodings = "binary";
 
@@ -238,7 +239,7 @@ export async function assertCallbackErrorUncaught(
     stderr: "piped",
   });
   const status = await p.status();
-  const stderr = new TextDecoder().decode(await Deno.readAll(p.stderr));
+  const stderr = new TextDecoder().decode(await readAll(p.stderr));
   p.close();
   p.stderr.close();
   await cleanup?.();

--- a/wasi/snapshot_preview1_test.ts
+++ b/wasi/snapshot_preview1_test.ts
@@ -3,6 +3,7 @@ import Context from "./snapshot_preview1.ts";
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { copy } from "../fs/mod.ts";
 import * as path from "../path/mod.ts";
+import { readAll, writeAll } from "../io/util.ts";
 
 const tests = [
   "testdata/std_env_args.wasm",
@@ -102,27 +103,27 @@ for (const pathname of tests) {
 
         if (options.stdin) {
           const stdin = new TextEncoder().encode(options.stdin);
-          await Deno.writeAll(process.stdin, stdin);
+          await writeAll(process.stdin, stdin);
         }
 
         process.stdin.close();
 
-        const stdout = await Deno.readAll(process.stdout);
+        const stdout = await readAll(process.stdout);
 
         if (options.stdout) {
           assertEquals(new TextDecoder().decode(stdout), options.stdout);
         } else {
-          await Deno.writeAll(Deno.stdout, stdout);
+          await writeAll(Deno.stdout, stdout);
         }
 
         process.stdout.close();
 
-        const stderr = await Deno.readAll(process.stderr);
+        const stderr = await readAll(process.stderr);
 
         if (options.stderr) {
           assertEquals(new TextDecoder().decode(stderr), options.stderr);
         } else {
-          await Deno.writeAll(Deno.stderr, stderr);
+          await writeAll(Deno.stderr, stderr);
         }
 
         process.stderr.close();


### PR DESCRIPTION
This moves the `Deno.Buffer` and `Deno.readAll` / `Deno.readAllSync` /
`Deno.writeAll` / `Deno.writeAllSync` implementations to std, so we can
deprecate them in Deno 1.9, and remove them in Deno 2.0.
