### PR TITLE
fix(encoding/toml): serializes mixed array

### DIFF
--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -559,7 +559,7 @@ class Dumper {
   maxPad = 0;
   srcObject: Record<string, unknown>;
   output: string[] = [];
-  _arrayTypeCache = new Map<unknown[], ArrayType>();
+  #arrayTypeCache = new Map<unknown[], ArrayType>();
   constructor(srcObjc: Record<string, unknown>) {
     this.srcObject = srcObjc;
   }
@@ -630,11 +630,11 @@ class Dumper {
       ["string", "number", "boolean"].includes(typeof value);
   }
   _getTypeOfArray(arr: unknown[]): ArrayType {
-    if (this._arrayTypeCache.has(arr)) {
-      return this._arrayTypeCache.get(arr)!;
+    if (this.#arrayTypeCache.has(arr)) {
+      return this.#arrayTypeCache.get(arr)!;
     }
     const type = this._doGetTypeOfArray(arr);
-    this._arrayTypeCache.set(arr, type);
+    this.#arrayTypeCache.set(arr, type);
     return type;
   }
   _doGetTypeOfArray(arr: unknown[]): ArrayType {

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -475,7 +475,7 @@ class Parser {
           !this.context.currentGroup ||
           (this.context.currentGroup &&
             this.context.currentGroup.name !==
-            line.replace(/(\[|\])/g, ""))
+              line.replace(/(\[|\])/g, ""))
         ) {
           this._createGroup(line);
           continue;
@@ -603,7 +603,7 @@ class Dumper {
         const arrayType = this._getTypeOfArray(value);
         if (arrayType === ArrayType.ONLY_PRIMITIVE) {
           out.push(this._arrayDeclaration([prop], value));
-        } else if(arrayType === ArrayType.ONLY_OBJECT_EXCLUDING_ARRAY) {
+        } else if (arrayType === ArrayType.ONLY_OBJECT_EXCLUDING_ARRAY) {
           // array of objects
           for (let i = 0; i < value.length; i++) {
             out.push("");
@@ -612,10 +612,9 @@ class Dumper {
           }
         } else {
           // this is a complex array, use the inline format.
-          const str = value.map(x => this._printAsInlineValue(x)).join(',')
-          out.push(`${prop} = [${str}]`)
+          const str = value.map((x) => this._printAsInlineValue(x)).join(",");
+          out.push(`${prop} = [${str}]`);
         }
-
       } else if (typeof value === "object") {
         out.push("");
         out.push(this._header([...keys, prop]));
@@ -632,12 +631,12 @@ class Dumper {
   _isPrimitive(value: unknown): boolean {
     return value instanceof Date ||
       value instanceof RegExp ||
-      ["string", "number", "boolean"].includes(typeof value)
+      ["string", "number", "boolean"].includes(typeof value);
   }
   _getTypeOfArray(arr: unknown[]): ArrayType {
     if (!arr.length) {
       // any type should be fine
-      return ArrayType.ONLY_PRIMITIVE
+      return ArrayType.ONLY_PRIMITIVE;
     }
 
     const onlyPrimitive = this._isPrimitive(arr[0]);
@@ -645,11 +644,15 @@ class Dumper {
       return ArrayType.MIXED;
     }
     for (let i = 1; i < arr.length; i++) {
-      if (onlyPrimitive !== this._isPrimitive(arr[i]) || arr[i] instanceof Array) {
-        return ArrayType.MIXED
+      if (
+        onlyPrimitive !== this._isPrimitive(arr[i]) || arr[i] instanceof Array
+      ) {
+        return ArrayType.MIXED;
       }
     }
-    return onlyPrimitive ? ArrayType.ONLY_PRIMITIVE : ArrayType.ONLY_OBJECT_EXCLUDING_ARRAY;
+    return onlyPrimitive
+      ? ArrayType.ONLY_PRIMITIVE
+      : ArrayType.ONLY_OBJECT_EXCLUDING_ARRAY;
   }
   _printAsInlineValue(value: unknown): string | number {
     if (value instanceof Date) {
@@ -663,20 +666,20 @@ class Dumper {
     } else if (
       value instanceof Array
     ) {
-      const str = value.map(x => this._printAsInlineValue(x)).join(",")
-      return `[${str}]`
+      const str = value.map((x) => this._printAsInlineValue(x)).join(",");
+      return `[${str}]`;
     } else if (typeof value === "object") {
       if (!value) {
-        throw new Error("should never reach")
+        throw new Error("should never reach");
       }
-      const str = Object.keys(value).map(key => {
+      const str = Object.keys(value).map((key) => {
         // deno-lint-ignore no-explicit-any
-        return `${key} = ${this._printAsInlineValue((value as any)[key])}`
-      }).join(",")
-      return `{${str}}`
+        return `${key} = ${this._printAsInlineValue((value as any)[key])}`;
+      }).join(",");
+      return `{${str}}`;
     }
 
-    throw new Error("should never reach")
+    throw new Error("should never reach");
   }
   _isSimplySerializable(value: unknown): boolean {
     return (

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -428,20 +428,24 @@ Deno.test({
   name: "[TOML] Mixed Array",
   fn(): void {
     const src = {
+      emptyArray: [],
       mixedArray1: [1, { b: 2 }],
       mixedArray2: [{ b: 2 }, 1],
       nestedArray1: [[{ b: 1 }]],
       nestedArray2: [[[{ b: 1 }]]],
+      nestedArray3: [[], [{ b: 1 }]],
       deepNested: {
         a: {
           b: [1, { c: 2, d: [{ e: 3 }, true] }],
         },
       },
     };
-    const expected = `mixedArray1 = [1,{b = 2}]
+    const expected = `emptyArray = []
+mixedArray1 = [1,{b = 2}]
 mixedArray2 = [{b = 2},1]
 nestedArray1 = [[{b = 1}]]
 nestedArray2 = [[[{b = 1}]]]
+nestedArray3 = [[],[{b = 1}]]
 
 [deepNested.a]
 b = [1,{c = 2,d = [{e = 3},true]}]

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -425,6 +425,32 @@ the     = "array"
 });
 
 Deno.test({
+  name: "[TOML] Mixed Array",
+  fn(): void {
+    const src = {
+      mixedArray1: [1, {b: 2}],
+      mixedArray2: [{b: 2}, 1],
+      nestedArray1: [[{b: 1}]],
+      nestedArray2: [[[{b: 1}]]],
+      deepNested: {
+        a: {
+          b: [1, { c: 2, d: [{ e: 3}, true] }]
+        }
+      }
+    };
+    const expected = `mixedArray1 = [1,{b = 2}]
+mixedArray2 = [{b = 2},1]
+nestedArray1 = [[{b = 1}]]
+nestedArray2 = [[[{b = 1}]]]
+[deepNested.a]
+b = [1,{c = 2,d = [{e = 3},true]}]
+`;
+    const actual = stringify(src);
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
   name: "[TOML] Comments",
   fn: () => {
     const expected = {

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -428,15 +428,15 @@ Deno.test({
   name: "[TOML] Mixed Array",
   fn(): void {
     const src = {
-      mixedArray1: [1, {b: 2}],
-      mixedArray2: [{b: 2}, 1],
-      nestedArray1: [[{b: 1}]],
-      nestedArray2: [[[{b: 1}]]],
+      mixedArray1: [1, { b: 2 }],
+      mixedArray2: [{ b: 2 }, 1],
+      nestedArray1: [[{ b: 1 }]],
+      nestedArray2: [[[{ b: 1 }]]],
       deepNested: {
         a: {
-          b: [1, { c: 2, d: [{ e: 3}, true] }]
-        }
-      }
+          b: [1, { c: 2, d: [{ e: 3 }, true] }],
+        },
+      },
     };
     const expected = `mixedArray1 = [1,{b = 2}]
 mixedArray2 = [{b = 2},1]

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -442,6 +442,7 @@ Deno.test({
 mixedArray2 = [{b = 2},1]
 nestedArray1 = [[{b = 1}]]
 nestedArray2 = [[[{b = 1}]]]
+
 [deepNested.a]
 b = [1,{c = 2,d = [{e = 3},true]}]
 `;


### PR DESCRIPTION
fixes #983

Previously, arrays are assumed to be homogenous, but that is not the case (or it is changed recently?).

>arrays can contain values of the same data types as allowed in key/value pairs. Values of different types may be mixed.

https://github.com/toml-lang/toml/blob/master/toml.md#user-content-array