### PR TITLE
feat(fs): add lookPath function

### DIFF
--- a/fs/_lp_unix.ts
+++ b/fs/_lp_unix.ts
@@ -1,0 +1,35 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { splitList } from "../path/separator.ts";
+import { join } from "../path/posix.ts";
+
+async function findExecutable(file: string) {
+  const s = await Deno.stat(file);
+  if (!s.isDirectory && ((s.mode as number) & 0o111) != 0) {
+    return;
+  }
+  throw new Deno.errors.PermissionDenied();
+}
+
+export async function lookPath(bin: string): Promise<string | undefined> {
+  if (bin.includes("/")) {
+    await findExecutable(bin); // throws if file doesn't exist
+    return bin;
+  }
+
+  let path = Deno.env.get("PATH") ?? "";
+  for (let dir of splitList(path)) {
+    if (dir === "") {
+      // Unix shell semantics: path element "" means "."
+      dir = ".";
+    }
+    path = join(dir, bin);
+    try {
+      await findExecutable(path);
+      // return first path found
+      return path;
+    } catch (_) {
+      // swallow the error and let the loop continue with the next dir in $PATH
+    }
+  }
+  throw new Deno.errors.NotFound(bin);
+}

--- a/fs/_lp_unix_test.ts
+++ b/fs/_lp_unix_test.ts
@@ -1,0 +1,24 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { assertThrowsAsync } from "../testing/asserts.ts";
+import { lookPath } from "./_lp_unix.ts";
+
+Deno.test({
+  name: "[fs/lookPath] unix empty path",
+  async fn () {
+    const tmp = await Deno.makeTempDir({ prefix: "test-deno-std-lookPath-empty" });
+    const cwd = Deno.cwd();
+    Deno.chdir(tmp);
+    const f = await Deno.open("exec_this", {
+      write: true,
+      create: true,
+      mode: 0o700,
+    });
+    f.close();
+    Deno.env.set("PATH", "");
+
+    assertThrowsAsync(() => lookPath("exec_this"));
+
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  },
+});

--- a/fs/_lp_windows.ts
+++ b/fs/_lp_windows.ts
@@ -1,0 +1,71 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { splitList } from "../path/separator.ts";
+import { join } from "../path/win32.ts";
+
+async function chkStat(file: string) {
+  const s = await Deno.stat(file);
+  if (s.isDirectory) {
+    throw new Deno.errors.PermissionDenied(file);
+  }
+  return;
+}
+
+function hasExt(file: string): boolean {
+  const i = file.lastIndexOf(".");
+  if (i < 0) {
+    return false;
+  }
+  return file.lastIndexOf(":") < i &&
+    file.lastIndexOf("\\") < i &&
+    file.lastIndexOf("/") < i;
+}
+
+async function findExecutable(file: string, exts: string[]): Promise<string> {
+  if (exts.length === 0) {
+    await chkStat(file);
+    return file;
+  }
+  if (hasExt(file)) {
+    await chkStat(file);
+    return file;
+  }
+  for (const e of exts) {
+    try {
+      const f = file + e;
+      await chkStat(f);
+      return f;
+    } catch (_) {
+      // swallow the error and let the loop continue with the next extension
+    }
+  }
+  throw new Deno.errors.NotFound(file);
+}
+
+export async function lookPath(bin: string): Promise<string | undefined> {
+  // Defaults taken from the Go source code.
+  const exts = splitList(Deno.env.get("PATHEXT") ?? ".com;.exe;.bat;.cmd")
+    .filter((e) => e !== "")
+    .map((e) => {
+      if (e[0] !== ".") {
+        e = "." + e;
+      }
+      return e;
+    });
+
+  if (bin.includes(":") || bin.includes("/") || bin.includes("\\")) {
+    return await findExecutable(bin, exts);
+  }
+
+  try {
+    return await findExecutable(join(".", bin), exts);
+  } catch (_) {
+    for (const dir in splitList(Deno.env.get("PATH") ?? "")) {
+      try {
+        return await findExecutable(join(dir, bin), exts);
+      } catch (_) {
+        // swallow the error and let the loop continue with the next extension
+      }
+    }
+  }
+  throw new Deno.errors.NotFound(bin);
+}

--- a/fs/_lp_windows_test.ts
+++ b/fs/_lp_windows_test.ts
@@ -1,0 +1,40 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { dirname, extname } from "../path/posix.ts";
+import { copy } from "../io/util.ts";
+import { lookPath } from "./_lp_windows.ts";
+
+async function installExe(dest: string, src: string) {
+  const fsrc = await Deno.open(src);
+  const fdest = await Deno.create(dest);
+  await copy(fsrc, fdest);
+}
+
+async function installBat(dest: string) {
+  await Deno.create(dest);
+}
+
+async function installProg(dest: string, srcExe: string) {
+  await Deno.mkdir(dirname(dest), {
+    mode: 0o700,
+    recursive: true,
+  });
+  if (extname(dest).toLowerCase() === ".bat") {
+    await installBat(dest);
+    return
+  }
+  await installExe(dest, srcExe);
+}
+
+type LookPathTest = {
+  rootDir: string,
+  PATH: string,
+  PATHEXT: string,
+  files: string[],
+  searchFor: string,
+  fails: boolean, // test is expected to fail
+};
+
+async function runProg(lpt: LookPathTest, env: string[], ...cmd: string[]): Promise<string> {
+  // should Deno.run something with cmd and env?
+  return await "";
+}

--- a/fs/lookpath.ts
+++ b/fs/lookpath.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// based on [Golang's `LookPath`][1] function.
+// [1] https://pkg.go.dev/os/exec#example-LookPath
+import { isWindows } from "../_util/os.ts";
+import { lookPath as unix } from "./_lp_unix.ts";
+import { lookPath as win32 } from "./_lp_windows.ts";
+
+export async function lookPath(bin: string): Promise<string | undefined> {
+  return await (isWindows ? win32(bin) : unix(bin));
+}

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -29,6 +29,6 @@ export const {
 } = path;
 
 export * from "./common.ts";
-export { SEP, SEP_PATTERN } from "./separator.ts";
+export { LIST_SEP, SEP, SEP_PATTERN } from "./separator.ts";
 export * from "./_interface.ts";
 export * from "./glob.ts";

--- a/path/separator.ts
+++ b/path/separator.ts
@@ -5,3 +5,11 @@ import { isWindows } from "../_util/os.ts";
 
 export const SEP = isWindows ? "\\" : "/";
 export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;
+export const LIST_SEP = isWindows ? ";" : ":";
+
+export function splitList(path: string): string[] {
+  if (path === "") {
+    return [];
+  }
+  return path.split(LIST_SEP);
+}


### PR DESCRIPTION
Port of the [lookPath][1] function from Go's exec package. Fixes #1056.

[1]https://pkg.go.dev/os/exec#example-LookPath