### PR TITLE
fix(http,ws): conn typings on internal utils

### DIFF
--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -1,7 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /** Create dummy Deno.Conn object with given base properties */
-export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
+export function mockConn(
+  base: Partial<Deno.Conn> = {},
+): Deno.Conn<Deno.NetAddr> {
   return {
     localAddr: {
       transport: "tcp",
@@ -25,5 +27,5 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
     },
     close: (): void => {},
     ...base,
-  };
+  } as Deno.Conn<Deno.NetAddr>;
 }

--- a/ws/test.ts
+++ b/ws/test.ts
@@ -282,7 +282,7 @@ Deno.test("[ws] ws.close() should use 1000 as close code", async () => {
   assertEquals(code, 1000);
 });
 
-function dummyConn(r: Deno.Reader, w: Deno.Writer): Deno.Conn {
+function dummyConn(r: Deno.Reader, w: Deno.Writer): Deno.Conn<Deno.NetAddr> {
   return {
     rid: -1,
     closeWrite: () => Promise.resolve(),


### PR DESCRIPTION
Update the return type from `Deno.Conn` to `Deno.Conn<Deno.NetAddr>` on
two of the internal functions used to mock conn objects. The issue was
introduced in core at `9c7c9a35`.

In the case of `http/_mock_conn.ts@mockConn` I also had to add an
explicit type hint on the return object because of the `base` parameter
that was causing the type checker to not like the `transport` property
on `localAddr` and `remoteAddr`.