### PR TITLE
encoding/TOML: delete useless replace

### DIFF
--- a/encoding/testdata/cargo.toml
+++ b/encoding/testdata/cargo.toml
@@ -49,3 +49,6 @@ url = "1.7.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.6"
+
+[target."cfg(linux)".dependencies]
+winapi = "0.3.9"

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -95,7 +95,8 @@ class Parser {
 
       // If a single line comment doesnt end on the same line, throw error
       if (
-        isOpenString && (openStringSyntax === "'" || openStringSyntax === '"')
+        isOpenString &&
+        (openStringSyntax === "'" || openStringSyntax === '"')
       ) {
         throw new TOMLError(`Single-line string is not closed:\n${line}`);
       }
@@ -177,10 +178,9 @@ class Parser {
         if (captureType === "string") {
           merged.push(
             acc
-              .join("\n")
+              .join("\\n")
               .replace(/"""/g, '"')
-              .replace(/'''/g, `'`)
-              .replace(/\n/g, "\\n"),
+              .replace(/'''/g, `'`),
           );
           isLiteral = false;
         } else {
@@ -214,8 +214,7 @@ class Parser {
   _groupToOutput(): void {
     assert(this.context.currentGroup != null, "currentGroup must be set");
     const arrProperty = this.context.currentGroup.name
-      .replace(/"/g, "")
-      .replace(/'/g, "")
+      .replace(/("|')/g, "")
       .split(".");
     let u = {};
     if (this.context.currentGroup.type === "array") {
@@ -244,7 +243,7 @@ class Parser {
       this._groupToOutput();
     }
 
-    let type;
+    let type: string;
     let m = line.match(captureReg);
     assert(m != null, "line mut be matched");
     let name = m[1];
@@ -482,7 +481,7 @@ class Parser {
           !this.context.currentGroup ||
           (this.context.currentGroup &&
             this.context.currentGroup.name !==
-              line.replace(/\[/g, "").replace(/\]/g, ""))
+              line.replace(/(\[|\])/g, ""))
         ) {
           this._createGroup(line);
           continue;
@@ -731,6 +730,6 @@ export function stringify(srcObj: Record<string, unknown>): string {
  */
 export function parse(tomlString: string): Record<string, unknown> {
   // File is potentially using EOL CRLF
-  tomlString = tomlString.replace(/\r\n/g, "\n").replace(/\\\n/g, "\n");
+  tomlString = tomlString.replace(/(\r\n|\\\n)/g, "\n");
   return new Parser(tomlString).parse();
 }

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -291,7 +291,10 @@ Deno.test({
         "tokio-threadpool": "0.1.11",
         url: "1.7.2",
       },
-      target: { "cfg(windows)": { dependencies: { winapi: "0.3.6" } } },
+      target: {
+        "cfg(windows)": { dependencies: { winapi: "0.3.6" } },
+        "cfg(linux)": { dependencies: { winapi: "0.3.9" } },
+      },
     };
     const actual = parseFile(path.join(testdataDir, "cargo.toml"));
     assertEquals(actual, expected);


### PR DESCRIPTION
Deleting double use of `string.replace` speeding up the parsing.