### PR TITLE
ci: Collect coverage from native node tests

### DIFF
--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -1,5 +1,5 @@
 import { walk } from "../../fs/walk.ts";
-import { dirname, fromFileUrl, relative } from "../../path/mod.ts";
+import { dirname, fromFileUrl, join, relative } from "../../path/mod.ts";
 import { assertEquals } from "../../testing/asserts.ts";
 import { config, testList } from "./common.ts";
 
@@ -22,14 +22,13 @@ for await (const file of dir) {
     name: relative(testsFolder, file.path),
     fn: async () => {
       const process = Deno.run({
-        cwd: testsFolder,
         cmd: [
           "deno",
           "run",
           "-A",
           "--quiet",
           "--unstable",
-          "require.ts",
+          join(testsFolder, "require.ts"),
           file.path,
         ],
       });


### PR DESCRIPTION
Currently, it looks like the coverage is not being collected from native node tests (https://github.com/denoland/deno_std/runs/2426282821) This PR fixes this problem.

* **Before this PR**: https://codecov.io/gh/denoland/deno_std/pull/876/src/node/assert.ts
* **After this PR**: https://codecov.io/gh/denoland/deno_std/pull/879/src/node/assert.ts

## Cause

In the following code, `cwd` is set to `node/_tools` directory:

https://github.com/denoland/deno_std/blob/3931030e7fae16158e3b6cb041a2a161c0cba6e3/node/_tools/test.ts#L21-L35

This will cause Deno to create coverage profile in the `node/_tools` directory instead of the project root directory.