### PR TITLE
Allow multiple set-cookie headers

### DIFF
--- a/http/_io.ts
+++ b/http/_io.ts
@@ -250,7 +250,11 @@ export async function writeResponse(
 
   let out = `HTTP/${protoMajor}.${protoMinor} ${statusCode} ${statusText}\r\n`;
 
-  const headers = r.headers ?? new Headers();
+  const rHeaders = r.headers as HeadersInit | undefined;
+  const headersIter = rHeaders instanceof Headers || Array.isArray(rHeaders)
+    ? rHeaders
+    : Object.entries(rHeaders ?? {});
+  const headers = new Headers(headersIter);
 
   if (r.body && !headers.get("content-length")) {
     if (r.body instanceof Uint8Array) {
@@ -260,7 +264,7 @@ export async function writeResponse(
     }
   }
 
-  for (const [key, value] of headers) {
+  for (const [key, value] of headersIter) {
     out += `${key}: ${value}\r\n`;
   }
 


### PR DESCRIPTION
This PR changes the internals of `writeResponse` to allow sending multiple `set-cookie` headers.

This approach similar to how Cloudflare Workers handles the same problem. There, if (and only if) a `Headers` object is initialised via a `[string, string][]` array, each entry will be put on the wire separately.

```ts
// this works in cf workers:
event.respondWith(new Response(null, { 
  headers: new Headers([['set-cookie', 'foo=bar'], ['set-cookie', 'fizz=buzz']])
}))
```

Luckily, changing the internals of the `Headers` class is not necessary here. Instead, allowing `[string, string][]` in the `respond` method is sufficient:

```ts
for await (const req of server) {
  req.respond({
    headers: [['set-cookie', 'foo=bar'], ['set-cookie', 'fizz=buzz']] as unknown as Headers,
  });
}
```

Note that the `Response` interface hasn't been changed on purpose, so as not to break any existing uses. If changing the interface is permissible, the following commit would reflect the change in the type system:

https://github.com/worker-tools/deno_std/commit/527109030ec91cd6937e447a645429355216235f