### PR TITLE
feat(async): add status to deferred promises

### DIFF
--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -22,7 +22,8 @@ export function deferred<T>(): Deferred<T> {
   let methods;
   const promise = new Promise<T>((resolve, reject): void => {
     methods = {
-      resolve(value: T | PromiseLike<T>) {
+      async resolve(value: T | PromiseLike<T>) {
+        await value;
         Object.assign(promise, { status: "fulfilled" });
         resolve(value);
       },

--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -5,6 +5,7 @@
 // See https://github.com/Microsoft/TypeScript/issues/15202
 // At the time of writing, the github issue is closed but the problem remains.
 export interface Deferred<T> extends Promise<T> {
+  status: "pending" | "fulfilled" | "rejected";
   resolve(value?: T | PromiseLike<T>): void;
   // deno-lint-ignore no-explicit-any
   reject(reason?: any): void;
@@ -20,7 +21,17 @@ export interface Deferred<T> extends Promise<T> {
 export function deferred<T>(): Deferred<T> {
   let methods;
   const promise = new Promise<T>((resolve, reject): void => {
-    methods = { resolve, reject };
+    methods = {
+      resolve(value: T | PromiseLike<T>) {
+        Object.assign(promise, { status: "fulfilled" });
+        resolve(value);
+      },
+      // deno-lint-ignore no-explicit-any
+      reject(reason?: any) {
+        Object.assign(promise, { status: "rejected" });
+        reject(reason);
+      },
+    };
   });
-  return Object.assign(promise, methods) as Deferred<T>;
+  return Object.assign(promise, methods, { status: "pending" }) as Deferred<T>;
 }

--- a/async/deferred_test.ts
+++ b/async/deferred_test.ts
@@ -4,14 +4,18 @@ import { deferred } from "./deferred.ts";
 
 Deno.test("[async] deferred: resolve", async function () {
   const d = deferred<string>();
+  assertEquals(d.status, "pending");
   d.resolve("🦕");
   assertEquals(await d, "🦕");
+  assertEquals(d.status, "fulfilled");
 });
 
 Deno.test("[async] deferred: reject", async function () {
   const d = deferred<number>();
+  assertEquals(d.status, "pending");
   d.reject(new Error("A deno error 🦕"));
   await assertThrowsAsync(async () => {
     await d;
   });
+  assertEquals(d.status, "rejected");
 });

--- a/async/deferred_test.ts
+++ b/async/deferred_test.ts
@@ -19,3 +19,14 @@ Deno.test("[async] deferred: reject", async function () {
   });
   assertEquals(d.status, "rejected");
 });
+
+Deno.test("[async] deferred: status with promised value", async function () {
+  const d = deferred<string>();
+  const e = deferred<string>();
+  assertEquals(d.status, "pending");
+  d.resolve(e);
+  assertEquals(d.status, "pending");
+  e.resolve("🦕");
+  assertEquals(await d, "🦕");
+  assertEquals(d.status, "fulfilled");
+});


### PR DESCRIPTION
This edits a bit `deferred<T>` in order to be able to track promise status, which is not exposed directly by default.
It's mostly useful to know whether the deferred promise is still `pending` or not (as they're manually resolved)

Personnaly I sometimes use it in unit testing so I figured out it may be useful for others too, though I could understand it may not be that revelant 🙂 
