### PR TITLE
chore: add coverage directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deno.d.ts
 package.json
 package-lock.json
 .vscode/settings.json
+**/cov/


### PR DESCRIPTION
After collecting coverage following directories are produced:
```
	cov/
	examples/cov/
	fs/testdata/cov/
	node/_tools/cov/
	node/cov/
```

Added them to `.gitignore`