### PR TITLE
fix(node/process): make process.env iterable

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -57,7 +57,7 @@ const _env: {
 
 Object.defineProperty(_env, Deno.customInspect, {
   enumerable: false,
-  configurable: false,
+  configurable: true,
   get: function () {
     return Deno.env.toObject();
   },
@@ -76,6 +76,9 @@ export const env: Record<string, string> = new Proxy(_env, {
   },
   ownKeys() {
     return Reflect.ownKeys(Deno.env.toObject());
+  },
+  getOwnPropertyDescriptor() {
+    return { enumerable: true, configurable: true };
   },
   set(_target, prop, value) {
     Deno.env.set(String(prop), String(value));

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -147,6 +147,9 @@ Deno.test({
 
     assertEquals(typeof env.HELLO, "string");
     assertEquals(env.HELLO, "WORLD");
+
+    assert(Object.getOwnPropertyNames(process.env).includes("HELLO"));
+    assert(Object.keys(process.env).includes("HELLO"));
   },
 });
 


### PR DESCRIPTION
This PR add `getOwnPropertyDescriptor()` to `process.env` in order to make it iterable.