### PR TITLE
fix: `setCookie` with `maxAge` of `0`

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -57,7 +57,10 @@ function toString(cookie: Cookie): string {
     out.push("HttpOnly");
   }
   if (typeof cookie.maxAge === "number" && Number.isInteger(cookie.maxAge)) {
-    assert(cookie.maxAge >= 0, "Max-Age must be an integer superior or equal to 0");
+    assert(
+      cookie.maxAge >= 0,
+      "Max-Age must be an integer superior or equal to 0",
+    );
     out.push(`Max-Age=${cookie.maxAge}`);
   }
   if (cookie.domain) {

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -11,7 +11,7 @@ export interface Cookie {
   value: string;
   /** Expiration date of the cookie. */
   expires?: Date;
-  /** Max-Age of the Cookie. Must be integer superior to 0. */
+  /** Max-Age of the Cookie. Must be a non-negative integer. */
   maxAge?: number;
   /** Specifies those hosts to which the cookie will be sent. */
   domain?: string;
@@ -57,7 +57,7 @@ function toString(cookie: Cookie): string {
     out.push("HttpOnly");
   }
   if (typeof cookie.maxAge === "number" && Number.isInteger(cookie.maxAge)) {
-    assert(cookie.maxAge > 0, "Max-Age must be an integer superior to 0");
+    assert(cookie.maxAge >= 0, "Max-Age must be a non-negative integer");
     out.push(`Max-Age=${cookie.maxAge}`);
   }
   if (cookie.domain) {

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -11,7 +11,7 @@ export interface Cookie {
   value: string;
   /** Expiration date of the cookie. */
   expires?: Date;
-  /** Max-Age of the Cookie. Must be a non-negative integer. */
+  /** Max-Age of the Cookie. Max-Age must be an integer superior or equal to 0. */
   maxAge?: number;
   /** Specifies those hosts to which the cookie will be sent. */
   domain?: string;
@@ -57,7 +57,7 @@ function toString(cookie: Cookie): string {
     out.push("HttpOnly");
   }
   if (typeof cookie.maxAge === "number" && Number.isInteger(cookie.maxAge)) {
-    assert(cookie.maxAge >= 0, "Max-Age must be a non-negative integer");
+    assert(cookie.maxAge >= 0, "Max-Age must be an integer superior or equal to 0");
     out.push(`Max-Age=${cookie.maxAge}`);
   }
   if (cookie.domain) {

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -186,6 +186,21 @@ Deno.test({
       maxAge: 0,
     });
 
+    let error = false;
+    res.headers = new Headers();
+    try {
+      setCookie(res, {
+        name: "Space",
+        value: "Cat",
+        httpOnly: true,
+        secure: true,
+        maxAge: -1,
+      });
+    } catch {
+      error = true;
+    }
+    assert(error);
+
     res.headers = new Headers();
     setCookie(res, {
       name: "Space",

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -185,6 +185,10 @@ Deno.test({
       secure: true,
       maxAge: 0,
     });
+    assertEquals(
+      res.headers.get("Set-Cookie"),
+      "Space=Cat; Secure; HttpOnly; Max-Age=0",
+    );
 
     let error = false;
     res.headers = new Headers();

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -177,20 +177,14 @@ Deno.test({
       "Space=Cat; Secure; HttpOnly; Max-Age=2",
     );
 
-    let error = false;
     res.headers = new Headers();
-    try {
-      setCookie(res, {
-        name: "Space",
-        value: "Cat",
-        httpOnly: true,
-        secure: true,
-        maxAge: 0,
-      });
-    } catch {
-      error = true;
-    }
-    assert(error);
+    setCookie(res, {
+      name: "Space",
+      value: "Cat",
+      httpOnly: true,
+      secure: true,
+      maxAge: 0,
+    });
 
     res.headers = new Headers();
     setCookie(res, {


### PR DESCRIPTION
This PR changes the `toString` function for `Cookie` in order for `setCookie` to allow for `maxAge` with a value of `0`. This fixes #989