### PR TITLE
fix(path/glob): Fixed array type error in glob.ts

### DIFF
--- a/path/glob.ts
+++ b/path/glob.ts
@@ -116,7 +116,7 @@ export function globToRegExp(
   // Terminates correctly. Trust that `j` is incremented every iteration.
   for (let j = 0; j < glob.length;) {
     let segment = "";
-    const groupStack = [];
+    const groupStack: string[] = [];
     let inRange = false;
     let inEscape = false;
     let endsWithSep = false;


### PR DESCRIPTION
**Description**

Hi!

This PR fixes the following error that I've been experiencing with [glob.ts](https://deno.land/std@0.99.0/path/glob.ts):

<details>
  <summary>Error log</summary>
  
```bash
error: TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
        groupStack.push("+");
                        ~~~
    at https://deno.land/std@0.99.0/path/glob.ts:219:25

TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
        groupStack.push("@");
                        ~~~
    at https://deno.land/std@0.99.0/path/glob.ts:226:25

TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
          groupStack.push("?");
                          ~~~
    at https://deno.land/std@0.99.0/path/glob.ts:234:27

TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
        groupStack.push("!");
                        ~~~
    at https://deno.land/std@0.99.0/path/glob.ts:244:25

TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
        groupStack.push("BRACE");
                        ~~~~~~~
    at https://deno.land/std@0.99.0/path/glob.ts:250:25

TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'never'.
          groupStack.push("*");
                          ~~~
    at https://deno.land/std@0.99.0/path/glob.ts:269:27

Found 6 errors.
``` 
</details>

**Minimal replicability**
tsconfig.json:
```json
{
  "compilerOptions": {
    "noImplicitAny": false
  }
}
```

example.ts:
```typescript
import "https://deno.land/std@0.99.0/path/glob.ts";
```

Running `deno run --config ./tsconfig.json ./example.ts` will result in the error log above:

**Reason**
I believe this is caused by `const groupStack = [];` which is being inferred as `never[]`.

**Fix**
I added `string[]` to `groupStack`.

Tried compiling the file directly with this change and it seems to fix the problem. Happy to do a full run of deno_std tests locally if need be (as per https://github.com/denoland/deno_std#contributing) but I'm assuming this change is pretty safe :)
