### PR TITLE
fix(testing): support array values in assertObjectMatch

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -498,9 +498,24 @@ export function assertObjectMatch(
       ]
         .filter((key) => key in b)
         .map((key) => [key, a[key as string]]) as Array<[string, unknown]>;
-      // Build filtered object and filter recursively on nested objects references
       for (const [key, value] of entries) {
-        if ((typeof value === "object") && (!Array.isArray(value))) {
+        // On array references, build a filtered array and filter nested objects inside
+        if (Array.isArray(value)) {
+          const subset = (b as loose)[key];
+          if (Array.isArray(subset)) {
+            filtered[key] = value
+              .slice(0, subset.length)
+              .map((element, index) => {
+                const subsetElement = subset[index];
+                if ((typeof subsetElement === "object") && (subsetElement)) {
+                  return filter(element, subsetElement);
+                }
+                return subsetElement;
+              });
+            continue;
+          }
+        } // On nested objects references, build a filtered object recursively
+        else if (typeof value === "object") {
           const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
             filtered[key] = filter(value as loose, subset as loose);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -500,7 +500,7 @@ export function assertObjectMatch(
         .map((key) => [key, a[key as string]]) as Array<[string, unknown]>;
       // Build filtered object and filter recursively on nested objects references
       for (const [key, value] of entries) {
-        if (typeof value === "object") {
+        if ((typeof value === "object") && (!Array.isArray(value))) {
           const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
             filtered[key] = filter(value as loose, subset as loose);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -510,7 +510,7 @@ export function assertObjectMatch(
                 if ((typeof subsetElement === "object") && (subsetElement)) {
                   return filter(element, subsetElement);
                 }
-                return subsetElement;
+                return element;
               });
             continue;
           }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -505,6 +505,19 @@ Deno.test("testingAssertObjectMatching", function (): void {
     let didThrow;
     try {
       assertObjectMatch(i, {
+        foo: [1, 2, 3, 4],
+      });
+      didThrow = false;
+    } catch (e) {
+      assert(e instanceof AssertionError);
+      didThrow = true;
+    }
+    assertEquals(didThrow, true);
+  }
+  {
+    let didThrow;
+    try {
+      assertObjectMatch(i, {
         foo: [{ bar: true }, { foo: false }],
       });
       didThrow = false;

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -322,6 +322,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
   }
   const g: r = { foo: true, bar: false };
   const h = { foo: [1, 2, 3], bar: true };
+  const i = { foo: [a, e], bar: true };
 
   // Simple subset
   assertObjectMatch(a, {
@@ -369,7 +370,15 @@ Deno.test("testingAssertObjectMatching", function (): void {
     [sym]: true,
   });
   // Subset with array inside
+  assertObjectMatch(h, { foo: [1, 2] });
   assertObjectMatch(h, { foo: [1, 2, 3] });
+  assertObjectMatch(i, { foo: [{ bar: false }] });
+  assertObjectMatch(i, {
+    foo: [
+      { bar: false },
+      { bar: { bar: { bar: { foo: true } } } },
+    ],
+  });
   // Missing key
   {
     let didThrow;
@@ -494,8 +503,8 @@ Deno.test("testingAssertObjectMatching", function (): void {
   {
     let didThrow;
     try {
-      assertObjectMatch(h, {
-        foo: [],
+      assertObjectMatch(i, {
+        foo: [{ bar: true }, { foo: false }],
       });
       didThrow = false;
     } catch (e) {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -321,6 +321,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
     bar: boolean;
   }
   const g: r = { foo: true, bar: false };
+  const h = { foo: [1, 2, 3], bar: true };
 
   // Simple subset
   assertObjectMatch(a, {
@@ -367,6 +368,8 @@ Deno.test("testingAssertObjectMatching", function (): void {
   assertObjectMatch(f, {
     [sym]: true,
   });
+  // Subset with array inside
+  assertObjectMatch(h, { foo: [1, 2, 3] });
   // Missing key
   {
     let didThrow;
@@ -479,6 +482,20 @@ Deno.test("testingAssertObjectMatching", function (): void {
     try {
       assertObjectMatch(f, {
         foo: true,
+      });
+      didThrow = false;
+    } catch (e) {
+      assert(e instanceof AssertionError);
+      didThrow = true;
+    }
+    assertEquals(didThrow, true);
+  }
+  // Subset with array inside but doesn't match key subset
+  {
+    let didThrow;
+    try {
+      assertObjectMatch(h, {
+        foo: [],
       });
       didThrow = false;
     } catch (e) {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -370,6 +370,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
     [sym]: true,
   });
   // Subset with array inside
+  assertObjectMatch(h, { foo: [] });
   assertObjectMatch(h, { foo: [1, 2] });
   assertObjectMatch(h, { foo: [1, 2, 3] });
   assertObjectMatch(i, { foo: [{ bar: false }] });


### PR DESCRIPTION
The filtered subset in `assertObjectMatch` is built with the following:

https://github.com/denoland/deno_std/blob/69183a05261b58870870b48e4191660b49212039/testing/asserts.ts#L502-L503

But because `typeof [] === "object"`, array values match this condition and we end up with the following:
```diff
    {
-     foo: {
-       "0": 1,
-       "1": 2,
-       "2": 3,
-       length: 3,
-     },
+     foo: [
+       1,
+       2,
+       3,
+     ],
    }
```

This add a skip for arrays to get the wanted behaviour