### PR TITLE
feat(async): add debounce method to async module

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -6,6 +6,21 @@ async is a module to provide help with asynchronous tasks.
 
 The following functions and class are exposed in `mod.ts`:
 
+## debounce
+
+Debounces a given function by a given time.
+
+```typescript
+import { debounce } from "https://deno.land/std/async/mod.ts";
+
+const p = debounce((value: string) => console.log("Function debounced after 200ms with %s", value), 200);
+p("foo");
+p("bar");
+p("baz");
+// wait 200ms ...
+// output: Function debounced after 200ms with baz
+```
+
 ## deferred
 
 Create a Promise with the `reject` and `resolve` functions.

--- a/async/README.md
+++ b/async/README.md
@@ -13,7 +13,11 @@ Debounces a given function by a given time.
 ```typescript
 import { debounce } from "https://deno.land/std/async/mod.ts";
 
-const p = debounce((value: string) => console.log("Function debounced after 200ms with %s", value), 200);
+const p = debounce(
+  (value: string) =>
+    console.log("Function debounced after 200ms with %s", value),
+  200,
+);
 p("foo");
 p("bar");
 p("baz");

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -41,7 +41,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
 // deno-lint-ignore no-explicit-any
 export function debounce<T extends Array<any>>(
   fn: (this: DebouncedFunction<T>, ...args: T) => void,
-  wait = 100,
+  wait: number,
 ): DebouncedFunction<T> {
   let timeout: number | null = null;
   let flush: (() => void) | null = null;

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -1,0 +1,61 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+export interface Debounce<T extends Array<unknown>> {
+  (...args: T): void;
+  clear(): void;
+  flush(): void;
+  readonly pending: boolean;
+}
+
+/**
+ * Creates a debounced function that delays the given func
+ * by a given wait time in miliseconds. If the method is called
+ * again before the timeout expires, the previous call will be
+ * aborted.
+ *
+ * @param func The function to debounce.
+ * @param wait The time in miliseconds to delay the function.
+ */
+// deno-lint-ignore no-explicit-any
+export function debounce<T extends Array<any>>(
+  func: (this: Debounce<T>, ...args: T) => void,
+  wait = 100,
+): Debounce<T> {
+  let timeout: number | null = null;
+  let debounced: null | (() => void) = null;
+
+  const debounce: Debounce<T> = ((...args: T): void => {
+    debounce.clear();
+    debounced = (): void => {
+      reset();
+      func.call(debounce, ...args);
+    };
+    timeout = setTimeout(debounced, wait);
+  }) as Debounce<T>;
+
+  debounce.clear = (): void => {
+    if (typeof timeout === "number") {
+      clearTimeout(timeout);
+      reset();
+    }
+  };
+
+  debounce.flush = (): void => {
+    if (debounced) {
+      const debouncedFn = debounced;
+      debounce.clear();
+      debouncedFn();
+    }
+  };
+
+  Object.defineProperty(debounce, "pending", {
+    get: () => typeof timeout === "number",
+  });
+
+  function reset() {
+    timeout = null;
+    debounced = null;
+  }
+
+  return debounce;
+}

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -1,20 +1,42 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+/**
+ * A debounced function that will be delayed by a given `wait`
+ * time in milliseconds. If the method is called again before
+ * the timeout expires, the previous call will be aborted.
+ */
 export interface Debounce<T extends Array<unknown>> {
   (...args: T): void;
+  /** Clears the debounce timeout and omits calling the debounced function. */
   clear(): void;
+  /** Clears the debounce timeout and calls the debounced function immediately. */
   flush(): void;
+  /** Returns a boolean wether a debounce call is pending or not. */
   readonly pending: boolean;
 }
 
 /**
- * Creates a debounced function that delays the given func
- * by a given wait time in miliseconds. If the method is called
+ * Creates a debounced function that delays the given `func`
+ * by a given `wait` time in milliseconds. If the method is called
  * again before the timeout expires, the previous call will be
  * aborted.
  *
+ * ```
+ * import { debounce } from "https://deno.land/std/async/mod.ts";
+ *
+ * const log = debounce(
+ *   (event: Deno.FsEvent) =>
+ *     console.log("[%s] %s", event.kind, event.paths[0]),
+ *   200,
+ * );
+ *
+ * for await (const event of Deno.watchFs("./")) {
+ *   log(event);
+ * }
+ * ```
+ *
  * @param func The function to debounce.
- * @param wait The time in miliseconds to delay the function.
+ * @param wait The time in milliseconds to delay the function.
  */
 // deno-lint-ignore no-explicit-any
 export function debounce<T extends Array<any>>(
@@ -22,7 +44,7 @@ export function debounce<T extends Array<any>>(
   wait = 100,
 ): Debounce<T> {
   let timeout: number | null = null;
-  let debounced: null | (() => void) = null;
+  let debounced: (() => void) | null = null;
 
   const debounce: Debounce<T> = ((...args: T): void => {
     debounce.clear();

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -49,7 +49,7 @@ export function debounce<T extends Array<any>>(
   const debounce: Debounce<T> = ((...args: T): void => {
     debounce.clear();
     debounced = (): void => {
-      reset();
+      debounce.clear();
       func.call(debounce, ...args);
     };
     timeout = setTimeout(debounced, wait);
@@ -58,26 +58,18 @@ export function debounce<T extends Array<any>>(
   debounce.clear = (): void => {
     if (typeof timeout === "number") {
       clearTimeout(timeout);
-      reset();
+      timeout = null;
+      debounced = null;
     }
   };
 
   debounce.flush = (): void => {
-    if (debounced) {
-      const debouncedFn = debounced;
-      debounce.clear();
-      debouncedFn();
-    }
+    debounced?.();
   };
 
   Object.defineProperty(debounce, "pending", {
     get: () => typeof timeout === "number",
   });
-
-  function reset() {
-    timeout = null;
-    debounced = null;
-  }
 
   return debounce;
 }

--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertStrictEquals } from "../testing/asserts.ts";
+import { debounce, DebouncedFunction } from "./debounce.ts";
 import { delay } from "./delay.ts";
 
 Deno.test("[async] debounce: called", async function () {
@@ -64,7 +65,8 @@ Deno.test("[async] debounce: with params & context", async function () {
 
 Deno.test("[async] debounce: with types", async function () {
   const params: Array<string> = [];
-  const d: Debounce<[string]> = debounce((param: string) => params.push(param));
+  const fn = (param: string) => params.push(param);
+  const d: DebouncedFunction<[string]> = debounce(fn);
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
   d(1);
   d("foo");

--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -5,7 +5,7 @@ import { delay } from "./delay.ts";
 
 Deno.test("[async] debounce: called", async function () {
   let called = 0;
-  const d = debounce(() => called++);
+  const d = debounce(() => called++, 100);
   d();
   d();
   d();
@@ -18,7 +18,7 @@ Deno.test("[async] debounce: called", async function () {
 
 Deno.test("[async] debounce: canceld", async function () {
   let called = 0;
-  const d = debounce(() => called++);
+  const d = debounce(() => called++, 100);
   d();
   d();
   d();
@@ -32,7 +32,7 @@ Deno.test("[async] debounce: canceld", async function () {
 
 Deno.test("[async] debounce: flushed", function () {
   let called = 0;
-  const d = debounce(() => called++);
+  const d = debounce(() => called++, 100);
   d();
   d();
   d();
@@ -66,7 +66,7 @@ Deno.test("[async] debounce: with params & context", async function () {
 Deno.test("[async] debounce: with types", async function () {
   const params: Array<string> = [];
   const fn = (param: string) => params.push(param);
-  const d: DebouncedFunction<[string]> = debounce(fn);
+  const d: DebouncedFunction<[string]> = debounce(fn, 100);
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
   d(1);
   d("foo");

--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "../testing/asserts.ts";
-import { Debounce, debounce } from "./debounce.ts";
+import { assertEquals, assertStrictEquals } from "../testing/asserts.ts";
 import { delay } from "./delay.ts";
 
 Deno.test("[async] debounce: called", async function () {
@@ -49,9 +48,7 @@ Deno.test("[async] debounce: with params & context", async function () {
     assertEquals(d.pending, false);
     params.push(param1);
     params.push(param2);
-    assertEquals(d, this);
-    assert(d.clear);
-    assert(d.flush);
+    assertStrictEquals(d, this);
   }, 100);
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
   d(1, 1);

--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -1,0 +1,79 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assert, assertEquals } from "../testing/asserts.ts";
+import { Debounce, debounce } from "./debounce.ts";
+import { delay } from "./delay.ts";
+
+Deno.test("[async] debounce: called", async function () {
+  let called = 0;
+  const d = debounce(() => called++);
+  d();
+  d();
+  d();
+  assertEquals(called, 0);
+  assertEquals(d.pending, true);
+  await delay(200);
+  assertEquals(called, 1);
+  assertEquals(d.pending, false);
+});
+
+Deno.test("[async] debounce: canceld", async function () {
+  let called = 0;
+  const d = debounce(() => called++);
+  d();
+  d();
+  d();
+  assertEquals(called, 0);
+  assertEquals(d.pending, true);
+  d.clear();
+  await delay(200);
+  assertEquals(called, 0);
+  assertEquals(d.pending, false);
+});
+
+Deno.test("[async] debounce: flushed", function () {
+  let called = 0;
+  const d = debounce(() => called++);
+  d();
+  d();
+  d();
+  assertEquals(called, 0);
+  assertEquals(d.pending, true);
+  d.flush();
+  assertEquals(called, 1);
+  assertEquals(d.pending, false);
+});
+
+Deno.test("[async] debounce: with params & context", async function () {
+  const params: Array<string | number> = [];
+  const d = debounce(function (param1: string, param2: number) {
+    assertEquals(d.pending, false);
+    params.push(param1);
+    params.push(param2);
+    assertEquals(d, this);
+    assert(d.clear);
+    assert(d.flush);
+  }, 100);
+  // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
+  d(1, 1);
+  d("foo", 1);
+  d("bar", 1);
+  d("baz", 1);
+  assertEquals(params.length, 0);
+  assertEquals(d.pending, true);
+  await delay(200);
+  assertEquals(params, ["baz", 1]);
+  assertEquals(d.pending, false);
+});
+
+Deno.test("[async] debounce: with types", async function () {
+  const params: Array<string> = [];
+  const d: Debounce<[string]> = debounce((param: string) => params.push(param));
+  // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
+  d(1);
+  d("foo");
+  assertEquals(params.length, 0);
+  assertEquals(d.pending, true);
+  await delay(200);
+  assertEquals(params, ["foo"]);
+  assertEquals(d.pending, false);
+});

--- a/async/mod.ts
+++ b/async/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+export * from "./debounce.ts";
 export * from "./deferred.ts";
 export * from "./delay.ts";
 export * from "./mux_async_iterator.ts";


### PR DESCRIPTION
Resolves: #1008 

This is a proposal for adding a debounce function to the async module.

I always use this function together with the `Deno.watchFs` method and I have seen it in another project as well.
So i think this is a usefull function that could be added to the async module.

It is just a first version of how the module could look like. I'm open for any suggestions and changes.

Example:
```ts
import { debounce } from "https://deno.land/std/async/debounce.ts";

const log = debounce((param: string) => console.log(param), 200);

log("foo");
log("bar");
log("baz");
// wait 200ms ...
// output: baz
```