### PR TITLE
fix(std/testing): equals does not differentiate undefined/absent keys

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -161,6 +161,9 @@ export function equal(c: unknown, d: unknown): boolean {
         if (!compare(a && a[key as Key], b && b[key as Key])) {
           return false;
         }
+        if (((key in a) && (!(key in b))) || ((key in b) && (!(key in a)))) {
+          return false;
+        }
       }
       seen.set(a, b);
       return true;

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -147,6 +147,9 @@ Deno.test("testingEqual", function (): void {
       new URL("https://example.test/with-path"),
     ),
   );
+  assert(
+    !equal({ a: undefined, b: undefined }, { a: undefined, c: undefined }),
+  );
 });
 
 Deno.test("testingNotEquals", function (): void {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -150,6 +150,9 @@ Deno.test("testingEqual", function (): void {
   assert(
     !equal({ a: undefined, b: undefined }, { a: undefined, c: undefined }),
   );
+  assert(
+    !equal({ a: undefined, b: undefined }, { a: undefined }),
+  );
 });
 
 Deno.test("testingNotEquals", function (): void {


### PR DESCRIPTION
Fix #842