### PR TITLE
fix: Improve type safety for browser-compatible modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         run: deno test --unstable --allow-all
 
+      - name: Type check browser compatible modules
+        run: grep -Rl --exclude-dir=./.github "// This module is browser compatible." . | xargs deno cache --config browser-compat.tsconfig.json
+
       - name: Generate lcov
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Run tests
         run: deno test --unstable --allow-all
 
-      - name: Type check browser compatible modules
-        run: grep -Rl "// This module is browser compatible." . | xargs deno cache --config browser-compat.tsconfig.json
-
       - name: Generate lcov
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Run tests
         run: deno test --unstable --allow-all
 
+      - name: Type check browser compatible modules
+        shell: bash
+        run: |
+          git grep --name-only "// This module is browser compatible." | grep -v ".github/workflows" | xargs deno cache --config browser-compat.tsconfig.json
+
       - name: Generate lcov
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Run tests
         run: deno test --unstable --allow-all
 
-      - name: Type check browser compatible modules
-        run: grep -Rl --exclude-dir=./.github "// This module is browser compatible." . | xargs deno cache --config browser-compat.tsconfig.json
-
       - name: Generate lcov
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         run: deno test --unstable --allow-all
 
+      - name: Type check browser compatible modules
+        run: grep -Rl "// This module is browser compatible." . | xargs deno cache --config browser-compat.tsconfig.json
+
       - name: Generate lcov
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 

--- a/_util/os.ts
+++ b/_util/os.ts
@@ -2,12 +2,14 @@
 // This module is browser compatible.
 
 export const osType = (() => {
-  if (globalThis.Deno != null) {
+  // deno-lint-ignore no-explicit-any
+  const { Deno } = globalThis as any;
+  if (typeof Deno?.build?.os === "string") {
     return Deno.build.os;
   }
 
   // deno-lint-ignore no-explicit-any
-  const navigator = (globalThis as any).navigator;
+  const { navigator } = globalThis as any;
   if (navigator?.appVersion?.includes?.("Win") ?? false) {
     return "windows";
   }

--- a/browser-compat.tsconfig.json
+++ b/browser-compat.tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ]
+  }
+}

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -12,7 +12,11 @@
 //
 // This module is browser compatible.
 
-const noColor = globalThis.Deno?.noColor ?? true;
+// deno-lint-ignore no-explicit-any
+const { Deno } = globalThis as any;
+const noColor = typeof Deno?.noColor === "boolean"
+  ? Deno.noColor as boolean
+  : true;
 
 interface Code {
   open: string;

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -21,7 +21,7 @@ export interface GlobOptions {
   /** Whether globstar should be case insensitive. */
   caseInsensitive?: boolean;
   /** Operating system. Defaults to the native OS. */
-  os?: typeof Deno.build.os;
+  os?: "darwin" | "linux" | "windows";
 }
 
 export type GlobToRegExpOptions = GlobOptions;

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -30,7 +30,9 @@ export function resolve(...pathSegments: string[]): string {
 
     if (i >= 0) path = pathSegments[i];
     else {
-      if (globalThis.Deno == null) {
+      // deno-lint-ignore no-explicit-any
+      const { Deno } = globalThis as any;
+      if (typeof Deno?.cwd !== "function") {
         throw new TypeError("Resolved a relative path without a CWD.");
       }
       path = Deno.cwd();

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -34,15 +34,19 @@ export function resolve(...pathSegments: string[]): string {
 
   for (let i = pathSegments.length - 1; i >= -1; i--) {
     let path: string;
+    // deno-lint-ignore no-explicit-any
+    const { Deno } = globalThis as any;
     if (i >= 0) {
       path = pathSegments[i];
     } else if (!resolvedDevice) {
-      if (globalThis.Deno == null) {
+      if (typeof Deno?.cwd !== "function") {
         throw new TypeError("Resolved a drive-letter-less path without a CWD.");
       }
       path = Deno.cwd();
     } else {
-      if (globalThis.Deno == null) {
+      if (
+        typeof Deno?.env?.get !== "function" || typeof Deno?.cwd !== "function"
+      ) {
         throw new TypeError("Resolved a relative path without a CWD.");
       }
       // Windows has the concept of drive-specific current working

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -34,7 +34,9 @@ export class AssertionError extends Error {
  * @param v Value to be formatted
  */
 export function _format(v: unknown): string {
-  return globalThis.Deno
+  // deno-lint-ignore no-explicit-any
+  const { Deno } = globalThis as any;
+  return typeof Deno?.inspect === "function"
     ? Deno.inspect(v, {
       depth: Infinity,
       sorted: true,


### PR DESCRIPTION
This PR fixes the current compiler errors emitted when using browser-compatible TypeScript modules without including the Deno namespace library in `compilerOptions.lib`.

---

There is a link to [contributing guidelines](https://github.com/denoland/deno/blob/de6e44794b7a95b6895a9aab907e01788820d18c/docs/contributing/style_guide.md#document-and-maintain-browser-compatibility) toward the end of the [Deno repo README](https://github.com/denoland/deno/tree/de6e44794b7a95b6895a9aab907e01788820d18c#contributing), which includes this:

> #### Document and maintain browser compatibility.
> 
> If a module is browser compatible, include the following in the JSDoc at the top of the module:
> 
> ```ts
> // This module is browser compatible.
> ```
> 
> Maintain browser compatibility for such a module by either not using the global `Deno` namespace or feature-testing for it. Make sure any new dependencies are also browser compatible.

This statement is not explicit about type compatibility, but I think it is natural for the type safety of browser-compatible modules to be aligned in the same way.

I searched for all files including the mentioned text using this method:
```
# cd to repo directory
grep -Rl "This module is browser compatible." .
```

For each file, I checked the diagnostic output of the compiler for warnings/errors using a browser-compatible TSConfig with Deno. ([The TSConfig is presently included in the PR](https://github.com/denoland/deno_std/blob/5d06b505e0535211a4d01f650ef5674ce271b2a0/browser-compat.tsconfig.json), but can be removed if desired.) If diagnostic messages were emitted for a file, I addressed them in the source. Most of the changes involve modifications to conditional expressions used to determine whether or not a Deno method or property exists.