### PR TITLE
fix(node/stream): Make `Stream` the default export

### DIFF
--- a/node/_stream/stream.ts
+++ b/node/_stream/stream.ts
@@ -1,7 +1,13 @@
 // Copyright Node.js contributors. All rights reserved. MIT License.
 import { Buffer } from "../buffer.ts";
+import type Duplex from "./duplex.ts";
+import type eos from "./end_of_stream.ts";
 import EventEmitter from "../events.ts";
+import type PassThrough from "./passthrough.ts";
+import type pipeline from "./pipeline.ts";
+import type * as promises from "./promises.ts";
 import type Readable from "./readable.ts";
+import type Transform from "./transform.ts";
 import type Writable from "./writable.ts";
 import { types } from "../util.ts";
 
@@ -76,6 +82,16 @@ class Stream extends EventEmitter {
 
     return dest;
   }
+
+  static Readable: typeof Readable;
+  static Writable: typeof Writable;
+  static Duplex: typeof Duplex;
+  static Transform: typeof Transform;
+  static PassThrough: typeof PassThrough;
+  static pipeline: typeof pipeline;
+  static finished: typeof eos;
+  static promises: typeof promises;
+  static Stream: typeof Stream;
 }
 
 export default Stream;

--- a/node/stream.ts
+++ b/node/stream.ts
@@ -27,19 +27,18 @@ import Stream from "./_stream/stream.ts";
 import Transform from "./_stream/transform.ts";
 import Writable from "./_stream/writable.ts";
 
-const exports = {
-  Duplex,
-  finished: eos,
-  PassThrough,
-  pipeline,
-  promises,
-  Readable,
-  Stream,
-  Transform,
-  Writable,
-};
+// This is here because doing it in _stream/stream.ts created some circular dependency hell.
+Stream.Readable = Readable;
+Stream.Writable = Writable;
+Stream.Duplex = Duplex;
+Stream.Transform = Transform;
+Stream.PassThrough = PassThrough;
+Stream.pipeline = pipeline;
+Stream.finished = eos;
+Stream.promises = promises;
+Stream.Stream = Stream;
 
-export default exports;
+export default Stream;
 export {
   Duplex,
   eos as finished,
@@ -51,3 +50,4 @@ export {
   Transform,
   Writable,
 };
+export const { _isUint8Array, _uint8ArrayToBuffer } = Stream;

--- a/node/stream_test.ts
+++ b/node/stream_test.ts
@@ -17,10 +17,19 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
-import { Readable, Transform, Writable } from "./stream.ts";
+import streamDefault, {
+  Readable,
+  Stream,
+  Transform,
+  Writable,
+} from "./stream.ts";
 import { Buffer } from "./buffer.ts";
 import { deferred } from "../async/mod.ts";
-import { assert, assertEquals } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+} from "../testing/asserts.ts";
 import { mustCall } from "./_utils.ts";
 
 Deno.test("Readable and Writable stream backpressure test", async () => {
@@ -130,4 +139,8 @@ Deno.test("Readable can be piped through Transform", async () => {
   await transformExecution;
   await flushExecution;
   await readableExecution;
+});
+
+Deno.test("The default export is Stream", () => {
+  assertStrictEquals(streamDefault, Stream);
 });


### PR DESCRIPTION
In Node, `require("stream")` returns `Stream` itself with all the other kinds of streams as properties. This maps to the default export for ESM, so I've changed the default export of `stream.ts` to be `Stream` and added all the other streams as properties.