### PR TITLE
ci: disable codecov's patch status

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,8 +3,7 @@ codecov:
   require_ci_to_pass: true
 coverage:
   status:
-    project:
-      default:
-        informational: true
+    project: off
+    patch: off
 ignore:
   - examples


### PR DESCRIPTION
codecov often reports failure status to the commit which has low coverage rate in diff, but we don't have such policy to reject such PRs. This PR disables that check from codecov.

ref: https://docs.codecov.io/docs/commit-status#disabling-a-status