### PR TITLE
feat(testing/asserts): Use assertion signature for "assertExists"

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -277,7 +277,7 @@ export function assertNotEquals(
 }
 
 /**
- * Make an assertion that `actual` and `expected` are strictly equal.  If
+ * Make an assertion that `actual` and `expected` are strictly equal. If
  * not then throw.
  * ```ts
  * assertStrictEquals(1, 2)
@@ -368,8 +368,8 @@ export function assertNotStrictEquals(
 }
 
 /**
- * Make an assertion that actual is not null or undefined. If not
- * then thrown.
+ * Make an assertion that actual is not null or undefined.
+ * If not then throw.
  */
 export function assertExists<T>(
   actual: T,
@@ -385,7 +385,7 @@ export function assertExists<T>(
 
 /**
  * Make an assertion that actual includes expected. If not
- * then thrown.
+ * then throw.
  */
 export function assertStringIncludes(
   actual: string,
@@ -451,7 +451,7 @@ export function assertArrayIncludes(
 
 /**
  * Make an assertion that `actual` match RegExp `expected`. If not
- * then thrown
+ * then throw.
  */
 export function assertMatch(
   actual: string,
@@ -468,7 +468,7 @@ export function assertMatch(
 
 /**
  * Make an assertion that `actual` not match RegExp `expected`. If match
- * then thrown
+ * then throw.
  */
 export function assertNotMatch(
   actual: string,

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -377,8 +377,7 @@ export function assertExists<T>(
 ): asserts actual is NonNullable<T> {
   if (actual === undefined || actual === null) {
     if (!msg) {
-      msg =
-        `actual: "${actual}" expected to not be null or undefined`;
+      msg = `actual: "${actual}" expected to not be null or undefined`;
     }
     throw new AssertionError(msg);
   }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -371,14 +371,14 @@ export function assertNotStrictEquals(
  * Make an assertion that actual is not null or undefined. If not
  * then thrown.
  */
-export function assertExists(
-  actual: unknown,
+export function assertExists<T>(
+  actual: T,
   msg?: string,
-): void {
+): asserts actual is NonNullable<T> {
   if (actual === undefined || actual === null) {
     if (!msg) {
       msg =
-        `actual: "${actual}" expected to match anything but null or undefined`;
+        `actual: "${actual}" expected to not be null or undefined`;
     }
     throw new AssertionError(msg);
   }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -213,6 +213,11 @@ Deno.test("testingAssertExists", function (): void {
   assertExists(-0);
   assertExists(0);
   assertExists(NaN);
+
+  const value = new URLSearchParams({ value: "test" }).get("value");
+  assertExists(value);
+  assertEquals(value.length, 4);
+
   let didThrow;
   try {
     assertExists(undefined);


### PR DESCRIPTION
This is an improvement which allows [using the function as a type guard](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) in addition to its runtime safety. See the following TS playground link for a comparison of before/after: [TS Playground](https://www.typescriptlang.org/play?target=99&strict=true#code/KYDwDg9gTgLgBAYwDYEMDOa4EEPFgSwgDsBRKKaOUGYIgE0zIqjgG8AoORYtGKAVwQxoACgC2wDCgDmwAFxxeUfEWkBKNpy6L+YPOMloZwNQG4tXGAAt8aAHREUEuAF44AIhxo8MQqXLQ7uZcAL7sYewA9ABU0ZzRcACyKADWwHAoRBm4BMRw1ijwKEL8KEhwtnBEEPBE-EjllPz0wABmKsB0dnAAkq1VNfH5VrTDFADuRHbxkeygkLBwrc1CftnesCQgtjBoAEJt0MAiWsUwpUgKzSnVkwA0WmJo0gD8Ckoq0g9qCgBuEPg6JouPh+iIzhdXC43M06G0OkCAD6IjIlMpQtx1BoaDjaCpggCET3UwLxcGJrgsZIABhCygp3AASVh0pAhdxUcDAISdfIQcmFBBWDJEACe1k+cAARvxavVGixYfCiJ1qcFtGE8dYJlVgONsDlfMQmKJiWYtGEIjE4nAEsk0iL1j41gUimjypVqnKGnAmi12iqukM+gN4NZRtqIONprbZvNoPBlkRVnl0BsYFsdmgsK0aFAADwAFQAfCcuKyFIWHlxiW9FHxPt8FGmfJhWRVMAA5Yid+UoKVIYBF4uk0FwcHujFwJUB3nI1HndHQzHynFUsciInPNdk8nPVxwWnuhnM1nszl6HlA4Sh6XpLEK6f+hFqqma7SR-Uq-VeZ3GgJQOI27qpa7DsAgPDwL8ZT8OkmJ6nAACqABKAAyADKwAoFAQoAArYU4aAiKw0FILBCgAOQ0LwFEhGodiyDAIgUaRsEUea7Atps2y8PshxQMcrEmOYEFEGgECDnYSAQNIIhCVJtDSNYHFcRmPG7DmeZyTBwngTwEnAFJMnaWRhmDqoynmEAA)

The contributing guidelines state to make sure that changes are covered by a test. However, I don't see any testing framework here for types. If I modify an existing test to include a case which requires calling the function to narrow a type before use, then any type-incompatible changes to the function later would later cause a compilation error of the test, rather than a runtime error during testing... but I'm not sure that kind of meta behavior is what the guidelines mean.