### PR TITLE
feat(testing/asserts.ts): allows custom error message that includes actual and expected values.

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -53,6 +53,20 @@ Deno.test({
 });
 ```
 
+`assertEquals` and other functions that allow custom messages also accept this syntax:
+```ts
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+Deno.test({
+  name: "testing example",
+  fn(): void {
+    assertEquals(dynamicValue1(), dynamicValue2(), ({message, actual, expected}) => {
+      return `${actual} didnt match ${expected}, here's the diff: ${message}`
+    });
+  },
+});
+```
+
 Short syntax (named function instead of object):
 
 ```ts

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -204,13 +204,13 @@ export function assert(expr: unknown, msg = ""): asserts expr {
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
-export function assertEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertEquals<T>(actual: T, expected: T, msg?: string | ((first: typeof actual, second: typeof expected) => string)): void;
 export function assertEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string), // uses first and second for the callback because ts complains when using actual/expected
 ): void {
   if (equal(actual, expected)) {
     return;
@@ -229,7 +229,11 @@ export function assertEquals(
     message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
   }
   if (msg) {
-    message = msg;
+    if (typeof msg === "string") {
+      message = msg;
+    } else if (typeof msg === "function") {
+      message = msg(actual, expected);
+    }
   }
   throw new AssertionError(message);
 }
@@ -247,19 +251,20 @@ export function assertEquals(
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
-export function assertNotEquals<T>(actual: T, expected: T, msg?: string): void;
+export function assertNotEquals<T>(actual: T, expected: T, msg?: string | ((first: typeof actual, second: typeof expected) => string)): void;
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (!equal(actual, expected)) {
     return;
   }
   let actualString: string;
   let expectedString: string;
+  let message = "";
   try {
     actualString = String(actual);
   } catch {
@@ -271,9 +276,15 @@ export function assertNotEquals(
     expectedString = "[Cannot display]";
   }
   if (!msg) {
-    msg = `actual: ${actualString} expected: ${expectedString}`;
+    message = `actual: ${actualString} expected: ${expectedString}`;
+  } else if (msg) {
+    if (typeof msg === "string") {
+      message = msg;
+    } else if (typeof msg === "function") {
+      message = msg(expected, actual);
+    }
   }
-  throw new AssertionError(msg);
+  throw new AssertionError(message);
 }
 
 /**

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -391,17 +391,17 @@ export function assertStrictEquals(
 export function assertNotStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: unknown, expected: unknown}) => string),
 ): void;
 export function assertNotStrictEquals<T>(
   actual: T,
   expected: T,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: T, expected: T}) => string),
 ): void;
 export function assertNotStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: unknown, expected: unknown}) => string),
 ): void {
   if (actual !== expected) {
     return;
@@ -413,7 +413,10 @@ export function assertNotStrictEquals(
     if (typeof msg === "string") {
       message = msg;
     } else if (typeof msg === "function") {
-      message = msg(actual, expected);
+      let objMsg = `Expected "actual" to be strictly unequal to: ${
+        _format(actual)
+      }\n`;
+      message = msg({message: objMsg, actual, expected});
     }
   } else {
     message = `Expected "actual" to be strictly unequal to: ${
@@ -430,7 +433,7 @@ export function assertNotStrictEquals(
  */
 export function assertExists(
   actual: unknown,
-  msg?: string | ((first: typeof actual) => string),
+  msg?: string | ((actual: unknown) => string),
 ): void {
   if (actual === undefined || actual === null) {
     let message = "";
@@ -456,7 +459,7 @@ export function assertExists(
 export function assertStringIncludes(
   actual: string,
   expected: string,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: string, expected: string}) => string),
 ): void {
   if (!actual.includes(expected)) {
     let message = "";
@@ -465,7 +468,8 @@ export function assertStringIncludes(
       if (typeof msg === "string") {
         message = msg;
       } else if (typeof msg === "function") {
-        message = msg(actual, expected);
+        let objMsg = `actual: "${actual}" expected to contain: "${expected}"`;
+        message = msg({message: objMsg, actual, expected});
       }
     } else {
       message = `actual: "${actual}" expected to contain: "${expected}"`;
@@ -487,17 +491,17 @@ export function assertStringIncludes(
 export function assertArrayIncludes(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: ArrayLike<unknown>, expected: ArrayLike<unknown>}) => string),
 ): void;
 export function assertArrayIncludes<T>(
   actual: ArrayLike<T>,
   expected: ArrayLike<T>,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: ArrayLike<T>, expected: ArrayLike<T>}) => string),
 ): void;
 export function assertArrayIncludes(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: ArrayLike<unknown>, expected: ArrayLike<unknown>}) => string),
 ): void {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
@@ -521,7 +525,10 @@ export function assertArrayIncludes(
     if (typeof msg === "string") {
       message = msg;
     } else if (typeof msg === "function") {
-      message = msg(actual, expected);
+      let objMsg = `actual: "${_format(actual)}" expected to include: "${
+        _format(expected)
+      }"\nmissing: ${_format(missing)}`
+      message = msg({message: objMsg, actual, expected});
     }
   } else {
     message = `actual: "${_format(actual)}" expected to include: "${
@@ -538,7 +545,7 @@ export function assertArrayIncludes(
 export function assertMatch(
   actual: string,
   expected: RegExp,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: string, expected: RegExp}) => string),
 ): void {
   if (!expected.test(actual)) {
     let message = "";
@@ -546,7 +553,8 @@ export function assertMatch(
       if (typeof msg === "string") {
         message = msg;
       } else if (typeof msg === "function") {
-        message = msg(actual, expected);
+        let objMsg = `actual: "${actual}" expected to match: "${expected}"`;
+        message = msg({message: objMsg, actual, expected});
       }
     } else {
       message = `actual: "${actual}" expected to match: "${expected}"`;
@@ -562,7 +570,7 @@ export function assertMatch(
 export function assertNotMatch(
   actual: string,
   expected: RegExp,
-  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+  msg?: string | ((obj: {message: string, actual: string, expected: RegExp}) => string),
 ): void {
   if (expected.test(actual)) {
     let message = "";
@@ -570,7 +578,8 @@ export function assertNotMatch(
       if (typeof msg === "string") {
         message = msg;
       } else if (typeof msg === "function") {
-        message = msg(actual, expected);
+        let objMsg = `actual: "${actual}" expected to not match: "${expected}"`;
+        message = msg({message: objMsg, actual, expected});
       }
     } else {
       message = `actual: "${actual}" expected to not match: "${expected}"`;

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -297,17 +297,17 @@ export function assertNotEquals(
 export function assertStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertStrictEquals<T>(
   actual: T,
   expected: T,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (actual === expected) {
     return;
@@ -315,8 +315,10 @@ export function assertStrictEquals(
 
   let message: string;
 
-  if (msg) {
-    message = msg;
+  if (msg && typeof msg === "string") {
+      message = msg;
+  } else if (msg && typeof msg === "function") {
+    message = msg(actual, expected);
   } else {
     const actualString = _format(actual);
     const expectedString = _format(expected);
@@ -357,25 +359,35 @@ export function assertStrictEquals(
 export function assertNotStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertNotStrictEquals<T>(
   actual: T,
   expected: T,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertNotStrictEquals(
   actual: unknown,
   expected: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (actual !== expected) {
     return;
   }
 
-  throw new AssertionError(
-    msg ?? `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`,
-  );
+  let message = "";
+
+  if (msg) {
+    if (typeof msg === "string") {
+      message = msg;
+    } else if (typeof msg === "function") {
+      message = msg(actual, expected);
+    }
+  } else {
+    message = `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`
+  }
+
+  throw new AssertionError(message);
 }
 
 /**
@@ -384,14 +396,22 @@ export function assertNotStrictEquals(
  */
 export function assertExists(
   actual: unknown,
-  msg?: string,
+  msg?: string | ((first: typeof actual) => string),
 ): void {
   if (actual === undefined || actual === null) {
-    if (!msg) {
-      msg =
+    let message = "";
+
+    if (msg) {
+      if (typeof msg === "string") {
+        message = msg;
+      } else if (typeof msg === "function") {
+        message = msg(actual);
+      }
+    } else {
+      message =
         `actual: "${actual}" expected to match anything but null or undefined`;
     }
-    throw new AssertionError(msg);
+    throw new AssertionError(message);
   }
 }
 
@@ -402,13 +422,21 @@ export function assertExists(
 export function assertStringIncludes(
   actual: string,
   expected: string,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (!actual.includes(expected)) {
-    if (!msg) {
+    let message = "";
+
+    if (msg) {
+      if (typeof msg === "string") {
+        message = msg;
+      } else if (typeof msg === "function") {
+        message = msg(actual, expected);
+      }
+    } else {
       msg = `actual: "${actual}" expected to contain: "${expected}"`;
     }
-    throw new AssertionError(msg);
+    throw new AssertionError(message);
   }
 }
 
@@ -425,17 +453,17 @@ export function assertStringIncludes(
 export function assertArrayIncludes(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertArrayIncludes<T>(
   actual: ArrayLike<T>,
   expected: ArrayLike<T>,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
 export function assertArrayIncludes(
   actual: ArrayLike<unknown>,
   expected: ArrayLike<unknown>,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
@@ -453,12 +481,20 @@ export function assertArrayIncludes(
   if (missing.length === 0) {
     return;
   }
-  if (!msg) {
-    msg = `actual: "${_format(actual)}" expected to include: "${
+
+  let message = "";
+  if (msg) {
+    if (typeof msg === "string") {
+      message = msg;
+    } else if (typeof msg === "function") {
+      message = msg(actual, expected);
+    }
+  } else {
+    message = `actual: "${_format(actual)}" expected to include: "${
       _format(expected)
     }"\nmissing: ${_format(missing)}`;
   }
-  throw new AssertionError(msg);
+  throw new AssertionError(message);
 }
 
 /**
@@ -468,13 +504,20 @@ export function assertArrayIncludes(
 export function assertMatch(
   actual: string,
   expected: RegExp,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (!expected.test(actual)) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to match: "${expected}"`;
+    let message = "";
+    if (msg) {
+      if (typeof msg === "string") {
+        message = msg;
+      } else if (typeof msg === "function") {
+        message = msg(actual, expected);
+      }
+    } else {
+      message = `actual: "${actual}" expected to match: "${expected}"`;
     }
-    throw new AssertionError(msg);
+    throw new AssertionError(message);
   }
 }
 
@@ -485,13 +528,20 @@ export function assertMatch(
 export function assertNotMatch(
   actual: string,
   expected: RegExp,
-  msg?: string,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void {
   if (expected.test(actual)) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to not match: "${expected}"`;
+    let message = "";
+    if (msg) {
+      if (typeof msg === "string") {
+        message = msg;
+      } else if (typeof msg === "function") {
+        message = msg(actual, expected);
+      }
+    } else {
+      message = `actual: "${actual}" expected to not match: "${expected}"`;
     }
-    throw new AssertionError(msg);
+    throw new AssertionError(message);
   }
 }
 

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -434,7 +434,7 @@ export function assertStringIncludes(
         message = msg(actual, expected);
       }
     } else {
-      msg = `actual: "${actual}" expected to contain: "${expected}"`;
+      message = `actual: "${actual}" expected to contain: "${expected}"`;
     }
     throw new AssertionError(message);
   }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -206,7 +206,11 @@ export function assertEquals(
   expected: unknown,
   msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
-export function assertEquals<T>(actual: T, expected: T, msg?: string | ((first: typeof actual, second: typeof expected) => string)): void;
+export function assertEquals<T>(
+  actual: T,
+  expected: T,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+): void;
 export function assertEquals(
   actual: unknown,
   expected: unknown,
@@ -253,7 +257,11 @@ export function assertNotEquals(
   expected: unknown,
   msg?: string | ((first: typeof actual, second: typeof expected) => string),
 ): void;
-export function assertNotEquals<T>(actual: T, expected: T, msg?: string | ((first: typeof actual, second: typeof expected) => string)): void;
+export function assertNotEquals<T>(
+  actual: T,
+  expected: T,
+  msg?: string | ((first: typeof actual, second: typeof expected) => string),
+): void;
 export function assertNotEquals(
   actual: unknown,
   expected: unknown,
@@ -316,7 +324,7 @@ export function assertStrictEquals(
   let message: string;
 
   if (msg && typeof msg === "string") {
-      message = msg;
+    message = msg;
   } else if (msg && typeof msg === "function") {
     message = msg(actual, expected);
   } else {
@@ -384,7 +392,9 @@ export function assertNotStrictEquals(
       message = msg(actual, expected);
     }
   } else {
-    message = `Expected "actual" to be strictly unequal to: ${_format(actual)}\n`
+    message = `Expected "actual" to be strictly unequal to: ${
+      _format(actual)
+    }\n`;
   }
 
   throw new AssertionError(message);


### PR DESCRIPTION
Implements #878 which allows this syntax:
```ts
Deno.test("some test", () => {
  assertEquals(1, 2, (actual, expected) => `actual: ${actual}, expected: ${expected}`);
});
```

Wasn't sure how to implement this for `assertThrows()` and `assertThrowsAsync()`, I would like some help with that.

Would also like to know if I should typealias `msg?: string | ((first: typeof actual, second: typeof expected) => string)` or leave it as is.

Will also be commiting a docs change that mentions this later today/tommrow, but wanted feedback on the actual implementation before i did that.