### PR TITLE
feat(node): Add console module

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -12,7 +12,7 @@ deno standard library as it's a compatibility module.
 - [x] buffer
 - [x] child_process _partly_
 - [ ] cluster
-- [ ] console
+- [x] console _partly_
 - [x] constants _partly_
 - [x] crypto _partly_
 - [ ] dgram

--- a/node/console.ts
+++ b/node/console.ts
@@ -1,0 +1,23 @@
+export default console;
+
+export const {
+  assert,
+  clear,
+  count,
+  countReset,
+  debug,
+  dir,
+  dirxml,
+  error,
+  group,
+  groupCollapsed,
+  groupEnd,
+  info,
+  log,
+  table,
+  time,
+  timeEnd,
+  timeLog,
+  trace,
+  warn,
+} = console;

--- a/node/module.ts
+++ b/node/module.ts
@@ -24,6 +24,7 @@ import "./global.ts";
 import nodeAssert from "./assert.ts";
 import nodeBuffer from "./buffer.ts";
 import nodeCrypto from "./crypto.ts";
+import nodeConsole from "./console.ts";
 import nodeConstants from "./constants.ts";
 import nodeChildProcess from "./child_process.ts";
 import nodeEvents from "./events.ts";
@@ -637,6 +638,7 @@ nativeModulePolyfill.set("timers", createNativeModule("timers", nodeTimers));
 nativeModulePolyfill.set("tty", createNativeModule("tty", nodeTty));
 nativeModulePolyfill.set("url", createNativeModule("url", nodeUrl));
 nativeModulePolyfill.set("util", createNativeModule("util", nodeUtil));
+nativeModulePolyfill.set("console", createNativeModule("console", nodeConsole));
 
 function loadNativeModule(
   _filename: string,


### PR DESCRIPTION
This just exports the `console` object.

I tried enabling the Node console tests, but all of them either don't work or don't really apply.

Note that Deno's console doesn't have all the same methods as Node's, so this isn't a perfect polyfill. Node has these extra properties:
- `Console`
- `context`
- `profile`
- `profileEnd`
- `timeStamp`

I've marked it as partly implemented for now, although I don't know whether those APIs are worth polyfilling.