### PR TITLE
fix: Apply node test suite 'ignore' configuration when running tests

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -98,6 +98,13 @@ To enable new tests, simply add a new entry inside `node/_tools/config.json`
 under the `tests` property. The structure this entries must have has to resemble
 a path inside `https://github.com/nodejs/node/tree/master/test`.
 
+Adding a new entry under the `ignore` option will indicate the test runner that
+it should not regenerate that file from scratch the next time the setup is run,
+this is specially useful to keep track of files that have been manually edited
+to pass certain tests. However, avoid doing such manual changes to the test
+files, since that may cover up inconsistencies between the node library and
+actual node behavior.
+
 ### Best practices
 
 When converting from promise-based to callback-based APIs, the most obvious way

--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -3,6 +3,10 @@
   "ignore": {
     "common": [
       "index.js"
+    ],
+    "parallel": [
+      "test-assert.js",
+      "test-assert-async.js"
     ]
   },
   "tests": {

--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -97,19 +97,11 @@ async function clearTests() {
 }
 
 /**
- * This will iterate over the ignore and test lists defined in the
- * configuration file
- *
- * If it were to be found in the ignore list or not found in the test list, the
- * function will return undefined, meaning the file won't be regenerated
+ * This will iterate over test list defined in the configuration file and test the
+ * passed file against it. If a match were to be found, it will return the test
+ * suite specified for that file
  */
 function getRequestedFileSuite(file: string): string | undefined {
-  for (const regex of ignoreList) {
-    if (regex.test(file)) {
-      return;
-    }
-  }
-
   for (const suite in config.tests) {
     for (const regex of config.tests[suite]) {
       if (new RegExp(regex).test(file)) {
@@ -161,7 +153,7 @@ async function copyTests(filePath: string): Promise<void> {
   const suitesFolder = fromFileUrl(
     new URL(config.suitesFolder, import.meta.url),
   );
-  for await (const entry of walk(path)) {
+  for await (const entry of walk(path, { skip: ignoreList })) {
     const suite = getRequestedFileSuite(entry.name);
     if (!suite) continue;
 


### PR DESCRIPTION
Currently the 'ignore' option in the configuration for the test runner is being ignored, causing edited test files to be regenerated when running the setup, deleting any manual changes and making it hard to track what files have been manually edited.

Additionally, the documentation about what this option actually did was not that clear, so that has been enhanced as well