### PR TITLE
feat(testing): improved strings diff

### DIFF
--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -274,15 +274,19 @@ export function diffstr(A: string, B: string) {
       return tokens;
     }
   }
-  //Try to autodetect the most suitable string rendering, starting by words-diff
+
+  // Try to autodetect the most suitable string rendering, starting by words-diff
   let wordDiff = true
   let diffResult = diff(tokenize(A, {wordDiff}), tokenize(B, {wordDiff}));
   const common = diffResult.filter(({type, value}) => type === DiffType.common && value.trim()).length
   const edited = diffResult.filter(({type}) => type === DiffType.added || type === DiffType.removed).length
-  //If edited ratio is too high switch to multi-line diff instead
-  if (edited/(common+edited) > 0.9**Math.max(1, A.search(/\n\r?/g), B.search(/\n\r?/g))) {
+
+  // If edited ratio is too high switch to multi-line diff instead
+  // We add a trailing newline to ensure that last tokens are displayed correctly
+  if (edited/(common+edited) > 0.85**Math.max(1, A.match(/\n/g)?.length ?? 0, B.match(/\n/g)?.length ?? 0)) {
     wordDiff = false
-    diffResult = diff(tokenize(A, {wordDiff}), tokenize(B, {wordDiff}));
+    diffResult = diff(tokenize(`${A}\n`, {wordDiff}), tokenize(`${B}\n`, {wordDiff}));
   }
+
   return {diffResult, wordDiff}
 }

