### PR TITLE
chore(io/buffer): Buffer should explicitly implement Reader & Writer

### DIFF
--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -23,7 +23,7 @@ const MAX_SIZE = 2 ** 32 - 2;
  *
  * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
 
-export class Buffer {
+export class Buffer implements Deno.Reader, Deno.Writer {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
 

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -23,7 +23,8 @@ const MAX_SIZE = 2 ** 32 - 2;
  *
  * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
 
-export class Buffer implements Deno.Reader, Deno.Writer {
+export class Buffer
+  implements Deno.Reader, Deno.ReaderSync, Deno.Writer, Deno.WriterSync {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
 


### PR DESCRIPTION
This PR adds `implements` declaration to `Buffer` class.

Originally, [`Deno.Buffer` class implemented `Deno.Reader` and `Deno.Writer`](https://github.com/denoland/deno/blob/v1.2.0/cli/js/buffer.ts). It seems that this `implements` declaration have been lost in migration from TypeScript to JavaScript. (https://github.com/denoland/deno/blob/v1.3.0/cli/rt/13_buffer.js#L29)