### PR TITLE
fix(encoding/yaml): fix `parseAll` type definition by using overloads

### DIFF
--- a/encoding/_yaml/parse.ts
+++ b/encoding/_yaml/parse.ts
@@ -23,9 +23,17 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * Same as `parse()`, but understands multi-document sources.
  * Applies iterator to each document if specified, or returns array of documents.
  */
+export function parseAll(content: string): unknown;
+export function parseAll(content: string, iterator: CbFunction): void;
 export function parseAll(
   content: string,
-  iterator?: CbFunction,
+  iterator: CbFunction,
+  options: ParseOptions,
+): void;
+export function parseAll(content: string, options: ParseOptions): unknown;
+export function parseAll(
+  content: string,
+  iterator?: CbFunction | ParseOptions,
   options?: ParseOptions,
 ): unknown {
   return loadAll(content, iterator, options);

--- a/encoding/_yaml/parse.ts
+++ b/encoding/_yaml/parse.ts
@@ -23,14 +23,12 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * Same as `parse()`, but understands multi-document sources.
  * Applies iterator to each document if specified, or returns array of documents.
  */
-export function parseAll(content: string): unknown;
-export function parseAll(content: string, iterator: CbFunction): void;
 export function parseAll(
   content: string,
   iterator: CbFunction,
-  options: ParseOptions,
+  options?: ParseOptions,
 ): void;
-export function parseAll(content: string, options: ParseOptions): unknown;
+export function parseAll(content: string, options?: ParseOptions): unknown;
 export function parseAll(
   content: string,
   iterator?: CbFunction | ParseOptions,

--- a/encoding/_yaml/parse_test.ts
+++ b/encoding/_yaml/parse_test.ts
@@ -135,3 +135,46 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name: "`parseAll` accepts parse options",
+  fn(): void {
+    const yaml = `
+---
+regexp: !!js/regexp foo
+---
+regexp: !!js/regexp bar
+    `;
+
+    const expected = [
+      {
+        regexp: /foo/,
+      },
+      {
+        regexp: /bar/,
+      },
+    ];
+    const mockCallback = () => {
+      let count = 0;
+      const fn = () => {
+        count++;
+      };
+      const callback = {
+        calls() {
+          return count;
+        },
+        fn,
+      };
+      return callback;
+    };
+
+    assertEquals(parseAll(yaml, { schema: EXTENDED_SCHEMA }), expected);
+
+    const callback = mockCallback();
+    assertEquals(
+      parseAll(yaml, callback.fn, { schema: EXTENDED_SCHEMA }),
+      undefined,
+    );
+    assertEquals(callback.calls(), 2);
+  },
+});


### PR DESCRIPTION
fix #679

This fixes type definition of `parseAll` in yaml module.

Current:
```ts
// ok
parseAll(yaml)
// ok
parseAll(yaml, callback)
// ok
parseAll(yaml, callback, options)
// typing is ok, but options are ignored
parseAll(yaml, undefined, options)
// type error, but options are accepted
parseAll(yaml, options)
```

Modified:
```ts
// ok
parseAll(yaml)
// ok
parseAll(yaml, callback)
// ok
parseAll(yaml, callback, options)
// type error
parseAll(yaml, undefined, options)
// ok
parseAll(yaml, options)
```