--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -234,7 +234,7 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
  * @param B Expected string
  */
 export function diffstr(A: string, B: string) {
-  function tokenize(string: string, {wordDiff = false} = {}): string[] {
+  function tokenize(string: string, { wordDiff = false } = {}): string[] {
     if (wordDiff) {
       // Split string on whitespace symbols
       const tokens = string.split(/([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/);
@@ -276,17 +276,30 @@ export function diffstr(A: string, B: string) {
   }
 
   // Try to autodetect the most suitable string rendering, starting by words-diff
-  let wordDiff = true
-  let diffResult = diff(tokenize(A, {wordDiff}), tokenize(B, {wordDiff}));
-  const common = diffResult.filter(({type, value}) => type === DiffType.common && value.trim()).length
-  const edited = diffResult.filter(({type}) => type === DiffType.added || type === DiffType.removed).length
+  let wordDiff = true;
+  let diffResult = diff(tokenize(A, { wordDiff }), tokenize(B, { wordDiff }));
+  const common =
+    diffResult.filter(({ type, value }) =>
+      type === DiffType.common && value.trim()
+    ).length;
+  const edited =
+    diffResult.filter(({ type }) =>
+      type === DiffType.added || type === DiffType.removed
+    ).length;
 
   // If edited ratio is too high switch to multi-line diff instead
   // We add a trailing newline to ensure that last tokens are displayed correctly
-  if (edited/(common+edited) > 0.85**Math.max(1, A.match(/\n/g)?.length ?? 0, B.match(/\n/g)?.length ?? 0)) {
-    wordDiff = false
-    diffResult = diff(tokenize(`${A}\n`, {wordDiff}), tokenize(`${B}\n`, {wordDiff}));
+  if (
+    edited / (common + edited) >
+      0.85 **
+        Math.max(1, A.match(/\n/g)?.length ?? 0, B.match(/\n/g)?.length ?? 0)
+  ) {
+    wordDiff = false;
+    diffResult = diff(
+      tokenize(`${A}\n`, { wordDiff }),
+      tokenize(`${B}\n`, { wordDiff }),
+    );
   }
 
-  return {diffResult, wordDiff}
+  return { diffResult, wordDiff };
 }

--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -234,25 +234,28 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
  * @param B Expected string
  * @param wordDiff If enabled, will tokenize words instead of lines
  */
-export function diffstr(A:string, B:string, {wordDiff = false} = {}) {
-  function tokenize(string:string):string[] {
+export function diffstr(A: string, B: string, { wordDiff = false } = {}) {
+  function tokenize(string: string): string[] {
     if (wordDiff) {
       // Split string on whitespace symbols
       const tokens = string.split(/([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/);
       // Extended Latin character set
-      const words = /^[a-zA-Z\u{C0}-\u{FF}\u{D8}-\u{F6}\u{F8}-\u{2C6}\u{2C8}-\u{2D7}\u{2DE}-\u{2FF}\u{1E00}-\u{1EFF}]+$/u;
+      const words =
+        /^[a-zA-Z\u{C0}-\u{FF}\u{D8}-\u{F6}\u{F8}-\u{2C6}\u{2C8}-\u{2D7}\u{2DE}-\u{2FF}\u{1E00}-\u{1EFF}]+$/u;
 
       // Join boundary splits that we do not consider to be boundaries and merge empty strings surrounded by word chars
       for (let i = 0; i < tokens.length - 1; i++) {
-        if (!tokens[i + 1] && tokens[i + 2] && words.test(tokens[i]) && words.test(tokens[i + 2])) {
+        if (
+          !tokens[i + 1] && tokens[i + 2] && words.test(tokens[i]) &&
+          words.test(tokens[i + 2])
+        ) {
           tokens[i] += tokens[i + 2];
           tokens.splice(i + 1, 2);
           i--;
         }
       }
-      return tokens.filter(token => token);
-    }
-    else {
+      return tokens.filter((token) => token);
+    } else {
       // Split string on new lines symbols
       const tokens = [], lines = string.split(/(\n|\r\n)/);
 
@@ -263,7 +266,7 @@ export function diffstr(A:string, B:string, {wordDiff = false} = {}) {
 
       // Merge the content and line separators into single tokens
       for (let i = 0; i < lines.length; i++) {
-        if (i % 2 ) {
+        if (i % 2) {
           tokens[tokens.length - 1] += lines[i];
         } else {
           tokens.push(lines[i]);
@@ -272,5 +275,5 @@ export function diffstr(A:string, B:string, {wordDiff = false} = {}) {
       return tokens;
     }
   }
-  return diff(tokenize(A), tokenize(B))
+  return diff(tokenize(A), tokenize(B));
 }

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { diff, diffstr } from "./_diff.ts";
-import { assert, assertEquals } from "../testing/asserts.ts";
+import { assertEquals } from "../testing/asserts.ts";
 
 Deno.test({
   name: "empty",

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-import { diff } from "./_diff.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { diff, diffstr } from "./_diff.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 
 Deno.test({
   name: "empty",
@@ -106,6 +106,42 @@ Deno.test({
       { type: "common", value: "abc" },
       { type: "added", value: "bcd" },
       { type: "common", value: "c" },
+    ]);
+  },
+});
+
+Deno.test({
+  name: '"a b c d" vs "a b x d e" (diffstr - word-diff)',
+  fn(): void {
+    const {diffResult, wordDiff} = diffstr([..."abcd"].join(" "), [..."abxde"].join(" "))
+    assert(wordDiff)
+    assertEquals(diffResult, [
+      { type: "common", value: "a" },
+      { type: "common", value: " " },
+      { type: "common", value: "b" },
+      { type: "common", value: " " },
+      { type: "added", value: "x" },
+      { type: "removed", value: "c" },
+      { type: "common", value: " " },
+      { type: "common", value: "d" },
+      { type: "added", value: " " },
+      { type: "added", value: "e" },
+    ]);
+  },
+});
+
+Deno.test({
+  name: '"a b c d" vs "a b x d e" (diffstr - multiline-diff)',
+  fn(): void {
+    const {diffResult, wordDiff} = diffstr([..."abcd"].join("\n"), [..."abxde"].join("\n"))
+    assert(!wordDiff)
+    assertEquals(diffResult, [
+      { type: "common", value: "a\n" },
+      { type: "common", value: "b\n" },
+      { type: "added", value: "x\n" },
+      { type: "removed", value: "c\n" },
+      { type: "common", value: "d\n" },
+      { type: "added", value: "e\n" }
     ]);
   },
 });

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -113,8 +113,11 @@ Deno.test({
 Deno.test({
   name: '"a b c d" vs "a b x d e" (diffstr - word-diff)',
   fn(): void {
-    const {diffResult, wordDiff} = diffstr([..."abcd"].join(" "), [..."abxde"].join(" "))
-    assert(wordDiff)
+    const { diffResult, wordDiff } = diffstr(
+      [..."abcd"].join(" "),
+      [..."abxde"].join(" "),
+    );
+    assert(wordDiff);
     assertEquals(diffResult, [
       { type: "common", value: "a" },
       { type: "common", value: " " },
@@ -133,15 +136,18 @@ Deno.test({
 Deno.test({
   name: '"a b c d" vs "a b x d e" (diffstr - multiline-diff)',
   fn(): void {
-    const {diffResult, wordDiff} = diffstr([..."abcd"].join("\n"), [..."abxde"].join("\n"))
-    assert(!wordDiff)
+    const { diffResult, wordDiff } = diffstr(
+      [..."abcd"].join("\n"),
+      [..."abxde"].join("\n"),
+    );
+    assert(!wordDiff);
     assertEquals(diffResult, [
       { type: "common", value: "a\n" },
       { type: "common", value: "b\n" },
       { type: "added", value: "x\n" },
       { type: "removed", value: "c\n" },
       { type: "common", value: "d\n" },
-      { type: "added", value: "e\n" }
+      { type: "added", value: "e\n" },
     ]);
   },
 });

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -111,43 +111,39 @@ Deno.test({
 });
 
 Deno.test({
-  name: '"a b c d" vs "a b x d e" (diffstr - word-diff)',
+  name: '"a b c d" vs "a b x d e" (diffstr)',
   fn(): void {
-    const { diffResult, wordDiff } = diffstr(
-      [..."abcd"].join(" "),
-      [..."abxde"].join(" "),
-    );
-    assert(wordDiff);
-    assertEquals(diffResult, [
-      { type: "common", value: "a" },
-      { type: "common", value: " " },
-      { type: "common", value: "b" },
-      { type: "common", value: " " },
-      { type: "added", value: "x" },
-      { type: "removed", value: "c" },
-      { type: "common", value: " " },
-      { type: "common", value: "d" },
-      { type: "added", value: " " },
-      { type: "added", value: "e" },
-    ]);
-  },
-});
-
-Deno.test({
-  name: '"a b c d" vs "a b x d e" (diffstr - multiline-diff)',
-  fn(): void {
-    const { diffResult, wordDiff } = diffstr(
+    const diffResult = diffstr(
       [..."abcd"].join("\n"),
       [..."abxde"].join("\n"),
     );
-    assert(!wordDiff);
     assertEquals(diffResult, [
       { type: "common", value: "a\n" },
       { type: "common", value: "b\n" },
       { type: "added", value: "x\n" },
-      { type: "removed", value: "c\n" },
+      {
+        type: "removed",
+        value: "c\n",
+        details: [{ type: "removed", value: "c" }, {
+          type: "common",
+          value: "\n",
+        }],
+      },
       { type: "common", value: "d\n" },
-      { type: "added", value: "e\n" },
+      {
+        type: "added",
+        value: "e\n",
+        details: [
+          {
+            type: "added",
+            value: "e",
+          },
+          {
+            type: "common",
+            value: "\n",
+          },
+        ],
+      },
     ]);
   },
 });

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -3,7 +3,7 @@
 // for AssertionError messages in browsers.
 
 import { bold, gray, green, red, stripColor, white } from "../fmt/colors.ts";
-import { diff, DiffResult, diffstr, DiffType } from "./_diff.ts";
+import { diff, diffstr, DiffResult, DiffType } from "./_diff.ts";
 
 const CAN_NOT_DISPLAY = "[Cannot display]";
 
@@ -214,8 +214,7 @@ export function assertEquals(
   const expectedString = _format(expected);
   try {
     if ((typeof actual === "string") && (typeof expected === "string")) {
-      const wordDiff = false; //TODO
-      const diffResult = diffstr(actual, expected, { wordDiff });
+      const {diffResult, wordDiff} = diffstr(actual, expected);
       const diffMsg = buildMessage(diffResult, {
         sign: !wordDiff,
         stringDiff: true,
@@ -326,8 +325,7 @@ export function assertStrictEquals(
     } else {
       try {
         if ((typeof actual === "string") && (typeof expected === "string")) {
-          const wordDiff = true; //TODO
-          const diffResult = diffstr(actual, expected, { wordDiff });
+          const {diffResult, wordDiff} = diffstr(actual, expected);
           const diffMsg = buildMessage(diffResult, {
             sign: !wordDiff,
             stringDiff: true,

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -338,7 +338,7 @@ export function assertStrictEquals(
           ? diffstr(actual as string, expected as string)
           : diff(actualString.split("\n"), expectedString.split("\n"));
         const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
-        message = `Values are not equal:\n${diffMsg}`;
+        message = `Values are not strictly equal:\n${diffMsg}`;
       } catch {
         message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
       }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -3,7 +3,7 @@
 // for AssertionError messages in browsers.
 
 import { bold, gray, green, red, stripColor, white } from "../fmt/colors.ts";
-import { diff, diffstr, DiffResult, DiffType } from "./_diff.ts";
+import { diff, DiffResult, diffstr, DiffType } from "./_diff.ts";
 
 const CAN_NOT_DISPLAY = "[Cannot display]";
 
@@ -66,7 +66,10 @@ function createSign(diffType: DiffType): string {
   }
 }
 
-function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>, {sign = true, stringDiff = false} = {}): string[] {
+function buildMessage(
+  diffResult: ReadonlyArray<DiffResult<string>>,
+  { sign = true, stringDiff = false } = {},
+): string[] {
   const messages: string[] = [], diffMessages: string[] = [];
   messages.push("");
   messages.push("");
@@ -79,9 +82,11 @@ function buildMessage(diffResult: ReadonlyArray<DiffResult<string>>, {sign = tru
   messages.push("");
   diffResult.forEach((result: DiffResult<string>): void => {
     const c = createColor(result.type);
-    diffMessages.push(c(`${sign ? createSign(result.type) : ""}${result.value}`));
+    diffMessages.push(
+      c(`${sign ? createSign(result.type) : ""}${result.value}`),
+    );
   });
-  messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages))
+  messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");
 
   return messages;
@@ -209,12 +214,14 @@ export function assertEquals(
   const expectedString = _format(expected);
   try {
     if ((typeof actual === "string") && (typeof expected === "string")) {
-      const wordDiff= false //TODO
-      const diffResult = diffstr(actual, expected, {wordDiff})
-      const diffMsg = buildMessage(diffResult, {sign:!wordDiff, stringDiff:true}).join("\n");
+      const wordDiff = false; //TODO
+      const diffResult = diffstr(actual, expected, { wordDiff });
+      const diffMsg = buildMessage(diffResult, {
+        sign: !wordDiff,
+        stringDiff: true,
+      }).join("\n");
       message = `Values are not equal:\n${diffMsg}`;
-    }
-    else {
+    } else {
       const diffResult = diff(
         actualString.split("\n"),
         expectedString.split("\n"),
@@ -319,12 +326,14 @@ export function assertStrictEquals(
     } else {
       try {
         if ((typeof actual === "string") && (typeof expected === "string")) {
-          const wordDiff= true //TODO
-          const diffResult = diffstr(actual, expected, {wordDiff})
-          const diffMsg = buildMessage(diffResult, {sign:!wordDiff, stringDiff:true}).join("\n");
+          const wordDiff = true; //TODO
+          const diffResult = diffstr(actual, expected, { wordDiff });
+          const diffMsg = buildMessage(diffResult, {
+            sign: !wordDiff,
+            stringDiff: true,
+          }).join("\n");
           message = `Values are not equal:\n${diffMsg}`;
-        }
-        else {
+        } else {
           const diffResult = diff(
             actualString.split("\n"),
             expectedString.split("\n"),

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -3,7 +3,7 @@
 // for AssertionError messages in browsers.
 
 import { bold, gray, green, red, stripColor, white } from "../fmt/colors.ts";
-import { diff, diffstr, DiffResult, DiffType } from "./_diff.ts";
+import { diff, DiffResult, diffstr, DiffType } from "./_diff.ts";
 
 const CAN_NOT_DISPLAY = "[Cannot display]";
 
@@ -214,7 +214,7 @@ export function assertEquals(
   const expectedString = _format(expected);
   try {
     if ((typeof actual === "string") && (typeof expected === "string")) {
-      const {diffResult, wordDiff} = diffstr(actual, expected);
+      const { diffResult, wordDiff } = diffstr(actual, expected);
       const diffMsg = buildMessage(diffResult, {
         sign: !wordDiff,
         stringDiff: true,
@@ -325,7 +325,7 @@ export function assertStrictEquals(
     } else {
       try {
         if ((typeof actual === "string") && (typeof expected === "string")) {
-          const {diffResult, wordDiff} = diffstr(actual, expected);
+          const { diffResult, wordDiff } = diffstr(actual, expected);
           const diffMsg = buildMessage(diffResult, {
             sign: !wordDiff,
             stringDiff: true,

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -95,7 +95,7 @@ function buildMessage(
   messages.push("");
   diffResult.forEach((result: DiffResult<string>): void => {
     const c = createColor(result.type);
-    let line = result.details?.map((detail) =>
+    const line = result.details?.map((detail) =>
       detail.type !== DiffType.common
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -927,6 +927,24 @@ Deno.test("assertEquals diff for differently ordered objects", () => {
   );
 });
 
+Deno.test("assert diff formatting (strings)", () => {
+  assertThrows(() => {
+    assertEquals([..."abcd"].join(" "),
+    [..."abxde"].join(" "));
+  }, undefined, `a b ${green("x")}${red("c")} d ${green("e")}`)
+
+  assertThrows(() => {
+    assertEquals([..."abcd"].join("\n"), [..."abxde"].join("\n"));
+  }, undefined, `
+    a
+    b
+${green("+   x")}
+${red("-   c")}
+    d
+${green("+   e")}
+`)
+});
+
 // Check that the diff formatter overrides some default behaviours of
 // `Deno.inspect()` which are problematic for diffing.
 Deno.test("assert diff formatting", () => {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -930,14 +930,6 @@ Deno.test("assertEquals diff for differently ordered objects", () => {
 Deno.test("assert diff formatting (strings)", () => {
   assertThrows(
     () => {
-      assertEquals([..."abcd"].join(" "), [..."abxde"].join(" "));
-    },
-    undefined,
-    `a b ${green("x")}${red("c")} d ${green("e")}`,
-  );
-
-  assertThrows(
-    () => {
       assertEquals([..."abcd"].join("\n"), [..."abxde"].join("\n"));
     },
     undefined,

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -928,21 +928,28 @@ Deno.test("assertEquals diff for differently ordered objects", () => {
 });
 
 Deno.test("assert diff formatting (strings)", () => {
-  assertThrows(() => {
-    assertEquals([..."abcd"].join(" "),
-    [..."abxde"].join(" "));
-  }, undefined, `a b ${green("x")}${red("c")} d ${green("e")}`)
+  assertThrows(
+    () => {
+      assertEquals([..."abcd"].join(" "), [..."abxde"].join(" "));
+    },
+    undefined,
+    `a b ${green("x")}${red("c")} d ${green("e")}`,
+  );
 
-  assertThrows(() => {
-    assertEquals([..."abcd"].join("\n"), [..."abxde"].join("\n"));
-  }, undefined, `
+  assertThrows(
+    () => {
+      assertEquals([..."abcd"].join("\n"), [..."abxde"].join("\n"));
+    },
+    undefined,
+    `
     a
     b
 ${green("+   x")}
 ${red("-   c")}
     d
 ${green("+   e")}
-`)
+`,
+  );
 });
 
 // Check that the diff formatter overrides some default behaviours of


### PR DESCRIPTION
This add a specialized tokenizer that is called when both operands are string before entering `diff()`, making changes in large strings assertions more visible.
 
A word diff has been implemented (similar to `git diff --word-diff`):
![image](https://user-images.githubusercontent.com/22963968/120538377-b87c9980-c3e6-11eb-9544-17a2882b9771.png)

As the above is not practical when a lot of words have been changed, a multiline diff has also been implemented:
![image](https://user-images.githubusercontent.com/22963968/120538352-b31f4f00-c3e6-11eb-98b1-44b7315735c2.png)

**Todo**
- [x] word diff
- [x] multiline diff
- [x] combine word and multiline diffs 
- [x] link new code with `diff()` and `buildMessage()` 
- [x] tests 
  - [x] `_diff_test`
  - [x] `asserts_test`
- [ ] find good colors
- [x] merge word diff token if a in-between token is a space 

Closes #929
