### PR TITLE
feat(async/mux): takes AsyncIterable as source iterator

### DIFF
--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -2,7 +2,7 @@
 import { Deferred, deferred } from "./deferred.ts";
 
 interface TaggedYieldedValue<T> {
-  iterator: AsyncIterableIterator<T>;
+  iterator: AsyncIterator<T>;
   value: T;
 }
 
@@ -18,13 +18,13 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
   private throws: any[] = [];
   private signal: Deferred<void> = deferred();
 
-  add(iterator: AsyncIterableIterator<T>): void {
+  add(iterable: AsyncIterable<T>): void {
     ++this.iteratorCount;
-    this.callIteratorNext(iterator);
+    this.callIteratorNext(iterable[Symbol.asyncIterator]());
   }
 
   private async callIteratorNext(
-    iterator: AsyncIterableIterator<T>,
+    iterator: AsyncIterator<T>,
   ) {
     try {
       const { value, done } = await iterator.next();
@@ -63,7 +63,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
     }
   }
 
-  [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+  [Symbol.asyncIterator](): AsyncIterator<T> {
     return this.iterate();
   }
 }

--- a/async/mux_async_iterator_test.ts
+++ b/async/mux_async_iterator_test.ts
@@ -19,6 +19,12 @@ async function* genThrows(): AsyncIterableIterator<number> {
   throw new Error("something went wrong");
 }
 
+class CustomAsyncIterable {
+  [Symbol.asyncIterator]() {
+    return gen123();
+  }
+}
+
 Deno.test("[async] MuxAsyncIterator", async function () {
   const mux = new MuxAsyncIterator<number>();
   mux.add(gen123());
@@ -28,10 +34,22 @@ Deno.test("[async] MuxAsyncIterator", async function () {
     results.add(value);
   }
   assertEquals(results.size, 6);
+  assertEquals(results, new Set([1, 2, 3, 4, 5, 6]));
+});
+
+Deno.test("[async] MuxAsyncIterator takes async iterable as source", async function () {
+  const mux = new MuxAsyncIterator<number>();
+  mux.add(new CustomAsyncIterable());
+  const results = new Set();
+  for await (const value of mux) {
+    results.add(value);
+  }
+  assertEquals(results.size, 3);
+  assertEquals(results, new Set([1, 2, 3]));
 });
 
 Deno.test({
-  name: "[async] MuxAsyncIterator throws",
+  name: "[async] MuxAsyncIterator throws when the source throws",
   async fn() {
     const mux = new MuxAsyncIterator<number>();
     mux.add(gen123());


### PR DESCRIPTION
Currently MuxAsyncIterator takes `AsyncIterableIterator<T>` as source of iterator, but `AsyncIterable<T>` is a more general form of async iterable data. This PR changes the signature of `add` method of MuxAsyncIterator from `add(iterator: AsyncIterableIterator<T>)` to `add(iterable: AsyncIterable<T>)` and makes it work with `AsyncIterable`s.