### PR TITLE
chore: restore coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.deno }}
           files: cov.lcov
 
+      - name: Remove coverage report
+        shell: bash
+        run: |
+          rm -rf ./cov/
+          rm cov.lcov
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           git grep --name-only "// This module is browser compatible." | grep -v ".github/workflows" | xargs deno cache --config browser-compat.tsconfig.json
 
       - name: Generate lcov
+        shell: bash
         # excludes tests, testdata, and generated sources from coverage report
         run: |
           deno coverage ./cov/ --lcov --exclude="test\\.(ts|js)|wasm\\.js|testdata|node/_tools|node/_module/cjs|node_modules" > cov.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Run tests
-        run: deno test --unstable --allow-all
+        run: deno test --unstable --allow-all --coverage=./cov
 
       - name: Type check browser compatible modules
         shell: bash
@@ -39,7 +39,9 @@ jobs:
           git grep --name-only "// This module is browser compatible." | grep -v ".github/workflows" | xargs deno cache --config browser-compat.tsconfig.json
 
       - name: Generate lcov
-        run: deno coverage --unstable --lcov ./cov > cov.lcov
+        # excludes tests, testdata, and generated sources from coverage report
+        run: |
+          deno coverage ./cov/ --lcov --exclude="test\\.(ts|js)|wasm\\.js|testdata|node/_tools|node/_module/cjs|node_modules" > cov.lcov
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
closes #1030 

This PR tries to restore coverage report of std.

The command excludes the following files/directories from the report:
- `.*test\.(ts|js)` - test files
- `wasm\.js` - wasm wrapper script (generated file)
- `testdata` - test fixture
- `node/_tools` - node.js test files
- `node/_module/cjs` - test fixture for node.js module testing
- `node_modules` - test fixture for node.js module testing