### PR TITLE
feat(http): allow custom http codes along with custom response text

### DIFF
--- a/http/_io.ts
+++ b/http/_io.ts
@@ -237,11 +237,8 @@ export async function writeResponse(
   const protoMajor = 1;
   const protoMinor = 1;
   const statusCode = r.status || 200;
-  const statusText = STATUS_TEXT.get(statusCode);
+  const statusText = r.statusText ?? STATUS_TEXT.get(statusCode) ?? "";
   const writer = BufWriter.create(w);
-  if (!statusText) {
-    throw new Deno.errors.InvalidData("Bad status code");
-  }
   if (!r.body) {
     r.body = new Uint8Array();
   }

--- a/http/_io.ts
+++ b/http/_io.ts
@@ -240,7 +240,9 @@ export async function writeResponse(
   const statusText = r.statusText ?? STATUS_TEXT.get(statusCode) ?? null;
   const writer = BufWriter.create(w);
   if (statusText === null) {
-    throw new Deno.errors.InvalidData("Empty statusText (explicitely pass an empty string if this was intentional)");
+    throw new Deno.errors.InvalidData(
+      "Empty statusText (explicitely pass an empty string if this was intentional)",
+    );
   }
   if (!r.body) {
     r.body = new Uint8Array();

--- a/http/_io.ts
+++ b/http/_io.ts
@@ -237,8 +237,11 @@ export async function writeResponse(
   const protoMajor = 1;
   const protoMinor = 1;
   const statusCode = r.status || 200;
-  const statusText = r.statusText ?? STATUS_TEXT.get(statusCode) ?? "";
+  const statusText = r.statusText ?? STATUS_TEXT.get(statusCode) ?? null;
   const writer = BufWriter.create(w);
+  if (statusText === null) {
+    throw new Deno.errors.InvalidData("Empty statusText (explicitely pass an empty string if this was intentional)");
+  }
   if (!r.body) {
     r.body = new Uint8Array();
   }

--- a/http/server.ts
+++ b/http/server.ts
@@ -391,6 +391,7 @@ export async function listenAndServeTLS(
  */
 export interface Response {
   status?: number;
+  statusText?: string;
   headers?: Headers;
   body?: Uint8Array | Deno.Reader | string;
   trailers?: () => Promise<Headers> | Headers;

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -532,12 +532,16 @@ Deno.test({
     const serverRoutine = async () => {
       const server = serve(":8124");
       for await (const req of server) {
-        await assertThrowsAsync(async () => {
-          await req.respond({
-            status: 12345,
-            body: new TextEncoder().encode("Hello World"),
-          });
-        }, Deno.errors.InvalidData, "Empty statusText");
+        await assertThrowsAsync(
+          async () => {
+            await req.respond({
+              status: 12345,
+              body: new TextEncoder().encode("Hello World"),
+            });
+          },
+          Deno.errors.InvalidData,
+          "Empty statusText",
+        );
         // The connection should be destroyed
         assert(!(req.conn.rid in Deno.resources()));
         server.close();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -56,6 +56,13 @@ const responseTests: ResponseTest[] = [
     },
     raw: "HTTP/1.1 893 Custom error\r\n" + "content-length: 0" + "\r\n\r\n",
   },
+  {
+    response: {
+      status: 893,
+      statusText: "",
+    },
+    raw: "HTTP/1.1 893 \r\n" + "content-length: 0" + "\r\n\r\n",
+  },
   // HTTP/1.1, chunked coding; empty trailer; close
   {
     response: {
@@ -516,6 +523,37 @@ Deno.test({
     const resources = Deno.resources();
     assertEquals(resources[conn.rid], "tcpStream");
     conn.close();
+  },
+});
+
+Deno.test({
+  name: "respond error closes connection",
+  async fn() {
+    const serverRoutine = async () => {
+      const server = serve(":8124");
+      for await (const req of server) {
+        await assertThrowsAsync(async () => {
+          await req.respond({
+            status: 12345,
+            body: new TextEncoder().encode("Hello World"),
+          });
+        }, Deno.errors.InvalidData, "Empty statusText");
+        // The connection should be destroyed
+        assert(!(req.conn.rid in Deno.resources()));
+        server.close();
+      }
+    };
+    const p = serverRoutine();
+    const conn = await Deno.connect({
+      hostname: "127.0.0.1",
+      port: 8124,
+    });
+    await writeAll(
+      conn,
+      new TextEncoder().encode("GET / HTTP/1.1\r\n\r\n"),
+    );
+    conn.close();
+    await p;
   },
 });
 


### PR DESCRIPTION
Closes #664

As specified in the [rfc2616 spec](https://tools.ietf.org/html/rfc2616):
> HTTP status codes are extensible. HTTP applications are not required to understand the meaning of all registered status codes, though such understanding is obviously desirable. However, applications MUST understand the class of any status code, as indicated by the first digit, and treat any unrecognized response as being equivalent to the x00 status code of that class, with the exception that an unrecognized response MUST NOT be cached. For example, if an unrecognized status code of 431 is received by the client, it can safely assume that there was something wrong with its request and treat the response as if it had received a 400 status code. In such cases, user agents SHOULD present to the user the entity returned with the response, since that entity is likely to include human- readable information which will explain the unusual status. 

Since this PR allows custom codes which may have not default response text defined, this also add `statusText` so custom error codes can be sent with human readable messages.

