### PR TITLE
refactor(node): move `throw error` out of finally block to pass `no-unsafe-finally`

### DIFF
--- a/node/_fs/_fs_writeFile.ts
+++ b/node/_fs/_fs_writeFile.ts
@@ -107,7 +107,7 @@ export function writeFileSync(
   } finally {
     // Make sure to close resource
     if (!isRid && file) file.close();
-
-    if (error) throw error;
   }
+
+  if (error) throw error;
 }


### PR DESCRIPTION
This code should violate `no-unsafe-finally`, but due to a bug of deno_lint, no lint error happens at the moment.
(This bug is fixed in https://github.com/denoland/deno_lint/pull/641)
In fact, if we run ESLint with `no-unsafe-finally` enabled, the following output is emitted:

```
  111:16  error  Unsafe usage of ThrowStatement  no-unsafe-finally

✖ 1 problem (1 error, 0 warnings)
```

It looks like this `if (error) throw error;` could be moved out of the finally block. This patch did so to work around `no-unsafe-finally`.
