### PR TITLE
fix(encoding/toml): comment line starting with whitespaces

### DIFF
--- a/encoding/testdata/comment.toml
+++ b/encoding/testdata/comment.toml
@@ -1,4 +1,5 @@
 # This is a full-line comment
+ # Comment line starting with whitespaces (#823 case 3) foo = "..."
 str0 = 'value' # This is a comment at the end of a line
 str1 = "# This is not a comment" # but this is
 str2 = """ # this is not a comment!

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -64,7 +64,7 @@ class Parser {
 
   _removeComments(): void {
     function isFullLineComment(line: string) {
-      return line.match(/^#/) ? true : false;
+      return line.match(/^[ \t]*#/) ? true : false;
     }
 
     function stringStart(line: string) {


### PR DESCRIPTION
Fix case 3b of https://github.com/denoland/deno_std/issues/823#issuecomment-814367934

As @danopia clearly showed an example, TOML Parser parses a comment line starting with whitespaces

```
 # comment = "..."
```

as a key-value:

```json
{
  "# comment": "..."
}
```

This PR fixes it.