### PR TITLE
docs: make collections examples executable

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -10,6 +10,9 @@ and `Set`.
 Splits the given array into chunks of the given size and returns them.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { chunked } from "https://deno.land/std/collections/chunked.ts";
+
 const words = [
   "lorem",
   "ipsum",
@@ -21,13 +24,11 @@ const words = [
 ];
 const chunks = chunked(words, 3);
 
-console.assert(
-  chunks === [
-    ["lorem", "ipsum", "dolor"],
-    ["sit", "amet", "consetetur"],
-    ["sadipscing"],
-  ],
-);
+assertEquals(chunks, [
+  ["lorem", "ipsum", "dolor"],
+  ["sit", "amet", "consetetur"],
+  ["sadipscing"],
+]);
 ```
 
 ## distinctBy
@@ -36,10 +37,13 @@ Returns all elements in the given array that produce a distinct value using the
 given selector, preserving order by first occurence.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { distinctBy } from "https://deno.land/std/collections/distinct_by.ts";
+
 const names = ["Anna", "Kim", "Arnold", "Kate"];
 const exampleNamesByFirstLetter = distinctBy(names, (it) => it.charAt(0));
 
-console.assert(exampleNamesByFirstLetter === ["Anna", "Kim"]);
+assertEquals(exampleNamesByFirstLetter, ["Anna", "Kim"]);
 ```
 
 ## distinct
@@ -48,10 +52,13 @@ Returns all distinct elements in the given array, preserving order by first
 occurence.
 
 ```ts
-const numbers = [3, 2, 5, 2, 5];
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { distinct } from "https://deno.land/std/collections/distinct.ts";
+
+const numbers = [3, 2, 5];
 const distinctNumbers = distinct(numbers);
 
-console.assert(distinctNumbers === [3, 2, 5]);
+assertEquals(distinctNumbers, [3, 2, 5]);
 ```
 
 ## filterEntries
@@ -60,6 +67,9 @@ Returns a new record with all entries of the given record except the ones that
 do not match the given predicate.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { filterEntries } from "https://deno.land/std/collections/filter_entries.ts";
+
 const menu = {
   "Salad": 11,
   "Soup": 8,
@@ -69,8 +79,9 @@ const myOptions = filterEntries(
   menu,
   ([item, price]) => item !== "Pasta" && price < 10,
 );
-console.assert(
-  myOptions === {
+assertEquals(
+  myOptions,
+  {
     "Soup": 8,
   },
 );
@@ -82,6 +93,9 @@ Returns a new record with all entries of the given record except the ones that
 have a key that does not match the given predicate.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { filterKeys } from "https://deno.land/std/collections/filter_keys.ts";
+
 const menu = {
   "Salad": 11,
   "Soup": 8,
@@ -89,8 +103,9 @@ const menu = {
 };
 const menuWithoutSalad = filterKeys(menu, (it) => it !== "Salad");
 
-console.assert(
-  menuWithoutSalad === {
+assertEquals(
+  menuWithoutSalad,
+  {
     "Soup": 8,
     "Pasta": 13,
   },
@@ -103,17 +118,21 @@ Returns a new record with all entries of the given record except the ones that
 have a value that does not match the given predicate.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { filterValues } from "https://deno.land/std/collections/filter_values.ts";
+
 const people = {
-  "Arnold": 37,
-  "Sarah": 7,
-  "Kim": 23,
+  "Arnold": { age: 37 },
+  "Sarah": { age: 7 },
+  "Kim": { age: 23 },
 };
 const adults = filterValues(people, (it) => it.age >= 18);
 
-console.assert(
-  adults === {
-    "Arnold": 37,
-    "Kim": 23,
+assertEquals(
+  adults,
+  {
+    "Arnold": { age: 37 },
+    "Kim": { age: 23 },
   },
 );
 ```
@@ -123,10 +142,13 @@ console.assert(
 Returns the last element in the given array matching the given predicate.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { findLast } from "https://deno.land/std/collections/find_last.ts";
+
 const numbers = [4, 2, 7];
 const lastEvenNumber = findLast(numbers, (it) => it % 2 === 0);
 
-console.assert(lastEvenNumber === 2);
+assertEquals(lastEvenNumber, 2);
 ```
 
 ## groupBy
@@ -136,6 +158,9 @@ Record containing the results as keys and all values that produced that key as
 values.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { groupBy } from "https://deno.land/std/collections/group_by.ts";
+
 const people = [
   { name: "Anna" },
   { name: "Arnold" },
@@ -143,8 +168,9 @@ const people = [
 ];
 const peopleByFirstLetter = groupBy(people, (it) => it.name.charAt(0));
 
-console.assert(
-  peopleByFirstLetter === {
+assertEquals(
+  peopleByFirstLetter,
+  {
     "A": [{ name: "Anna" }, { name: "Arnold" }],
     "K": [{ name: "Kim" }],
   },
@@ -157,11 +183,14 @@ Returns all distinct elements that appear at least once in each of the given
 arrays.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { intersect } from "https://deno.land/std/collections/intersect.ts";
+
 const lisaInterests = ["Cooking", "Music", "Hiking"];
 const kimInterests = ["Music", "Tennis", "Cooking"];
-const commonInterests = intersectTest(lisaInterests, kimInterests);
+const commonInterests = intersect(lisaInterests, kimInterests);
 
-console.assert(commonInterests === ["Cooking", "Music"]);
+assertEquals(commonInterests, ["Cooking", "Music"]);
 ```
 
 ## mapEntries
@@ -170,6 +199,9 @@ Applies the given transformer to all entries in the given record and returns a
 new record containing the results.
 
 ```typescript
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { mapEntries } from "https://deno.land/std/collections/map_entries.ts";
+
 const usersById = {
   "a2e": { name: "Kim", age: 22 },
   "dfe": { name: "Anna", age: 31 },
@@ -177,8 +209,9 @@ const usersById = {
 };
 const agesByNames = mapEntries(usersById, ([id, { name, age }]) => [name, age]);
 
-console.assert(
-  agesByNames === {
+assertEquals(
+  agesByNames,
+  {
     "Kim": 22,
     "Anna": 31,
     "Tim": 58,
@@ -195,10 +228,14 @@ If the transformed entries contain the same key multiple times, only the last
 one will appear in the returned record.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { mapKeys } from "https://deno.land/std/collections/map_keys.ts";
+
 const counts = { a: 5, b: 3, c: 8 };
 
-console.assert(
-  mapKeys(counts, (it) => it.toUppercase()) === {
+assertEquals(
+  mapKeys(counts, (it) => it.toUpperCase()),
+  {
     A: 5,
     B: 3,
     C: 8,
@@ -213,14 +250,18 @@ record containing the resulting keys associated to the last value that produced
 them.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { mapValues } from "https://deno.land/std/collections/map_values.ts";
+
 const usersById = {
   "a5ec": { name: "Mischa" },
   "de4f": { name: "Kim" },
 };
 const namesById = mapValues(usersById, (it) => it.name);
 
-console.assert(
-  namesById === {
+assertEquals(
+  namesById,
+  {
     "a5ec": "Mischa",
     "de4f": "Kim",
   },
@@ -234,11 +275,14 @@ given array that match the given predicate and the second one containing all
 that do not.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { partition } from "https://deno.land/std/collections/partition.ts";
+
 const numbers = [5, 6, 7, 8, 9];
 const [even, odd] = partition(numbers, (it) => it % 2 == 0);
 
-console.assert(even === [6, 8]);
-console.assert(odd === [5, 7, 9]);
+assertEquals(even, [6, 8]);
+assertEquals(odd, [5, 7, 9]);
 ```
 
 ## permutations
@@ -248,13 +292,77 @@ of elements, meaning this will always reutrn the same number of permutations for
 a given length of input.
 
 ```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { permutations } from "https://deno.land/std/collections/permutations.ts";
+
 const numbers = [1, 2];
 const windows = permutations(numbers);
 
-console.assert(
-  windows === [
+assertEquals(
+  windows,
+  [
     [1, 2],
     [2, 1],
+  ],
+);
+```
+
+## union
+
+Returns all distinct elements that appear in any of the given arrays.
+
+```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { union } from "https://deno.land/std/collections/union.ts";
+
+const soupIngredients = ["Pepper", "Carrots", "Leek"];
+const saladIngredients = ["Carrots", "Radicchio", "Pepper"];
+const shoppingList = union(soupIngredients, saladIngredients);
+
+assertEquals(shoppingList, ["Pepper", "Carrots", "Leek", "Radicchio"]);
+```
+
+## unzip
+
+Builds two separate arrays from the given array of 2-tuples, with the first
+returned array holding all first tuple elements and the second one holding all
+the second elements.
+
+```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { unzip } from "https://deno.land/std/collections/unzip.ts";
+
+const parents = [
+  ["Maria", "Jeff"],
+  ["Anna", "Kim"],
+  ["John", "Leroy"],
+];
+const [moms, dads] = unzip(parents);
+
+assertEquals(moms, ["Maria", "Anna", "John"]);
+assertEquals(dads, ["Jeff", "Kim", "Leroy"]);
+```
+
+## zip
+
+Builds 2-tuples of elements from the given array with matching indices, stopping
+when the smaller array's end is reached.
+
+```ts
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { zip } from "https://deno.land/std/collections/zip.ts";
+
+const numbers = [1, 2, 3, 4];
+const letters = ["a", "b", "c", "d"];
+const pairs = zip(numbers, letters);
+
+assertEquals(
+  pairs,
+  [
+    [1, "a"],
+    [2, "b"],
+    [3, "c"],
+    [4, "d"],
   ],
 );
 ```

--- a/collections/chunked.ts
+++ b/collections/chunked.ts
@@ -6,14 +6,25 @@
  * Example:
  *
  * ```typescript
- * const words = [ 'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consetetur', 'sadipscing' ]
- * const chunks = chunked(words, 3)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { chunked } from "https://deno.land/std/collections/chunked.ts";
  *
- * console.assert(chunks === [
- *     [ 'lorem', 'ipsum', 'dolor' ],
- *     [ 'sit', 'amet', 'consetetur' ],
- *     [ 'sadipscing' ],
- * ])
+ * const words = [
+ *   "lorem",
+ *   "ipsum",
+ *   "dolor",
+ *   "sit",
+ *   "amet",
+ *   "consetetur",
+ *   "sadipscing",
+ * ];
+ * const chunks = chunked(words, 3);
+ *
+ * assertEquals(chunks, [
+ *   ["lorem", "ipsum", "dolor"],
+ *   ["sit", "amet", "consetetur"],
+ *   ["sadipscing"],
+ * ]);
  * ```
  */
 export function chunked<T>(

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -6,10 +6,13 @@
  * Example:
  *
  * ```typescript
- * const numbers = [ 3, 2, 5, 2, 5 ]
- * const distinctNumbers = distinct(numbers)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { distinct } from "https://deno.land/std/collections/distinct.ts";
  *
- * console.assert(distinctNumbers === [ 3, 2, 5 ])
+ * const numbers = [3, 2, 5];
+ * const distinctNumbers = distinct(numbers);
+ *
+ * assertEquals(distinctNumbers, [3, 2, 5]);
  * ```
  */
 export function distinct<T>(array: Array<T>): Array<T> {

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -8,10 +8,13 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const names = [ 'Anna', 'Kim', 'Arnold', 'Kate' ]
- * const exampleNamesByFirstLetter = distinctBy(names, it => it.charAt(0))
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { distinctBy } from "https://deno.land/std/collections/distinct_by.ts";
  *
- * console.assert(exampleNamesByFirstLetter === [ 'Anna', 'Kim' ])
+ * const names = ["Anna", "Kim", "Arnold", "Kate"];
+ * const exampleNamesByFirstLetter = distinctBy(names, (it) => it.charAt(0));
+ *
+ * assertEquals(exampleNamesByFirstLetter, ["Anna", "Kim"]);
  * ```
  */
 export function distinctBy<T, D>(

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -8,18 +8,24 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const menu = {
- *     'Salad': 11,
- *     'Soup': 8,
- *     'Pasta': 13,
- * }
- * const myOptions = filterEntries(menu,
- *     ([ item, price ]) => item !== 'Pasta' && price < 10,
- * )
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { filterEntries } from "https://deno.land/std/collections/filter_entries.ts";
  *
- * console.assert(myOptions === {
- *     'Soup': 8,
- * })
+ * const menu = {
+ *   "Salad": 11,
+ *   "Soup": 8,
+ *   "Pasta": 13,
+ * };
+ * const myOptions = filterEntries(
+ *   menu,
+ *   ([item, price]) => item !== "Pasta" && price < 10,
+ * );
+ * assertEquals(
+ *   myOptions,
+ *   {
+ *     "Soup": 8,
+ *   },
+ * );
  * ```
  */
 export function filterEntries<T>(

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -8,17 +8,22 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const menu = {
- *     'Salad': 11,
- *     'Soup': 8,
- *     'Pasta': 13,
- * }
- * const menuWithoutSalad = filterKeys(menu, it => it !== 'Salad')
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { filterKeys } from "https://deno.land/std/collections/filter_keys.ts";
  *
- * console.assert(menuWithoutSalad === {
- *     'Soup': 8,
- *     'Pasta': 13,
- * })
+ * const menu = {
+ *   "Salad": 11,
+ *   "Soup": 8,
+ *   "Pasta": 13,
+ * };
+ * const menuWithoutSalad = filterKeys(menu, (it) => it !== "Salad");
+ *
+ * assertEquals(
+ *   menuWithoutSalad, {
+ *     "Soup": 8,
+ *     "Pasta": 13,
+ *   },
+ * );
  * ```
  */
 export function filterKeys<T>(

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -8,17 +8,23 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const people = {
- *     'Arnold': 37,
- *     'Sarah': 7,
- *     'Kim': 23,
- * }
- * const adults = filterValues(people, it => it.age >= 18)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { filterValues } from "https://deno.land/std/collections/filter_values.ts";
  *
- * console.assert(adults === {
- *     'Arnold': 37,
- *     'Kim': 23,
- * })
+ * const people = {
+ *   "Arnold": { age: 37 },
+ *   "Sarah": { age: 7 },
+ *   "Kim": { age: 23 },
+ * };
+ * const adults = filterValues(people, (it) => it.age >= 18);
+ *
+ * assertEquals(
+ *   adults,
+ *   {
+ *     "Arnold": { age: 37 },
+ *     "Kim": { age: 23 },
+ *   },
+ * );
  * ```
  */
 export function filterValues<T>(

--- a/collections/find_last.ts
+++ b/collections/find_last.ts
@@ -8,10 +8,13 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const numbers = [ 4, 2, 7 ]
- * const lastEvenNumber = findLast(numbers, it => it % 2 === 0)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { findLast } from "https://deno.land/std/collections/find_last.ts";
  *
- * console.assert(lastEvenNumber === 2)
+ * const numbers = [4, 2, 7];
+ * const lastEvenNumber = findLast(numbers, (it) => it % 2 === 0);
+ *
+ * assertEquals(lastEvenNumber, 2);
  * ```
  */
 export function findLast<T>(

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -9,17 +9,23 @@ import { Grouping, Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const people = [
- *     { name: 'Anna' },
- *     { name: 'Arnold' },
- *     { name: 'Kim' },
- * ]
- * const peopleByFirstLetter = groupBy(people, it => it.name.charAt(0))
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { groupBy } from "https://deno.land/std/collections/group_by.ts";
  *
- * console.assert(peopleByFirstLetter === {
- *     'A': [ { name: 'Anna' }, { name: 'Arnold' } ],
- *     'K': [ { name: 'Kim' } ],
- * })
+ * const people = [
+ *   { name: "Anna" },
+ *   { name: "Arnold" },
+ *   { name: "Kim" },
+ * ];
+ * const peopleByFirstLetter = groupBy(people, (it) => it.name.charAt(0));
+ *
+ * assertEquals(
+ *   peopleByFirstLetter,
+ *   {
+ *     "A": [{ name: "Anna" }, { name: "Arnold" }],
+ *     "K": [{ name: "Kim" }],
+ *   },
+ * );
  * ```
  */
 export function groupBy<T>(

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -8,11 +8,14 @@ import { filterInPlace } from "./_utils.ts";
  * Example:
  *
  * ```typescript
- * const lisaInterests = [ 'Cooking', 'Music', 'Hiking' ]
- * const kimInterests = [ 'Music', 'Tennis', 'Cooking' ]
- * const commonInterests = intersectTest(lisaInterests, kimInterests)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { intersect } from "https://deno.land/std/collections/intersect.ts";
  *
- * console.assert(commonInterests === [ 'Cooking', 'Music' ])
+ * const lisaInterests = ["Cooking", "Music", "Hiking"];
+ * const kimInterests = ["Music", "Tennis", "Cooking"];
+ * const commonInterests = intersect(lisaInterests, kimInterests);
+ *
+ * assertEquals(commonInterests, ["Cooking", "Music"]);
  * ```
  */
 export function intersect<T>(...arrays: Array<Array<T>>): Array<T> {

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -8,20 +8,23 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const usersById = {
- *     'a2e': { name: 'Kim', age: 22 },
- *     'dfe': { name: 'Anna', age: 31 },
- *     '34b': { name: 'Tim', age: 58 },
- * }
- * const agesByNames = mapEntries(usersById,
- *     ([ id, { name, age } ]) => [ name, age ],
- * )
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { mapEntries } from "https://deno.land/std/collections/map_entries.ts";
  *
- * console.assert(agesByNames === {
- *     'Kim': 22,
- *     'Anna': 31,
- *     'Tim': 58,
- * })
+ * const usersById = {
+ *   "a2e": { name: "Kim", age: 22 },
+ *   "dfe": { name: "Anna", age: 31 },
+ *   "34b": { name: "Tim", age: 58 },
+ * };
+ * const agesByNames = mapEntries(usersById, ([id, { name, age }]) => [name, age]);
+ *
+ * assertEquals(
+ *   agesByNames, {
+ *     "Kim": 22,
+ *     "Anna": 31,
+ *     "Tim": 58,
+ *   },
+ * );
  * ```
  */
 export function mapEntries<T, O>(

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -11,13 +11,19 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const counts = { a: 5, b: 3, c: 8 }
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { mapKeys } from "https://deno.land/std/collections/map_keys.ts";
  *
- * console.assert(mapKeys(counts, it => it.toUppercase()) === {
+ * const counts = { a: 5, b: 3, c: 8 };
+ *
+ * assertEquals(
+ *   mapKeys(counts, (it) => it.toUpperCase()),
+ *   {
  *     A: 5,
  *     B: 3,
  *     C: 8,
- * })
+ *   },
+ * );
  * ```
  */
 export function mapKeys<T>(

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -9,16 +9,21 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const usersById = {
- *     'a5ec': { name: 'Mischa' },
- *     'de4f': { name: 'Kim' },
- * }
- * const namesById = mapValues(usersById, it => it.name)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { mapValues } from "https://deno.land/std/collections/map_values.ts";
  *
- * console.assert(namesById === {
- *     'a5ec': 'Mischa',
- *     'de4f': 'Kim',
- * }
+ * const usersById = {
+ *   "a5ec": { name: "Mischa" },
+ *   "de4f": { name: "Kim" },
+ * };
+ * const namesById = mapValues(usersById, (it) => it.name);
+ *
+ * assertEquals(
+ *   namesById, {
+ *     "a5ec": "Mischa",
+ *     "de4f": "Kim",
+ *   },
+ * );
  * ```
  */
 export function mapValues<T, O>(

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -9,11 +9,14 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const numbers = [ 5, 6, 7, 8, 9 ]
- * const [ even, odd ] = partition(numbers, it => it % 2 == 0)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { partition } from "https://deno.land/std/collections/partition.ts";
  *
- * console.assert(even === [ 6, 8 ])
- * console.assert(odd === [ 5, 7, 9 ])
+ * const numbers = [5, 6, 7, 8, 9];
+ * const [even, odd] = partition(numbers, (it) => it % 2 == 0);
+ *
+ * assertEquals(even, [6, 8]);
+ * assertEquals(odd, [5, 7, 9]);
  * ```
  */
 export function partition<T>(

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -8,13 +8,19 @@
  * Example:
  *
  * ```typescript
- * const numbers = [ 1, 2 ]
- * const windows = permutations(numbers)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { permutations } from "https://deno.land/std/collections/permutations.ts";
  *
- * console.assert(windows === [
- *     [ 1, 2 ],
- *     [ 2, 1 ],
- * ])
+ * const numbers = [1, 2];
+ * const windows = permutations(numbers);
+ *
+ * assertEquals(
+ *   windows,
+ *   [
+ *     [1, 2],
+ *     [2, 1],
+ *   ],
+ * );
  * ```
  */
 export function permutations<T>(array: Array<T>): Array<Array<T>> {

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -7,15 +7,18 @@
  * Example:
  *
  * ```typescript
- * const parents = [
- *     [ 'Maria', 'Jeff' ],
- *     [ 'Anna', 'Kim' ],
- *     [ 'John', 'Leroy' ],
- * ]
- * const [ moms, dads ] = unzip(parents)
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { zip } from "https://deno.land/std/collections/unzip.ts";
  *
- * console.assert(moms === [ 'Maria', 'Anna', 'John' ])
- * console.assert(moms === [ 'Jeff', 'Kim', 'Leroy' ])
+ * const parents = [
+ *   ["Maria", "Jeff"],
+ *   ["Anna", "Kim"],
+ *   ["John", "Leroy"],
+ * ];
+ * const [moms, dads] = unzip(parents);
+ *
+ * assertEquals(moms, ["Maria", "Anna", "John"]);
+ * assertEquals(moms, ["Jeff", "Kim", "Leroy"]);
  * ```
  */
 export function unzip<T, U>(pairs: Array<[T, U]>): [Array<T>, Array<U>] {

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -6,16 +6,22 @@
  * Example:
  *
  * ```typescript
- * const numbers = [ 1, 2, 3, 4 ]
- * const letters = [ 'a', 'b', 'c', 'd' ]
- * const pairs = zip(numbers, letters)
- *
- * console.assert(pairs === [
- *     [ 1, 'a' ],
- *     [ 2, 'b' ],
- *     [ 3, 'c' ],
- *     [ 4, 'd' ],
- * ])
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { zip } from "https://deno.land/std/collections/zip.ts";
+ * 
+ * const numbers = [1, 2, 3, 4];
+ * const letters = ["a", "b", "c", "d"];
+ * const pairs = zip(numbers, letters);
+ * 
+ * assertEquals(
+ *   pairs,
+ *   [
+ *     [1, "a"],
+ *     [2, "b"],
+ *     [3, "c"],
+ *     [4, "d"],
+ *   ],
+ * );
  * ```
  */
 export function zip<T, U>(

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -8,11 +8,11 @@
  * ```typescript
  * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
  * import { zip } from "https://deno.land/std/collections/zip.ts";
- * 
+ *
  * const numbers = [1, 2, 3, 4];
  * const letters = ["a", "b", "c", "d"];
  * const pairs = zip(numbers, letters);
- * 
+ *
  * assertEquals(
  *   pairs,
  *   [


### PR DESCRIPTION
This PR makes the examples of collections module executable. You can copy & paste these examples in repl. (This also replaces `console.assert(a === b)` with `assertEquals(a, b)` because `===` equality doesn't work for arrays and objects.)