### PR TITLE
chore: enable doc type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,23 @@ jobs:
 
       - name: Generate lcov
         shell: bash
+        # TODO(kt3k): Excludes ubuntu for now because it panics while processing io/util.ts
+        # See https://github.com/denoland/deno/issues/10420
+        if: matrix.os != 'ubuntu-latest'
         # excludes tests, testdata, and generated sources from coverage report
         run: |
           deno coverage ./cov/ --lcov --exclude="test\\.(ts|js)|wasm\\.js|testdata|node/_tools|node/_module/cjs|node_modules" > cov.lcov
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
+        if: matrix.os != 'ubuntu-latest'
         with:
           name: ${{ matrix.os }}-${{ matrix.deno }}
           files: cov.lcov
 
       - name: Remove coverage report
         shell: bash
+        if: matrix.os != 'ubuntu-latest'
         run: |
           rm -rf ./cov/
           rm cov.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Run tests
-        run: deno test --unstable --allow-all
+        run: deno test --doc --unstable --allow-all
 
       - name: Type check browser compatible modules
         shell: bash

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -22,7 +22,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * aborted.
  *
  * ```
- * import { debounce } from "https://deno.land/std/async/mod.ts";
+ * import { debounce } from "./debounce.ts";
  *
  * const log = debounce(
  *   (event: Deno.FsEvent) =>

--- a/async/tee_test.ts
+++ b/async/tee_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { tee } from "./tee.ts";
-import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
+import { assertEquals } from "../testing/asserts.ts";
 
 /** An example async generator */
 const gen = async function* iter() {

--- a/collections/chunked.ts
+++ b/collections/chunked.ts
@@ -6,6 +6,8 @@
  * Example:
  *
  * ```typescript
+ * import { chunked } from "https://deno.land/std/collections/chunked.ts";
+ *
  * const words = [ 'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consetetur', 'sadipscing' ]
  * const chunks = chunked(words, 3)
  *

--- a/collections/chunked.ts
+++ b/collections/chunked.ts
@@ -6,7 +6,7 @@
  * Example:
  *
  * ```typescript
- * import { chunked } from "https://deno.land/std/collections/chunked.ts";
+ * import { chunked } from "./chunked.ts";
  *
  * const words = [ 'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consetetur', 'sadipscing' ]
  * const chunks = chunked(words, 3)

--- a/collections/chunked.ts
+++ b/collections/chunked.ts
@@ -5,7 +5,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { chunked } from "./chunked.ts";
  *
  * const words = [ 'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consetetur', 'sadipscing' ]

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -5,7 +5,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { distinct } from "./distinct.ts";
  *
  * const numbers = [ 3, 2, 5, 2, 5 ]

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -6,7 +6,7 @@
  * Example:
  *
  * ```typescript
