### PR TITLE
fix(node/fs): Actually export everything

### DIFF
--- a/node/fs.ts
+++ b/node/fs.ts
@@ -5,23 +5,33 @@ import { chmod, chmodSync } from "./_fs/_fs_chmod.ts";
 import { chown, chownSync } from "./_fs/_fs_chown.ts";
 import { close, closeSync } from "./_fs/_fs_close.ts";
 import * as constants from "./_fs/_fs_constants.ts";
-import { readFile, readFileSync } from "./_fs/_fs_readFile.ts";
-import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
+import { copyFile, copyFileSync } from "./_fs/_fs_copy.ts";
+import Dir from "./_fs/_fs_dir.ts";
+import Dirent from "./_fs/_fs_dirent.ts";
 import { exists, existsSync } from "./_fs/_fs_exists.ts";
+import { fdatasync, fdatasyncSync } from "./_fs/_fs_fdatasync.ts";
+import { fstat, fstatSync } from "./_fs/_fs_fstat.ts";
+import { fsync, fsyncSync } from "./_fs/_fs_fsync.ts";
+import { ftruncate, ftruncateSync } from "./_fs/_fs_ftruncate.ts";
+import { futimes, futimesSync } from "./_fs/_fs_futimes.ts";
+import { link, linkSync } from "./_fs/_fs_link.ts";
+import { lstat, lstatSync } from "./_fs/_fs_lstat.ts";
 import { mkdir, mkdirSync } from "./_fs/_fs_mkdir.ts";
 import { mkdtemp, mkdtempSync } from "./_fs/_fs_mkdtemp.ts";
-import { copyFile, copyFileSync } from "./_fs/_fs_copy.ts";
-import { writeFile, writeFileSync } from "./_fs/_fs_writeFile.ts";
+import { open, openSync } from "./_fs/_fs_open.ts";
 import { readdir, readdirSync } from "./_fs/_fs_readdir.ts";
+import { readFile, readFileSync } from "./_fs/_fs_readFile.ts";
+import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
 import { realpath, realpathSync } from "./_fs/_fs_realpath.ts";
 import { rename, renameSync } from "./_fs/_fs_rename.ts";
 import { rmdir, rmdirSync } from "./_fs/_fs_rmdir.ts";
-import { unlink, unlinkSync } from "./_fs/_fs_unlink.ts";
-import { watch } from "./_fs/_fs_watch.ts";
-import { open, openSync } from "./_fs/_fs_open.ts";
 import { stat, statSync } from "./_fs/_fs_stat.ts";
-import { lstat, lstatSync } from "./_fs/_fs_lstat.ts";
+import { symlink, symlinkSync } from "./_fs/_fs_symlink.ts";
 import { truncate, truncateSync } from "./_fs/_fs_truncate.ts";
+import { unlink, unlinkSync } from "./_fs/_fs_unlink.ts";
+import { utimes, utimesSync } from "./_fs/_fs_utimes.ts";
+import { watch } from "./_fs/_fs_watch.ts";
+import { writeFile, writeFileSync } from "./_fs/_fs_writeFile.ts";
 
 import * as promises from "./_fs/promises/mod.ts";
 
@@ -39,8 +49,22 @@ export default {
   constants,
   copyFile,
   copyFileSync,
+  Dir,
+  Dirent,
   exists,
   existsSync,
+  fdatasync,
+  fdatasyncSync,
+  fstat,
+  fstatSync,
+  fsync,
+  fsyncSync,
+  ftruncate,
+  ftruncateSync,
+  futimes,
+  futimesSync,
+  link,
+  linkSync,
   lstat,
   lstatSync,
   mkdir,
@@ -64,13 +88,17 @@ export default {
   rmdirSync,
   stat,
   statSync,
+  symlink,
+  symlinkSync,
+  truncate,
+  truncateSync,
   unlink,
   unlinkSync,
+  utimes,
+  utimesSync,
   watch,
   writeFile,
   writeFileSync,
-  truncate,
-  truncateSync,
 };
 
 export {
@@ -87,8 +115,22 @@ export {
   constants,
   copyFile,
   copyFileSync,
+  Dir,
+  Dirent,
   exists,
   existsSync,
+  fdatasync,
+  fdatasyncSync,
+  fstat,
+  fstatSync,
+  fsync,
+  fsyncSync,
+  ftruncate,
+  ftruncateSync,
+  futimes,
+  futimesSync,
+  link,
+  linkSync,
   lstat,
   lstatSync,
   mkdir,
@@ -112,10 +154,14 @@ export {
   rmdirSync,
   stat,
   statSync,
+  symlink,
+  symlinkSync,
   truncate,
   truncateSync,
   unlink,
   unlinkSync,
+  utimes,
+  utimesSync,
   watch,
   writeFile,
   writeFileSync,


### PR DESCRIPTION
There were a lot of `fs` apis which had been implemented, but not actually exported in the main `node/fs.ts`.

I also sorted everything, so it was easier to read the file tree and check everything was there.