### PR TITLE
fix(testing/_diff) Don't merge diff when a token that is surrounded by word-diffs isn't a space

### DIFF
--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -287,7 +287,7 @@ export function diffstr(A: string, B: string) {
     ).map((result, i, t) => {
       if (
         (result.type === DiffType.common) && (t[i - 1]) &&
-        (t[i - 1]?.type === t[i + 1]?.type)
+        (t[i - 1]?.type === t[i + 1]?.type) && /\s+/.test(result.value)
       ) {
         result.type = t[i - 1].type;
       }

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -147,3 +147,84 @@ Deno.test({
     ]);
   },
 });
+
+Deno.test({
+  name: `"3.14" vs "2.71" (diffstr)`,
+  fn(): void {
+    const diffResult = diffstr("3.14", "2.71");
+    assertEquals(diffResult, [
+      {
+        type: "removed",
+        value: "3.14\n",
+        details: [
+          {
+            type: "removed",
+            value: "3",
+          },
+          {
+            type: "common",
+            value: ".",
+          },
+          {
+            type: "removed",
+            value: "14",
+          },
+          {
+            type: "common",
+            value: "\n",
+          },
+        ],
+      },
+      {
+        type: "added",
+        value: "2.71\n",
+        details: [
+          {
+            type: "added",
+            value: "2",
+          },
+          {
+            type: "common",
+            value: ".",
+          },
+          {
+            type: "added",
+            value: "71",
+          },
+          {
+            type: "common",
+            value: "\n",
+          },
+        ],
+      },
+    ]);
+  },
+});
+
+Deno.test({
+  name: `single line "a b" vs "c d" (diffstr)`,
+  fn(): void {
+    const diffResult = diffstr("a b", "c d");
+    assertEquals(diffResult, [
+      {
+        type: "removed",
+        value: "a b\n",
+        details: [
+          { type: "removed", value: "a" },
+          { type: "removed", value: " " },
+          { type: "removed", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "added",
+        value: "c d\n",
+        details: [
+          { type: "added", value: "c" },
+          { type: "added", value: "d" },
+          { type: "common", value: "\n" },
+        ],
+      },
+    ]);
+  },
+});


### PR DESCRIPTION
Thanks to #948 by @lowlighter's great contribution, strings diff of assertion is now very readable.

But I found some edge case that strings diff displays like unwelcome.

It's a feature of merging word diffs if a in-between token is a space. Actually word diffs are merged even when the in-between token is not a space.

For example, this is as expected. Fine.

<img width="358" alt="foo bar vs yoo yoo" src="https://user-images.githubusercontent.com/16313897/125459813-378f9887-b153-4860-9a48-54ab7c9d9d23.png">

However, this is not as expected.

<img width="341" alt="2 71 vs 3 14" src="https://user-images.githubusercontent.com/16313897/125459892-8c0ff456-cd35-444c-a708-7abc4605898a.png">

And this is also not as expected.

<img width="362" alt="It's vs Don't" src="https://user-images.githubusercontent.com/16313897/125459938-ad0329e5-dfe5-4bf3-babc-f4cec7ea4969.png">

That's the issue. So this PR fixes it not to merge if the in-between token is not a space.

After fixed, above 2 bad examples will be improved as below.

<img width="337" alt="2 71 vs 3 14 (expected)" src="https://user-images.githubusercontent.com/16313897/125460451-7c43e36c-d193-4394-b425-3347419aa054.png">
<img width="354" alt="It's vs Don't (expected)" src="https://user-images.githubusercontent.com/16313897/125460469-0bcd3dbc-396f-440d-9630-c1994b323661.png">
