### PR TITLE
chore: add underscore prefix to unused variables

### DIFF
--- a/encoding/_yaml/type/function.ts
+++ b/encoding/_yaml/type/function.ts
@@ -25,7 +25,7 @@ export const func = new Type("tag:yaml.org,2002:js/function", {
     try {
       reconstructFunction(`${data}`);
       return true;
-    } catch (err) {
+    } catch (_err) {
       return false;
     }
   },

--- a/node/_fs/_fs_utimes_test.ts
+++ b/node/_fs/_fs_utimes_test.ts
@@ -34,7 +34,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        utimes("some/path", Infinity, 0, (err: Error | null) => {});
+        utimes("some/path", Infinity, 0, (_err: Error | null) => {});
       },
       Error,
       "invalid atime, must not be infitiny or NaN",
@@ -47,7 +47,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        utimes("some/path", "some string", 0, (err: Error | null) => {});
+        utimes("some/path", "some string", 0, (_err: Error | null) => {});
       },
       Error,
       "invalid atime, must not be infitiny or NaN",


### PR DESCRIPTION
deno_lint's `no-unused-vars` rule will be enabled (see https://github.com/denoland/deno_lint/pull/625). Before it comes, I've added underscore prefixes to unused variables.