### PR TITLE
chore: add underscore prefix to unused variables

### DIFF
--- a/node/_stream/async_iterator_test.ts
+++ b/node/_stream/async_iterator_test.ts
@@ -133,7 +133,7 @@ Deno.test("Async iterator throws on Readable destroyed sync", async () => {
   await assertThrowsAsync(
     async () => {
       // deno-lint-ignore no-empty
-      for await (const k of readable) {}
+      for await (const _k of readable) {}
     },
     Error,
     message,
@@ -235,7 +235,7 @@ Deno.test("Async iterator: 'close' called on forced iteration end", async () => 
   readable.push("asd");
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  for await (const d of readable) {
+  for await (const _d of readable) {
     break;
   }
 

--- a/node/events_test.ts
+++ b/node/events_test.ts
@@ -541,7 +541,7 @@ Deno.test({
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const event of iterable) {
+      for await (const _event of iterable) {
         fail("no events should be processed due to the error thrown");
       }
     } catch (err) {


### PR DESCRIPTION
The current published version of deno_lint doesn't claim, but the next version is going to check if variables declared in `for-of` and `for-in` are used or not.
https://github.com/denoland/deno_lint/issues/697
So I added underscore prefix to such variables, in order to tell the linter that it's intentional to declare unused ones.

As a side note: we should remove ESLint disable directives because the linter doesn't support them since https://github.com/denoland/deno/issues/8226. ~~I'm working on this.~~ Done in #941 