### PR TITLE
fix(fs): no root path in walk error

### DIFF
--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -285,7 +285,7 @@ testWalk(
     }
   },
   // TODO(kt3k): Enable this test on windows when Deno.chmod is implemented
-  Deno.build.os === "windows"
+  Deno.build.os === "windows",
 );
 
 testWalk(
@@ -307,5 +307,5 @@ testWalk(
     }
   },
   // TODO(kt3k): Enable this test on windows when Deno.chmod is implemented
-  Deno.build.os === "windows"
+  Deno.build.os === "windows",
 );

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { walk, WalkEntry, WalkOptions, walkSync } from "./walk.ts";
-import { assert, assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "../testing/asserts.ts";
 
 export function testWalk(
   setup: (arg0: string) => void | Promise<void>,
@@ -258,5 +263,45 @@ testWalk(
     const arr = await walkArray("a", { followSymlinks: true });
     assertEquals(arr.length, 5);
     assert(arr.some((f): boolean => f.endsWith("/b/z")));
+  },
+);
+
+testWalk(
+  async (d: string) => {
+    await Deno.mkdir(d + "/a/b", { recursive: true });
+    await Deno.chmod(d + "/a/b", 0o000);
+  },
+  async function subDirNoPermissionAsync() {
+    try {
+      await assertThrowsAsync(
+        async () => {
+          await walkArray("a");
+        },
+        Deno.errors.PermissionDenied,
+        'for path "a/b"',
+      );
+    } finally {
+      await Deno.chmod("a/b", 0o755);
+    }
+  },
+);
+
+testWalk(
+  async (d: string) => {
+    await Deno.mkdir(d + "/a/b", { recursive: true });
+    await Deno.chmod(d + "/a/b", 0o000);
+  },
+  async function subDirNoPermissionSync() {
+    try {
+      assertThrows(
+        () => {
+          return [...walkSync("a")];
+        },
+        Deno.errors.PermissionDenied,
+        'for path "a/b"',
+      );
+    } finally {
+      await Deno.chmod("a/b", 0o755);
+    }
   },
 );

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -284,6 +284,8 @@ testWalk(
       await Deno.chmod("a/b", 0o755);
     }
   },
+  // TODO(kt3k): Enable this test on windows when Deno.chmod is implemented
+  Deno.build.os === "windows"
 );
 
 testWalk(
@@ -304,4 +306,6 @@ testWalk(
       await Deno.chmod("a/b", 0o755);
     }
   },
+  // TODO(kt3k): Enable this test on windows when Deno.chmod is implemented
+  Deno.build.os === "windows"
 );


### PR DESCRIPTION
This adds the root path to error object. I am not sure this is the way to go, maybe I should put it in the message?

Fix #863