### PR TITLE
fix(testing): change `assertThrows` and `assertThrowsAsync` return type to `void` and `Promise<void>`

### DIFF
--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -32,13 +32,19 @@ Deno.test("[async] pooledMap errors", async function () {
     return n;
   }
   const mappedNumbers: number[] = [];
-  const error = await assertThrowsAsync(async () => {
-    for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
-      mappedNumbers.push(m);
+  let error = new AggregateError([]);
+  await assertThrowsAsync(async () => {
+    try {
+      for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
+        mappedNumbers.push(m);
+      }
+    } catch (e) {
+      error = e;
+      throw e;
     }
-  }, AggregateError) as AggregateError;
+  }, AggregateError);
   assertEquals(mappedNumbers, [3]);
-  assertEquals(error.errors.length, 2);
-  assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
-  assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
+  assertEquals(error?.errors.length, 2);
+  assertStringIncludes(error?.errors[0].stack, "Error: Bad number: 1");
+  assertStringIncludes(error?.errors[1].stack, "Error: Bad number: 2");
 });

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -472,14 +472,20 @@ for (const t of testCases) {
       }
       let actual;
       if (t.Error) {
-        const err = await assertThrowsAsync(async () => {
-          await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
-            separator,
-            comment: comment,
-            trimLeadingSpace: trim,
-            fieldsPerRecord: fieldsPerRec,
-            lazyQuotes: lazyquote,
-          });
+        let err;
+        await assertThrowsAsync(async () => {
+          try {
+            await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
+              separator,
+              comment: comment,
+              trimLeadingSpace: trim,
+              fieldsPerRecord: fieldsPerRec,
+              lazyQuotes: lazyquote,
+            });
+          } catch (e) {
+            err = e;
+            throw e;
+          }
         });
 
         assertEquals(err, t.Error);

--- a/testing/README.md
+++ b/testing/README.md
@@ -33,7 +33,9 @@ pretty-printed diff of failing assertion.
   string.
 - `assertThrowsAsync()` - Expects the passed `fn` to be async and throw (or
   return a `Promise` that rejects). If the `fn` does not throw or reject, this
-  function will throw asynchronously. Also compares any errors thrown to an
+  function will throw asynchronously _(⚠️ assertion should be awaited or be the
+  return value of the test function to avoid any uncaught rejections which could
+  result in unexpected process exit)_. Also compares any errors thrown to an
   optional expected `Error` class and checks that the error `.message` includes
   an optional string.
 - `unimplemented()` - Use this to stub out methods that will throw when invoked.
@@ -107,10 +109,6 @@ Deno.test("fails", function (): void {
 ```
 
 Using `assertThrowsAsync()`:
-
-> ⚠️ Note that it is _required_ to `await` for `assertThrowsAsync` to ensure
-> that all promises get resolved within the test `Deno.test` callback. Failing
-> to do so may result in early exit or triggering the Op sanitizer
 
 ```ts
 Deno.test("doesThrow", async function () {

--- a/testing/README.md
+++ b/testing/README.md
@@ -108,6 +108,10 @@ Deno.test("fails", function (): void {
 
 Using `assertThrowsAsync()`:
 
+> ⚠️ Note that it is _required_ to `await` for `assertThrowsAsync` to ensure
+> that all promises get resolved within the test `Deno.test` callback. Failing
+> to do so may result in early exit or triggering the Op sanitizer
+
 ```ts
 Deno.test("doesThrow", async function () {
   await assertThrowsAsync(

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -584,9 +584,8 @@ export function assertThrows<T = void>(
   ErrorClass?: Constructor,
   msgIncludes = "",
   msg?: string,
-): Error {
+): void {
   let doesThrow = false;
-  let error = null;
   try {
     fn();
   } catch (e) {
@@ -611,13 +610,11 @@ export function assertThrows<T = void>(
       throw new AssertionError(msg);
     }
     doesThrow = true;
-    error = e;
   }
   if (!doesThrow) {
     msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
     throw new AssertionError(msg);
   }
-  return error;
 }
 
 /**

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -630,9 +630,8 @@ export async function assertThrowsAsync<T = void>(
   ErrorClass?: Constructor,
   msgIncludes = "",
   msg?: string,
-): Promise<Error> {
+): Promise<void> {
   let doesThrow = false;
-  let error = null;
   try {
     await fn();
   } catch (e) {
@@ -657,13 +656,11 @@ export async function assertThrowsAsync<T = void>(
       throw new AssertionError(msg);
     }
     doesThrow = true;
-    error = e;
   }
   if (!doesThrow) {
     msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
     throw new AssertionError(msg);
   }
-  return error;
 }
 
 /** Use this to stub out methods that will throw when invoked. */


### PR DESCRIPTION
This add a side note in documentation about `assertThrowsAsync` to mention that it is actually **required** to `await` them.

Examples are correct, but I feel like this should be highlighted as this is pretty hard to debug. 

Since it's the only assertion that is async it's not really intuitive.
Failing to do so can result in the whole runner to be interrupted... (see below where `test 3` is not even executed) 

```ts
import { assert, assertThrowsAsync } from "https://deno.land/std@0.102.0/testing/asserts.ts";
Deno.test("1", () => { throw new Error() });
Deno.test("2", () => void assertThrowsAsync(async () => {}, Error));
Deno.test("3", () => {});
```

```
running 3 tests from file:///deno_std/test.ts
test 1 ... FAILED (25ms)
test 2 ...
test result: FAILED. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (129ms)

error: Uncaught (in promise) AssertionError: Expected function to throw.
    throw new AssertionError(msg);
          ^
    at assertThrowsAsync (https://deno.land/std@0.102.0/testing/asserts.ts:664:11)
```

What is confusing is that the assertion does have the expected result and looks fine looking at logs, and throwing inside `Deno.test` is fairly common but in this specific case it makes the test runner fails

I don't have another easy reproduction snippet, but sometimes it seems it could also result in having a mismatch between dispatched and fulfilled promises which will make the test case fails too.
