### PR TITLE
fix(testing): `assertThrowsAsync` always reporting `Error` instead of actual error class

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -641,7 +641,7 @@ export async function assertThrowsAsync<T = void>(
     }
     if (ErrorClass && !(e instanceof ErrorClass)) {
       msg =
-        `Expected error to be instance of "${ErrorClass.name}", but got "${e.name}"${
+        `Expected error to be instance of "${ErrorClass.name}", but was "${e.constructor.name}"${
           msg ? `: ${msg}` : "."
         }`;
       throw new AssertionError(msg);

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1039,3 +1039,18 @@ Deno.test("Assert Throws Async Parent Error", () => {
     "Fail!",
   );
 });
+
+Deno.test("Assert Throws Async promise rejected with custom Error", async () => {
+  class CustomError extends Error {}
+  class AnotherCustomError extends Error {}
+  await assertThrowsAsync(
+    () =>
+      assertThrowsAsync(
+        () => Promise.reject(new AnotherCustomError("failed")),
+        CustomError,
+        "fail",
+      ),
+    AssertionError,
+    'Expected error to be instance of "CustomError", but was "AnotherCustomError".',
+  );
+});


### PR DESCRIPTION
Closes #967

As `assertThrowsAsync` has an implementation drift from `assertThrows` which result in hiding the actual typing of errors in result messages when using custom errors:

```ts
class CustomError extends Error {}
Deno.test("test", async () => void await assertThrowsAsync(() => Promise.reject(new CustomError()), TypeError))
```

Before (making test harder to debug):
```
AssertionError: Expected error to be instance of "TypeError", but got "Error".
```

After:
```
AssertionError: Expected error to be instance of "TypeError", but got "CustomError ".
```

___
References:

AssertThrows:
https://github.com/denoland/deno_std/blob/e4c6419c466335eb697df38a387a2def06e6f3c5/testing/asserts.ts#L598

AssertThrowsAsync:
https://github.com/denoland/deno_std/blob/e4c6419c466335eb697df38a387a2def06e6f3c5/testing/asserts.ts#L644


