### PR TITLE
fix(hash): Partially mitigate WASM memory leak #786 using FinalizationRegistry

### DIFF
--- a/hash/_wasm/hash.ts
+++ b/hash/_wasm/hash.ts
@@ -17,12 +17,19 @@ await init(source);
 const TYPE_ERROR_MSG = "hash: `data` is invalid type";
 
 export class Hash implements Hasher {
+  static #finalizationRegistry = new FinalizationRegistry(
+    (wasmHash: DenoHash) => {
+      wasmHash.free();
+    },
+  );
+
   #hash: DenoHash;
   #digested: boolean;
 
   constructor(algorithm: string) {
     this.#hash = createHash(algorithm);
     this.#digested = false;
+    Hash.#finalizationRegistry.register(this, this.#hash);
   }
 
   /**

--- a/hash/_wasm/hash.ts
+++ b/hash/_wasm/hash.ts
@@ -16,20 +16,20 @@ await init(source);
 
 const TYPE_ERROR_MSG = "hash: `data` is invalid type";
 
-export class Hash implements Hasher {
-  static #finalizationRegistry = new FinalizationRegistry(
-    (wasmHash: DenoHash) => {
-      wasmHash.free();
-    },
-  );
+const finalizationRegistry = new FinalizationRegistry(
+  (wasmHash: DenoHash) => {
+    wasmHash.free();
+  },
+);
 
+export class Hash implements Hasher {
   #hash: DenoHash;
   #digested: boolean;
 
   constructor(algorithm: string) {
     this.#hash = createHash(algorithm);
     this.#digested = false;
-    Hash.#finalizationRegistry.register(this, this.#hash);
+    finalizationRegistry.register(this, this.#hash);
   }
 
   /**


### PR DESCRIPTION
As described in #786, the `createHash` function currently leaks memory every time it's used: the Hasher instance allocated in the WASM heap is never freed.

This change uses `FinalizationRegistry` (which is working correctly on deno@main as of today 🎉) to .free() the Hasher instances in WASM when their corresponding `Hash` JavaScript objects are garbage collected. This does **not** entirely resolve the memory leak: the WASM heap will never shrink and release the used memory, but it can significantly mitigate it. In a test on my machine, endlessly calling `createHash('sha256')`, the WASM heap grew more slowly, and stopped growing around ~70MB, as the allocator inside the WASM was able to reuse the heap space we freed. Without this change, the memory use continued to grow without bound; I stopped it after 1GB.

This won't be effective in all cases: The garbage collector may not get a chance to run if you're repeatedly creating hashes in a hot sync loop. If you're passing huge chunks of data into WASM, the heap will still need to be expanded to hold them ([discussed in Discord](https://discord.com/channels/684898665143206084/775393009981849600/860494502475988992)). But I think it's still a significant improvement.

It appears that `wasm-bindgen` does have an option that would allow it to do this automatically internally, but [it hasn't been exposed through `wasm-pack` that we're using here, and it's not clear that it will be soon](https://github.com/rustwasm/wasm-pack/issues/930).

---

Test script:

```typescript
#!/usr/bin/env -S deno run --unstable --allow-all
import { createHash } from "./mod.ts";
import { Hash, _wasm } from "./_wasm/hash.ts";


for (let i = 0; i < 1_000_000_000; i++) {
    createHash("sha512");

    if (i % 10_000 === 0) {
      // Yield thread, making it more likely for the GC to run.
      await new Promise((resolve) => setTimeout(resolve, 1));
    }

    if (i % 100_000 === 0) {
      console.log(`
        ${i} hashes created
        ${_wasm.memory.buffer.byteLength} bytes used by WASM`)
    }
  }
```

with

```typescript
export const _wasm = await init(source);
```

added in `hash.ts` to let us check the memory use.