- * import { distinct } from "https://deno.land/std/collections/distinct.ts";
+ * import { distinct } from "./distinct.ts";
  *
  * const numbers = [ 3, 2, 5, 2, 5 ]
  * const distinctNumbers = distinct(numbers)

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -6,6 +6,8 @@
  * Example:
  *
  * ```typescript
+ * import { distinct } from "https://deno.land/std/collections/distinct.ts";
+ *
  * const numbers = [ 3, 2, 5, 2, 5 ]
  * const distinctNumbers = distinct(numbers)
  *

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -8,7 +8,7 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { distinctBy } from "https://deno.land/std/collections/distinct_by.ts";
+ * import { distinctBy } from "./distinct_by.ts";
  *
  * const names = [ 'Anna', 'Kim', 'Arnold', 'Kate' ]
  * const exampleNamesByFirstLetter = distinctBy(names, it => it.charAt(0))

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -8,6 +8,8 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { distinctBy } from "https://deno.land/std/collections/distinct_by.ts";
+ *
  * const names = [ 'Anna', 'Kim', 'Arnold', 'Kate' ]
  * const exampleNamesByFirstLetter = distinctBy(names, it => it.charAt(0))
  *

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -7,7 +7,7 @@ import { Selector } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { distinctBy } from "./distinct_by.ts";
  *
  * const names = [ 'Anna', 'Kim', 'Arnold', 'Kate' ]

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -8,7 +8,7 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { filterEntries } from "https://deno.land/std/collections/filter_entries.ts";
+ * import { filterEntries } from "./filter_entries.ts";
  *
  * const menu = {
  *     'Salad': 11,

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -8,11 +8,13 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { filterEntries } from "https://deno.land/std/collections/filter_entries.ts";
+ *
  * const menu = {
  *     'Salad': 11,
  *     'Soup': 8,
  *     'Pasta': 13,
- * }
+ * } as const;
  * const myOptions = filterEntries(menu,
  *     ([ item, price ]) => item !== 'Pasta' && price < 10,
  * )

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -7,7 +7,7 @@ import { Predicate } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { filterEntries } from "./filter_entries.ts";
  *
  * const menu = {

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -8,7 +8,7 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { filterKeys } from "https://deno.land/std/collections/filter_keys.ts";
+ * import { filterKeys } from "./filter_keys.ts";
  *
  * const menu = {
  *     'Salad': 11,

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -8,6 +8,8 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { filterKeys } from "https://deno.land/std/collections/filter_keys.ts";
+ *
  * const menu = {
  *     'Salad': 11,
  *     'Soup': 8,

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -7,7 +7,7 @@ import { Predicate } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { filterKeys } from "./filter_keys.ts";
  *
  * const menu = {

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -7,7 +7,7 @@ import { Predicate } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { filterValues } from "./filter_values.ts";
  *
  * type Person = { age: number };

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -8,7 +8,7 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { filterValues } from "https://deno.land/std/collections/filter_values.ts";
+ * import { filterValues } from "./filter_values.ts";
  *
  * type Person = { age: number };
  *

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -8,16 +8,20 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const people = {
- *     'Arnold': 37,
- *     'Sarah': 7,
- *     'Kim': 23,
- * }
+ * import { filterValues } from "https://deno.land/std/collections/filter_values.ts";
+ *
+ * type Person = { age: number };
+ *
+ * const people: Record<string, Person> = {
+ *     'Arnold': { age: 37 },
+ *     'Sarah': { age: 7 },
+ *     'Kim': { age: 23 },
+ * };
  * const adults = filterValues(people, it => it.age >= 18)
  *
  * console.assert(adults === {
- *     'Arnold': 37,
- *     'Kim': 23,
+ *     'Arnold': { age: 37 },
+ *     'Kim': { age: 23 },
  * })
  * ```
  */

--- a/collections/find_last.ts
+++ b/collections/find_last.ts
@@ -8,7 +8,7 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { findLast } from "https://deno.land/std/collections/find_last.ts";
+ * import { findLast } from "./find_last.ts";
  *
  * const numbers = [ 4, 2, 7 ]
  * const lastEvenNumber = findLast(numbers, it => it % 2 === 0)

--- a/collections/find_last.ts
+++ b/collections/find_last.ts
@@ -7,7 +7,7 @@ import { Predicate } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { findLast } from "./find_last.ts";
  *
  * const numbers = [ 4, 2, 7 ]

