### PR TITLE
remove `Promise<void>` return type annotation

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -318,7 +318,7 @@ export class Tar {
    *                 e.g., test.txt; use slash for directory separators
    * @param opts options
    */
-  async append(fn: string, opts: TarOptions): Promise<void> {
+  async append(fn: string, opts: TarOptions) {
     if (typeof fn !== "string") {
       throw new Error("file name not specified");
     }
@@ -509,7 +509,7 @@ class TarEntry implements Reader {
     return offset < 0 ? n - Math.abs(offset) : offset;
   }
 
-  async discard(): Promise<void> {
+  async discard() {
     // Discard current entry
     if (this.#consumed) return;
     this.#consumed = true;

--- a/archive/tar_test.ts
+++ b/archive/tar_test.ts
@@ -47,7 +47,7 @@ async function createTar(entries: TestEntry[]): Promise<Tar> {
   return tar;
 }
 
-Deno.test("createTarArchive", async function (): Promise<void> {
+Deno.test("createTarArchive", async function () {
   // initialize
   const tar = new Tar();
 
@@ -72,7 +72,7 @@ Deno.test("createTarArchive", async function (): Promise<void> {
   assertEquals(wrote, 3072);
 });
 
-Deno.test("deflateTarArchive", async function (): Promise<void> {
+Deno.test("deflateTarArchive", async function () {
   const fileName = "output.txt";
   const text = "hello tar world!";
 
@@ -124,7 +124,7 @@ Deno.test("appendFileWithLongNameToTarArchive", async function (): Promise<
   assertEquals(untarText, text);
 });
 
-Deno.test("untarAsyncIterator", async function (): Promise<void> {
+Deno.test("untarAsyncIterator", async function () {
   const entries: TestEntry[] = [
     {
       name: "output.txt",
@@ -191,7 +191,7 @@ Deno.test("untarAsyncIteratorWithoutReadingBody", async function (): Promise<
 
 Deno.test(
   "untarAsyncIteratorWithoutReadingBodyFromFileReader",
-  async function (): Promise<void> {
+  async function () {
     const entries: TestEntry[] = [
       {
         name: "output.txt",
@@ -226,7 +226,7 @@ Deno.test(
   },
 );
 
-Deno.test("untarAsyncIteratorFromFileReader", async function (): Promise<void> {
+Deno.test("untarAsyncIteratorFromFileReader", async function () {
   const entries: TestEntry[] = [
     {
       name: "output.txt",
@@ -269,7 +269,7 @@ Deno.test("untarAsyncIteratorFromFileReader", async function (): Promise<void> {
 
 Deno.test(
   "untarAsyncIteratorReadingLessThanRecordSize",
-  async function (): Promise<void> {
+  async function () {
     // record size is 512
     const bufSizes = [1, 53, 256, 511];
 
@@ -313,7 +313,7 @@ Deno.test(
   },
 );
 
-Deno.test("untarLinuxGeneratedTar", async function (): Promise<void> {
+Deno.test("untarLinuxGeneratedTar", async function () {
   const filePath = resolve(testdataDir, "deno.tar");
   const file = await Deno.open(filePath, { read: true });
 
@@ -407,7 +407,7 @@ Deno.test("untarLinuxGeneratedTar", async function (): Promise<void> {
   file.close();
 });
 
-Deno.test("directoryEntryType", async function (): Promise<void> {
+Deno.test("directoryEntryType", async function () {
   const tar = new Tar();
 
   tar.append("directory/", {

--- a/async/deferred_test.ts
+++ b/async/deferred_test.ts
@@ -2,13 +2,13 @@
 import { assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
 import { deferred } from "./deferred.ts";
 
-Deno.test("[async] deferred: resolve", async function (): Promise<void> {
+Deno.test("[async] deferred: resolve", async function () {
   const d = deferred<string>();
   d.resolve("🦕");
   assertEquals(await d, "🦕");
 });
 
-Deno.test("[async] deferred: reject", async function (): Promise<void> {
+Deno.test("[async] deferred: reject", async function () {
   const d = deferred<number>();
   d.reject(new Error("A deno error 🦕"));
   await assertThrowsAsync(async () => {

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -2,7 +2,7 @@
 import { delay } from "./delay.ts";
 import { assert } from "../testing/asserts.ts";
 
-Deno.test("[async] delay", async function (): Promise<void> {
+Deno.test("[async] delay", async function () {
   const start = new Date();
   const delayedPromise = delay(100);
   const result = await delayedPromise;

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -25,7 +25,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
 
   private async callIteratorNext(
     iterator: AsyncIterableIterator<T>,
-  ): Promise<void> {
+  ) {
     try {
       const { value, done } = await iterator.next();
       if (done) {

--- a/async/mux_async_iterator_test.ts
+++ b/async/mux_async_iterator_test.ts
@@ -19,7 +19,7 @@ async function* genThrows(): AsyncIterableIterator<number> {
   throw new Error("something went wrong");
 }
 
-Deno.test("[async] MuxAsyncIterator", async function (): Promise<void> {
+Deno.test("[async] MuxAsyncIterator", async function () {
   const mux = new MuxAsyncIterator<number>();
   mux.add(gen123());
   mux.add(gen456());

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -24,12 +24,12 @@ export function pooledMap<T, R>(
     async transform(
       p: Promise<R>,
       controller: TransformStreamDefaultController<R>,
-    ): Promise<void> {
+    ) {
       controller.enqueue(await p);
     },
   });
   // Start processing items from the iterator
-  (async (): Promise<void> => {
+  (async () => {
     const writer = res.writable.getWriter();
     const executing: Array<Promise<unknown>> = [];
     try {

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -8,7 +8,7 @@ import {
   assertThrowsAsync,
 } from "../testing/asserts.ts";
 
-Deno.test("[async] pooledMap", async function (): Promise<void> {
+Deno.test("[async] pooledMap", async function () {
   const start = new Date();
   const results = pooledMap(
     2,
@@ -23,7 +23,7 @@ Deno.test("[async] pooledMap", async function (): Promise<void> {
   assert(diff < 3000);
 });
 
-Deno.test("[async] pooledMap errors", async function (): Promise<void> {
+Deno.test("[async] pooledMap errors", async function () {
   async function mapNumber(n: number): Promise<number> {
     if (n <= 2) {
       throw new Error(`Bad number: ${n}`);

--- a/encoding/binary_test.ts
+++ b/encoding/binary_test.ts
@@ -17,14 +17,14 @@ import {
 } from "./binary.ts";
 import { Buffer } from "../io/buffer.ts";
 
-Deno.test("testGetNBytes", async function (): Promise<void> {
+Deno.test("testGetNBytes", async function () {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Buffer(data.buffer);
   const rslt = await getNBytes(buff, 8);
   assertEquals(rslt, data);
 });
 
-Deno.test("testGetNBytesThrows", async function (): Promise<void> {
+Deno.test("testGetNBytesThrows", async function () {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Buffer(data.buffer);
   await assertThrowsAsync(async () => {
@@ -62,28 +62,28 @@ Deno.test("testPutVarnumLittleEndian", function (): void {
   assertEquals(buff, new Uint8Array([0xff, 0xee, 0xdd, 0xcc]));
 });
 
-Deno.test("testReadVarbig", async function (): Promise<void> {
+Deno.test("testReadVarbig", async function () {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Buffer(data.buffer);
   const rslt = await readVarbig(buff);
   assertEquals(rslt, 0x0102030405060708n);
 });
 
-Deno.test("testReadVarbigLittleEndian", async function (): Promise<void> {
+Deno.test("testReadVarbigLittleEndian", async function () {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   const buff = new Buffer(data.buffer);
   const rslt = await readVarbig(buff, { endian: "little" });
   assertEquals(rslt, 0x0807060504030201n);
 });
 
-Deno.test("testReadVarnum", async function (): Promise<void> {
+Deno.test("testReadVarnum", async function () {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Buffer(data.buffer);
   const rslt = await readVarnum(buff);
   assertEquals(rslt, 0x01020304);
 });
 
-Deno.test("testReadVarnumLittleEndian", async function (): Promise<void> {
+Deno.test("testReadVarnumLittleEndian", async function () {
   const data = new Uint8Array([1, 2, 3, 4]);
   const buff = new Buffer(data.buffer);
   const rslt = await readVarnum(buff, { endian: "little" });
@@ -126,7 +126,7 @@ Deno.test("testVarnumLittleEndian", function (): void {
   assertEquals(rslt, 0x04030201);
 });
 
-Deno.test("testWriteVarbig", async function (): Promise<void> {
+Deno.test("testWriteVarbig", async function () {
   const data = new Uint8Array(8);
   const buff = new Buffer();
   await writeVarbig(buff, 0x0102030405060708n);
@@ -137,7 +137,7 @@ Deno.test("testWriteVarbig", async function (): Promise<void> {
   );
 });
 
-Deno.test("testWriteVarbigLittleEndian", async function (): Promise<void> {
+Deno.test("testWriteVarbigLittleEndian", async function () {
   const data = new Uint8Array(8);
   const buff = new Buffer();
   await writeVarbig(buff, 0x0807060504030201n, { endian: "little" });
@@ -148,7 +148,7 @@ Deno.test("testWriteVarbigLittleEndian", async function (): Promise<void> {
   );
 });
 
-Deno.test("testWriteVarnum", async function (): Promise<void> {
+Deno.test("testWriteVarnum", async function () {
   const data = new Uint8Array(4);
   const buff = new Buffer();
   await writeVarnum(buff, 0x01020304);
@@ -156,7 +156,7 @@ Deno.test("testWriteVarnum", async function (): Promise<void> {
   assertEquals(data, new Uint8Array([0x01, 0x02, 0x03, 0x04]));
 });
 
-Deno.test("testWriteVarnumLittleEndian", async function (): Promise<void> {
+Deno.test("testWriteVarnumLittleEndian", async function () {
   const data = new Uint8Array(4);
   const buff = new Buffer();
   await writeVarnum(buff, 0x04030201, { endian: "little" });

--- a/examples/chat/server.ts
+++ b/examples/chat/server.ts
@@ -15,7 +15,7 @@ function dispatch(msg: string): void {
     client.send(msg);
   }
 }
-async function wsHandler(ws: WebSocket): Promise<void> {
+async function wsHandler(ws: WebSocket) {
   const id = ++clientId;
   clients.set(id, ws);
   dispatch(`Connected: [${id}]`);

--- a/examples/curl_test.ts
+++ b/examples/curl_test.ts
@@ -9,7 +9,7 @@ Deno.test({
   name: "[examples/curl] send a request to a specified url",
   fn: async () => {
     const server = serve({ port: 8081 });
-    const serverPromise = (async (): Promise<void> => {
+    const serverPromise = (async () => {
       for await (const req of server) {
         req.respond({ body: "Hello world" });
       }

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -14,7 +14,7 @@ Deno.test("t2", function (): void {
 });
 
 /** A more complicated test that runs a subprocess. */
-Deno.test("catSmoke", async function (): Promise<void> {
+Deno.test("catSmoke", async function () {
   const p = Deno.run({
     cmd: [
       Deno.execPath(),

--- a/examples/xeval.ts
+++ b/examples/xeval.ts
@@ -3,7 +3,7 @@ import { parse } from "../flags/mod.ts";
 import { readStringDelim } from "../io/bufio.ts";
 
 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction.
-const AsyncFunction = Object.getPrototypeOf(async function (): Promise<void> {})
+const AsyncFunction = Object.getPrototypeOf(async function () {})
   .constructor;
 
 const HELP_MSG = `xeval
@@ -39,7 +39,7 @@ export async function xeval(
   reader: Deno.Reader,
   xevalFunc: XevalFunc,
   { delimiter = DEFAULT_DELIMITER }: XevalOptions = {},
-): Promise<void> {
+) {
   for await (const chunk of readStringDelim(reader, delimiter)) {
     // Ignore empty chunks.
     if (chunk.length > 0) {
@@ -48,7 +48,7 @@ export async function xeval(
   }
 }
 
-async function main(): Promise<void> {
+async function main() {
   const parsedArgs = parse(Deno.args, {
     boolean: ["help"],
     string: ["delim", "replvar"],

--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -10,13 +10,13 @@ import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 
-Deno.test("xevalSuccess", async function (): Promise<void> {
+Deno.test("xevalSuccess", async function () {
   const chunks: string[] = [];
   await xeval(new StringReader("a\nb\nc"), ($): number => chunks.push($));
   assertEquals(chunks, ["a", "b", "c"]);
 });
 
-Deno.test("xevalDelimiter", async function (): Promise<void> {
+Deno.test("xevalDelimiter", async function () {
   const chunks: string[] = [];
   await xeval(
     new StringReader("!MADMADAMADAM!"),
@@ -32,7 +32,7 @@ const xevalPath = "xeval.ts";
 
 Deno.test({
   name: "xevalCliReplvar",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -56,7 +56,7 @@ Deno.test({
   },
 });
 
-Deno.test("xevalCliSyntaxError", async function (): Promise<void> {
+Deno.test("xevalCliSyntaxError", async function () {
   const p = Deno.run({
     cmd: [Deno.execPath(), "run", "--quiet", xevalPath, "("],
     cwd: moduleDir,

--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -86,7 +86,7 @@ async function copyFile(
   src: string,
   dest: string,
   options: InternalCopyOptions,
-): Promise<void> {
+) {
   await ensureValidCopy(src, dest, options);
   await Deno.copyFile(src, dest);
   if (options.preserveTimestamps) {
@@ -117,7 +117,7 @@ async function copySymLink(
   src: string,
   dest: string,
   options: InternalCopyOptions,
-): Promise<void> {
+) {
   await ensureValidCopy(src, dest, options);
   const originSrcFilePath = await Deno.readLink(src);
   const type = getFileInfoType(await Deno.lstat(src));
@@ -166,7 +166,7 @@ async function copyDir(
   src: string,
   dest: string,
   options: CopyOptions,
-): Promise<void> {
+) {
   const destStat = await ensureValidCopy(src, dest, {
     ...options,
     isFolder: true,
@@ -242,7 +242,7 @@ export async function copy(
   src: string,
   dest: string,
   options: CopyOptions = {},
-): Promise<void> {
+) {
   src = path.resolve(src);
   dest = path.resolve(dest);
 

--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -22,7 +22,7 @@ function testCopy(
 ): void {
   Deno.test({
     name,
-    async fn(): Promise<void> {
+    async fn() {
       const tempDir = await Deno.makeTempDir({
         prefix: "deno_std_copy_async_test_",
       });
@@ -48,11 +48,11 @@ function testCopySync(name: string, cb: (tempDir: string) => void): void {
 
 testCopy(
   "[fs] copy file if it does no exist",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcFile = path.join(testdataDir, "copy_file_not_exists.txt");
     const destFile = path.join(tempDir, "copy_file_not_exists_1.txt");
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcFile, destFile);
       },
     );
@@ -61,11 +61,11 @@ testCopy(
 
 testCopy(
   "[fs] copy if src and dest are the same paths",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcFile = path.join(tempDir, "copy_file_same.txt");
     const destFile = path.join(tempDir, "copy_file_same.txt");
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcFile, destFile);
       },
       Error,
@@ -76,7 +76,7 @@ testCopy(
 
 testCopy(
   "[fs] copy file",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcFile = path.join(testdataDir, "copy_file.txt");
     const destFile = path.join(tempDir, "copy_file_copy.txt");
 
@@ -112,7 +112,7 @@ testCopy(
 
     // Copy again and it should throw an error.
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcFile, destFile);
       },
       Error,
@@ -140,7 +140,7 @@ testCopy(
 
 testCopy(
   "[fs] copy with preserve timestamps",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcFile = path.join(testdataDir, "copy_file.txt");
     const destFile = path.join(tempDir, "copy_file_copy.txt");
 
@@ -166,14 +166,14 @@ testCopy(
 
 testCopy(
   "[fs] copy directory to its subdirectory",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcDir = path.join(tempDir, "parent");
     const destDir = path.join(srcDir, "child");
 
     await ensureDir(srcDir);
 
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcDir, destDir);
       },
       Error,
@@ -184,7 +184,7 @@ testCopy(
 
 testCopy(
   "[fs] copy directory and destination exist and not a directory",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcDir = path.join(tempDir, "parent");
     const destDir = path.join(tempDir, "child.txt");
 
@@ -192,7 +192,7 @@ testCopy(
     await ensureFile(destDir);
 
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcDir, destDir);
       },
       Error,
@@ -203,7 +203,7 @@ testCopy(
 
 testCopy(
   "[fs] copy directory",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcDir = path.join(testdataDir, "copy_dir");
     const destDir = path.join(tempDir, "copy_dir");
     const srcFile = path.join(srcDir, "0.txt");
@@ -228,7 +228,7 @@ testCopy(
 
     // Copy again without overwrite option and it should throw an error.
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await copy(srcDir, destDir);
       },
       Error,
@@ -255,7 +255,7 @@ testCopy(
 
 testCopy(
   "[fs] copy symlink file",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const dir = path.join(testdataDir, "copy_dir_link_file");
     const srcLink = path.join(dir, "0.txt");
     const destLink = path.join(tempDir, "0_copy.txt");
@@ -275,7 +275,7 @@ testCopy(
 
 testCopy(
   "[fs] copy symlink directory",
-  async (tempDir: string): Promise<void> => {
+  async (tempDir: string) => {
     const srcDir = path.join(testdataDir, "copy_dir");
     const srcLink = path.join(tempDir, "copy_dir_link");
     const destLink = path.join(tempDir, "copy_dir_link_copy");

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -8,7 +8,7 @@ import { join } from "../path/mod.ts";
  * The directory itself is not deleted.
  * Requires the `--allow-read` and `--allow-write` flag.
  */
-export async function emptyDir(dir: string): Promise<void> {
+export async function emptyDir(dir: string) {
   try {
     const items = [];
     for await (const dirEntry of Deno.readDir(dir)) {

--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -12,7 +12,7 @@ import { emptyDir, emptyDirSync } from "./empty_dir.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("emptyDirIfItNotExist", async function (): Promise<void> {
+Deno.test("emptyDirIfItNotExist", async function () {
   const testDir = path.join(testdataDir, "empty_dir_test_1");
   const testNestDir = path.join(testDir, "nest");
   // empty a dir which not exist. then it will create new one
@@ -44,7 +44,7 @@ Deno.test("emptyDirSyncIfItNotExist", function (): void {
   }
 });
 
-Deno.test("emptyDirIfItExist", async function (): Promise<void> {
+Deno.test("emptyDirIfItExist", async function () {
   const testDir = path.join(testdataDir, "empty_dir_test_3");
   const testNestDir = path.join(testDir, "nest");
   // create test dir
@@ -70,14 +70,14 @@ Deno.test("emptyDirIfItExist", async function (): Promise<void> {
 
     // nest directory have been removed
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await Deno.stat(testNestDir);
       },
     );
 
     // test file have been removed
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await Deno.stat(testDirFile);
       },
     );

--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -6,7 +6,7 @@ import { getFileInfoType } from "./_util.ts";
  * If the directory structure does not exist, it is created. Like mkdir -p.
  * Requires the `--allow-read` and `--allow-write` flag.
  */
-export async function ensureDir(dir: string): Promise<void> {
+export async function ensureDir(dir: string) {
   try {
     const fileInfo = await Deno.lstat(dir);
     if (!fileInfo.isDirectory) {

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -7,14 +7,14 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("ensureDirIfItNotExist", async function (): Promise<void> {
+Deno.test("ensureDirIfItNotExist", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_not_exist");
   const testDir = path.join(baseDir, "test");
 
   await ensureDir(testDir);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await Deno.stat(testDir).then((): void => {
         throw new Error("test dir should exists.");
       });
@@ -35,7 +35,7 @@ Deno.test("ensureDirSyncIfItNotExist", function (): void {
   Deno.removeSync(baseDir, { recursive: true });
 });
 
-Deno.test("ensureDirIfItExist", async function (): Promise<void> {
+Deno.test("ensureDirIfItExist", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_exist");
   const testDir = path.join(baseDir, "test");
 
@@ -45,7 +45,7 @@ Deno.test("ensureDirIfItExist", async function (): Promise<void> {
   await ensureDir(testDir);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await Deno.stat(testDir).then((): void => {
         throw new Error("test dir should still exists.");
       });
@@ -72,14 +72,14 @@ Deno.test("ensureDirSyncIfItExist", function (): void {
   Deno.removeSync(baseDir, { recursive: true });
 });
 
-Deno.test("ensureDirIfItAsFile", async function (): Promise<void> {
+Deno.test("ensureDirIfItAsFile", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_exist_file");
   const testFile = path.join(baseDir, "test");
 
   await ensureFile(testFile);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await ensureDir(testFile);
     },
     Error,

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -11,7 +11,7 @@ import { getFileInfoType } from "./_util.ts";
  * it is NOTMODIFIED.
  * Requires the `--allow-read` and `--allow-write` flag.
  */
-export async function ensureFile(filePath: string): Promise<void> {
+export async function ensureFile(filePath: string) {
   try {
     // if file exists
     const stat = await Deno.lstat(filePath);

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -6,14 +6,14 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("ensureFileIfItNotExist", async function (): Promise<void> {
+Deno.test("ensureFileIfItNotExist", async function () {
   const testDir = path.join(testdataDir, "ensure_file_1");
   const testFile = path.join(testDir, "test.txt");
 
   await ensureFile(testFile);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await Deno.stat(testFile).then((): void => {
         throw new Error("test file should exists.");
       });
@@ -37,7 +37,7 @@ Deno.test("ensureFileSyncIfItNotExist", function (): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test("ensureFileIfItExist", async function (): Promise<void> {
+Deno.test("ensureFileIfItExist", async function () {
   const testDir = path.join(testdataDir, "ensure_file_3");
   const testFile = path.join(testDir, "test.txt");
 
@@ -47,7 +47,7 @@ Deno.test("ensureFileIfItExist", async function (): Promise<void> {
   await ensureFile(testFile);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await Deno.stat(testFile).then((): void => {
         throw new Error("test file should exists.");
       });
@@ -74,13 +74,13 @@ Deno.test("ensureFileSyncIfItExist", function (): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test("ensureFileIfItExistAsDir", async function (): Promise<void> {
+Deno.test("ensureFileIfItExistAsDir", async function () {
   const testDir = path.join(testdataDir, "ensure_file_5");
 
   await Deno.mkdir(testDir, { recursive: true });
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await ensureFile(testDir);
     },
     Error,

--- a/fs/ensure_link.ts
+++ b/fs/ensure_link.ts
@@ -11,7 +11,7 @@ import { getFileInfoType } from "./_util.ts";
  * @param src the source file path. Directory hard links are not allowed.
  * @param dest the destination link path
  */
-export async function ensureLink(src: string, dest: string): Promise<void> {
+export async function ensureLink(src: string, dest: string) {
   if (await exists(dest)) {
     const destStatInfo = await Deno.lstat(dest);
     const destFilePathType = getFileInfoType(destStatInfo);

--- a/fs/ensure_link_test.ts
+++ b/fs/ensure_link_test.ts
@@ -11,14 +11,14 @@ import { ensureLink, ensureLinkSync } from "./ensure_link.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("ensureLinkIfItNotExist", async function (): Promise<void> {
+Deno.test("ensureLinkIfItNotExist", async function () {
   const srcDir = path.join(testdataDir, "ensure_link_1");
   const destDir = path.join(testdataDir, "ensure_link_1_2");
   const testFile = path.join(srcDir, "test.txt");
   const linkFile = path.join(destDir, "link.txt");
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await ensureLink(testFile, linkFile);
     },
   );
@@ -38,7 +38,7 @@ Deno.test("ensureLinkSyncIfItNotExist", function (): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test("ensureLinkIfItExist", async function (): Promise<void> {
+Deno.test("ensureLinkIfItExist", async function () {
   const testDir = path.join(testdataDir, "ensure_link_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -133,7 +133,7 @@ Deno.test("ensureLinkSyncIfItExist", function (): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test("ensureLinkDirectoryIfItExist", async function (): Promise<void> {
+Deno.test("ensureLinkDirectoryIfItExist", async function () {
   const testDir = path.join(testdataDir, "ensure_link_origin_3");
   const linkDir = path.join(testdataDir, "ensure_link_link_3");
   const testFile = path.join(testDir, "test.txt");
@@ -142,7 +142,7 @@ Deno.test("ensureLinkDirectoryIfItExist", async function (): Promise<void> {
   await Deno.writeFile(testFile, new Uint8Array());
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await ensureLink(testDir, linkDir);
     },
     // "Operation not permitted (os error 1)" // throw an local matching test

--- a/fs/ensure_symlink.ts
+++ b/fs/ensure_symlink.ts
@@ -12,7 +12,7 @@ import { isWindows } from "../_util/os.ts";
  * @param src the source file path
  * @param dest the destination link path
  */
-export async function ensureSymlink(src: string, dest: string): Promise<void> {
+export async function ensureSymlink(src: string, dest: string) {
   const srcStatInfo = await Deno.lstat(src);
   const srcFilePathType = getFileInfoType(srcStatInfo);
 

--- a/fs/ensure_symlink_test.ts
+++ b/fs/ensure_symlink_test.ts
@@ -11,18 +11,18 @@ import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("ensureSymlinkIfItNotExist", async function (): Promise<void> {
+Deno.test("ensureSymlinkIfItNotExist", async function () {
   const testDir = path.join(testdataDir, "link_file_1");
   const testFile = path.join(testDir, "test.txt");
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await ensureSymlink(testFile, path.join(testDir, "test1.txt"));
     },
   );
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await Deno.stat(testFile).then((): void => {
         throw new Error("test file should exists.");
       });
@@ -44,7 +44,7 @@ Deno.test("ensureSymlinkSyncIfItNotExist", function (): void {
   });
 });
 
-Deno.test("ensureSymlinkIfItExist", async function (): Promise<void> {
+Deno.test("ensureSymlinkIfItExist", async function () {
   const testDir = path.join(testdataDir, "link_file_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
@@ -83,7 +83,7 @@ Deno.test("ensureSymlinkSyncIfItExist", function (): void {
   Deno.removeSync(testDir, { recursive: true });
 });
 
-Deno.test("ensureSymlinkDirectoryIfItExist", async function (): Promise<void> {
+Deno.test("ensureSymlinkDirectoryIfItExist", async function () {
   const testDir = path.join(testdataDir, "link_file_origin_3");
   const linkDir = path.join(testdataDir, "link_file_link_3");
   const testFile = path.join(testDir, "test.txt");

--- a/fs/exists_test.ts
+++ b/fs/exists_test.ts
@@ -6,7 +6,7 @@ import { exists, existsSync } from "./exists.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("[fs] existsFile", async function (): Promise<void> {
+Deno.test("[fs] existsFile", async function () {
   assertEquals(
     await exists(path.join(testdataDir, "not_exist_file.ts")),
     false,
@@ -19,7 +19,7 @@ Deno.test("[fs] existsFileSync", function (): void {
   assertEquals(existsSync(path.join(testdataDir, "0.ts")), true);
 });
 
-Deno.test("[fs] existsDirectory", async function (): Promise<void> {
+Deno.test("[fs] existsDirectory", async function () {
   assertEquals(
     await exists(path.join(testdataDir, "not_exist_directory")),
     false,
@@ -41,7 +41,7 @@ Deno.test("[fs] existsLinkSync", function (): void {
   assertEquals(existsSync(path.join(testdataDir, "0-link")), true);
 });
 
-Deno.test("[fs] existsLink", async function (): Promise<void> {
+Deno.test("[fs] existsLink", async function () {
   // TODO(axetroy): generate link file use Deno api instead of set a link file
   // in repository
   assertEquals(await exists(path.join(testdataDir, "0-link")), true);
@@ -112,7 +112,7 @@ const scenes: Scenes[] = [
 for (const s of scenes) {
   let title = `test ${s.async ? "exists" : "existsSync"}("testdata/${s.file}")`;
   title += ` ${s.read ? "with" : "without"} --allow-read`;
-  Deno.test(`[fs] existsPermission ${title}`, async function (): Promise<void> {
+  Deno.test(`[fs] existsPermission ${title}`, async function () {
     const args = [Deno.execPath(), "run", "--quiet"];
 
     if (s.read) {

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -49,7 +49,7 @@ const EG_OPTIONS: ExpandGlobOptions = {
   globstar: false,
 };
 
-Deno.test("expandGlobWildcard", async function (): Promise<void> {
+Deno.test("expandGlobWildcard", async function () {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("*", options), [
     "abc",
@@ -59,12 +59,12 @@ Deno.test("expandGlobWildcard", async function (): Promise<void> {
   ]);
 });
 
-Deno.test("expandGlobTrailingSeparator", async function (): Promise<void> {
+Deno.test("expandGlobTrailingSeparator", async function () {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("*/", options), ["subdir"]);
 });
 
-Deno.test("expandGlobParent", async function (): Promise<void> {
+Deno.test("expandGlobParent", async function () {
   const options = EG_OPTIONS;
   assertEquals(await expandGlobArray("subdir/../*", options), [
     "abc",
@@ -74,7 +74,7 @@ Deno.test("expandGlobParent", async function (): Promise<void> {
   ]);
 });
 
-Deno.test("expandGlobExt", async function (): Promise<void> {
+Deno.test("expandGlobExt", async function () {
   const options = { ...EG_OPTIONS, extended: true };
   assertEquals(await expandGlobArray("abc?(def|ghi)", options), [
     "abc",
@@ -94,7 +94,7 @@ Deno.test("expandGlobExt", async function (): Promise<void> {
   assertEquals(await expandGlobArray("abc!(def|ghi)", options), ["abc"]);
 });
 
-Deno.test("expandGlobGlobstar", async function (): Promise<void> {
+Deno.test("expandGlobGlobstar", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["**", "abc"], options), options),
@@ -102,7 +102,7 @@ Deno.test("expandGlobGlobstar", async function (): Promise<void> {
   );
 });
 
-Deno.test("expandGlobGlobstarParent", async function (): Promise<void> {
+Deno.test("expandGlobGlobstarParent", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["subdir", "**", ".."], options), options),
@@ -110,12 +110,12 @@ Deno.test("expandGlobGlobstarParent", async function (): Promise<void> {
   );
 });
 
-Deno.test("expandGlobIncludeDirs", async function (): Promise<void> {
+Deno.test("expandGlobIncludeDirs", async function () {
   const options = { ...EG_OPTIONS, includeDirs: false };
   assertEquals(await expandGlobArray("subdir", options), []);
 });
 
-Deno.test("expandGlobPermError", async function (): Promise<void> {
+Deno.test("expandGlobPermError", async function () {
   const exampleUrl = new URL("testdata/expand_wildcard.js", import.meta.url);
   const p = Deno.run({
     cmd: [

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -11,7 +11,7 @@ export async function move(
   src: string,
   dest: string,
   { overwrite = false }: MoveOptions = {},
-): Promise<void> {
+) {
   const srcStat = await Deno.stat(src);
 
   if (srcStat.isDirectory && isSubdir(src, dest)) {

--- a/fs/move_test.ts
+++ b/fs/move_test.ts
@@ -13,18 +13,18 @@ import { exists, existsSync } from "./exists.ts";
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
-Deno.test("moveDirectoryIfSrcNotExists", async function (): Promise<void> {
+Deno.test("moveDirectoryIfSrcNotExists", async function () {
   const srcDir = path.join(testdataDir, "move_test_src_1");
   const destDir = path.join(testdataDir, "move_test_dest_1");
   // if src directory not exist
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcDir, destDir);
     },
   );
 });
 
-Deno.test("moveDirectoryIfDestNotExists", async function (): Promise<void> {
+Deno.test("moveDirectoryIfDestNotExists", async function () {
   const srcDir = path.join(testdataDir, "move_test_src_2");
   const destDir = path.join(testdataDir, "move_test_dest_2");
 
@@ -32,7 +32,7 @@ Deno.test("moveDirectoryIfDestNotExists", async function (): Promise<void> {
 
   // if dest directory not exist
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcDir, destDir);
       throw new Error("should not throw error");
     },
@@ -45,7 +45,7 @@ Deno.test("moveDirectoryIfDestNotExists", async function (): Promise<void> {
 
 Deno.test(
   "moveDirectoryIfDestNotExistsAndOverwrite",
-  async function (): Promise<void> {
+  async function () {
     const srcDir = path.join(testdataDir, "move_test_src_2");
     const destDir = path.join(testdataDir, "move_test_dest_2");
 
@@ -53,7 +53,7 @@ Deno.test(
 
     // if dest directory not exist
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await move(srcDir, destDir, { overwrite: true });
         throw new Error("should not throw error");
       },
@@ -65,19 +65,19 @@ Deno.test(
   },
 );
 
-Deno.test("moveFileIfSrcNotExists", async function (): Promise<void> {
+Deno.test("moveFileIfSrcNotExists", async function () {
   const srcFile = path.join(testdataDir, "move_test_src_3", "test.txt");
   const destFile = path.join(testdataDir, "move_test_dest_3", "test.txt");
 
   // if src directory not exist
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcFile, destFile);
     },
   );
 });
 
-Deno.test("moveFileIfDestExists", async function (): Promise<void> {
+Deno.test("moveFileIfDestExists", async function () {
   const srcDir = path.join(testdataDir, "move_test_src_4");
   const destDir = path.join(testdataDir, "move_test_dest_4");
   const srcFile = path.join(srcDir, "test.txt");
@@ -100,7 +100,7 @@ Deno.test("moveFileIfDestExists", async function (): Promise<void> {
 
   // move it without override
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcFile, destFile);
     },
     Error,
@@ -109,7 +109,7 @@ Deno.test("moveFileIfDestExists", async function (): Promise<void> {
 
   // move again with overwrite
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcFile, destFile, { overwrite: true });
       throw new Error("should not throw error");
     },
@@ -127,7 +127,7 @@ Deno.test("moveFileIfDestExists", async function (): Promise<void> {
   ]);
 });
 
-Deno.test("moveDirectory", async function (): Promise<void> {
+Deno.test("moveDirectory", async function () {
   const srcDir = path.join(testdataDir, "move_test_src_5");
   const destDir = path.join(testdataDir, "move_test_dest_5");
   const srcFile = path.join(srcDir, "test.txt");
@@ -154,7 +154,7 @@ Deno.test("moveDirectory", async function (): Promise<void> {
 
 Deno.test(
   "moveIfSrcAndDestDirectoryExistsAndOverwrite",
-  async function (): Promise<void> {
+  async function () {
     const srcDir = path.join(testdataDir, "move_test_src_6");
     const destDir = path.join(testdataDir, "move_test_dest_6");
     const srcFile = path.join(srcDir, "test.txt");
@@ -188,14 +188,14 @@ Deno.test(
   },
 );
 
-Deno.test("moveIntoSubDir", async function (): Promise<void> {
+Deno.test("moveIntoSubDir", async function () {
   const srcDir = path.join(testdataDir, "move_test_src_7");
   const destDir = path.join(srcDir, "nest");
 
   await ensureDir(destDir);
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await move(srcDir, destDir);
     },
     Error,

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -8,7 +8,7 @@ export function testWalk(
   ignore = false,
 ): void {
   const name = t.name;
-  async function fn(): Promise<void> {
+  async function fn() {
     const origCwd = Deno.cwd();
     const d = await Deno.makeTempDir();
     Deno.chdir(d);
@@ -42,7 +42,7 @@ export async function walkArray(
   return arr;
 }
 
-export async function touch(path: string): Promise<void> {
+export async function touch(path: string) {
   const f = await Deno.create(path);
   f.close();
 }
@@ -54,30 +54,30 @@ function assertReady(expectedLength: number): void {
 }
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await Deno.mkdir(d + "/empty");
   },
-  async function emptyDir(): Promise<void> {
+  async function emptyDir() {
     const arr = await walkArray(".");
     assertEquals(arr, [".", "empty"]);
   },
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
   },
-  async function singleFile(): Promise<void> {
+  async function singleFile() {
     const arr = await walkArray(".");
     assertEquals(arr, [".", "x"]);
   },
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
   },
-  async function iteratable(): Promise<void> {
+  async function iteratable() {
     let count = 0;
     for (const _ of walkSync(".")) {
       count += 1;
@@ -91,22 +91,22 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await Deno.mkdir(d + "/a");
     await touch(d + "/a/x");
   },
-  async function nestedSingleFile(): Promise<void> {
+  async function nestedSingleFile() {
     const arr = await walkArray(".");
     assertEquals(arr, [".", "a", "a/x"]);
   },
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await Deno.mkdir(d + "/a/b/c/d", { recursive: true });
     await touch(d + "/a/b/c/d/x");
   },
-  async function depth(): Promise<void> {
+  async function depth() {
     assertReady(6);
     const arr3 = await walkArray(".", { maxDepth: 3 });
     assertEquals(arr3, [".", "a", "a/b", "a/b/c"]);
@@ -116,12 +116,12 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/a");
     await Deno.mkdir(d + "/b");
     await touch(d + "/b/c");
   },
-  async function includeDirs(): Promise<void> {
+  async function includeDirs() {
     assertReady(4);
     const arr = await walkArray(".", { includeDirs: false });
     assertEquals(arr, ["a", "b/c"]);
@@ -129,12 +129,12 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/a");
     await Deno.mkdir(d + "/b");
     await touch(d + "/b/c");
   },
-  async function includeFiles(): Promise<void> {
+  async function includeFiles() {
     assertReady(4);
     const arr = await walkArray(".", { includeFiles: false });
     assertEquals(arr, [".", "b"]);
@@ -142,11 +142,11 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x.ts");
     await touch(d + "/y.rs");
   },
-  async function ext(): Promise<void> {
+  async function ext() {
     assertReady(3);
     const arr = await walkArray(".", { exts: [".ts"] });
     assertEquals(arr, ["x.ts"]);
@@ -154,12 +154,12 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x.ts");
     await touch(d + "/y.rs");
     await touch(d + "/z.py");
   },
-  async function extAny(): Promise<void> {
+  async function extAny() {
     assertReady(4);
     const arr = await walkArray(".", { exts: [".rs", ".ts"] });
     assertEquals(arr, ["x.ts", "y.rs"]);
@@ -167,11 +167,11 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
     await touch(d + "/y");
   },
-  async function match(): Promise<void> {
+  async function match() {
     assertReady(3);
     const arr = await walkArray(".", { match: [/x/] });
     assertEquals(arr, ["x"]);
@@ -179,12 +179,12 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
     await touch(d + "/y");
     await touch(d + "/z");
   },
-  async function matchAny(): Promise<void> {
+  async function matchAny() {
     assertReady(4);
     const arr = await walkArray(".", { match: [/x/, /y/] });
     assertEquals(arr, ["x", "y"]);
@@ -192,11 +192,11 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
     await touch(d + "/y");
   },
-  async function skip(): Promise<void> {
+  async function skip() {
     assertReady(3);
     const arr = await walkArray(".", { skip: [/x/] });
     assertEquals(arr, [".", "y"]);
@@ -204,12 +204,12 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await touch(d + "/x");
     await touch(d + "/y");
     await touch(d + "/z");
   },
-  async function skipAny(): Promise<void> {
+  async function skipAny() {
     assertReady(4);
     const arr = await walkArray(".", { skip: [/x/, /y/] });
     assertEquals(arr, [".", "z"]);
@@ -217,14 +217,14 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await Deno.mkdir(d + "/a");
     await Deno.mkdir(d + "/b");
     await touch(d + "/a/x");
     await touch(d + "/a/y");
     await touch(d + "/b/z");
   },
-  async function subDir(): Promise<void> {
+  async function subDir() {
     assertReady(6);
     const arr = await walkArray("b");
     assertEquals(arr, ["b", "b/z"]);
@@ -232,8 +232,8 @@ testWalk(
 );
 
 testWalk(
-  async (_d: string): Promise<void> => {},
-  async function nonexistentRoot(): Promise<void> {
+  async (_d: string) => {},
+  async function nonexistentRoot() {
     await assertThrowsAsync(async () => {
       await walkArray("nonexistent");
     }, Deno.errors.NotFound);
@@ -241,7 +241,7 @@ testWalk(
 );
 
 testWalk(
-  async (d: string): Promise<void> => {
+  async (d: string) => {
     await Deno.mkdir(d + "/a");
     await Deno.mkdir(d + "/b");
     await touch(d + "/a/x");
@@ -249,7 +249,7 @@ testWalk(
     await touch(d + "/b/z");
     await Deno.symlink(d + "/b", d + "/a/bb");
   },
-  async function symlink(): Promise<void> {
+  async function symlink() {
     assertReady(6);
     const files = await walkArray("a");
     assertEquals(files.length, 3);

--- a/hash/_wasm/build.ts
+++ b/hash/_wasm/build.ts
@@ -3,7 +3,7 @@
 import { encode as base64Encode } from "../../encoding/base64.ts";
 
 // 1. build wasm
-async function buildWasm(path: string): Promise<void> {
+async function buildWasm(path: string) {
   const cmd = [
     "wasm-pack",
     "build",
@@ -29,7 +29,7 @@ async function encodeWasm(wasmPath: string): Promise<string> {
 }
 
 // 3. generate script
-async function generate(wasm: string, output: string): Promise<void> {
+async function generate(wasm: string, output: string) {
   const initScript = await Deno.readTextFile(`${output}/deno_hash.js`);
   const denoHashScript = "// deno-lint-ignore-file\n" +
     "//deno-fmt-ignore-file\n" +

--- a/http/_io.ts
+++ b/http/_io.ts
@@ -125,7 +125,7 @@ function isProhibidedForTrailer(key: string): boolean {
 export async function readTrailers(
   headers: Headers,
   r: BufReader,
-): Promise<void> {
+) {
   const trailers = parseTrailer(headers.get("trailer"));
   if (trailers == null) return;
   const trailerNames = [...trailers.keys()];
@@ -174,7 +174,7 @@ function parseTrailer(field: string | null): Headers | undefined {
 export async function writeChunkedBody(
   w: BufWriter,
   r: Deno.Reader,
-): Promise<void> {
+) {
   for await (const chunk of Deno.iter(r)) {
     if (chunk.byteLength <= 0) continue;
     const start = encoder.encode(`${chunk.byteLength.toString(16)}\r\n`);
@@ -195,7 +195,7 @@ export async function writeTrailers(
   w: Deno.Writer,
   headers: Headers,
   trailers: Headers,
-): Promise<void> {
+) {
   const trailer = headers.get("trailer");
   if (trailer === null) {
     throw new TypeError("Missing trailer header.");
@@ -232,7 +232,7 @@ export async function writeTrailers(
 export async function writeResponse(
   w: Deno.Writer,
   r: Response,
-): Promise<void> {
+) {
   const protoMajor = 1;
   const protoMinor = 1;
   const statusCode = r.status || 200;

--- a/http/_io_test.ts
+++ b/http/_io_test.ts
@@ -236,7 +236,7 @@ Deno.test("parseHttpVersion", (): void => {
   }
 });
 
-Deno.test("writeUint8ArrayResponse", async function (): Promise<void> {
+Deno.test("writeUint8ArrayResponse", async function () {
   const shortText = "Hello";
 
   const body = new TextEncoder().encode(shortText);
@@ -272,7 +272,7 @@ Deno.test("writeUint8ArrayResponse", async function (): Promise<void> {
   assertEquals(eof, null);
 });
 
-Deno.test("writeStringResponse", async function (): Promise<void> {
+Deno.test("writeStringResponse", async function () {
   const body = "Hello";
 
   const res: Response = { body };
@@ -307,7 +307,7 @@ Deno.test("writeStringResponse", async function (): Promise<void> {
   assertEquals(eof, null);
 });
 
-Deno.test("writeStringReaderResponse", async function (): Promise<void> {
+Deno.test("writeStringReaderResponse", async function () {
   const shortText = "Hello";
 
   const body = new StringReader(shortText);
@@ -392,7 +392,7 @@ Deno.test("writeResponseShouldNotModifyOriginHeaders", async () => {
   assert(decoder.decode(await readAll(buf)).includes("content-length: 5"));
 });
 
-Deno.test("readRequestError", async function (): Promise<void> {
+Deno.test("readRequestError", async function () {
   const input = `GET / HTTP/1.1
 malformedHeader
 `;
@@ -410,7 +410,7 @@ malformedHeader
 // Ported from Go
 // https://github.com/golang/go/blob/go1.12.5/src/net/http/request_test.go#L377-L443
 // TODO(zekth) fix tests
-Deno.test("testReadRequestError", async function (): Promise<void> {
+Deno.test("testReadRequestError", async function () {
   const testCases = [
     {
       in: "GET / HTTP/1.1\r\nheader: foo\r\n\r\n",

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -14,7 +14,7 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       port: 0,
     },
     rid: -1,
-    closeWrite: (): Promise<void> => {
+    closeWrite: () => {
       return Promise.resolve();
     },
     read: (): Promise<number | null> => {

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -416,7 +416,7 @@ function main(): void {
     Deno.exit();
   }
 
-  const handler = async (req: ServerRequest): Promise<void> => {
+  const handler = async (req: ServerRequest) => {
     let response: Response | undefined;
     try {
       const normalizedUrl = normalizeURL(req.url);

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -23,7 +23,7 @@ async function startFileServer({
   port = 4507,
   "dir-listing": dirListing = true,
   dotfiles = true,
-}: FileServerCfg = {}): Promise<void> {
+}: FileServerCfg = {}) {
   fileServer = Deno.run({
     cmd: [
       Deno.execPath(),
@@ -50,7 +50,7 @@ async function startFileServer({
   assert(s !== null && s.includes("server listening"));
 }
 
-async function startFileServerAsLibrary({}: FileServerCfg = {}): Promise<void> {
+async function startFileServerAsLibrary({}: FileServerCfg = {}) {
   fileServer = await Deno.run({
     cmd: [
       Deno.execPath(),
@@ -70,7 +70,7 @@ async function startFileServerAsLibrary({}: FileServerCfg = {}): Promise<void> {
   assert(s !== null && s.includes("Server running..."));
 }
 
-async function killFileServer(): Promise<void> {
+async function killFileServer() {
   fileServer.close();
   // Process.close() kills the file server process. However this termination
   // happens asynchronously, and since we've just closed the process resource,
@@ -156,7 +156,7 @@ async function fetchExactPath(
 
 Deno.test(
   "file_server serveFile",
-  async (): Promise<void> => {
+  async () => {
     await startFileServer();
     try {
       const res = await fetch("http://localhost:4507/README.md");
@@ -176,7 +176,7 @@ Deno.test(
 
 Deno.test(
   "file_server serveFile in testdata",
-  async (): Promise<void> => {
+  async () => {
     await startFileServer({ target: "./testdata" });
     try {
       const res = await fetch("http://localhost:4507/hello.html");
@@ -194,7 +194,7 @@ Deno.test(
   },
 );
 
-Deno.test("serveDirectory", async function (): Promise<void> {
+Deno.test("serveDirectory", async function () {
   await startFileServer();
   try {
     const res = await fetch("http://localhost:4507/");
@@ -216,7 +216,7 @@ Deno.test("serveDirectory", async function (): Promise<void> {
   }
 });
 
-Deno.test("serveFallback", async function (): Promise<void> {
+Deno.test("serveFallback", async function () {
   await startFileServer();
   try {
     const res = await fetch("http://localhost:4507/badfile.txt");
@@ -229,7 +229,7 @@ Deno.test("serveFallback", async function (): Promise<void> {
   }
 });
 
-Deno.test("checkPathTraversal", async function (): Promise<void> {
+Deno.test("checkPathTraversal", async function () {
   await startFileServer();
   try {
     const res = await fetch(
@@ -245,7 +245,7 @@ Deno.test("checkPathTraversal", async function (): Promise<void> {
   }
 });
 
-Deno.test("checkPathTraversalNoLeadingSlash", async function (): Promise<void> {
+Deno.test("checkPathTraversalNoLeadingSlash", async function () {
   await startFileServer();
   try {
     const res = await fetchExactPath("127.0.0.1", 4507, "../../../..");
@@ -255,7 +255,7 @@ Deno.test("checkPathTraversalNoLeadingSlash", async function (): Promise<void> {
   }
 });
 
-Deno.test("checkPathTraversalAbsoluteURI", async function (): Promise<void> {
+Deno.test("checkPathTraversalAbsoluteURI", async function () {
   await startFileServer();
   try {
     //allowed per https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html
@@ -271,7 +271,7 @@ Deno.test("checkPathTraversalAbsoluteURI", async function (): Promise<void> {
   }
 });
 
-Deno.test("checkURIEncodedPathTraversal", async function (): Promise<void> {
+Deno.test("checkURIEncodedPathTraversal", async function () {
   await startFileServer();
   try {
     const res = await fetch(
@@ -286,7 +286,7 @@ Deno.test("checkURIEncodedPathTraversal", async function (): Promise<void> {
   }
 });
 
-Deno.test("serveWithUnorthodoxFilename", async function (): Promise<void> {
+Deno.test("serveWithUnorthodoxFilename", async function () {
   await startFileServer();
   try {
     let res = await fetch("http://localhost:4507/testdata/%");
@@ -304,7 +304,7 @@ Deno.test("serveWithUnorthodoxFilename", async function (): Promise<void> {
   }
 });
 
-Deno.test("printHelp", async function (): Promise<void> {
+Deno.test("printHelp", async function () {
   const helpProcess = Deno.run({
     cmd: [
       Deno.execPath(),
@@ -335,7 +335,7 @@ Deno.test("contentType", async () => {
   (response.body as Deno.File).close();
 });
 
-Deno.test("file_server running as library", async function (): Promise<void> {
+Deno.test("file_server running as library", async function () {
   await startFileServerAsLibrary();
   try {
     const res = await fetch("http://localhost:8000");
@@ -364,7 +364,7 @@ Deno.test("file_server should ignore query params", async () => {
 async function startTlsFileServer({
   target = ".",
   port = 4577,
-}: FileServerCfg = {}): Promise<void> {
+}: FileServerCfg = {}) {
   fileServer = Deno.run({
     cmd: [
       Deno.execPath(),
@@ -395,7 +395,7 @@ async function startTlsFileServer({
   assert(s !== null && s.includes("server listening"));
 }
 
-Deno.test("serveDirectory TLS", async function (): Promise<void> {
+Deno.test("serveDirectory TLS", async function () {
   await startTlsFileServer();
   try {
     // Valid request after invalid
@@ -420,7 +420,7 @@ Deno.test("serveDirectory TLS", async function (): Promise<void> {
   }
 });
 
-Deno.test("partial TLS arguments fail", async function (): Promise<void> {
+Deno.test("partial TLS arguments fail", async function () {
   fileServer = Deno.run({
     cmd: [
       Deno.execPath(),
@@ -454,7 +454,7 @@ Deno.test("partial TLS arguments fail", async function (): Promise<void> {
   }
 });
 
-Deno.test("file_server disable dir listings", async function (): Promise<void> {
+Deno.test("file_server disable dir listings", async function () {
   await startFileServer({ "dir-listing": false });
   try {
     const res = await fetch("http://localhost:4507/");
@@ -467,7 +467,7 @@ Deno.test("file_server disable dir listings", async function (): Promise<void> {
   }
 });
 
-Deno.test("file_server do not show dotfiles", async function (): Promise<void> {
+Deno.test("file_server do not show dotfiles", async function () {
   await startFileServer({ target: "./testdata", dotfiles: false });
   try {
     let res = await fetch("http://localhost:4507/");

--- a/http/racing_server.ts
+++ b/http/racing_server.ts
@@ -11,12 +11,12 @@ function body(i: number): string {
 async function delayedRespond(
   request: ServerRequest,
   step: number,
-): Promise<void> {
+) {
   await delay(3000);
   await request.respond({ status: 200, body: body(step) });
 }
 
-async function largeRespond(request: ServerRequest, c: string): Promise<void> {
+async function largeRespond(request: ServerRequest, c: string) {
   const b = new Uint8Array(1024 * 1024);
   b.fill(c.charCodeAt(0));
   await request.respond({ status: 200, body: b });
@@ -25,7 +25,7 @@ async function largeRespond(request: ServerRequest, c: string): Promise<void> {
 async function ignoreToConsume(
   request: ServerRequest,
   step: number,
-): Promise<void> {
+) {
   await request.respond({ status: 200, body: body(step) });
 }
 

--- a/http/racing_server_test.ts
+++ b/http/racing_server_test.ts
@@ -7,7 +7,7 @@ import { dirname, fromFileUrl } from "../path/mod.ts";
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 let server: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
-async function startServer(): Promise<void> {
+async function startServer() {
   server = Deno.run({
     cmd: [Deno.execPath(), "run", "--quiet", "-A", "racing_server.ts"],
     cwd: moduleDir,
@@ -62,7 +62,7 @@ content-length: 6
 Step7
 `;
 
-Deno.test("serverPipelineRace", async function (): Promise<void> {
+Deno.test("serverPipelineRace", async function () {
   await startServer();
 
   const conn = await Deno.connect({ port: 4501 });

--- a/http/server.ts
+++ b/http/server.ts
@@ -80,7 +80,7 @@ export class ServerRequest {
     return this.#body;
   }
 
-  async respond(r: Response): Promise<void> {
+  async respond(r: Response) {
     let err: Error | undefined;
     try {
       // Write our response!
@@ -103,7 +103,7 @@ export class ServerRequest {
     }
   }
 
-  async finalize(): Promise<void> {
+  async finalize() {
     if (this.#finalized) return;
     // Consume unread body
     const body = this.body;
@@ -319,7 +319,7 @@ export function serve(addr: string | HTTPOptions): Server {
 export async function listenAndServe(
   addr: string | HTTPOptions,
   handler: (req: ServerRequest) => void,
-): Promise<void> {
+) {
   const server = serve(addr);
 
   for await (const request of server) {
@@ -376,7 +376,7 @@ export function serveTLS(options: HTTPSOptions): Server {
 export async function listenAndServeTLS(
   options: HTTPSOptions,
   handler: (req: ServerRequest) => void,
-): Promise<void> {
+) {
   const server = serveTLS(options);
 
   for await (const request of server) {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -62,7 +62,7 @@ const responseTests: ResponseTest[] = [
   },
 ];
 
-Deno.test("responseWrite", async function (): Promise<void> {
+Deno.test("responseWrite", async function () {
   for (const testCase of responseTests) {
     const buf = new Buffer();
     const bufw = new BufWriter(buf);
@@ -129,7 +129,7 @@ function totalReader(r: Deno.Reader): TotalReader {
     },
   };
 }
-Deno.test("requestBodyWithContentLength", async function (): Promise<void> {
+Deno.test("requestBodyWithContentLength", async function () {
   {
     const req = new ServerRequest();
     req.headers = new Headers();
@@ -204,7 +204,7 @@ Deno.test(
     assertEquals(req.headers.get("node"), "js");
   },
 );
-Deno.test("requestBodyWithTransferEncoding", async function (): Promise<void> {
+Deno.test("requestBodyWithTransferEncoding", async function () {
   {
     const shortText = "Hello";
     const req = new ServerRequest();
@@ -365,7 +365,7 @@ Deno.test("requestBodyReaderWithTransferEncoding", async function (): Promise<
 
 Deno.test({
   name: "destroyed connection",
-  fn: async (): Promise<void> => {
+  fn: async () => {
     // Runs a simple server as another process
     const p = Deno.run({
       cmd: [
@@ -411,7 +411,7 @@ Deno.test({
 
 Deno.test({
   name: "serveTLS",
-  fn: async (): Promise<void> => {
+  fn: async () => {
     // Runs a simple server as another process
     const p = Deno.run({
       cmd: [
@@ -470,7 +470,7 @@ Deno.test({
 
 Deno.test(
   "close server while iterating",
-  async (): Promise<void> => {
+  async () => {
     const server = serve(":8123");
     const nextWhileClosing = server[Symbol.asyncIterator]().next();
     server.close();
@@ -483,8 +483,8 @@ Deno.test(
 
 Deno.test({
   name: "[http] close server while connection is open",
-  async fn(): Promise<void> {
-    async function iteratorReq(server: Server): Promise<void> {
+  async fn() {
+    async function iteratorReq(server: Server) {
       for await (const req of server) {
         await req.respond({ body: new TextEncoder().encode(req.url) });
       }
@@ -514,8 +514,8 @@ Deno.test({
 
 Deno.test({
   name: "respond error closes connection",
-  async fn(): Promise<void> {
-    const serverRoutine = async (): Promise<void> => {
+  async fn() {
+    const serverRoutine = async () => {
       const server = serve(":8124");
       for await (const req of server) {
         await assertThrowsAsync(async () => {
@@ -545,7 +545,7 @@ Deno.test({
 
 Deno.test({
   name: "[http] request error gets 400 response",
-  async fn(): Promise<void> {
+  async fn() {
     const server = serve(":8124");
     const entry = server[Symbol.asyncIterator]().next();
     const conn = await Deno.connect({
@@ -571,8 +571,8 @@ Deno.test({
 
 Deno.test({
   name: "[http] finalizing invalid chunked data closes connection",
-  async fn(): Promise<void> {
-    const serverRoutine = async (): Promise<void> => {
+  async fn() {
+    const serverRoutine = async () => {
       const server = serve(":8124");
       for await (const req of server) {
         await req.respond({ status: 200, body: "Hello, world!" });
@@ -604,8 +604,8 @@ Deno.test({
 
 Deno.test({
   name: "[http] finalizing chunked unexpected EOF closes connection",
-  async fn(): Promise<void> {
-    const serverRoutine = async (): Promise<void> => {
+  async fn() {
+    const serverRoutine = async () => {
       const server = serve(":8124");
       for await (const req of server) {
         await req.respond({ status: 200, body: "Hello, world!" });
@@ -638,9 +638,9 @@ Deno.test({
 Deno.test({
   name:
     "[http] receiving bad request from a closed connection should not throw",
-  async fn(): Promise<void> {
+  async fn() {
     const server = serve(":8124");
-    const serverRoutine = async (): Promise<void> => {
+    const serverRoutine = async () => {
       for await (const req of server) {
         await req.respond({ status: 200, body: "Hello, world!" });
       }
@@ -685,8 +685,8 @@ Deno.test({
 
 Deno.test({
   name: "serveTLS Invalid Cert",
-  fn: async (): Promise<void> => {
-    async function iteratorReq(server: Server): Promise<void> {
+  fn: async () => {
+    async function iteratorReq(server: Server) {
       for await (const req of server) {
         await req.respond({ body: new TextEncoder().encode("Hello HTTPS") });
       }

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -66,7 +66,7 @@ async function empty(
   buf: Buffer,
   s: string,
   fub: Uint8Array,
-): Promise<void> {
+) {
   check(buf, s);
   while (true) {
     const r = await buf.read(fub);

--- a/io/bufio.ts
+++ b/io/bufio.ts
@@ -71,7 +71,7 @@ export class BufReader implements Reader {
   }
 
   // Reads a new chunk into the buffer.
-  private async _fill(): Promise<void> {
+  private async _fill() {
     // Slide existing data to beginning.
     if (this.r > 0) {
       this.buf.copyWithin(0, this.r, this.w);
@@ -462,7 +462,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
   }
 
   /** Flush writes any buffered data to the underlying io.Writer. */
-  async flush(): Promise<void> {
+  async flush() {
     if (this.err !== null) throw this.err;
     if (this.usedBufferBytes === 0) return;
 

--- a/io/bufio_test.ts
+++ b/io/bufio_test.ts
@@ -37,7 +37,7 @@ async function readBytes(buf: BufReader): Promise<string> {
   return decoder.decode(b.subarray(0, nb));
 }
 
-Deno.test("bufioReaderSimple", async function (): Promise<void> {
+Deno.test("bufioReaderSimple", async function () {
   const data = "hello world";
   const b = new BufReader(new StringReader(data));
   const s = await readBytes(b);
@@ -105,7 +105,7 @@ const bufsizes: number[] = [
   4096,
 ];
 
-Deno.test("bufioBufReader", async function (): Promise<void> {
+Deno.test("bufioBufReader", async function () {
   const texts = new Array<string>(31);
   let str = "";
   let all = "";
@@ -132,7 +132,7 @@ Deno.test("bufioBufReader", async function (): Promise<void> {
   }
 });
 
-Deno.test("bufioBufferFull", async function (): Promise<void> {
+Deno.test("bufioBufferFull", async function () {
   const longString =
     "And now, hello, world! It is the time for all good men to come to the" +
     " aid of their party";
@@ -154,7 +154,7 @@ Deno.test("bufioBufferFull", async function (): Promise<void> {
   assertEquals(actual, "world!");
 });
 
-Deno.test("bufioReadString", async function (): Promise<void> {
+Deno.test("bufioReadString", async function () {
   const string = "And now, hello world!";
   const buf = new BufReader(new StringReader(string), MIN_READ_BUFFER_SIZE);
 
@@ -208,7 +208,7 @@ class TestReader implements Deno.Reader {
   }
 }
 
-async function testReadLine(input: Uint8Array): Promise<void> {
+async function testReadLine(input: Uint8Array) {
   for (let stride = 1; stride < 2; stride++) {
     let done = 0;
     const reader = new TestReader(input, stride);
@@ -238,12 +238,12 @@ async function testReadLine(input: Uint8Array): Promise<void> {
   }
 }
 
-Deno.test("bufioReadLine", async function (): Promise<void> {
+Deno.test("bufioReadLine", async function () {
   await testReadLine(testInput);
   await testReadLine(testInputrn);
 });
 
-Deno.test("bufioPeek", async function (): Promise<void> {
+Deno.test("bufioPeek", async function () {
   const decoder = new TextDecoder();
   const p = new Uint8Array(10);
   // string is 16 (minReadBufferSize) long.
@@ -327,7 +327,7 @@ Deno.test("bufioPeek", async function (): Promise<void> {
   */
 });
 
-Deno.test("bufioWriter", async function (): Promise<void> {
+Deno.test("bufioWriter", async function () {
   const data = new Uint8Array(8192);
 
   for (let i = 0; i < data.byteLength; i++) {
@@ -395,7 +395,7 @@ Deno.test("bufioWriterSync", function (): void {
   }
 });
 
-Deno.test("bufReaderReadFull", async function (): Promise<void> {
+Deno.test("bufReaderReadFull", async function () {
   const enc = new TextEncoder();
   const dec = new TextDecoder();
   const text = "Hello World";
@@ -422,7 +422,7 @@ Deno.test("bufReaderReadFull", async function (): Promise<void> {
   }
 });
 
-Deno.test("readStringDelimAndLines", async function (): Promise<void> {
+Deno.test("readStringDelimAndLines", async function () {
   const enc = new TextEncoder();
   const data = new Buffer(
     enc.encode("Hello World\tHello World 2\tHello World 3"),
@@ -461,7 +461,7 @@ Deno.test("readStringDelimAndLines", async function (): Promise<void> {
 
 Deno.test(
   "bufReaderShouldNotShareArrayBufferAcrossReads",
-  async function (): Promise<void> {
+  async function () {
     const decoder = new TextDecoder();
     const data = "abcdefghijklmnopqrstuvwxyz";
     const bufSize = 25;
@@ -483,7 +483,7 @@ Deno.test(
 
 Deno.test({
   name: "Reset buffer after flush",
-  async fn(): Promise<void> {
+  async fn() {
     const stringWriter = new StringWriter();
     const bufWriter = new BufWriter(stringWriter);
     const encoder = new TextEncoder();
@@ -513,7 +513,7 @@ Deno.test({
 
 Deno.test({
   name: "BufWriter.flush should write all bytes",
-  async fn(): Promise<void> {
+  async fn() {
     const bufSize = 16 * 1024;
     const data = new Uint8Array(bufSize);
     data.fill("a".charCodeAt(0));

--- a/io/ioutil_test.ts
+++ b/io/ioutil_test.ts
@@ -23,19 +23,19 @@ class BinaryReader implements Deno.Reader {
   }
 }
 
-Deno.test("testReadShort", async function (): Promise<void> {
+Deno.test("testReadShort", async function () {
   const r = new BinaryReader(new Uint8Array([0x12, 0x34]));
   const short = await readShort(new BufReader(r));
   assertEquals(short, 0x1234);
 });
 
-Deno.test("testReadInt", async function (): Promise<void> {
+Deno.test("testReadInt", async function () {
   const r = new BinaryReader(new Uint8Array([0x12, 0x34, 0x56, 0x78]));
   const int = await readInt(new BufReader(r));
   assertEquals(int, 0x12345678);
 });
 
-Deno.test("testReadLong", async function (): Promise<void> {
+Deno.test("testReadLong", async function () {
   const r = new BinaryReader(
     new Uint8Array([0x00, 0x00, 0x00, 0x78, 0x12, 0x34, 0x56, 0x78]),
   );
@@ -43,7 +43,7 @@ Deno.test("testReadLong", async function (): Promise<void> {
   assertEquals(long, 0x7812345678);
 });
 
-Deno.test("testReadLong2", async function (): Promise<void> {
+Deno.test("testReadLong2", async function () {
   const r = new BinaryReader(
     new Uint8Array([0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78]),
   );
@@ -69,7 +69,7 @@ Deno.test("testSliceLongToBytes2", function (): void {
   assertEquals(arr, [0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78]);
 });
 
-Deno.test("testCopyN1", async function (): Promise<void> {
+Deno.test("testCopyN1", async function () {
   const w = new Buffer();
   const r = new StringReader("abcdefghij");
   const n = await copyN(r, w, 3);
@@ -77,7 +77,7 @@ Deno.test("testCopyN1", async function (): Promise<void> {
   assertEquals(new TextDecoder().decode(w.bytes()), "abc");
 });
 
-Deno.test("testCopyN2", async function (): Promise<void> {
+Deno.test("testCopyN2", async function () {
   const w = new Buffer();
   const r = new StringReader("abcdefghij");
   const n = await copyN(r, w, 11);
@@ -85,7 +85,7 @@ Deno.test("testCopyN2", async function (): Promise<void> {
   assertEquals(new TextDecoder().decode(w.bytes()), "abcdefghij");
 });
 
-Deno.test("copyNWriteAllData", async function (): Promise<void> {
+Deno.test("copyNWriteAllData", async function () {
   const tmpDir = await Deno.makeTempDir();
   const filepath = `${tmpDir}/data`;
   const file = await Deno.open(filepath, { create: true, write: true });
@@ -100,7 +100,7 @@ Deno.test("copyNWriteAllData", async function (): Promise<void> {
   assertEquals(n, size);
 });
 
-Deno.test("testStringReaderEof", async function (): Promise<void> {
+Deno.test("testStringReaderEof", async function () {
   const r = new StringReader("abc");
   assertEquals(await r.read(new Uint8Array()), 0);
   assertEquals(await r.read(new Uint8Array(4)), 3);

--- a/io/readers_test.ts
+++ b/io/readers_test.ts
@@ -5,7 +5,7 @@ import { StringWriter } from "./writers.ts";
 import { copyN } from "./ioutil.ts";
 import { readAll } from "../io/util.ts";
 
-Deno.test("ioStringReader", async function (): Promise<void> {
+Deno.test("ioStringReader", async function () {
   const r = new StringReader("abcdef");
   const res0 = await r.read(new Uint8Array(6));
   assertEquals(res0, 6);
@@ -13,7 +13,7 @@ Deno.test("ioStringReader", async function (): Promise<void> {
   assertEquals(res1, null);
 });
 
-Deno.test("ioStringReader", async function (): Promise<void> {
+Deno.test("ioStringReader", async function () {
   const decoder = new TextDecoder();
   const r = new StringReader("abcdef");
   const buf = new Uint8Array(3);
@@ -28,7 +28,7 @@ Deno.test("ioStringReader", async function (): Promise<void> {
   assertEquals(decoder.decode(buf), "def");
 });
 
-Deno.test("ioMultiReader", async function (): Promise<void> {
+Deno.test("ioMultiReader", async function () {
   const r = new MultiReader(new StringReader("abc"), new StringReader("def"));
   const w = new StringWriter();
   const n = await copyN(r, w, 4);
@@ -38,7 +38,7 @@ Deno.test("ioMultiReader", async function (): Promise<void> {
   assertEquals(w.toString(), "abcdef");
 });
 
-Deno.test("ioLimitedReader", async function (): Promise<void> {
+Deno.test("ioLimitedReader", async function () {
   const decoder = new TextDecoder();
   let sr = new StringReader("abc");
   let r = new LimitedReader(sr, 2);
@@ -57,7 +57,7 @@ Deno.test("ioLimitedReader", async function (): Promise<void> {
   assertEquals((await readAll(r)).length, 0);
 });
 
-Deno.test("ioLimitedReader", async function (): Promise<void> {
+Deno.test("ioLimitedReader", async function () {
   const rb = new StringReader("abc");
   const wb = new StringWriter();
   await Deno.copy(new LimitedReader(rb, -1), wb);

--- a/io/util.ts
+++ b/io/util.ts
@@ -71,7 +71,7 @@ export function readAllSync(r: Deno.ReaderSync): Uint8Array {
  * console.log(writer.bytes().length);  // 11
  * ```
  */
-export async function writeAll(w: Deno.Writer, arr: Uint8Array): Promise<void> {
+export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
   let nwritten = 0;
   while (nwritten < arr.length) {
     nwritten += await w.write(arr.subarray(nwritten));

--- a/io/writers_test.ts
+++ b/io/writers_test.ts
@@ -4,7 +4,7 @@ import { StringWriter } from "./writers.ts";
 import { StringReader } from "./readers.ts";
 import { copyN } from "./ioutil.ts";
 
-Deno.test("ioStringWriter", async function (): Promise<void> {
+Deno.test("ioStringWriter", async function () {
   const w = new StringWriter("base");
   const r = new StringReader("0123456789");
   await copyN(r, w, 4);

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -50,8 +50,8 @@ export class BaseHandler {
   }
 
   log(_msg: string): void {}
-  async setup(): Promise<void> {}
-  async destroy(): Promise<void> {}
+  async setup() {}
+  async destroy() {}
 }
 
 export class ConsoleHandler extends BaseHandler {
@@ -102,7 +102,7 @@ export class FileHandler extends WriterHandler {
   protected _mode: LogMode;
   protected _openOptions: Deno.OpenOptions;
   protected _encoder = new TextEncoder();
-  #unloadCallback = (): Promise<void> => this.destroy();
+  #unloadCallback = () => this.destroy();
 
   constructor(levelName: LevelName, options: FileHandlerOptions) {
     super(levelName, options);
@@ -118,7 +118,7 @@ export class FileHandler extends WriterHandler {
     };
   }
 
-  async setup(): Promise<void> {
+  async setup() {
     this._file = await Deno.open(this._filename, this._openOptions);
     this._writer = this._file;
     this._buf = new BufWriterSync(this._file);
@@ -145,7 +145,7 @@ export class FileHandler extends WriterHandler {
     }
   }
 
-  destroy(): Promise<void> {
+  destroy() {
     this.flush();
     this._file?.close();
     this._file = undefined;
@@ -170,7 +170,7 @@ export class RotatingFileHandler extends FileHandler {
     this.#maxBackupCount = options.maxBackupCount;
   }
 
-  async setup(): Promise<void> {
+  async setup() {
     if (this.#maxBytes < 1) {
       this.destroy();
       throw new Error("maxBytes cannot be less than 1");

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -162,7 +162,7 @@ export function critical<T>(
 }
 
 /** Setup logger config. */
-export async function setup(config: LogConfig): Promise<void> {
+export async function setup(config: LogConfig) {
   state.config = {
     handlers: { ...DEFAULT_CONFIG.handlers, ...config.handlers },
     loggers: { ...DEFAULT_CONFIG.loggers, ...config.loggers },

--- a/log/test.ts
+++ b/log/test.ts
@@ -16,7 +16,7 @@ class TestHandler extends log.handlers.BaseHandler {
   }
 }
 
-Deno.test("defaultHandlers", async function (): Promise<void> {
+Deno.test("defaultHandlers", async function () {
   const loggers: {
     [key: string]: (msg: string, ...args: unknown[]) => void;
   } = {
@@ -54,7 +54,7 @@ Deno.test("defaultHandlers", async function (): Promise<void> {
   }
 });
 
-Deno.test("getLogger", async function (): Promise<void> {
+Deno.test("getLogger", async function () {
   const handler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -75,7 +75,7 @@ Deno.test("getLogger", async function (): Promise<void> {
   assertEquals(logger.handlers, [handler]);
 });
 
-Deno.test("getLoggerWithName", async function (): Promise<void> {
+Deno.test("getLoggerWithName", async function () {
   const fooHandler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -96,7 +96,7 @@ Deno.test("getLoggerWithName", async function (): Promise<void> {
   assertEquals(logger.handlers, [fooHandler]);
 });
 
-Deno.test("getLoggerUnknown", async function (): Promise<void> {
+Deno.test("getLoggerUnknown", async function () {
   await log.setup({
     handlers: {},
     loggers: {},

--- a/mime/multipart.ts
+++ b/mime/multipart.ts
@@ -440,7 +440,7 @@ function multipartFormData(
     yield* fileMap;
     yield* valueMap;
   }
-  async function removeAll(): Promise<void> {
+  async function removeAll() {
     const promises: Array<Promise<void>> = [];
     for (const val of fileMap.values()) {
       if (Array.isArray(val)) {
@@ -581,7 +581,7 @@ export class MultipartWriter {
     return this.createPart(h);
   }
 
-  async writeField(field: string, value: string): Promise<void> {
+  async writeField(field: string, value: string) {
     const f = await this.createFormField(field);
     await f.write(encoder.encode(value));
   }
@@ -590,17 +590,17 @@ export class MultipartWriter {
     field: string,
     filename: string,
     file: Deno.Reader,
-  ): Promise<void> {
+  ) {
     const f = await this.createFormFile(field, filename);
     await Deno.copy(file, f);
   }
 
-  private flush(): Promise<void> {
+  private flush() {
     return this.bufWriter.flush();
   }
 
   /** Close writer. No additional data can be written to stream */
-  async close(): Promise<void> {
+  async close() {
     if (this.isClosed) {
       throw new Error("multipart: writer is closed");
     }

--- a/mime/multipart_test.ts
+++ b/mime/multipart_test.ts
@@ -90,7 +90,7 @@ Deno.test("multipartMatchAfterPrefix3", function (): void {
   assertEquals(v, 0);
 });
 
-Deno.test("multipartMultipartWriter", async function (): Promise<void> {
+Deno.test("multipartMultipartWriter", async function () {
   const buf = new Buffer();
   const mw = new MultipartWriter(buf);
   await mw.writeField("foo", "foo");
@@ -132,20 +132,20 @@ Deno.test("multipartMultipartWriter2", function (): void {
   );
 });
 
-Deno.test("multipartMultipartWriter3", async function (): Promise<void> {
+Deno.test("multipartMultipartWriter3", async function () {
   const w = new StringWriter();
   const mw = new MultipartWriter(w);
   await mw.writeField("foo", "foo");
   await mw.close();
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await mw.close();
     },
     Error,
     "closed",
   );
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       // deno-lint-ignore no-explicit-any
       await mw.writeFile("bar", "file", null as any);
     },
@@ -153,7 +153,7 @@ Deno.test("multipartMultipartWriter3", async function (): Promise<void> {
     "closed",
   );
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await mw.writeField("bar", "bar");
     },
     Error,

--- a/node/_fs/_fs_writeFile.ts
+++ b/node/_fs/_fs_writeFile.ts
@@ -46,7 +46,7 @@ export function writeFile(
   let file;
 
   let error: Error | null = null;
-  (async (): Promise<void> => {
+  (async () => {
     try {
       file = isRid
         ? new Deno.File(pathOrRid as number)

--- a/node/_util/_util_types_test.ts
+++ b/node/_util/_util_types_test.ts
@@ -121,7 +121,7 @@ Deno.test("Should return false for invalid ArrayBuffer types", () => {
 
 // isAsyncFunction
 Deno.test("Should return true for valid async function types", () => {
-  const asyncFunction = async (): Promise<void> => {};
+  const asyncFunction = async () => {};
   assertStrictEquals(isAsyncFunction(asyncFunction), true);
 });
 

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -101,7 +101,7 @@ export async function grantOrThrow(
 export async function grantOrThrow(
   descriptor: Deno.PermissionDescriptor[] | Deno.PermissionDescriptor,
   ...descriptors: Deno.PermissionDescriptor[]
-): Promise<void> {
+) {
   const denied: Deno.PermissionDescriptor[] = [];
   descriptors = Array.isArray(descriptor)
     ? descriptor

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -63,7 +63,7 @@ export function onSignal(signo: number, callback: () => void): Disposable {
   const sig = signal(signo);
 
   // allows `sig` to be returned before blocking on the await
-  (async (): Promise<void> => {
+  (async () => {
     for await (const _ of sig) {
       callback();
     }

--- a/signal/test.ts
+++ b/signal/test.ts
@@ -21,7 +21,7 @@ Deno.test({
 Deno.test({
   name: "signal() iterates for multiple signals",
   ignore: Deno.build.os === "windows",
-  fn: async (): Promise<void> => {
+  fn: async () => {
     // This prevents the program from exiting.
     const t = setInterval(() => {}, 1000);
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -109,33 +109,33 @@ Deno.test("fails", function (): void {
 Using `assertThrowsAsync()`:
 
 ```ts
-Deno.test("doesThrow", async function (): Promise<void> {
+Deno.test("doesThrow", async function () {
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       throw new TypeError("hello world!");
     },
   );
-  await assertThrowsAsync(async (): Promise<void> => {
+  await assertThrowsAsync(async () => {
     throw new TypeError("hello world!");
   }, TypeError);
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       throw new TypeError("hello world!");
     },
     TypeError,
     "hello",
   );
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       return Promise.reject(new Error());
     },
   );
 });
 
 // This test will not pass.
-Deno.test("fails", async function (): Promise<void> {
+Deno.test("fails", async function () {
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       console.log("Hello world");
     },
   );

--- a/testing/bench.ts
+++ b/testing/bench.ts
@@ -351,7 +351,7 @@ async function publishProgress(
   progress: BenchmarkRunProgress,
   state: ProgressState,
   progressCb?: (progress: BenchmarkRunProgress) => void | Promise<void>,
-): Promise<void> {
+) {
   progressCb && (await progressCb(cloneProgressWithState(progress, state)));
 }
 

--- a/testing/bench_test.ts
+++ b/testing/bench_test.ts
@@ -17,7 +17,7 @@ import {
 Deno.test({
   name: "benching",
 
-  fn: async function (): Promise<void> {
+  fn: async function () {
     bench(function forIncrementX1e3(b): void {
       b.start();
       for (let i = 0; i < 1e3; i++);
@@ -30,7 +30,7 @@ Deno.test({
       b.stop();
     });
 
-    bench(async function forAwaitFetchDenolandX10(b): Promise<void> {
+    bench(async function forAwaitFetchDenolandX10(b) {
       b.start();
       for (let i = 0; i < 10; i++) {
         const r = await fetch("https://deno.land/");
@@ -39,12 +39,12 @@ Deno.test({
       b.stop();
     });
 
-    bench(async function promiseAllFetchDenolandX10(b): Promise<void> {
+    bench(async function promiseAllFetchDenolandX10(b) {
       const urls = new Array(10).fill("https://deno.land/");
       b.start();
       await Promise.all(
         urls.map(
-          async (denoland: string): Promise<void> => {
+          async (denoland: string) => {
             const r = await fetch(denoland);
             await r.text();
           },
@@ -116,9 +116,9 @@ Deno.test({
 
 Deno.test({
   name: "Bench without stop should throw",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         bench(function benchWithoutStop(b): void {
           b.start();
           // Throws bc the timer's stop method is never called
@@ -133,9 +133,9 @@ Deno.test({
 
 Deno.test({
   name: "Bench without start should throw",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         bench(function benchWithoutStart(b): void {
           b.stop();
           // Throws bc the timer's start method is never called
@@ -150,9 +150,9 @@ Deno.test({
 
 Deno.test({
   name: "Bench with stop before start should throw",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         bench(function benchStopBeforeStart(b): void {
           b.stop();
           b.start();
@@ -168,7 +168,7 @@ Deno.test({
 
 Deno.test({
   name: "clearBenchmarks should clear all candidates",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     dummyBench("test");
 
     clearBenchmarks();
@@ -181,7 +181,7 @@ Deno.test({
 
 Deno.test({
   name: "clearBenchmarks with only as option",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     // to reset candidates
     clearBenchmarks();
 
@@ -199,7 +199,7 @@ Deno.test({
 
 Deno.test({
   name: "clearBenchmarks with skip as option",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     // to reset candidates
     clearBenchmarks();
 
@@ -217,7 +217,7 @@ Deno.test({
 
 Deno.test({
   name: "clearBenchmarks with only and skip as option",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     // to reset candidates
     clearBenchmarks();
 
@@ -238,7 +238,7 @@ Deno.test({
 
 Deno.test({
   name: "progressCallback of runBenchmarks",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     clearBenchmarks();
     dummyBench("skip");
     dummyBench("single");
@@ -348,7 +348,7 @@ Deno.test({
 
 Deno.test({
   name: "async progressCallback",
-  fn: async function (): Promise<void> {
+  fn: async function () {
     clearBenchmarks();
     dummyBench("single");
 

--- a/textproto/test.ts
+++ b/textproto/test.ts
@@ -15,7 +15,7 @@ function reader(s: string): TextProtoReader {
 Deno.test({
   ignore: true,
   name: "[textproto] Reader : DotBytes",
-  fn(): Promise<void> {
+  fn() {
     const _input =
       "dotlines\r\n.foo\r\n..bar\n...baz\nquux\r\n\r\n.\r\nanot.her\r\n";
     return Promise.resolve();
@@ -42,7 +42,7 @@ Deno.test("[textproto] Reader", async () => {
 
 Deno.test({
   name: "[textproto] Reader : MIME Header",
-  async fn(): Promise<void> {
+  async fn() {
     const input =
       "my-key: Value 1  \r\nLong-key: Even Longer Value\r\nmy-Key: " +
       "Value 2\r\n\n";
@@ -56,7 +56,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Single",
-  async fn(): Promise<void> {
+  async fn() {
     const input = "Foo: bar\n\n";
     const r = reader(input);
     const m = await r.readMIMEHeader();
@@ -67,7 +67,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header No Key",
-  async fn(): Promise<void> {
+  async fn() {
     const input = ": bar\ntest-1: 1\n\n";
     const r = reader(input);
     const m = await r.readMIMEHeader();
@@ -78,7 +78,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : Large MIME Header",
-  async fn(): Promise<void> {
+  async fn() {
     const data: string[] = [];
     // Go test is 16*1024. But seems it can't handle more
     for (let i = 0; i < 1024; i++) {
@@ -96,7 +96,7 @@ Deno.test({
 // with spaces before colons, and spaces in keys.
 Deno.test({
   name: "[textproto] Reader : MIME Header Non compliant",
-  async fn(): Promise<void> {
+  async fn() {
     const input = "Foo: bar\r\n" +
       "Content-Language: en\r\n" +
       "SID : 0\r\n" +
@@ -119,7 +119,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Malformed",
-  async fn(): Promise<void> {
+  async fn() {
     const input = [
       "No colon first line\r\nFoo: foo\r\n\r\n",
       " No colon first line with leading space\r\nFoo: foo\r\n\r\n",
@@ -142,7 +142,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Trim Continued",
-  async fn(): Promise<void> {
+  async fn() {
     const input = "a:\n" +
       " 0 \r\n" +
       "b:1 \t\r\n" +
@@ -162,7 +162,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] #409 issue : multipart form boundary",
-  async fn(): Promise<void> {
+  async fn() {
     const input = [
       "Accept: */*\r\n",
       'Content-Disposition: form-data; name="test"\r\n',

--- a/ws/example_server.ts
+++ b/ws/example_server.ts
@@ -7,7 +7,7 @@ import {
   WebSocket,
 } from "./mod.ts";
 
-async function handleWs(sock: WebSocket): Promise<void> {
+async function handleWs(sock: WebSocket) {
   console.log("socket connected!");
   try {
     for await (const ev of sock) {

--- a/ws/mod.ts
+++ b/ws/mod.ts
@@ -108,7 +108,7 @@ export function unmask(payload: Uint8Array, mask?: Uint8Array): void {
 export async function writeFrame(
   frame: WebSocketFrame,
   writer: Deno.Writer,
-): Promise<void> {
+) {
   const payloadLength = frame.payload.byteLength;
   let header: Uint8Array;
   const hasMask = frame.mask ? 0x80 : 0;
@@ -344,7 +344,7 @@ class WebSocketImpl implements WebSocket {
     return this._isClosed;
   }
 
-  async close(code = 1000, reason?: string): Promise<void> {
+  async close(code = 1000, reason?: string) {
     try {
       const header = [code >>> 8, code & 0x00ff];
       let payload: Uint8Array;
@@ -470,7 +470,7 @@ export async function handshake(
   headers: Headers,
   bufReader: BufReader,
   bufWriter: BufWriter,
-): Promise<void> {
+) {
   const { hostname, pathname, search } = url;
   const key = createSecKey();
 

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -228,7 +228,7 @@ Deno.test("[ws] handshake should not send search when it's empty", async () => {
   const reader = new Buffer(new TextEncoder().encode("HTTP/1.1 400\r\n"));
 
   await assertThrowsAsync(
-    async (): Promise<void> => {
+    async () => {
       await handshake(
         new URL("ws://example.com"),
         new Headers(),
@@ -246,14 +246,14 @@ Deno.test("[ws] handshake should not send search when it's empty", async () => {
 
 Deno.test(
   "[ws] handshake should send search correctly",
-  async function wsHandshakeWithSearch(): Promise<void> {
+  async function wsHandshakeWithSearch() {
     const writer = new Buffer();
     const reader = new Buffer(
       new TextEncoder().encode("HTTP/1.1 400\r\n"),
     );
 
     await assertThrowsAsync(
-      async (): Promise<void> => {
+      async () => {
         await handshake(
           new URL("ws://example.com?a=1"),
           new Headers(),
@@ -285,7 +285,7 @@ Deno.test("[ws] ws.close() should use 1000 as close code", async () => {
 function dummyConn(r: Deno.Reader, w: Deno.Writer): Deno.Conn {
   return {
     rid: -1,
-    closeWrite: (): Promise<void> => Promise.resolve(),
+    closeWrite: () => Promise.resolve(),
     read: (x: Uint8Array): Promise<number | null> => r.read(x),
     write: (x: Uint8Array): Promise<number> => w.write(x),
     close: (): void => {},
@@ -298,7 +298,7 @@ function delayedWriter(ms: number, dest: Deno.Writer): Deno.Writer {
   return {
     write(p: Uint8Array): Promise<number> {
       return new Promise<number>((resolve) => {
-        setTimeout(async (): Promise<void> => {
+        setTimeout(async () => {
           resolve(await dest.write(p));
         }, ms);
       });
@@ -307,7 +307,7 @@ function delayedWriter(ms: number, dest: Deno.Writer): Deno.Writer {
 }
 Deno.test({
   name: "[ws] WebSocket.send(), WebSocket.ping() should be exclusive",
-  fn: async (): Promise<void> => {
+  fn: async () => {
     const buf = new Buffer();
     const conn = dummyConn(new Buffer(), delayedWriter(1, buf));
     const sock = createWebSocket({ conn });


### PR DESCRIPTION
Follow-up of #818

There's a couple of instances where `Promise<void>` is still there,
those are the exceptions, for example functions that explicitely return
a `Promise` object or functions that return the promise from another
function call without any `await` statement.

used this one-liner to automatically remove everything:

```bash
grep -rli 'promise<void>' | xargs sed -i 's/: Promise<void>//g
```