### PR TITLE
fix(io/buffer): make Buffer compatible with Deploy

### DIFF
--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -1,13 +1,7 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assert } from "../_util/assert.ts";
 import { copy } from "../bytes/mod.ts";
-
-interface Reader {
-  read(p: Uint8Array): Promise<number | null>;
-}
-
-interface ReaderSync {
-  readSync(p: Uint8Array): number | null;
-}
+import type { Reader, ReaderSync } from "./types.d.ts";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -1,6 +1,14 @@
 import { assert } from "../_util/assert.ts";
 import { copy } from "../bytes/mod.ts";
 
+interface Reader {
+  read(p: Uint8Array): Promise<number | null>;
+}
+
+interface ReaderSync {
+  readSync(p: Uint8Array): number | null;
+}
+
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
 // what is required to hold the contents of r, readFrom() will not grow the
@@ -189,7 +197,7 @@ export class Buffer {
    *
    * Based on Go Lang's
    * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
-  async readFrom(r: Deno.Reader): Promise<number> {
+  async readFrom(r: Reader): Promise<number> {
     let n = 0;
     const tmp = new Uint8Array(MIN_READ);
     while (true) {
@@ -219,7 +227,7 @@ export class Buffer {
    *
    * Based on Go Lang's
    * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
-  readFromSync(r: Deno.ReaderSync): number {
+  readFromSync(r: ReaderSync): number {
     let n = 0;
     const tmp = new Uint8Array(MIN_READ);
     while (true) {

--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -1,0 +1,82 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+export interface Reader {
+  /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
+   * bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
+   * encountered. Even if `read()` resolves to `n` < `p.byteLength`, it may
+   * use all of `p` as scratch space during the call. If some data is
+   * available but not `p.byteLength` bytes, `read()` conventionally resolves
+   * to what is available instead of waiting for more.
+   *
+   * When `read()` encounters end-of-file condition, it resolves to EOF
+   * (`null`).
+   *
+   * When `read()` encounters an error, it rejects with an error.
+   *
+   * Callers should always process the `n` > `0` bytes returned before
+   * considering the EOF (`null`). Doing so correctly handles I/O errors that
+   * happen after reading some bytes and also both of the allowed EOF
+   * behaviors.
+   *
+   * Implementations should not retain a reference to `p`.
+   *
+   * Use iter() from https://deno.land/std/io/util.ts to turn a Reader into an
+   * AsyncIterator.
+   */
+  read(p: Uint8Array): Promise<number | null>;
+}
+
+export interface ReaderSync {
+  /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
+   * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
+   * encountered. Even if `read()` returns `n` < `p.byteLength`, it may use
+   * all of `p` as scratch space during the call. If some data is available
+   * but not `p.byteLength` bytes, `read()` conventionally returns what is
+   * available instead of waiting for more.
+   *
+   * When `readSync()` encounters end-of-file condition, it returns EOF
+   * (`null`).
+   *
+   * When `readSync()` encounters an error, it throws with an error.
+   *
+   * Callers should always process the `n` > `0` bytes returned before
+   * considering the EOF (`null`). Doing so correctly handles I/O errors that happen
+   * after reading some bytes and also both of the allowed EOF behaviors.
+   *
+   * Implementations should not retain a reference to `p`.
+   *
+   * Use iterSync() from https://deno.land/std/io/util.ts to turn a ReaderSync
+   * into an Iterator.
+   */
+  readSync(p: Uint8Array): number | null;
+}
+
+export interface Writer {
+  /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
+   * resolves to the number of bytes written from `p` (`0` <= `n` <=
+   * `p.byteLength`) or reject with the error encountered that caused the
+   * write to stop early. `write()` must reject with a non-null error if
+   * would resolve to `n` < `p.byteLength`. `write()` must not modify the
+   * slice data, even temporarily.
+   *
+   * Implementations should not retain a reference to `p`.
+   */
+  write(p: Uint8Array): Promise<number>;
+}
+
+export interface WriterSync {
+  /** Writes `p.byteLength` bytes from `p` to the underlying data
+   * stream. It returns the number of bytes written from `p` (`0` <= `n`
+   * <= `p.byteLength`) and any error encountered that caused the write to
+   * stop early. `writeSync()` must throw a non-null error if it returns `n` <
+   * `p.byteLength`. `writeSync()` must not modify the slice data, even
+   * temporarily.
+   *
+   * Implementations should not retain a reference to `p`.
+   */
+  writeSync(p: Uint8Array): number;
+}
+
+export interface Closer {
+  close(): void;
+}


### PR DESCRIPTION
This PR fixes type error of `io/buffer` in Deploy environment by inlining `Reader` / `ReaderSync` interafaces.

This enables deploy script using, for example, `encoding/yaml` module without type error with `deployctl run`. https://gist.github.com/kt3k/43e25efffc6e1c360fc64274ea0381eb

closes #907 