--- a/collections/find_last.ts
+++ b/collections/find_last.ts
@@ -8,6 +8,8 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { findLast } from "https://deno.land/std/collections/find_last.ts";
+ *
  * const numbers = [ 4, 2, 7 ]
  * const lastEvenNumber = findLast(numbers, it => it % 2 === 0)
  *

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -9,7 +9,7 @@ import { Grouping, Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { groupBy } from "https://deno.land/std/collections/group_by.ts";
+ * import { groupBy } from "./group_by.ts";
  *
  * type Person = {
  *   name: string;

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -8,7 +8,7 @@ import { Grouping, Selector } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { groupBy } from "./group_by.ts";
  *
  * type Person = {

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -9,11 +9,17 @@ import { Grouping, Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * const people = [
+ * import { groupBy } from "https://deno.land/std/collections/group_by.ts";
+ *
+ * type Person = {
+ *   name: string;
+ * };
+ *
+ * const people: Person[] = [
  *     { name: 'Anna' },
  *     { name: 'Arnold' },
  *     { name: 'Kim' },
- * ]
+ * ];
  * const peopleByFirstLetter = groupBy(people, it => it.name.charAt(0))
  *
  * console.assert(peopleByFirstLetter === {

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -7,7 +7,7 @@ import { filterInPlace } from "./_utils.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { intersect } from "./intersect.ts";
  *
  * const lisaInterests = [ 'Cooking', 'Music', 'Hiking' ]

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -8,9 +8,11 @@ import { filterInPlace } from "./_utils.ts";
  * Example:
  *
  * ```typescript
+ * import { intersect } from "https://deno.land/std/collections/intersect.ts";
+ *
  * const lisaInterests = [ 'Cooking', 'Music', 'Hiking' ]
  * const kimInterests = [ 'Music', 'Tennis', 'Cooking' ]
- * const commonInterests = intersectTest(lisaInterests, kimInterests)
+ * const commonInterests = intersect(lisaInterests, kimInterests)
  *
  * console.assert(commonInterests === [ 'Cooking', 'Music' ])
  * ```

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -8,7 +8,7 @@ import { filterInPlace } from "./_utils.ts";
  * Example:
  *
  * ```typescript
- * import { intersect } from "https://deno.land/std/collections/intersect.ts";
+ * import { intersect } from "./intersect.ts";
  *
  * const lisaInterests = [ 'Cooking', 'Music', 'Hiking' ]
  * const kimInterests = [ 'Music', 'Tennis', 'Cooking' ]

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -7,7 +7,7 @@ import { Selector } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { mapEntries } from "./map_entries.ts";
  *
  * const usersById = {

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -8,11 +8,14 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { mapEntries } from "https://deno.land/std/collections/map_entries.ts";
+ *
  * const usersById = {
  *     'a2e': { name: 'Kim', age: 22 },
  *     'dfe': { name: 'Anna', age: 31 },
  *     '34b': { name: 'Tim', age: 58 },
- * }
+ * } as const;
+ *
  * const agesByNames = mapEntries(usersById,
  *     ([ id, { name, age } ]) => [ name, age ],
  * )

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -8,7 +8,7 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { mapEntries } from "https://deno.land/std/collections/map_entries.ts";
+ * import { mapEntries } from "./map_entries.ts";
  *
  * const usersById = {
  *     'a2e': { name: 'Kim', age: 22 },

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -10,7 +10,7 @@ import { Selector } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { mapKeys } from "./map_keys.ts";
  *
  * const counts = { a: 5, b: 3, c: 8 }

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -11,9 +11,11 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { mapKeys } from "https://deno.land/std/collections/map_keys.ts";
+ *
  * const counts = { a: 5, b: 3, c: 8 }
  *
- * console.assert(mapKeys(counts, it => it.toUppercase()) === {
+ * console.assert(mapKeys(counts, it => it.toUpperCase()) === {
  *     A: 5,
  *     B: 3,
  *     C: 8,

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -11,7 +11,7 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { mapKeys } from "https://deno.land/std/collections/map_keys.ts";
+ * import { mapKeys } from "./map_keys.ts";
  *
  * const counts = { a: 5, b: 3, c: 8 }
  *

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -9,7 +9,7 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { mapValues } from "https://deno.land/std/collections/map_values.ts";
+ * import { mapValues } from "./map_values.ts";
  *
  * const usersById = {
  *     'a5ec': { name: 'Mischa' },

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -8,7 +8,7 @@ import { Selector } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { mapValues } from "./map_values.ts";
  *
  * const usersById = {

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -9,6 +9,8 @@ import { Selector } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { mapValues } from "https://deno.land/std/collections/map_values.ts";
+ *
  * const usersById = {
  *     'a5ec': { name: 'Mischa' },
  *     'de4f': { name: 'Kim' },
@@ -18,7 +20,7 @@ import { Selector } from "./types.ts";
  * console.assert(namesById === {
  *     'a5ec': 'Mischa',
  *     'de4f': 'Kim',
- * }
+ * });
  * ```
  */
 export function mapValues<T, O>(

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -9,7 +9,7 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
- * import { partition } from "https://deno.land/std/collections/partition.ts";
+ * import { partition } from "./partition.ts";
  *
  * const numbers = [ 5, 6, 7, 8, 9 ]
  * const [ even, odd ] = partition(numbers, it => it % 2 == 0)

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -9,6 +9,8 @@ import { Predicate } from "./types.ts";
  * Example:
  *
  * ```typescript
+ * import { partition } from "https://deno.land/std/collections/partition.ts";
+ *
  * const numbers = [ 5, 6, 7, 8, 9 ]
  * const [ even, odd ] = partition(numbers, it => it % 2 == 0)
  *

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -8,7 +8,7 @@ import { Predicate } from "./types.ts";
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { partition } from "./partition.ts";
  *
  * const numbers = [ 5, 6, 7, 8, 9 ]

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -8,7 +8,7 @@
  * Example:
  *
  * ```typescript
- * import { permutations } from "https://deno.land/std/collections/permutations.ts";
+ * import { permutations } from "./permutations.ts";
  *
  * const numbers = [ 1, 2 ]
  * const windows = permutations(numbers)

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -8,6 +8,8 @@
  * Example:
  *
  * ```typescript
+ * import { permutations } from "https://deno.land/std/collections/permutations.ts";
+ *
  * const numbers = [ 1, 2 ]
  * const windows = permutations(numbers)
  *

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -7,7 +7,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { permutations } from "./permutations.ts";
  *
  * const numbers = [ 1, 2 ]

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -6,6 +6,8 @@
  * Example:
  *
  * ```typescript
+ * import { union } from "https://deno.land/std/collections/union.ts";
+ *
  * const soupIngredients = [ 'Pepper', 'Carrots', 'Leek' ]
  * const saladIngredients = [ 'Carrots', 'Radicchio', 'Pepper' ]
  * const shoppingList = union(soupIngredients, saladIngredients)

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -5,7 +5,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { union } from "./union.ts";
  *
  * const soupIngredients = [ 'Pepper', 'Carrots', 'Leek' ]

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -6,7 +6,7 @@
  * Example:
  *
  * ```typescript
- * import { union } from "https://deno.land/std/collections/union.ts";
+ * import { union } from "./union.ts";
  *
  * const soupIngredients = [ 'Pepper', 'Carrots', 'Leek' ]
  * const saladIngredients = [ 'Carrots', 'Radicchio', 'Pepper' ]

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -7,11 +7,14 @@
  * Example:
  *
  * ```typescript
+ * import { unzip } from "https://deno.land/std/collections/unzip.ts";
+ *
  * const parents = [
  *     [ 'Maria', 'Jeff' ],
  *     [ 'Anna', 'Kim' ],
  *     [ 'John', 'Leroy' ],
- * ]
+ * ] as [string, string][];
+ *
  * const [ moms, dads ] = unzip(parents)
  *
  * console.assert(moms === [ 'Maria', 'Anna', 'John' ])

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -7,7 +7,7 @@
  * Example:
  *
  * ```typescript
- * import { unzip } from "https://deno.land/std/collections/unzip.ts";
+ * import { unzip } from "./unzip.ts";
  *
  * const parents = [
  *     [ 'Maria', 'Jeff' ],

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -6,7 +6,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { unzip } from "./unzip.ts";
  *
  * const parents = [

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -6,7 +6,7 @@
  * Example:
  *
  * ```typescript
- * import { zip } from "https://deno.land/std/collections/zip.ts";
+ * import { zip } from "./zip.ts";
  *
  * const numbers = [ 1, 2, 3, 4 ]
  * const letters = [ 'a', 'b', 'c', 'd' ]

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -6,6 +6,8 @@
  * Example:
  *
  * ```typescript
+ * import { zip } from "https://deno.land/std/collections/zip.ts";
+ *
  * const numbers = [ 1, 2, 3, 4 ]
  * const letters = [ 'a', 'b', 'c', 'd' ]
  * const pairs = zip(numbers, letters)

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -5,7 +5,7 @@
  *
  * Example:
  *
- * ```typescript
+ * ```ts
  * import { zip } from "./zip.ts";
  *
  * const numbers = [ 1, 2, 3, 4 ]

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -160,6 +160,8 @@ export type DifferenceOptions = {
  * example :
  *
  * ```typescript
+ * import * as datetime from "https://deno.land/std/datetime/mod.ts";
+ *
  * datetime.difference(new Date("2020/1/1"),new Date("2020/2/2"),{ units : ["days","months"] })
  * ```
  */

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -160,7 +160,7 @@ export type DifferenceOptions = {
  * example :
  *
  * ```typescript
- * import * as datetime from "https://deno.land/std/datetime/mod.ts";
+ * import * as datetime from "./mod.ts";
  *
  * datetime.difference(new Date("2020/1/1"),new Date("2020/2/2"),{ units : ["days","months"] })
  * ```

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -15,7 +15,7 @@ export interface ArgParsingOptions {
    * the result `['--']` with everything after the `--`. Here's an example:
    *
    *      // $ deno run example.ts -- a arg1
-   *      import { parse } from "https://deno.land/std/flags/mod.ts";
+   *      import { parse } from "./mod.ts";
    *      console.dir(parse(Deno.args, { "--": false }));
    *      // output: { _: [ "a", "arg1" ] }
    *      console.dir(parse(Deno.args, { "--": true }));

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -188,6 +188,9 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
  * Example:
  *
  * ```ts
+ * import { setCookie } from "https://deno.land/std/http/cookie.ts";
+ *
+ * const response = new Response("");
  * setCookie(response, { name: 'deno', value: 'runtime',
  *   httpOnly: true, secure: true, maxAge: 2, domain: "deno.land" });
  * ```

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -188,7 +188,7 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
  * Example:
  *
  * ```ts
- * import { setCookie } from "https://deno.land/std/http/cookie.ts";
+ * import { setCookie } from "./cookie.ts";
  *
  * const response = new Response("");
  * setCookie(response, { name: 'deno', value: 'runtime',

--- a/io/streams.ts
+++ b/io/streams.ts
@@ -189,7 +189,7 @@ export interface ReadableStreamFromReaderOptions {
  * An example converting a `Deno.File` into a readable stream:
  *
  * ```ts
- * import { readableStreamFromReader } from "https://deno.land/std/io/mod.ts";
+ * import { readableStreamFromReader } from "./mod.ts";
  *
  * const file = await Deno.open("./file.txt", { read: true });
  * const fileStream = readableStreamFromReader(file);

--- a/io/util.ts
+++ b/io/util.ts
@@ -8,8 +8,8 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * Uint8Array`.
  *
  * ```ts
- * import { readAll } from "https://deno.land/std/io/util.ts";
- * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { readAll } from "./util.ts";
+ * import { Buffer } from "./buffer.ts";
  *
  * // Example from stdin
  * const stdinContent = await readAll(Deno.stdin);
@@ -36,8 +36,8 @@ export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
  * as `Uint8Array`.
  *
  * ```ts
- * import { readAllSync } from "https://deno.land/std/io/util.ts";
- * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { readAllSync } from "./util.ts";
+ * import { Buffer } from "./buffer.ts";
  *
  * // Example from stdin
  * const stdinContent = readAllSync(Deno.stdin);
@@ -74,8 +74,8 @@ export interface ByteRange {
  * range.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
- * import { readRange } from "https://deno.land/std/io/util.ts";
+ * import { assertEquals } from "../testing/asserts.ts";
+ * import { readRange } from "./util.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = await Deno.open("example.txt", { read: true });
@@ -112,8 +112,8 @@ export async function readRange(
  * within that range.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
- * import { readRangeSync } from "https://deno.land/std/io/util.ts";
+ * import { assertEquals } from "../testing/asserts.ts";
+ * import { readRangeSync } from "./util.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = Deno.openSync("example.txt", { read: true });
@@ -147,8 +147,8 @@ export function readRangeSync(
 /** Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std/io/buffer.ts";
- * import { writeAll } from "https://deno.land/std/io/util.ts";
+ * import { Buffer } from "./buffer.ts";
+ * import { writeAll } from "./util.ts";
 
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");
@@ -178,8 +178,8 @@ export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
  * writer (`w`).
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std/io/buffer.ts";
- * import { writeAllSync } from "https://deno.land/std/io/util.ts";
+ * import { Buffer } from "./buffer.ts";
+ * import { writeAllSync } from "./util.ts";
  *
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");
@@ -208,7 +208,7 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
 /** Turns a Reader, `r`, into an async iterator.
  *
  * ```ts
- * import { iter } from "https://deno.land/std/io/util.ts";
+ * import { iter } from "./util.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * for await (const chunk of iter(f)) {
@@ -221,7 +221,7 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iter } from "https://deno.land/std/io/util.ts";
+ * import { iter } from "./util.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * const it = iter(f, {
@@ -259,7 +259,7 @@ export async function* iter(
 /** Turns a ReaderSync, `r`, into an iterator.
  *
  * ```ts
- * import { iterSync } from "https://deno.land/std/io/util.ts";
+ * import { iterSync } from "./util.ts";
  *
  * let f = Deno.openSync("/etc/passwd");
  * for (const chunk of iterSync(f)) {
@@ -272,7 +272,7 @@ export async function* iter(
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iterSync } from "https://deno.land/std/io/util.ts";
+ * import { iterSync } from "./util.ts";
 
  * let f = await Deno.open("/etc/passwd");
  * const iter = iterSync(f, {
@@ -312,7 +312,7 @@ export function* iterSync(
  * the first error encountered while copying.
  *
  * ```ts
- * import { copy } from "https://deno.land/std/io/util.ts";
+ * import { copy } from "./util.ts";
  *
  * const source = await Deno.open("my_file.txt");
  * const bytesCopied1 = await copy(source, Deno.stdout);

--- a/io/util.ts
+++ b/io/util.ts
@@ -8,6 +8,8 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * Uint8Array`.
  *
  * ```ts
+ * import { readAll } from "https://deno.land/std/io/util.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
  *
  * // Example from stdin
  * const stdinContent = await readAll(Deno.stdin);
@@ -34,6 +36,9 @@ export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
  * as `Uint8Array`.
  *
  * ```ts
+ * import { readAllSync } from "https://deno.land/std/io/util.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ *
  * // Example from stdin
  * const stdinContent = readAllSync(Deno.stdin);
  *
@@ -69,10 +74,13 @@ export interface ByteRange {
  * range.
  *
  * ```ts
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { readRange } from "https://deno.land/std/io/util.ts";
+ *
  * // Read the first 10 bytes of a file
  * const file = await Deno.open("example.txt", { read: true });
  * const bytes = await readRange(file, { start: 0, end: 9 });
- * assert(bytes.length, 10);
+ * assertEquals(bytes.length, 10);
  * ```
  */
 export async function readRange(
@@ -104,10 +112,13 @@ export async function readRange(
  * within that range.
  *
  * ```ts
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { readRangeSync } from "https://deno.land/std/io/util.ts";
+ *
  * // Read the first 10 bytes of a file
  * const file = Deno.openSync("example.txt", { read: true });
  * const bytes = readRangeSync(file, { start: 0, end: 9 });
- * assert(bytes.length, 10);
+ * assertEquals(bytes.length, 10);
  * ```
  */
 export function readRangeSync(
@@ -136,18 +147,21 @@ export function readRangeSync(
 /** Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
  * ```ts
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { writeAll } from "https://deno.land/std/io/util.ts";
+
  * // Example writing to stdout
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * let contentBytes = new TextEncoder().encode("Hello World");
  * await writeAll(Deno.stdout, contentBytes);
  *
  * // Example writing to file
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * contentBytes = new TextEncoder().encode("Hello World");
  * const file = await Deno.open('test.file', {write: true});
  * await writeAll(file, contentBytes);
  * Deno.close(file.rid);
  *
  * // Example writing to buffer
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * contentBytes = new TextEncoder().encode("Hello World");
  * const writer = new Buffer();
  * await writeAll(writer, contentBytes);
  * console.log(writer.bytes().length);  // 11
@@ -164,18 +178,21 @@ export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
  * writer (`w`).
  *
  * ```ts
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { writeAllSync } from "https://deno.land/std/io/util.ts";
+ *
  * // Example writing to stdout
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * let contentBytes = new TextEncoder().encode("Hello World");
  * writeAllSync(Deno.stdout, contentBytes);
  *
  * // Example writing to file
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * contentBytes = new TextEncoder().encode("Hello World");
  * const file = Deno.openSync('test.file', {write: true});
  * writeAllSync(file, contentBytes);
  * Deno.close(file.rid);
  *
  * // Example writing to buffer
- * const contentBytes = new TextEncoder().encode("Hello World");
+ * contentBytes = new TextEncoder().encode("Hello World");
  * const writer = new Buffer();
  * writeAllSync(writer, contentBytes);
  * console.log(writer.bytes().length);  // 11
@@ -191,6 +208,8 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
 /** Turns a Reader, `r`, into an async iterator.
  *
  * ```ts
+ * import { iter } from "https://deno.land/std/io/util.ts";
+ *
  * let f = await Deno.open("/etc/passwd");
  * for await (const chunk of iter(f)) {
  *   console.log(chunk);
@@ -202,11 +221,13 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
  * Default size of the buffer is 32kB.
  *
  * ```ts
+ * import { iter } from "https://deno.land/std/io/util.ts";
+ *
  * let f = await Deno.open("/etc/passwd");
- * const iter = iter(f, {
+ * const it = iter(f, {
  *   bufSize: 1024 * 1024
  * });
- * for await (const chunk of iter) {
+ * for await (const chunk of it) {
  *   console.log(chunk);
  * }
  * f.close();
@@ -238,6 +259,8 @@ export async function* iter(
 /** Turns a ReaderSync, `r`, into an iterator.
  *
  * ```ts
+ * import { iterSync } from "https://deno.land/std/io/util.ts";
+ *
  * let f = Deno.openSync("/etc/passwd");
  * for (const chunk of iterSync(f)) {
  *   console.log(chunk);
@@ -249,6 +272,8 @@ export async function* iter(
  * Default size of the buffer is 32kB.
  *
  * ```ts
+ * import { iterSync } from "https://deno.land/std/io/util.ts";
+
  * let f = await Deno.open("/etc/passwd");
  * const iter = iterSync(f, {
  *   bufSize: 1024 * 1024
@@ -287,6 +312,8 @@ export function* iterSync(
  * the first error encountered while copying.
  *
  * ```ts
+ * import { copy } from "https://deno.land/std/io/util.ts";
+ *
  * const source = await Deno.open("my_file.txt");
  * const bytesCopied1 = await copy(source, Deno.stdout);
  * const destination = await Deno.create("my_file_2.txt");

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -221,9 +221,11 @@ export function assert(expr: unknown, msg = ""): asserts expr {
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
- *```ts
- *assertEquals<number>(1, 2)
- *```
+ * ```ts
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ *
+ * assertEquals<number>(1, 2)
+ * ```
  */
 export function assertEquals(
   actual: unknown,
@@ -265,9 +267,11 @@ export function assertEquals(
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
- *```ts
- *assertNotEquals<number>(1, 2)
- *```
+ * ```ts
+ * import { assertNotEquals } from "https://deno.land/std/testing/asserts.ts";
+ *
+ * assertNotEquals<number>(1, 2)
+ * ```
  */
 export function assertNotEquals(
   actual: unknown,
@@ -304,7 +308,10 @@ export function assertNotEquals(
 /**
  * Make an assertion that `actual` and `expected` are strictly equal. If
  * not then throw.
+ *
  * ```ts
+ * import { assertStrictEquals } from "https://deno.land/std/testing/asserts.ts";
+ *
  * assertStrictEquals(1, 2)
  * ```
  */
@@ -365,7 +372,10 @@ export function assertStrictEquals(
 /**
  * Make an assertion that `actual` and `expected` are not strictly equal.
  * If the values are strictly equal then throw.
+ *
  * ```ts
+ * import { assertNotStrictEquals } from "https://deno.land/std/testing/asserts.ts";
+ *
  * assertNotStrictEquals(1, 1)
  * ```
  */
@@ -432,9 +442,12 @@ export function assertStringIncludes(
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
- *```ts
- *assertArrayIncludes<number>([1, 2], [2])
- *```
+ *
+ * ```ts
+ * import { assertArrayIncludes } from "https://deno.land/std/testing/asserts.ts";
+ *
+ * assertArrayIncludes<number>([1, 2], [2])
+ * ```
  */
 export function assertArrayIncludes(
   actual: ArrayLike<unknown>,

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -222,7 +222,7 @@ export function assert(expr: unknown, msg = ""): asserts expr {
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
  * ```ts
- * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { assertEquals } from "./asserts.ts";
  *
  * assertEquals<number>(1, 2)
  * ```
@@ -268,7 +268,7 @@ export function assertEquals(
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
  * ```ts
- * import { assertNotEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { assertNotEquals } from "./asserts.ts";
  *
  * assertNotEquals<number>(1, 2)
  * ```
@@ -310,7 +310,7 @@ export function assertNotEquals(
  * not then throw.
  *
  * ```ts
- * import { assertStrictEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { assertStrictEquals } from "./asserts.ts";
  *
  * assertStrictEquals(1, 2)
  * ```
@@ -374,7 +374,7 @@ export function assertStrictEquals(
  * If the values are strictly equal then throw.
  *
  * ```ts
- * import { assertNotStrictEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { assertNotStrictEquals } from "./asserts.ts";
  *
  * assertNotStrictEquals(1, 1)
  * ```
@@ -444,7 +444,7 @@ export function assertStringIncludes(
  * For example:
  *
  * ```ts
- * import { assertArrayIncludes } from "https://deno.land/std/testing/asserts.ts";
+ * import { assertArrayIncludes } from "./asserts.ts";
  *
  * assertArrayIncludes<number>([1, 2], [2])
  * ```


### PR DESCRIPTION
This PR enables the type checking of examples in jsdocs.

closes #1038 