### PR TITLE
feat(http): Add Cookie domain validation

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -64,6 +64,7 @@ function toString(cookie: Cookie): string {
     out.push(`Max-Age=${cookie.maxAge}`);
   }
   if (cookie.domain) {
+    validateDomain(cookie.domain);
     out.push(`Domain=${cookie.domain}`);
   }
   if (cookie.sameSite) {
@@ -115,7 +116,7 @@ function validatePath(path: string | null): void {
 }
 
 /**
- *Validate Cookie Value.
+ * Validate Cookie Value.
  * @see https://tools.ietf.org/html/rfc6265#section-4.1
  * @param value Cookie value.
  */
@@ -138,6 +139,24 @@ function validateValue(name: string, value: string | null): void {
           c.charCodeAt(0).toString(16),
       );
     }
+  }
+}
+
+/**
+ * Validate Cookie Domain.
+ * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3
+ * @param domain Cookie domain.
+ */
+function validateDomain(domain: string): void {
+  if (domain == null) {
+    return;
+  }
+  const char1 = domain.charAt(0);
+  const charN = domain.charAt(domain.length - 1);
+  if (char1 == "-" || charN == "." || charN == "-") {
+    throw new Error(
+      "Invalid first/last char in cookie domain: " + domain,
+    );
   }
 }
 

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -144,7 +144,7 @@ Deno.test({
         });
       },
       Error,
-      "Invalid first/last char in cookie domain: " + domain
+      "Invalid first/last char in cookie domain: " + domain,
     );
   },
 });

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -130,22 +130,24 @@ Deno.test({
   name: "Cookie Domain Validation",
   fn(): void {
     const res: Response = {};
-    const domain = "-sub.domain.com";
+    const tokens = ["-domain.com", "domain.org.", "domain.org-"];
     res.headers = new Headers();
-    assertThrows(
-      (): void => {
-        setCookie(res, {
-          name: "Space",
-          value: "Cat",
-          httpOnly: true,
-          secure: true,
-          domain,
-          maxAge: 3,
-        });
-      },
-      Error,
-      "Invalid first/last char in cookie domain: " + domain,
-    );
+    tokens.forEach((domain) => {
+      assertThrows(
+        (): void => {
+          setCookie(res, {
+            name: "Space",
+            value: "Cat",
+            httpOnly: true,
+            secure: true,
+            domain,
+            maxAge: 3,
+          });
+        },
+        Error,
+        "Invalid first/last char in cookie domain: " + domain,
+      );
+    });
   },
 });
 

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -127,6 +127,29 @@ Deno.test({
 });
 
 Deno.test({
+  name: "Cookie Domain Validation",
+  fn(): void {
+    const res: Response = {};
+    const domain = "-sub.domain.com";
+    res.headers = new Headers();
+    assertThrows(
+      (): void => {
+        setCookie(res, {
+          name: "Space",
+          value: "Cat",
+          httpOnly: true,
+          secure: true,
+          domain,
+          maxAge: 3,
+        });
+      },
+      Error,
+      "Invalid first/last char in cookie domain: " + domain
+    );
+  },
+});
+
+Deno.test({
   name: "Cookie Delete",
   fn(): void {
     const res: Response = {};


### PR DESCRIPTION
Cookie domain should not start with `-` and end with `.` or `-`.
https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3