### PR TITLE
feat(testing): assertMatch function support string as param

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -72,7 +72,9 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>): string[] {
   messages.push("");
   messages.push(
     `    ${gray(bold("[Diff]"))} ${red(bold("Actual"))} / ${
-      green(bold("Expected"))
+      green(
+        bold("Expected"),
+      )
     }`,
   );
   messages.push("");
@@ -302,7 +304,9 @@ export function assertStrictEquals(
         .join("\n");
       message =
         `Values have the same structure but are not reference-equal:\n\n${
-          red(withOffset)
+          red(
+            withOffset,
+          )
         }\n`;
     } else {
       try {
@@ -356,10 +360,7 @@ export function assertNotStrictEquals(
  * Make an assertion that actual is not null or undefined. If not
  * then thrown.
  */
-export function assertExists(
-  actual: unknown,
-  msg?: string,
-): void {
+export function assertExists(actual: unknown, msg?: string): void {
   if (actual === undefined || actual === null) {
     if (!msg) {
       msg =
@@ -429,7 +430,9 @@ export function assertArrayIncludes(
   }
   if (!msg) {
     msg = `actual: "${_format(actual)}" expected to include: "${
-      _format(expected)
+      _format(
+        expected,
+      )
     }"\nmissing: ${_format(missing)}`;
   }
   throw new AssertionError(msg);
@@ -441,10 +444,13 @@ export function assertArrayIncludes(
  */
 export function assertMatch(
   actual: string,
-  expected: RegExp,
+  expected: RegExp | string,
   msg?: string,
 ): void {
-  if (!expected.test(actual)) {
+  const pass = typeof expected === "string"
+    ? actual.includes(expected)
+    : new RegExp(expected).test(actual);
+  if (!pass) {
     if (!msg) {
       msg = `actual: "${actual}" expected to match: "${expected}"`;
     }
@@ -482,7 +488,7 @@ export function assertObjectMatch(
   return assertEquals(
     (function filter(a: loose, b: loose): loose {
       // Prevent infinite loop with circular references with same filter
-      if ((seen.has(a)) && (seen.get(a) === b)) {
+      if (seen.has(a) && seen.get(a) === b) {
         return a;
       }
       seen.set(a, b);
@@ -498,7 +504,7 @@ export function assertObjectMatch(
       for (const [key, value] of entries) {
         if (typeof value === "object") {
           const subset = (b as loose)[key];
-          if ((typeof subset === "object") && (subset)) {
+          if (typeof subset === "object" && subset) {
             filtered[key] = filter(value as loose, subset as loose);
             continue;
           }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -42,18 +42,8 @@ Deno.test("testingEqual", function (): void {
       { hello: "world", hi: { there: "everyone else" } },
     ),
   );
-  assert(
-    equal(
-      { [Symbol.for("foo")]: "bar" },
-      { [Symbol.for("foo")]: "bar" },
-    ),
-  );
-  assert(
-    !equal(
-      { [Symbol("foo")]: "bar" },
-      { [Symbol("foo")]: "bar" },
-    ),
-  );
+  assert(equal({ [Symbol.for("foo")]: "bar" }, { [Symbol.for("foo")]: "bar" }));
+  assert(!equal({ [Symbol("foo")]: "bar" }, { [Symbol("foo")]: "bar" }));
   assert(equal(/deno/, /deno/));
   assert(!equal(/deno/, /node/));
   assert(equal(new Date(2019, 0, 3), new Date(2019, 0, 3)));
@@ -158,10 +148,7 @@ Deno.test("testingNotEquals", function (): void {
     new Date(2019, 0, 3, 4, 20, 1, 10),
     new Date(2019, 0, 3, 4, 20, 1, 20),
   );
-  assertNotEquals(
-    new Date("invalid"),
-    new Date(2019, 0, 3, 4, 20, 1, 20),
-  );
+  assertNotEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20));
   let didThrow;
   try {
     assertNotEquals("Raptor", "Raptor");
@@ -265,6 +252,7 @@ Deno.test("testingAssertStringContainsThrow", function (): void {
 
 Deno.test("testingAssertStringMatching", function (): void {
   assertMatch("foobar@deno.com", RegExp(/[a-zA-Z]+@[a-zA-Z]+.com/));
+  assertMatch("foobar@deno.com", "deno.com");
 });
 
 Deno.test("testingAssertStringMatchingThrows", function (): void {
@@ -357,12 +345,15 @@ Deno.test("testingAssertObjectMatching", function (): void {
   {
     let didThrow;
     try {
-      assertObjectMatch({
-        foo: true,
-      }, {
-        foo: true,
-        bar: false,
-      });
+      assertObjectMatch(
+        {
+          foo: true,
+        },
+        {
+          foo: true,
+          bar: false,
+        },
+      );
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);
@@ -659,10 +650,7 @@ Deno.test({
     );
     assertThrows(
       (): void =>
-        assertEquals(
-          new Date("invalid"),
-          new Date(2019, 0, 3, 4, 20, 1, 20),
-        ),
+        assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
       AssertionError,
       [
         "Values are not equal:",


### PR DESCRIPTION
`assertMatch` accepts a string, which it will try to match:
```ts
assertMatch("foobar@deno.com", "deno.com");
```