### PR TITLE
feat(path/glob): add caseInsensitive option

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -78,7 +78,7 @@ export async function* expandGlob(
     includeDirs = true,
     extended = false,
     globstar = false,
-    caseInsensitive = Deno.build.os === "windows",
+    caseInsensitive,
   }: ExpandGlobOptions = {},
 ): AsyncIterableIterator<WalkEntry> {
   const globOptions: GlobOptions = { extended, globstar, caseInsensitive };
@@ -185,7 +185,7 @@ export function* expandGlobSync(
     includeDirs = true,
     extended = false,
     globstar = false,
-    caseInsensitive = Deno.build.os === "windows",
+    caseInsensitive,
   }: ExpandGlobOptions = {},
 ): IterableIterator<WalkEntry> {
   const globOptions: GlobOptions = { extended, globstar, caseInsensitive };

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -78,9 +78,10 @@ export async function* expandGlob(
     includeDirs = true,
     extended = false,
     globstar = false,
+    caseInsensitive = Deno.build.os === "windows",
   }: ExpandGlobOptions = {},
 ): AsyncIterableIterator<WalkEntry> {
-  const globOptions: GlobOptions = { extended, globstar };
+  const globOptions: GlobOptions = { extended, globstar, caseInsensitive };
   const absRoot = isAbsolute(root)
     ? normalize(root)
     : joinGlobs([Deno.cwd(), root], globOptions);
@@ -184,9 +185,10 @@ export function* expandGlobSync(
     includeDirs = true,
     extended = false,
     globstar = false,
+    caseInsensitive = Deno.build.os === "windows",
   }: ExpandGlobOptions = {},
 ): IterableIterator<WalkEntry> {
-  const globOptions: GlobOptions = { extended, globstar };
+  const globOptions: GlobOptions = { extended, globstar, caseInsensitive };
   const absRoot = isAbsolute(root)
     ? normalize(root)
     : joinGlobs([Deno.cwd(), root], globOptions);

--- a/path/README.md
+++ b/path/README.md
@@ -11,6 +11,8 @@ import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
 Generate a regex based on glob pattern and options This was meant to be using
 the `fs.walk` function but can be used anywhere else.
 
+_Note: On Windows systems, generated regex will be case-insensitive by default_
+
 ```ts
 import { globToRegExp } from "https://deno.land/std@$STD_VERSION/path/glob.ts";
 

--- a/path/README.md
+++ b/path/README.md
@@ -11,8 +11,6 @@ import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
 Generate a regex based on glob pattern and options This was meant to be using
 the `fs.walk` function but can be used anywhere else.
 
-_Note: On Windows systems, generated regex will be case-insensitive by default_
-
 ```ts
 import { globToRegExp } from "https://deno.land/std@$STD_VERSION/path/glob.ts";
 
@@ -20,5 +18,6 @@ globToRegExp("foo/**/*.json", {
   flags: "g",
   extended: true,
   globstar: true,
+  caseInsensitive: false,
 }); // returns the regex to find all .json files in the folder foo.
 ```

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -85,8 +85,8 @@ export function globToRegExp(
   {
     extended = true,
     globstar: globstarOption = true,
-    caseInsensitive = Deno.build.os === "windows",
     os = osType,
+    caseInsensitive = os === "windows",
   }: GlobToRegExpOptions = {},
 ): RegExp {
   if (glob == "") {

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -79,7 +79,13 @@ const rangeEscapeChars = ["-", "\\", "]"];
  *   look-ahead followed by a wildcard. This means that `!(foo).js` will wrongly
  *   fail to match `foobar.js`, even though `foobar` is not `foo`. Effectively,
  *   `!(foo|bar)` is treated like `!(@(foo|bar)*)`. This will work correctly if
- *   the group occurs not nested at the end of the segment. */
+ *   the group occurs not nested at the end of the segment.
+ *
+ * Additional notes:
+ * - As Windows file systems are case-insensitive, generated `RegExp` will be
+ *   case-insensitive by default when `os` option is set to "windows".
+ *   You can still override this behaviour by forcing `caseInsensitive` to false
+ *   when working on Windows systems. */
 export function globToRegExp(
   glob: string,
   {

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -92,7 +92,7 @@ export function globToRegExp(
     extended = true,
     globstar: globstarOption = true,
     os = osType,
-    caseInsensitive = os === "windows",
+    caseInsensitive = false,
   }: GlobToRegExpOptions = {},
 ): RegExp {
   if (glob == "") {

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -79,13 +79,7 @@ const rangeEscapeChars = ["-", "\\", "]"];
  *   look-ahead followed by a wildcard. This means that `!(foo).js` will wrongly
  *   fail to match `foobar.js`, even though `foobar` is not `foo`. Effectively,
  *   `!(foo|bar)` is treated like `!(@(foo|bar)*)`. This will work correctly if
- *   the group occurs not nested at the end of the segment.
- *
- * Additional notes:
- * - As Windows file systems are case-insensitive, generated `RegExp` will be
- *   case-insensitive by default when `os` option is set to "windows".
- *   You can still override this behaviour by forcing `caseInsensitive` to false
- *   when working on Windows systems. */
+ *   the group occurs not nested at the end of the segment. */
 export function globToRegExp(
   glob: string,
   {

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -85,7 +85,7 @@ export function globToRegExp(
   {
     extended = true,
     globstar: globstarOption = true,
-    caseInsensitive = false,
+    caseInsensitive = Deno.build.os === "windows",
     os = osType,
   }: GlobToRegExpOptions = {},
 ): RegExp {

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -14,6 +14,8 @@ export interface GlobOptions {
    * See https://www.linuxjournal.com/content/globstar-new-bash-globbing-option.
    * If false, `**` is treated like `*`. Defaults to true. */
   globstar?: boolean;
+  /** Whether globstar should be case insensitive. */
+  caseInsensitive?: boolean;
   /** Operating system. Defaults to the native OS. */
   os?: typeof Deno.build.os;
 }
@@ -80,8 +82,12 @@ const rangeEscapeChars = ["-", "\\", "]"];
  *   the group occurs not nested at the end of the segment. */
 export function globToRegExp(
   glob: string,
-  { extended = true, globstar: globstarOption = true, os = osType }:
-    GlobToRegExpOptions = {},
+  {
+    extended = true,
+    globstar: globstarOption = true,
+    caseInsensitive = false,
+    os = osType,
+  }: GlobToRegExpOptions = {},
 ): RegExp {
   if (glob == "") {
     return /(?!)/;
@@ -310,7 +316,7 @@ export function globToRegExp(
   }
 
   regExpString = `^${regExpString}$`;
-  return new RegExp(regExpString);
+  return new RegExp(regExpString, caseInsensitive ? "i" : "");
 }
 
 /** Test whether the given string is a glob */

--- a/path/glob_test.ts
+++ b/path/glob_test.ts
@@ -502,6 +502,19 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[path] GlobToRegExpOptions::caseInsensitive",
+  fn() {
+    const pattern1 = globToRegExp("foo/bar", { caseInsensitive: false });
+    assertEquals("foo/bar".match(pattern1)?.[0], "foo/bar");
+    assertEquals("Foo/Bar".match(pattern1)?.[0], undefined);
+
+    const pattern2 = globToRegExp("foo/bar", { caseInsensitive: true });
+    assertEquals("foo/bar".match(pattern2)?.[0], "foo/bar");
+    assertEquals("Foo/Bar".match(pattern2)?.[0], "Foo/Bar");
+  },
+});
+
+Deno.test({
   name: "[path] GlobToRegExpOptions::os",
   fn() {
     const pattern1 = globToRegExp("foo/bar", { os: "linux" });


### PR DESCRIPTION
Closes #806

This add a `caseInsensitive` option to `globToRegExp`.

When `os` option (which defaults to current os) is set to `"windows"`, this option will be enabled by default as file system is case insensitive on it