### PR TITLE
feat(io/streams): add readableStreamFromReader

### DIFF
--- a/io/streams.ts
+++ b/io/streams.ts
@@ -3,6 +3,14 @@
 import { Buffer } from "./buffer.ts";
 import { writeAll } from "./util.ts";
 
+const DEFAULT_CHUNK_SIZE = 16_640;
+
+function isCloser(value: unknown): value is Deno.Closer {
+  return typeof value === "object" && value != null && "close" in value &&
+    // deno-lint-ignore no-explicit-any
+    typeof (value as Record<string, any>)["close"] === "function";
+}
+
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
  *      // Server-sent events: Send runtime metrics to the client every second.
@@ -125,4 +133,75 @@ export function readableStreamFromIterable<T>(
       }
     },
   });
+}
+
+export interface ReadableStreamFromReaderOptions {
+  /** If the `reader` is also a `Deno.Closer`, automatically close the `reader`
+   * when `EOF` is encountered, or a read error occurs.
+   * 
+   * Defaults to `true`. */
+  autoClose?: boolean;
+
+  /** The size of chunks to allocate to read, the default is ~16KiB, which is
+   * the maximum size that Deno operations can currently support. */
+  chunkSize?: number;
+
+  /** The queuing strategy to create the `ReadableStream` with. */
+  strategy?: { highWaterMark?: number | undefined; size?: undefined };
+}
+
+/**
+ * Create a `ReadableStream<Uint8Array>` from from a `Deno.Reader`.
+ * 
+ * When the pull algorithm is called on the stream, a chunk from the reader
+ * will be read.  When `null` is returned from the reader, the stream will be
+ * closed along with the reader (if it is also a `Deno.Closer`).
+ * 
+ * An example converting a `Deno.File` into a readable stream:
+ * 
+ * ```ts
+ * import { readableStreamFromReader } from "https://deno.land/std/io/mod.ts";
+ * 
+ * const file = await Deno.open("./file.txt", { read: true });
+ * const fileStream = readableStreamFromReader(file);
+ * ```
+ * 
+ */
+export function readableStreamFromReader(
+  reader: Deno.Reader | (Deno.Reader & Deno.Closer),
+  options: ReadableStreamFromReaderOptions = {},
+): ReadableStream<Uint8Array> {
+  const {
+    autoClose = true,
+    chunkSize = DEFAULT_CHUNK_SIZE,
+    strategy,
+  } = options;
+
+  return new ReadableStream({
+    async pull(controller) {
+      const chunk = new Uint8Array(chunkSize);
+      try {
+        const read = await reader.read(chunk);
+        if (read === null) {
+          if (isCloser(reader) && autoClose) {
+            reader.close();
+          }
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk.subarray(0, read));
+      } catch (e) {
+        controller.error(e);
+        if (isCloser(reader)) {
+          reader.close();
+        }
+      }
+    },
+    cancel() {
+      if (isCloser(reader) && autoClose) {
+        reader.close();
+      }
+    },
+    type: "bytes",
+  }, strategy);
 }


### PR DESCRIPTION
This adds `readableStreamFromReader` to `io/streams`.  This is quite useful when dealing with files and the new native HTTP bindings.  For example to "stream" a file from disk in a response you would do something like this:

```ts
import { readableStreamFromReader } from "https://deno.land/std/io/streams.ts";

for await (const conn of Deno.listen({ port: 8000 })) {
  (async () => {
    const httpConn = Deno.serveHttp(conn);
    for await (const { request, respondWith } of httpConn) {
      const file = await Deno.open("./big_file.zip", { read: true });
      respondWith(new Response(readableStreamFromReader(file)));
    }
  })();
}
```
