### PR TITLE
fix(node/fs): fix type error in fs.watch impl

### DIFF
--- a/node/_fs/_fs_watch.ts
+++ b/node/_fs/_fs_watch.ts
@@ -88,7 +88,7 @@ export function watch(
 
   fsWatcher.on("change", listener);
 
-  asyncIterableIteratorToCallback<Deno.FsEvent>(iterator, (val, done) => {
+  asyncIterableToCallback<Deno.FsEvent>(iterator, (val, done) => {
     if (done) return;
     fsWatcher.emit("change", val.kind, val.paths[0]);
   });


### PR DESCRIPTION
This PR fixes the type error in fs.watch impl of std/node. This error is caused by the change of builtin API in https://github.com/denoland/deno/pull/10798