### PR TITLE
ref:  Promise<void> return types are unnecessary boilerplate

### DIFF
--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -449,7 +449,7 @@ x,,,
 for (const t of testCases) {
   Deno.test({
     name: `[CSV] ${t.Name}`,
-    async fn(): Promise<void> {
+    async fn() {
       let separator = ",";
       let comment: string | undefined;
       let fieldsPerRec: number | undefined;
@@ -473,16 +473,13 @@ for (const t of testCases) {
       let actual;
       if (t.Error) {
         const err = await assertThrowsAsync(async () => {
-          await readMatrix(
-            new BufReader(new StringReader(t.Input ?? "")),
-            {
-              separator,
-              comment: comment,
-              trimLeadingSpace: trim,
-              fieldsPerRecord: fieldsPerRec,
-              lazyQuotes: lazyquote,
-            },
-          );
+          await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
+            separator,
+            comment: comment,
+            trimLeadingSpace: trim,
+            fieldsPerRecord: fieldsPerRec,
+            lazyQuotes: lazyquote,
+          });
         });
 
         assertEquals(err, t.Error);
@@ -621,7 +618,7 @@ const parseTestCases = [
 for (const testCase of parseTestCases) {
   Deno.test({
     name: `[CSV] Parse ${testCase.name}`,
-    async fn(): Promise<void> {
+    async fn() {
       const r = await parse(testCase.in, {
         skipFirstRow: testCase.skipFirstRow,
         columns: testCase.columns,

--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -22,7 +22,7 @@ function testCopy(
 ): void {
   Deno.test({
     name,
-    async fn(): Promise<void> {
+    async fn() {
       const tempDir = await Deno.makeTempDir({
         prefix: "deno_std_copy_async_test_",
       });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -481,7 +481,7 @@ Deno.test(
 
 Deno.test({
   name: "[http] close server while connection is open",
-  async fn(): Promise<void> {
+  async fn() {
     async function iteratorReq(server: Server): Promise<void> {
       for await (const req of server) {
         await req.respond({ body: new TextEncoder().encode(req.url) });
@@ -512,7 +512,7 @@ Deno.test({
 
 Deno.test({
   name: "respond error closes connection",
-  async fn(): Promise<void> {
+  async fn() {
     const serverRoutine = async (): Promise<void> => {
       const server = serve(":8124");
       for await (const req of server) {
@@ -543,7 +543,7 @@ Deno.test({
 
 Deno.test({
   name: "[http] request error gets 400 response",
-  async fn(): Promise<void> {
+  async fn() {
     const server = serve(":8124");
     const entry = server[Symbol.asyncIterator]().next();
     const conn = await Deno.connect({
@@ -569,7 +569,7 @@ Deno.test({
 
 Deno.test({
   name: "[http] finalizing invalid chunked data closes connection",
-  async fn(): Promise<void> {
+  async fn() {
     const serverRoutine = async (): Promise<void> => {
       const server = serve(":8124");
       for await (const req of server) {
@@ -602,7 +602,7 @@ Deno.test({
 
 Deno.test({
   name: "[http] finalizing chunked unexpected EOF closes connection",
-  async fn(): Promise<void> {
+  async fn() {
     const serverRoutine = async (): Promise<void> => {
       const server = serve(":8124");
       for await (const req of server) {
@@ -636,7 +636,7 @@ Deno.test({
 Deno.test({
   name:
     "[http] receiving bad request from a closed connection should not throw",
-  async fn(): Promise<void> {
+  async fn() {
     const server = serve(":8124");
     const serverRoutine = async (): Promise<void> => {
       for await (const req of server) {
@@ -650,18 +650,20 @@ Deno.test({
     });
     await Deno.writeAll(
       conn,
-      new TextEncoder().encode([
-        // A normal request is required:
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "",
-        // The bad request:
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "INVALID!HEADER!",
-        "",
-        "",
-      ].join("\r\n")),
+      new TextEncoder().encode(
+        [
+          // A normal request is required:
+          "GET / HTTP/1.1",
+          "Host: localhost",
+          "",
+          // The bad request:
+          "GET / HTTP/1.1",
+          "Host: localhost",
+          "INVALID!HEADER!",
+          "",
+          "",
+        ].join("\r\n"),
+      ),
     );
     // After sending the two requests, don't receive the reponses.
 

--- a/io/bufio_test.ts
+++ b/io/bufio_test.ts
@@ -482,7 +482,7 @@ Deno.test(
 
 Deno.test({
   name: "Reset buffer after flush",
-  async fn(): Promise<void> {
+  async fn() {
     const stringWriter = new StringWriter();
     const bufWriter = new BufWriter(stringWriter);
     const encoder = new TextEncoder();
@@ -512,7 +512,7 @@ Deno.test({
 
 Deno.test({
   name: "BufWriter.flush should write all bytes",
-  async fn(): Promise<void> {
+  async fn() {
     const bufSize = 16 * 1024;
     const data = new Uint8Array(bufSize);
     data.fill("a".charCodeAt(0));

--- a/textproto/test.ts
+++ b/textproto/test.ts
@@ -97,8 +97,7 @@ Deno.test({
 Deno.test({
   name: "[textproto] Reader : MIME Header Non compliant",
   async fn() {
-    const input =
-      "Foo: bar\r\n" +
+    const input = "Foo: bar\r\n" +
       "Content-Language: en\r\n" +
       "SID : 0\r\n" +
       "Audio Mode : None\r\n" +
@@ -144,8 +143,7 @@ Deno.test({
 Deno.test({
   name: "[textproto] Reader : MIME Header Trim Continued",
   async fn() {
-    const input =
-      "a:\n" +
+    const input = "a:\n" +
       " 0 \r\n" +
       "b:1 \t\r\n" +
       "c: 2\r\n" +

--- a/textproto/test.ts
+++ b/textproto/test.ts
@@ -15,7 +15,7 @@ function reader(s: string): TextProtoReader {
 Deno.test({
   ignore: true,
   name: "[textproto] Reader : DotBytes",
-  fn(): Promise<void> {
+  fn() {
     const _input =
       "dotlines\r\n.foo\r\n..bar\n...baz\nquux\r\n\r\n.\r\nanot.her\r\n";
     return Promise.resolve();
@@ -42,7 +42,7 @@ Deno.test("[textproto] Reader", async () => {
 
 Deno.test({
   name: "[textproto] Reader : MIME Header",
-  async fn(): Promise<void> {
+  async fn() {
     const input =
       "my-key: Value 1  \r\nLong-key: Even Longer Value\r\nmy-Key: " +
       "Value 2\r\n\n";
@@ -56,7 +56,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Single",
-  async fn(): Promise<void> {
+  async fn() {
     const input = "Foo: bar\n\n";
     const r = reader(input);
     const m = await r.readMIMEHeader();
@@ -67,7 +67,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header No Key",
-  async fn(): Promise<void> {
+  async fn() {
     const input = ": bar\ntest-1: 1\n\n";
     const r = reader(input);
     const m = await r.readMIMEHeader();
@@ -78,7 +78,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : Large MIME Header",
-  async fn(): Promise<void> {
+  async fn() {
     const data: string[] = [];
     // Go test is 16*1024. But seems it can't handle more
     for (let i = 0; i < 1024; i++) {
@@ -96,8 +96,9 @@ Deno.test({
 // with spaces before colons, and spaces in keys.
 Deno.test({
   name: "[textproto] Reader : MIME Header Non compliant",
-  async fn(): Promise<void> {
-    const input = "Foo: bar\r\n" +
+  async fn() {
+    const input =
+      "Foo: bar\r\n" +
       "Content-Language: en\r\n" +
       "SID : 0\r\n" +
       "Audio Mode : None\r\n" +
@@ -119,7 +120,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Malformed",
-  async fn(): Promise<void> {
+  async fn() {
     const input = [
       "No colon first line\r\nFoo: foo\r\n\r\n",
       " No colon first line with leading space\r\nFoo: foo\r\n\r\n",
@@ -142,8 +143,9 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] Reader : MIME Header Trim Continued",
-  async fn(): Promise<void> {
-    const input = "a:\n" +
+  async fn() {
+    const input =
+      "a:\n" +
       " 0 \r\n" +
       "b:1 \t\r\n" +
       "c: 2\r\n" +
@@ -162,7 +164,7 @@ Deno.test({
 
 Deno.test({
   name: "[textproto] #409 issue : multipart form boundary",
-  async fn(): Promise<void> {
+  async fn() {
     const input = [
       "Accept: */*\r\n",
       'Content-Disposition: form-data; name="test"\r\n',


### PR DESCRIPTION
We should strive for concise code. `void` and `Promoise<void>` return types are unnecessary boilerplate.
Discussion denoland/deno#8832.
This changes includes folders:
- [x] encoding
- [x] io
- [x] http
- [x] text-proto 