### PR TITLE
fix: rename deferred.status -> state

### DIFF
--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -5,7 +5,7 @@
 // See https://github.com/Microsoft/TypeScript/issues/15202
 // At the time of writing, the github issue is closed but the problem remains.
 export interface Deferred<T> extends Promise<T> {
-  status: "pending" | "fulfilled" | "rejected";
+  readonly state: "pending" | "fulfilled" | "rejected";
   resolve(value?: T | PromiseLike<T>): void;
   // deno-lint-ignore no-explicit-any
   reject(reason?: any): void;
@@ -20,19 +20,21 @@ export interface Deferred<T> extends Promise<T> {
  */
 export function deferred<T>(): Deferred<T> {
   let methods;
+  let state = "pending";
   const promise = new Promise<T>((resolve, reject): void => {
     methods = {
       async resolve(value: T | PromiseLike<T>) {
         await value;
-        Object.assign(promise, { status: "fulfilled" });
+        state = "fulfilled";
         resolve(value);
       },
       // deno-lint-ignore no-explicit-any
       reject(reason?: any) {
-        Object.assign(promise, { status: "rejected" });
+        state = "rejected";
         reject(reason);
       },
     };
   });
-  return Object.assign(promise, methods, { status: "pending" }) as Deferred<T>;
+  Object.defineProperty(promise, "state", { get: () => state });
+  return Object.assign(promise, methods) as Deferred<T>;
 }

--- a/async/deferred_test.ts
+++ b/async/deferred_test.ts
@@ -1,32 +1,44 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrowsAsync } from "../testing/asserts.ts";
+import {
+  assertEquals,
+  assertThrows,
+  assertThrowsAsync,
+} from "../testing/asserts.ts";
 import { deferred } from "./deferred.ts";
 
 Deno.test("[async] deferred: resolve", async function () {
   const d = deferred<string>();
-  assertEquals(d.status, "pending");
+  assertEquals(d.state, "pending");
   d.resolve("🦕");
   assertEquals(await d, "🦕");
-  assertEquals(d.status, "fulfilled");
+  assertEquals(d.state, "fulfilled");
 });
 
 Deno.test("[async] deferred: reject", async function () {
   const d = deferred<number>();
-  assertEquals(d.status, "pending");
+  assertEquals(d.state, "pending");
   d.reject(new Error("A deno error 🦕"));
   await assertThrowsAsync(async () => {
     await d;
   });
-  assertEquals(d.status, "rejected");
+  assertEquals(d.state, "rejected");
 });
 
-Deno.test("[async] deferred: status with promised value", async function () {
+Deno.test("[async] deferred: state with promised value", async function () {
   const d = deferred<string>();
   const e = deferred<string>();
-  assertEquals(d.status, "pending");
+  assertEquals(d.state, "pending");
   d.resolve(e);
-  assertEquals(d.status, "pending");
+  assertEquals(d.state, "pending");
   e.resolve("🦕");
   assertEquals(await d, "🦕");
-  assertEquals(d.status, "fulfilled");
+  assertEquals(d.state, "fulfilled");
+});
+
+Deno.test("[async] deferred: state is readonly", () => {
+  const d = deferred<string>();
+  assertEquals(d.state, "pending");
+  assertThrows(() => {
+    (d.state as unknown) = "fulfilled";
+  });
 });


### PR DESCRIPTION
As pointed in https://github.com/denoland/deno_std/pull/1047#discussion_r674598436 by @kitsonk, ecma262 spec calls this property of promise [[PromiseState]] (ref: https://tc39.es/ecma262/#sec-fulfillpromise). This PR follows that convention to reduce confusions in the future, and renames the property to '.state'

This PR also makes the property 'readonly' (both in typings and runtime)

cc @lowlighter 