### PR TITLE
fix: fix lint errors in deno 1.12

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -4,6 +4,7 @@ import { notImplemented } from "./_utils.ts";
 import EventEmitter from "./events.ts";
 import { fromFileUrl } from "../path/mod.ts";
 
+const customInspect = Symbol.for("Deno.customInspect");
 const notImplementedEvents = [
   "beforeExit",
   "disconnect",
@@ -52,10 +53,10 @@ export const cwd = Deno.cwd;
 //deno-lint-ignore ban-ts-comment
 //@ts-ignore
 const _env: {
-  [Deno.customInspect]: () => string;
+  [customInspect]: () => string;
 } = {};
 
-Object.defineProperty(_env, Deno.customInspect, {
+Object.defineProperty(_env, customInspect, {
   enumerable: false,
   configurable: true,
   get: function () {
@@ -69,8 +70,8 @@ Object.defineProperty(_env, Deno.customInspect, {
  * */
 export const env: Record<string, string> = new Proxy(_env, {
   get(target, prop) {
-    if (prop === Deno.customInspect) {
-      return target[Deno.customInspect];
+    if (prop === customInspect) {
+      return target[customInspect];
     }
     return Deno.env.get(String(prop));
   },

--- a/node/util.ts
+++ b/node/util.ts
@@ -22,7 +22,7 @@ const DEFAULT_INSPECT_OPTIONS = {
 };
 
 inspect.defaultOptions = DEFAULT_INSPECT_OPTIONS;
-inspect.custom = Deno.customInspect;
+inspect.custom = Symbol.for("Deno.customInspect");
 
 // TODO(schwarzkopfb): make it in-line with Node's implementation
 // Ref: https://nodejs.org/dist/latest-v14.x/docs/api/util.html#util_util_inspect_object_options


### PR DESCRIPTION
`Deno.customInspect` has been deprecated since Deno v1.12 https://github.com/denoland/deno/pull/10035 and the usage of it now causes lint errors. This PR fixes them.