### PR TITLE
fix: bad assumption about tls in server tests

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -720,17 +720,18 @@ Deno.test({
     const p = iteratorReq(server);
 
     try {
-      // Invalid certificate, connection should throw
+      // Invalid certificate, connection should throw on first read or write
       // but should not crash the server
-      assertThrowsAsync(
-        () =>
-          Deno.connectTls({
-            hostname: "localhost",
-            port,
-            // certFile
-          }),
+      const badConn = await Deno.connectTls({
+        hostname: "localhost",
+        port,
+        // certFile
+      });
+      await assertThrowsAsync(
+        () => badConn.read(new Uint8Array(1)),
         Deno.errors.InvalidData,
       );
+      badConn.close();
 
       // Valid request after invalid
       const conn = await Deno.connectTls({


### PR DESCRIPTION
This commit fixes a bad assumption that `connectTls` will throw on a
handshaking error. Really the TLS conn will only fail on first read or
write.
