### PR TITLE
fix: handle upstream type changes

### DIFF
--- a/node/buffer.ts
+++ b/node/buffer.ts
@@ -446,7 +446,7 @@ export class Buffer extends Uint8Array {
    * not contain enough space to fit the entire string, only part of string will
    * be written. However, partially encoded characters will not be written.
    */
-  write(string: string, offset = 0, length = this.length): number {
+  write(string: string, offset = 0, length = this.length): number | undefined {
     return new TextEncoder().encodeInto(
       string,
       this.subarray(offset, offset + length),


### PR DESCRIPTION
More aligned types in `TextEncoder` have required an update to `node/decode.ts` that should be backwards compatible.