### PR TITLE
fix(datetime) dayOfYear now works for negative timezones

### DIFF
--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -56,8 +56,7 @@ export function dayOfYear(date: Date): number {
   yearStart.setUTCFullYear(date.getUTCFullYear(), 0, 0);
   const diff = date.getTime() -
     yearStart.getTime() +
-    (yearStart.getTimezoneOffset() - date.getTimezoneOffset()) * 60 * 1000;
-
+    (Math.abs(yearStart.getTimezoneOffset()) - Math.abs(date.getTimezoneOffset())) * 60 * 1000;
   return Math.floor(diff / DAY);
 }
 /**

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -56,7 +56,8 @@ export function dayOfYear(date: Date): number {
   yearStart.setUTCFullYear(date.getUTCFullYear(), 0, 0);
   const diff = date.getTime() -
     yearStart.getTime() +
-    (Math.abs(yearStart.getTimezoneOffset()) - Math.abs(date.getTimezoneOffset())) * 60 * 1000;
+    (Math.abs(yearStart.getTimezoneOffset()) -
+        Math.abs(date.getTimezoneOffset())) * 60 * 1000;
   return Math.floor(diff / DAY);
 }
 /**


### PR DESCRIPTION
see issue in #925 

Added a math.abs so that negative timezones work like positive ones. Unsure if this has any other consequences as removing this line entirely also caused the tests to pass. (but im unsure if theres timezone consequences to this, maybe a test should be added for a specific timezone boundary). 