### PR TITLE
ref(encoding): Promise<void> return types are unnecessary boilerplate.

### DIFF
--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -377,8 +377,8 @@ x,,,
    */
   {
     Name: "HugeLines",
-    Input:
-      "#ignore\n".repeat(10000) + "@".repeat(5000) + "," + "*".repeat(5000),
+    Input: "#ignore\n".repeat(10000) + "@".repeat(5000) + "," +
+      "*".repeat(5000),
     Output: [["@".repeat(5000), "*".repeat(5000)]],
     Comment: "#",
   },
@@ -492,7 +492,7 @@ for (const t of testCases) {
             trimLeadingSpace: trim,
             fieldsPerRecord: fieldsPerRec,
             lazyQuotes: lazyquote,
-          }
+          },
         );
         const expected = t.Output;
         assertEquals(actual, expected);
@@ -634,17 +634,17 @@ Deno.test({
   fn(): void {
     assertEquals(
       new ParseError(2, 2, null, ERR_FIELD_COUNT).message,
-      `record on line 2: ${ERR_FIELD_COUNT}`
+      `record on line 2: ${ERR_FIELD_COUNT}`,
     );
 
     assertEquals(
       new ParseError(1, 2, 1, ERR_QUOTE).message,
-      `record on line 1; parse error on line 2, column 1: ${ERR_QUOTE}`
+      `record on line 1; parse error on line 2, column 1: ${ERR_QUOTE}`,
     );
 
     assertEquals(
       new ParseError(1, 1, 7, ERR_QUOTE).message,
-      `parse error on line 1, column 7: ${ERR_QUOTE}`
+      `parse error on line 1, column 7: ${ERR_QUOTE}`,
     );
   },
 });

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -449,7 +449,7 @@ x,,,
 for (const t of testCases) {
   Deno.test({
     name: `[CSV] ${t.Name}`,
-    async fn(): Promise<void> {
+    async fn() {
       let separator = ",";
       let comment: string | undefined;
       let fieldsPerRec: number | undefined;
@@ -473,16 +473,13 @@ for (const t of testCases) {
       let actual;
       if (t.Error) {
         const err = await assertThrowsAsync(async () => {
-          await readMatrix(
-            new BufReader(new StringReader(t.Input ?? "")),
-            {
-              separator,
-              comment: comment,
-              trimLeadingSpace: trim,
-              fieldsPerRecord: fieldsPerRec,
-              lazyQuotes: lazyquote,
-            },
-          );
+          await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
+            separator,
+            comment: comment,
+            trimLeadingSpace: trim,
+            fieldsPerRecord: fieldsPerRec,
+            lazyQuotes: lazyquote,
+          });
         });
 
         assertEquals(err, t.Error);
@@ -621,7 +618,7 @@ const parseTestCases = [
 for (const testCase of parseTestCases) {
   Deno.test({
     name: `[CSV] Parse ${testCase.name}`,
-    async fn(): Promise<void> {
+    async fn() {
       const r = await parse(testCase.in, {
         skipFirstRow: testCase.skipFirstRow,
         columns: testCase.columns,

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -377,8 +377,8 @@ x,,,
    */
   {
     Name: "HugeLines",
-    Input: "#ignore\n".repeat(10000) + "@".repeat(5000) + "," +
-      "*".repeat(5000),
+    Input:
+      "#ignore\n".repeat(10000) + "@".repeat(5000) + "," + "*".repeat(5000),
     Output: [["@".repeat(5000), "*".repeat(5000)]],
     Comment: "#",
   },
@@ -492,7 +492,7 @@ for (const t of testCases) {
             trimLeadingSpace: trim,
             fieldsPerRecord: fieldsPerRec,
             lazyQuotes: lazyquote,
-          },
+          }
         );
         const expected = t.Output;
         assertEquals(actual, expected);
@@ -634,17 +634,17 @@ Deno.test({
   fn(): void {
     assertEquals(
       new ParseError(2, 2, null, ERR_FIELD_COUNT).message,
-      `record on line 2: ${ERR_FIELD_COUNT}`,
+      `record on line 2: ${ERR_FIELD_COUNT}`
     );
 
     assertEquals(
       new ParseError(1, 2, 1, ERR_QUOTE).message,
-      `record on line 1; parse error on line 2, column 1: ${ERR_QUOTE}`,
+      `record on line 1; parse error on line 2, column 1: ${ERR_QUOTE}`
     );
 
     assertEquals(
       new ParseError(1, 1, 7, ERR_QUOTE).message,
-      `parse error on line 1, column 7: ${ERR_QUOTE}`,
+      `parse error on line 1, column 7: ${ERR_QUOTE}`
     );
   },
 });


### PR DESCRIPTION
We should strive for concise code. `void` and `Promoise<void>` return types are unnecessary boilerplate.
Discussion https://github.com/denoland/deno/issues/8832