### PR TITLE
fix(encoding/binary): allow getNBytes to read until EOF

### DIFF
--- a/encoding/binary.ts
+++ b/encoding/binary.ts
@@ -51,7 +51,7 @@ export async function readExact(
 ): Promise<void> {
   let totalRead = 0;
   do {
-    let tmp = new Uint8Array(b.length - totalRead);
+    const tmp = new Uint8Array(b.length - totalRead);
     const nRead = await r.read(tmp);
     if (nRead === null) throw new Deno.errors.UnexpectedEof();
     b.set(tmp, totalRead);

--- a/encoding/binary.ts
+++ b/encoding/binary.ts
@@ -42,7 +42,24 @@ export function sizeof(dataType: DataType): number {
   return rawTypeSizes[dataType];
 }
 
-/** Reads `n` bytes from `r`.
+/** Reads the exact number of bytes from `r` required to fill `b`.
+ *
+ * Throws `Deno.errors.UnexpectedEof` if `n` bytes cannot be read. */
+export async function readExact(
+  r: Deno.Reader,
+  b: Uint8Array,
+): Promise<void> {
+  let totalRead = 0;
+  do {
+    let tmp = new Uint8Array(b.length - totalRead);
+    const nRead = await r.read(tmp);
+    if (nRead === null) throw new Deno.errors.UnexpectedEof();
+    b.set(tmp, totalRead);
+    totalRead += nRead;
+  } while (totalRead < b.length);
+}
+
+/** Reads exactly `n` bytes from `r`.
  *
  * Resolves it in a `Uint8Array`, or throws `Deno.errors.UnexpectedEof` if `n` bytes cannot be read. */
 export async function getNBytes(
@@ -50,8 +67,7 @@ export async function getNBytes(
   n: number,
 ): Promise<Uint8Array> {
   const scratch = new Uint8Array(n);
-  const nRead = await r.read(scratch);
-  if (nRead === null || nRead < n) throw new Deno.errors.UnexpectedEof();
+  await readExact(r, scratch);
   return scratch;
 }
 

--- a/encoding/binary_test.ts
+++ b/encoding/binary_test.ts
@@ -19,12 +19,26 @@ import {
 import { Buffer } from "../io/buffer.ts";
 import { readerFromIterable } from "../io/streams.ts";
 
-Deno.test("testReadExact", async function () {
+Deno.test("testReadExactMultipleReads", async function () {
   const reader = readerFromIterable([
     new Uint8Array([1]),
     new Uint8Array([2, 3]),
     new Uint8Array([4, 5, 6]),
   ]);
+  const scratch = new Uint8Array(4);
+  await readExact(reader, scratch);
+  assertEquals(scratch, new Uint8Array([1, 2, 3, 4]));
+});
+
+Deno.test("testReadExactMultipleReadsDelayed", async function () {
+  const reader = readerFromIterable((async function* () {
+    yield new Uint8Array([1]);
+    await new Promise((r) => setTimeout(r, 1));
+    yield new Uint8Array([2, 3]);
+    await new Promise((r) => setTimeout(r, 10));
+    yield new Uint8Array([4, 5, 6]);
+  })());
+
   const scratch = new Uint8Array(4);
   await readExact(reader, scratch);
   assertEquals(scratch, new Uint8Array([1, 2, 3, 4]));

--- a/encoding/binary_test.ts
+++ b/encoding/binary_test.ts
@@ -30,13 +30,16 @@ Deno.test("testReadExact", async function () {
   assertEquals(scratch, new Uint8Array([1, 2, 3, 4]));
 });
 
-Deno.test("testReadExactThrows", async function() {
-  const reader = readerFromIterable([new Uint8Array([1]), new Uint8Array([2, 3])])
+Deno.test("testReadExactThrows", async function () {
+  const reader = readerFromIterable([
+    new Uint8Array([1]),
+    new Uint8Array([2, 3]),
+  ]);
   const scratch = new Uint8Array(4);
   await assertThrowsAsync(async () => {
     await readExact(reader, scratch);
   }, Deno.errors.UnexpectedEof);
-})
+});
 
 Deno.test("testGetNBytes", async function () {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/encoding/binary_test.ts
+++ b/encoding/binary_test.ts
@@ -5,6 +5,7 @@ import {
   getNBytes,
   putVarbig,
   putVarnum,
+  readExact,
   readVarbig,
   readVarnum,
   sizeof,
@@ -16,6 +17,26 @@ import {
   writeVarnum,
 } from "./binary.ts";
 import { Buffer } from "../io/buffer.ts";
+import { readerFromIterable } from "../io/streams.ts";
+
+Deno.test("testReadExact", async function () {
+  const reader = readerFromIterable([
+    new Uint8Array([1]),
+    new Uint8Array([2, 3]),
+    new Uint8Array([4, 5, 6]),
+  ]);
+  const scratch = new Uint8Array(4);
+  await readExact(reader, scratch);
+  assertEquals(scratch, new Uint8Array([1, 2, 3, 4]));
+});
+
+Deno.test("testReadExactThrows", async function() {
+  const reader = readerFromIterable([new Uint8Array([1]), new Uint8Array([2, 3])])
+  const scratch = new Uint8Array(4);
+  await assertThrowsAsync(async () => {
+    await readExact(reader, scratch);
+  }, Deno.errors.UnexpectedEof);
+})
 
 Deno.test("testGetNBytes", async function () {
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
## Changes

- Write `readExact` function for `encoding/binary`:
  - Read from `reader` until the `Uint8Array` array is filled.
  - If the reader reaches EOF, throws a `UnexpectedEof` error.
- Rewrite `getNBytes` to use `readExact`.

closes #651 