### PR TITLE
feat: add iter and iterSync to io/util

### DIFF
--- a/http/_io.ts
+++ b/http/_io.ts
@@ -4,6 +4,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 import { assert } from "../_util/assert.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { STATUS_TEXT } from "./http_status.ts";
+import { iter } from "../io/util.ts";
 
 const encoder = new TextEncoder();
 
@@ -175,7 +176,7 @@ export async function writeChunkedBody(
   w: BufWriter,
   r: Deno.Reader,
 ) {
-  for await (const chunk of Deno.iter(r)) {
+  for await (const chunk of iter(r)) {
     if (chunk.byteLength <= 0) continue;
     const start = encoder.encode(`${chunk.byteLength.toString(16)}\r\n`);
     const end = encoder.encode("\r\n");

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -9,7 +9,7 @@ import { TextProtoReader } from "../textproto/mod.ts";
 import { Response, ServerRequest } from "./server.ts";
 import { FileServerArgs, serveFile } from "./file_server.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
-import { readAll, writeAll } from "../io/util.ts";
+import { iter, readAll, writeAll } from "../io/util.ts";
 
 let fileServer: Deno.Process<Deno.RunOptions & { stdout: "piped" }>;
 
@@ -104,7 +104,7 @@ async function fetchExactPath(
     let currentResult = "";
     let contentLength = -1;
     let startOfBody = -1;
-    for await (const chunk of Deno.iter(conn)) {
+    for await (const chunk of iter(conn)) {
       currentResult += decoder.decode(chunk);
       if (contentLength === -1) {
         const match = /^content-length: (.*)$/m.exec(currentResult);

--- a/io/util.ts
+++ b/io/util.ts
@@ -1,5 +1,7 @@
 import { Buffer } from "./buffer.ts";
 
+const DEFAULT_BUFFER_SIZE = 32 * 1024;
+
 /** Read Reader `r` until EOF (`null`) and resolve to the content as
  * Uint8Array`.
  *
@@ -103,5 +105,99 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
   let nwritten = 0;
   while (nwritten < arr.length) {
     nwritten += w.writeSync(arr.subarray(nwritten));
+  }
+}
+
+/** Turns a Reader, `r`, into an async iterator.
+ *
+ * ```ts
+ * let f = await Deno.open("/etc/passwd");
+ * for await (const chunk of iter(f)) {
+ *   console.log(chunk);
+ * }
+ * f.close();
+ * ```
+ *
+ * Second argument can be used to tune size of a buffer.
+ * Default size of the buffer is 32kB.
+ *
+ * ```ts
+ * let f = await Deno.open("/etc/passwd");
+ * const iter = iter(f, {
+ *   bufSize: 1024 * 1024
+ * });
+ * for await (const chunk of iter) {
+ *   console.log(chunk);
+ * }
+ * f.close();
+ * ```
+ *
+ * Iterator uses an internal buffer of fixed size for efficiency; it returns
+ * a view on that buffer on each iteration. It is therefore caller's
+ * responsibility to copy contents of the buffer if needed; otherwise the
+ * next iteration will overwrite contents of previously returned chunk.
+ */
+export async function* iter(
+  r: Deno.Reader,
+  options?: {
+    bufSize?: number;
+  },
+): AsyncIterableIterator<Uint8Array> {
+  const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
+  const b = new Uint8Array(bufSize);
+  while (true) {
+    const result = await r.read(b);
+    if (result === null) {
+      break;
+    }
+
+    yield b.subarray(0, result);
+  }
+}
+
+/** Turns a ReaderSync, `r`, into an iterator.
+ *
+ * ```ts
+ * let f = Deno.openSync("/etc/passwd");
+ * for (const chunk of iterSync(f)) {
+ *   console.log(chunk);
+ * }
+ * f.close();
+ * ```
+ *
+ * Second argument can be used to tune size of a buffer.
+ * Default size of the buffer is 32kB.
+ *
+ * ```ts
+ * let f = await Deno.open("/etc/passwd");
+ * const iter = iterSync(f, {
+ *   bufSize: 1024 * 1024
+ * });
+ * for (const chunk of iter) {
+ *   console.log(chunk);
+ * }
+ * f.close();
+ * ```
+ *
+ * Iterator uses an internal buffer of fixed size for efficiency; it returns
+ * a view on that buffer on each iteration. It is therefore caller's
+ * responsibility to copy contents of the buffer if needed; otherwise the
+ * next iteration will overwrite contents of previously returned chunk.
+ */
+export function* iterSync(
+  r: Deno.ReaderSync,
+  options?: {
+    bufSize?: number;
+  },
+): IterableIterator<Uint8Array> {
+  const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
+  const b = new Uint8Array(bufSize);
+  while (true) {
+    const result = r.readSync(b);
+    if (result === null) {
+      break;
+    }
+
+    yield b.subarray(0, result);
   }
 }

--- a/io/util_test.ts
+++ b/io/util_test.ts
@@ -190,7 +190,7 @@ Deno.test("readerIterSync", () => {
   const reader = new TestReader("hello world!");
 
   let totalSize = 0;
-  for await (const buf of iterSync(reader)) {
+  for (const buf of iterSync(reader)) {
     totalSize += buf.byteLength;
   }
 

--- a/io/util_test.ts
+++ b/io/util_test.ts
@@ -65,3 +65,127 @@ Deno.test("testWriteAllSync", () => {
     assertEquals(testBytes[i], actualBytes[i]);
   }
 });
+
+function helloWorldFile(): Buffer {
+  return new Buffer(new TextEncoder().encode("Hello World!"));
+}
+
+Deno.test("filesIter", async () => {
+  const file = helloWorldFile();
+
+  let totalSize = 0;
+  for await (const buf of Deno.iter(file)) {
+    totalSize += buf.byteLength;
+  }
+
+  assertEquals(totalSize, 12);
+});
+
+Deno.test("filesIterCustomBufSize", async () => {
+  const file = helloWorldFile();
+
+  let totalSize = 0;
+  let iterations = 0;
+  for await (const buf of Deno.iter(file, { bufSize: 6 })) {
+    totalSize += buf.byteLength;
+    iterations += 1;
+  }
+
+  assertEquals(totalSize, 12);
+  assertEquals(iterations, 2);
+});
+
+Deno.test("filesIterSync", () => {
+  const file = helloWorldFile();
+
+  let totalSize = 0;
+  for (const buf of Deno.iterSync(file)) {
+    totalSize += buf.byteLength;
+  }
+
+  assertEquals(totalSize, 12);
+});
+
+Deno.test("filesIterSyncCustomBufSize", () => {
+  const file = helloWorldFile();
+
+  let totalSize = 0;
+  let iterations = 0;
+  for (const buf of Deno.iterSync(file, { bufSize: 6 })) {
+    totalSize += buf.byteLength;
+    iterations += 1;
+  }
+
+  assertEquals(totalSize, 12);
+  assertEquals(iterations, 2);
+});
+
+Deno.test("readerIter", async () => {
+  // ref: https://github.com/denoland/deno/issues/2330
+  const encoder = new TextEncoder();
+
+  class TestReader implements Deno.Reader {
+    #offset = 0;
+    #buf: Uint8Array;
+
+    constructor(s: string) {
+      this.#buf = new Uint8Array(encoder.encode(s));
+    }
+
+    read(p: Uint8Array): Promise<number | null> {
+      const n = Math.min(p.byteLength, this.#buf.byteLength - this.#offset);
+      p.set(this.#buf.slice(this.#offset, this.#offset + n));
+      this.#offset += n;
+
+      if (n === 0) {
+        return Promise.resolve(null);
+      }
+
+      return Promise.resolve(n);
+    }
+  }
+
+  const reader = new TestReader("hello world!");
+
+  let totalSize = 0;
+  for await (const buf of Deno.iter(reader)) {
+    totalSize += buf.byteLength;
+  }
+
+  assertEquals(totalSize, 12);
+});
+
+Deno.test("readerIterSync", () => {
+  // ref: https://github.com/denoland/deno/issues/2330
+  const encoder = new TextEncoder();
+
+  class TestReader implements Deno.ReaderSync {
+    #offset = 0;
+    #buf: Uint8Array;
+
+    constructor(s: string) {
+      this.#buf = new Uint8Array(encoder.encode(s));
+    }
+
+    readSync(p: Uint8Array): number | null {
+      const n = Math.min(p.byteLength, this.#buf.byteLength - this.#offset);
+      p.set(this.#buf.slice(this.#offset, this.#offset + n));
+      this.#offset += n;
+
+      if (n === 0) {
+        return null;
+      }
+
+      return n;
+    }
+  }
+
+  const reader = new TestReader("hello world!");
+
+  let totalSize = 0;
+  for await (const buf of Deno.iterSync(reader)) {
+    totalSize += buf.byteLength;
+  }
+
+  assertEquals(totalSize, 12);
+});

--- a/io/util_test.ts
+++ b/io/util_test.ts
@@ -5,7 +5,14 @@
 // https://github.com/golang/go/blob/master/LICENSE
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { Buffer } from "./buffer.ts";
-import { readAll, readAllSync, writeAll, writeAllSync } from "./util.ts";
+import {
+  iter,
+  iterSync,
+  readAll,
+  readAllSync,
+  writeAll,
+  writeAllSync,
+} from "./util.ts";
 
 // N controls how many iterations of certain checks are performed.
 const N = 100;
@@ -74,7 +81,7 @@ Deno.test("filesIter", async () => {
   const file = helloWorldFile();
 
   let totalSize = 0;
-  for await (const buf of Deno.iter(file)) {
+  for await (const buf of iter(file)) {
     totalSize += buf.byteLength;
   }
 
@@ -86,7 +93,7 @@ Deno.test("filesIterCustomBufSize", async () => {
 
   let totalSize = 0;
   let iterations = 0;
-  for await (const buf of Deno.iter(file, { bufSize: 6 })) {
+  for await (const buf of iter(file, { bufSize: 6 })) {
     totalSize += buf.byteLength;
     iterations += 1;
   }
@@ -99,7 +106,7 @@ Deno.test("filesIterSync", () => {
   const file = helloWorldFile();
 
   let totalSize = 0;
-  for (const buf of Deno.iterSync(file)) {
+  for (const buf of iterSync(file)) {
     totalSize += buf.byteLength;
   }
 
@@ -111,7 +118,7 @@ Deno.test("filesIterSyncCustomBufSize", () => {
 
   let totalSize = 0;
   let iterations = 0;
-  for (const buf of Deno.iterSync(file, { bufSize: 6 })) {
+  for (const buf of iterSync(file, { bufSize: 6 })) {
     totalSize += buf.byteLength;
     iterations += 1;
   }
@@ -148,7 +155,7 @@ Deno.test("readerIter", async () => {
   const reader = new TestReader("hello world!");
 
   let totalSize = 0;
-  for await (const buf of Deno.iter(reader)) {
+  for await (const buf of iter(reader)) {
     totalSize += buf.byteLength;
   }
 
@@ -183,7 +190,7 @@ Deno.test("readerIterSync", () => {
   const reader = new TestReader("hello world!");
 
   let totalSize = 0;
-  for await (const buf of Deno.iterSync(reader)) {
+  for await (const buf of iterSync(reader)) {
     totalSize += buf.byteLength;
   }
 

--- a/node/_fs/_fs_futimes_test.ts
+++ b/node/_fs/_fs_futimes_test.ts
@@ -38,7 +38,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        futimes(123, Infinity, 0, (err: Error | null) => {});
+        futimes(123, Infinity, 0, (_err: Error | null) => {});
       },
       Error,
       "invalid atime, must not be infitiny or NaN",
@@ -51,7 +51,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        futimes(123, "some string", 0, (err: Error | null) => {});
+        futimes(123, "some string", 0, (_err: Error | null) => {});
       },
       Error,
       "invalid atime, must not be infitiny or NaN",

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -30,7 +30,6 @@ export class Hash extends Transform {
         callback();
       },
       flush(callback: () => void): void {
-        // deno-lint-ignore no-this-before-super
         this.push(hash.digest());
         callback();
       },


### PR DESCRIPTION
This moves the `Deno.iter` and `Deno.iterSync` implementations to std,
so we can deprecate them in Deno 1.9, and remove them in Deno 2.0.
