### PR TITLE
feat(collections): add `deepMerge`

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -30,6 +30,25 @@ console.assert(
 );
 ```
 
+## deepMerge
+
+Merges the two given Records, recursively merging any nested Records with the
+second collection overriding the first in case of conflict
+
+For arrays, maps and sets, a merging strategy can be specified to either
+`replace` values, or `merge` them instead. Use `includeNonEnumerable` option to
+include non enumerable properties too.
+
+```ts
+import { deepMerge } from "./deep_merge.ts";
+import { assertEquals } from "../testing/assert.ts";
+
+const a = { foo: true };
+const b = { foo: { bar: true } };
+
+assertEquals(deepMerge(a, b), { foo: { bar: true } });
+```
+
 ## distinctBy
 
 Returns all elements in the given array that produce a distinct value using the

--- a/collections/README.md
+++ b/collections/README.md
@@ -41,7 +41,7 @@ include non enumerable properties too.
 
 ```ts
 import { deepMerge } from "./deep_merge.ts";
-import { assertEquals } from "../testing/assert.ts";
+import { assertEquals } from "../testing/asserts.ts";
 
 const a = { foo: true };
 const b = { foo: { bar: true } };

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,9 +1,11 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /**
- * Merges the two given Records, recursively merging any nested Records with the second collection overriding the first in case of conflict
+ * Merges the two given Records, recursively merging any nested Records with
+ * the second collection overriding the first in case of conflict
  *
- * For arrays, maps and sets, a merging strategy can be specified to either "replace" values, or "concat" them instead.
+ * For arrays, maps and sets, a merging strategy can be specified to either
+ * "replace" values, or "concat" them instead.
  * Use "includeNonEnumerable" option to include non enumerable properties too.
  */
 export function deepMerge<
@@ -19,17 +21,17 @@ export function deepMerge<
     includeNonEnumerable = false,
   }: deepMergeOptions = {},
 ): T & U {
-  //Extract property and symbols
+  // Extract property and symbols
   const keys = [
     ...Object.getOwnPropertyNames(other),
     ...Object.getOwnPropertySymbols(other),
   ].filter((key) => includeNonEnumerable || other.propertyIsEnumerable(key));
 
-  //Iterate through each key of other object and use correct merging strategy
+  // Iterate through each key of other object and use correct merging strategy
   for (const key of keys as propertyKey[]) {
     const a = collection[key], b = other[key];
 
-    //Handle arrays
+    // Handle arrays
     if ((Array.isArray(a)) && (Array.isArray(b))) {
       if (arrays === "concat") {
         collection[key] = a.concat(...b);
@@ -39,7 +41,7 @@ export function deepMerge<
       continue;
     }
 
-    //Handle maps
+    // Handle maps
     if ((a instanceof Map) && (b instanceof Map)) {
       if (maps === "concat") {
         for (const [k, v] of b.entries()) {
@@ -51,7 +53,7 @@ export function deepMerge<
       continue;
     }
 
-    //Handle sets
+    // Handle sets
     if ((a instanceof Set) && (b instanceof Set)) {
       if (sets === "concat") {
         for (const v of b.values()) {
@@ -63,13 +65,13 @@ export function deepMerge<
       continue;
     }
 
-    //Recursively merge mergeable objects
+    // Recursively merge mergeable objects
     if (isMergeable<T | U>(a) && isMergeable<T | U>(b)) {
       collection[key] = deepMerge(a ?? {}, b);
       continue;
     }
 
-    //Override value
+    // Override value
     collection[key] = b;
   }
 
@@ -81,18 +83,18 @@ export function deepMerge<
  * Builtins object like, null and user classes are not considered mergeable
  */
 function isMergeable<T>(value: unknown): value is T {
-  //Ignore null
+  // Ignore null
   if (value === null) {
     return false;
   }
-  //Ignore builtins
+  // Ignore builtins
   if (
     (value instanceof RegExp) || (value instanceof Date) ||
     (value instanceof Array)
   ) {
     return false;
   }
-  //Ignore classes
+  // Ignore classes
   if ((typeof value === "object") && ("constructor" in value!)) {
     return !/^class /.test(value.constructor.toString());
   }
@@ -111,6 +113,7 @@ interface deepMergeOptions {
   includeNonEnumerable?: boolean;
 }
 
-//TypeScript does not support 'symbol' as index type currently though it's perfectly valid
-//deno-lint-ignore no-explicit-any
+// TypeScript does not support 'symbol' as index type currently though
+// it's perfectly valid
+// deno-lint-ignore no-explicit-any
 type propertyKey = any;

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,18 +1,4 @@
-/** Deep merge options */
-interface deepMergeOptions {
-  /** Merging strategy for arrays */
-  arrays?: "replace" | "concat";
-  /** Merging strategy for Maps */
-  maps?: "replace" | "concat";
-  /** Merging strategy for Sets */
-  sets?: "replace" | "concat";
-  /** Whether to include non enumerable properties */
-  includeNonEnumerable?: boolean;
-}
-
-//TypeScript does not support 'symbol' as index type currently though it's perfectly valid
-//deno-lint-ignore no-explicit-any
-type propertyKey = any;
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 /**
  * Merges the two given Records, recursively merging any nested Records with the second collection overriding the first in case of conflict
@@ -112,3 +98,19 @@ function isMergeable<T>(value: unknown): value is T {
   }
   return typeof value === "object";
 }
+
+/** Deep merge options */
+interface deepMergeOptions {
+  /** Merging strategy for arrays */
+  arrays?: "replace" | "concat";
+  /** Merging strategy for Maps */
+  maps?: "replace" | "concat";
+  /** Merging strategy for Sets */
+  sets?: "replace" | "concat";
+  /** Whether to include non enumerable properties */
+  includeNonEnumerable?: boolean;
+}
+
+//TypeScript does not support 'symbol' as index type currently though it's perfectly valid
+//deno-lint-ignore no-explicit-any
+type propertyKey = any;

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,14 +1,18 @@
 /** Deep merge options */
 interface deepMergeOptions {
   /** Merging strategy for arrays */
-  arrays?:"replace"|"concat",
+  arrays?: "replace" | "concat";
   /** Merging strategy for Maps */
-  maps?:"replace"|"concat",
+  maps?: "replace" | "concat";
   /** Merging strategy for Sets */
-  sets?:"replace"|"concat",
+  sets?: "replace" | "concat";
   /** Whether to include non enumerable properties */
-  includeNonEnumerable?:boolean
+  includeNonEnumerable?: boolean;
 }
+
+//TypeScript does not support 'symbol' as index type currently though it's perfectly valid
+//deno-lint-ignore no-explicit-any
+type propertyKey = any;
 
 /**
  * Merges the two given Records, recursively merging any nested Records with the second collection overriding the first in case of conflict
@@ -16,74 +20,95 @@ interface deepMergeOptions {
  * For arrays, maps and sets, a merging strategy can be specified to either "replace" values, or "concat" them instead.
  * Use "includeNonEnumerable" option to include non enumerable properties too.
  */
-export function deepMerge<T extends Record<keyof any, unknown>>(collection: Partial<T>, other: Partial<T>, options?:deepMergeOptions): T
-export function deepMerge<T extends Record<keyof any, unknown>, U extends Record<keyof unknown, unknown>>(collection: T, other: U, options?:deepMergeOptions): T & U
-export function deepMerge(collection:any, other:any, {arrays = "replace", maps = "replace", sets = "replace", includeNonEnumerable = false} = {}) {
-
+export function deepMerge<
+  T extends Record<PropertyKey, unknown>,
+  U extends Record<PropertyKey, unknown>,
+>(
+  collection: T,
+  other: U,
+  {
+    arrays = "replace",
+    maps = "replace",
+    sets = "replace",
+    includeNonEnumerable = false,
+  }: deepMergeOptions = {},
+): T & U {
   //Extract property and symbols
-  const keys = [...Object.getOwnPropertyNames(other), ...Object.getOwnPropertySymbols(other)].filter(key => includeNonEnumerable || other.propertyIsEnumerable(key))
+  const keys = [
+    ...Object.getOwnPropertyNames(other),
+    ...Object.getOwnPropertySymbols(other),
+  ].filter((key) => includeNonEnumerable || other.propertyIsEnumerable(key));
 
   //Iterate through each key of other object and use correct merging strategy
-  for (const key of keys) {
-    const a = collection[key], b = other[key]
+  for (const key of keys as propertyKey[]) {
+    const a = collection[key], b = other[key];
 
     //Handle arrays
-    if ((Array.isArray(a))&&(Array.isArray(b))) {
-      if (arrays === "concat")
-        collection[key] = a.concat(...b)
-      else
-        collection[key] = b
-      continue
+    if ((Array.isArray(a)) && (Array.isArray(b))) {
+      if (arrays === "concat") {
+        collection[key] = a.concat(...b);
+      } else {
+        collection[key] = b;
+      }
+      continue;
     }
 
     //Handle maps
-    if ((a instanceof Map)&&(b instanceof Map)) {
+    if ((a instanceof Map) && (b instanceof Map)) {
       if (maps === "concat") {
-        for (const [k, v] of b.entries())
-          a.set(k, v)
+        for (const [k, v] of b.entries()) {
+          a.set(k, v);
+        }
+      } else {
+        collection[key] = b;
       }
-      else
-        collection[key] = b
-      continue
+      continue;
     }
 
     //Handle sets
-    if ((a instanceof Set)&&(b instanceof Set)) {
+    if ((a instanceof Set) && (b instanceof Set)) {
       if (sets === "concat") {
-        for (const v of b.values())
-          a.add(v)
+        for (const v of b.values()) {
+          a.add(v);
+        }
+      } else {
+        collection[key] = b;
       }
-      else
-        collection[key] = b
-      continue
+      continue;
     }
 
     //Recursively merge mergeable objects
-    if (isMergeable(a) && isMergeable(b)) {
-      collection[key] = deepMerge(collection[key] ?? {}, b)
-      continue
+    if (isMergeable<T | U>(a) && isMergeable<T | U>(b)) {
+      collection[key] = deepMerge(a ?? {}, b);
+      continue;
     }
 
     //Override value
-    collection[key] = b
+    collection[key] = b;
   }
 
-  return collection
+  return collection as T & U;
 }
 
 /**
  * Test whether a value is mergeable or not
  * Builtins object like, null and user classes are not considered mergeable
  */
-function isMergeable(value:unknown) {
+function isMergeable<T>(value: unknown): value is T {
   //Ignore null
-  if (value === null)
-    return false
+  if (value === null) {
+    return false;
+  }
   //Ignore builtins
-  if ((value instanceof RegExp)||(value instanceof Date))
-    return false
+  if (
+    (value instanceof RegExp) || (value instanceof Date) ||
+    (value instanceof Array)
+  ) {
+    return false;
+  }
   //Ignore classes
-  if ((typeof value === "object")&&("constructor" in value!))
-    return !/^class /.test(value.constructor.toString())
-  return typeof value === "object"
+  if ((typeof value === "object") && ("constructor" in value!)) {
+    return !/^class /.test(value.constructor.toString());
+  }
+  return typeof value === "object";
 }

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,0 +1,89 @@
+/** Deep merge options */
+interface deepMergeOptions {
+  /** Merging strategy for arrays */
+  arrays?:"replace"|"concat",
+  /** Merging strategy for Maps */
+  maps?:"replace"|"concat",
+  /** Merging strategy for Sets */
+  sets?:"replace"|"concat",
+  /** Whether to include non enumerable properties */
+  includeNonEnumerable?:boolean
+}
+
+/**
+ * Merges the two given Records, recursively merging any nested Records with the second collection overriding the first in case of conflict
+ *
+ * For arrays, maps and sets, a merging strategy can be specified to either "replace" values, or "concat" them instead.
+ * Use "includeNonEnumerable" option to include non enumerable properties too.
+ */
+export function deepMerge<T extends Record<keyof any, unknown>>(collection: Partial<T>, other: Partial<T>, options?:deepMergeOptions): T
+export function deepMerge<T extends Record<keyof any, unknown>, U extends Record<keyof unknown, unknown>>(collection: T, other: U, options?:deepMergeOptions): T & U
+export function deepMerge(collection:any, other:any, {arrays = "replace", maps = "replace", sets = "replace", includeNonEnumerable = false} = {}) {
+
+  //Extract property and symbols
+  const keys = [...Object.getOwnPropertyNames(other), ...Object.getOwnPropertySymbols(other)].filter(key => includeNonEnumerable || other.propertyIsEnumerable(key))
+
+  //Iterate through each key of other object and use correct merging strategy
+  for (const key of keys) {
+    const a = collection[key], b = other[key]
+
+    //Handle arrays
+    if ((Array.isArray(a))&&(Array.isArray(b))) {
+      if (arrays === "concat")
+        collection[key] = a.concat(...b)
+      else
+        collection[key] = b
+      continue
+    }
+
+    //Handle maps
+    if ((a instanceof Map)&&(b instanceof Map)) {
+      if (maps === "concat") {
+        for (const [k, v] of b.entries())
+          a.set(k, v)
+      }
+      else
+        collection[key] = b
+      continue
+    }
+
+    //Handle sets
+    if ((a instanceof Set)&&(b instanceof Set)) {
+      if (sets === "concat") {
+        for (const v of b.values())
+          a.add(v)
+      }
+      else
+        collection[key] = b
+      continue
+    }
+
+    //Recursively merge mergeable objects
+    if (isMergeable(a) && isMergeable(b)) {
+      collection[key] = deepMerge(collection[key] ?? {}, b)
+      continue
+    }
+
+    //Override value
+    collection[key] = b
+  }
+
+  return collection
+}
+
+/**
+ * Test whether a value is mergeable or not
+ * Builtins object like, null and user classes are not considered mergeable
+ */
+function isMergeable(value:unknown) {
+  //Ignore null
+  if (value === null)
+    return false
+  //Ignore builtins
+  if ((value instanceof RegExp)||(value instanceof Date))
+    return false
+  //Ignore classes
+  if ((typeof value === "object")&&("constructor" in value!))
+    return !/^class /.test(value.constructor.toString())
+  return typeof value === "object"
+}

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -31,27 +31,32 @@ export function deepMerge<
 export function deepMerge<
   T extends Record<PropertyKey, unknown>,
   U extends Record<PropertyKey, unknown>,
+  Options extends DeepMergeOptions,
 >(
   record: T,
   other: U,
-  options?: DeepMergeOptions,
-): DeepMerge<T, U>;
+  options?: Options,
+): DeepMerge<T, U, Options>;
 
 export function deepMerge<
   T extends Record<PropertyKey, unknown>,
   U extends Record<PropertyKey, unknown>,
+  Options extends DeepMergeOptions,
 >(
   record: T,
   other: U,
-  {
+  options?: Options,
+): DeepMerge<T, U, Options> {
+  //
+  const {
     arrays = "merge",
     maps = "merge",
     sets = "merge",
     includeNonEnumerable = false,
-  }: DeepMergeOptions = {},
-): DeepMerge<T, U> {
+  } = options ?? {};
+
   // Clone left operand to avoid performing mutations in-place
-  type Result = DeepMerge<T, U>;
+  type Result = DeepMerge<T, U, Options>;
   const result = clone(record as Result, { includeNonEnumerable });
 
   // Extract property and symbols
@@ -356,10 +361,7 @@ type Merge<
 export type DeepMerge<
   T,
   U,
-  Options extends Record<string, MergingStrategy> = Record<
-    string,
-    MergingStrategy
-  >,
+  Options = Record<string, MergingStrategy>,
 > =
   // Handle objects
   [T, U] extends [Record<PropertyKey, unknown>, Record<PropertyKey, unknown>]

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * import { deepMerge } from "./deep_merge.ts";
- * import { assertEquals } from "../testing/assert.ts";
+ * import { assertEquals } from "../testing/asserts.ts";
  *
  * const a = {foo: true}
  * const b = {foo: {bar: true}}

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -35,7 +35,7 @@ export function deepMerge<
   record: T,
   other: U,
   options?: DeepMergeOptions,
-): T;
+): T & U;
 
 export function deepMerge<
   T extends Record<PropertyKey, unknown>,
@@ -65,7 +65,7 @@ export function deepMerge<
     // Handle arrays
     if ((Array.isArray(a)) && (Array.isArray(b))) {
       if (arrays === "merge") {
-        (result[key] as typeof a).push(...b);
+        (result[key] as (typeof a & typeof b)).push(...b);
       } else {
         result[key] = b;
       }
@@ -97,8 +97,8 @@ export function deepMerge<
     }
 
     // Recursively merge mergeable objects
-    if (isMergeable<T | U>(a) && isMergeable<T | U>(b)) {
-      result[key] = deepMerge(a ?? {}, b);
+    if (isMergeable(a) && isMergeable(b)) {
+      result[key] = deepMerge(a, b);
       continue;
     }
 
@@ -140,7 +140,7 @@ function clone<T extends Record<PropertyKey, unknown>>(
       cloned[key] = new Set(v);
       continue;
     }
-    if (isMergeable<Record<PropertyKey, unknown>>(v)) {
+    if (isMergeable(v)) {
       cloned[key] = clone(v);
       continue;
     }
@@ -154,7 +154,9 @@ function clone<T extends Record<PropertyKey, unknown>>(
  * Test whether a value is mergeable or not
  * Builtins object like, null and user classes are not considered mergeable
  */
-function isMergeable<T>(value: unknown): value is T {
+function isMergeable<T extends Record<PropertyKey, unknown>>(
+  value: unknown,
+): value is T {
   // Ignore null
   if (value === null) {
     return false;

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -1,189 +1,265 @@
 import { assertEquals } from "../testing/asserts.ts";
+import { deepMerge } from "./deep_merge.ts";
 
 Deno.test("deepMerge: simple merge", () => {
-  assertEquals(deepMerge({
-    foo:true
-  }, {
-    bar:true
-  }), {
-    foo:true,
-    bar:true
-  })
-})
+  assertEquals(
+    deepMerge({
+      foo: true,
+    }, {
+      bar: true,
+    }),
+    {
+      foo: true,
+      bar: true,
+    },
+  );
+});
 
 Deno.test("deepMerge: symbol merge", () => {
-  assertEquals(deepMerge({}, {
-    [Symbol.for("deepmerge.test")]:true
-  }), {
-    [Symbol.for("deepmerge.test")]:true
-  })
-})
+  assertEquals(
+    deepMerge({}, {
+      [Symbol.for("deepmerge.test")]: true,
+    }),
+    {
+      [Symbol.for("deepmerge.test")]: true,
+    },
+  );
+});
 
 Deno.test("deepMerge: ignore non enumerable", () => {
-  assertEquals(deepMerge({}, Object.defineProperties({}, {
-    foo:{enumerable:false, value:true},
-    bar:{enumerable:true, value:true}
-  })), {
-    bar:true
-  })
-})
+  assertEquals(
+    deepMerge(
+      {},
+      Object.defineProperties({}, {
+        foo: { enumerable: false, value: true },
+        bar: { enumerable: true, value: true },
+      }),
+    ),
+    {
+      bar: true,
+    },
+  );
+});
 
 Deno.test("deepMerge: include non enumerable", () => {
-  assertEquals(deepMerge({}, Object.defineProperties({}, {
-    foo:{enumerable:false, value:true},
-    bar:{enumerable:true, value:true}
-  }), {includeNonEnumerable:true}), {
-    foo:true,
-    bar:true
-  })
-})
+  assertEquals(
+    deepMerge(
+      {},
+      Object.defineProperties({}, {
+        foo: { enumerable: false, value: true },
+        bar: { enumerable: true, value: true },
+      }),
+      { includeNonEnumerable: true },
+    ),
+    {
+      foo: true,
+      bar: true,
+    },
+  );
+});
 
 Deno.test("deepMerge: nested merge", () => {
-  assertEquals(deepMerge({
-    foo:{
-      bar:true
-    }
-  }, {
-    foo:{
-      baz:true,
-      quux:{}
+  assertEquals(
+    deepMerge({
+      foo: {
+        bar: true,
+      },
+    }, {
+      foo: {
+        baz: true,
+        quux: {},
+      },
+      qux: true,
+    }),
+    {
+      foo: {
+        bar: true,
+        baz: true,
+        quux: {},
+      },
+      qux: true,
     },
-    qux:true
-  }), {
-    foo:{
-      bar:true,
-      baz:true,
-      quux:{}
-    },
-    qux:true
-  })
-})
+  );
+});
 
 Deno.test("deepMerge: override target (non-mergeable source)", () => {
-  assertEquals(deepMerge({
-    foo:{
-      bar:true
-    }
-  }, {
-    foo:true
-  }), {
-    foo:true
-  })
-})
+  assertEquals(
+    deepMerge({
+      foo: {
+        bar: true,
+      },
+    }, {
+      foo: true,
+    }),
+    {
+      foo: true,
+    },
+  );
+});
 
-Deno.test("deepMerge: override target (non-mergeable destination #1)", () => {
-  const CustomClass = class {}
-  assertEquals(deepMerge({
-    foo:new CustomClass()
-  }, {
-    foo:true
-  }), {
-    foo:true
-  })
-})
+Deno.test("deepMerge: override target (non-mergeable destination, object like)", () => {
+  const CustomClass = class {};
+  assertEquals(
+    deepMerge({
+      foo: new CustomClass(),
+    }, {
+      foo: true,
+    }),
+    {
+      foo: true,
+    },
+  );
+});
 
-Deno.test("deepMerge: override target (non-mergeable destination #2)", () => {
-  assertEquals(deepMerge({
-    foo:[]
-  }, {
-    foo:true
-  }), {
-    foo:true
-  })
-})
+Deno.test("deepMerge: override target (non-mergeable destination, array like)", () => {
+  assertEquals(
+    deepMerge({
+      foo: [],
+    }, {
+      foo: true,
+    }),
+    {
+      foo: true,
+    },
+  );
+});
+
+Deno.test("deepMerge: override target (different object like source and destination)", () => {
+  assertEquals(
+    deepMerge({
+      foo: {},
+    }, {
+      foo: [1, 2],
+    }),
+    {
+      foo: [1, 2],
+    },
+  );
+  assertEquals(
+    deepMerge({
+      foo: [],
+    }, {
+      foo: { bar: true },
+    }),
+    {
+      foo: { bar: true },
+    },
+  );
+});
 
 Deno.test("deepMerge: primitive types handling", () => {
-  const CustomClass = class {}
+  const CustomClass = class {};
   const expected = {
-    boolean:true,
-    null:null,
-    undefined:undefined,
-    number:1,
-    bigint:1n,
-    string:"string",
-    symbol:Symbol.for("deepmerge.test"),
-    object:{foo:true},
-    regexp:/regex/,
-    date:new Date(),
+    boolean: true,
+    null: null,
+    undefined: undefined,
+    number: 1,
+    bigint: 1n,
+    string: "string",
+    symbol: Symbol.for("deepmerge.test"),
+    object: { foo: true },
+    regexp: /regex/,
+    date: new Date(),
     function() {},
     async async() {},
-    arrow:() => {},
-    class:new CustomClass(),
-  }
-  assertEquals(deepMerge({
-    boolean:false,
-    null:undefined,
-    undefined:null,
-    number:-1,
-    bigint:-1n,
-    string:"foo",
-    symbol:Symbol(),
-    object:null,
-    regexp:/foo/,
-    date:new Date(0),
-    function:function () {},
-    async: async function() {},
     arrow: () => {},
-    class:null,
-  }, expected), expected)
-})
+    class: new CustomClass(),
+  };
+  assertEquals(
+    deepMerge({
+      boolean: false,
+      null: undefined,
+      undefined: null,
+      number: -1,
+      bigint: -1n,
+      string: "foo",
+      symbol: Symbol(),
+      object: null,
+      regexp: /foo/,
+      date: new Date(0),
+      function: function () {},
+      async: async function () {},
+      arrow: () => {},
+      class: null,
+    }, expected),
+    expected,
+  );
+});
 
 Deno.test("deepMerge: array merge (replace)", () => {
-  assertEquals(deepMerge({
-    foo:[1, 2, 3]
-  }, {
-    foo:[4, 5, 6]
-  }), {
-    foo:[4, 5, 6]
-  })
-})
+  assertEquals(
+    deepMerge({
+      foo: [1, 2, 3],
+    }, {
+      foo: [4, 5, 6],
+    }),
+    {
+      foo: [4, 5, 6],
+    },
+  );
+});
 
 Deno.test("deepMerge: array merge (concat)", () => {
-  assertEquals(deepMerge({
-    foo:[1, 2, 3]
-  }, {
-    foo:[4, 5, 6]
-  }, {arrays:"concat"}), {
-    foo:[1, 2, 3, 4, 5, 6]
-  })
-})
+  assertEquals(
+    deepMerge({
+      foo: [1, 2, 3],
+    }, {
+      foo: [4, 5, 6],
+    }, { arrays: "concat" }),
+    {
+      foo: [1, 2, 3, 4, 5, 6],
+    },
+  );
+});
 
 Deno.test("deepMerge: maps merge (replace)", () => {
-  assertEquals(deepMerge({
-    map:new Map([["foo", true]])
-  }, {
-    map:new Map([["bar", true]])
-  }), {
-    map:new Map([["bar", true]])
-  })
-})
+  assertEquals(
+    deepMerge({
+      map: new Map([["foo", true]]),
+    }, {
+      map: new Map([["bar", true]]),
+    }),
+    {
+      map: new Map([["bar", true]]),
+    },
+  );
+});
 
 Deno.test("deepMerge: maps merge (concat)", () => {
-  assertEquals(deepMerge({
-    map:new Map([["foo", true]])
-  }, {
-    map:new Map([["bar", true]])
-  }, {maps:"concat"}), {
-    map:new Map([["foo", true], ["bar", true]])
-  })
-})
+  assertEquals(
+    deepMerge({
+      map: new Map([["foo", true]]),
+    }, {
+      map: new Map([["bar", true]]),
+    }, { maps: "concat" }),
+    {
+      map: new Map([["foo", true], ["bar", true]]),
+    },
+  );
+});
 
 Deno.test("deepMerge: sets merge (replace)", () => {
-  assertEquals(deepMerge({
-    set:new Set(["foo"])
-  }, {
-    set:new Set(["bar"])
-  }), {
-    set:new Set(["bar"])
-  })
-})
+  assertEquals(
+    deepMerge({
+      set: new Set(["foo"]),
+    }, {
+      set: new Set(["bar"]),
+    }),
+    {
+      set: new Set(["bar"]),
+    },
+  );
+});
 
 Deno.test("deepMerge: sets merge (concat)", () => {
-  assertEquals(deepMerge({
-    set:new Set(["foo"])
-  }, {
-    set:new Set(["bar"])
-  }, {sets:"concat"}), {
-    set:new Set(["foo", "bar"])
-  })
-})
+  assertEquals(
+    deepMerge({
+      set: new Set(["foo"]),
+    }, {
+      set: new Set(["bar"]),
+    }, { sets: "concat" }),
+    {
+      set: new Set(["foo", "bar"]),
+    },
+  );
+});

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -196,20 +196,20 @@ Deno.test("deepMerge: array merge (replace)", () => {
       foo: [1, 2, 3],
     }, {
       foo: [4, 5, 6],
-    }),
+    }, { arrays: "replace" }),
     {
       foo: [4, 5, 6],
     },
   );
 });
 
-Deno.test("deepMerge: array merge (concat)", () => {
+Deno.test("deepMerge: array merge (merge)", () => {
   assertEquals(
     deepMerge({
       foo: [1, 2, 3],
     }, {
       foo: [4, 5, 6],
-    }, { arrays: "concat" }),
+    }, { arrays: "merge" }),
     {
       foo: [1, 2, 3, 4, 5, 6],
     },
@@ -222,20 +222,20 @@ Deno.test("deepMerge: maps merge (replace)", () => {
       map: new Map([["foo", true]]),
     }, {
       map: new Map([["bar", true]]),
-    }),
+    }, { maps: "replace" }),
     {
       map: new Map([["bar", true]]),
     },
   );
 });
 
-Deno.test("deepMerge: maps merge (concat)", () => {
+Deno.test("deepMerge: maps merge (merge)", () => {
   assertEquals(
     deepMerge({
       map: new Map([["foo", true]]),
     }, {
       map: new Map([["bar", true]]),
-    }, { maps: "concat" }),
+    }, { maps: "merge" }),
     {
       map: new Map([["foo", true], ["bar", true]]),
     },
@@ -248,20 +248,20 @@ Deno.test("deepMerge: sets merge (replace)", () => {
       set: new Set(["foo"]),
     }, {
       set: new Set(["bar"]),
-    }),
+    }, { sets: "replace" }),
     {
       set: new Set(["bar"]),
     },
   );
 });
 
-Deno.test("deepMerge: sets merge (concat)", () => {
+Deno.test("deepMerge: sets merge (merge)", () => {
   assertEquals(
     deepMerge({
       set: new Set(["foo"]),
     }, {
       set: new Set(["bar"]),
-    }, { sets: "concat" }),
+    }, { sets: "merge" }),
     {
       set: new Set(["foo", "bar"]),
     },

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -164,6 +164,9 @@ Deno.test("deepMerge: primitive types handling", () => {
     async async() {},
     arrow: () => {},
     class: new CustomClass(),
+    get get() {
+      return true;
+    },
   };
   assertEquals(
     deepMerge({
@@ -181,6 +184,7 @@ Deno.test("deepMerge: primitive types handling", () => {
       async: async function () {},
       arrow: () => {},
       class: null,
+      get: false,
     }, expected),
     expected,
   );
@@ -262,4 +266,49 @@ Deno.test("deepMerge: sets merge (concat)", () => {
       set: new Set(["foo", "bar"]),
     },
   );
+});
+
+Deno.test("deepMerge: complex test", () => {
+  assertEquals(
+    deepMerge({
+      foo: {
+        bar: {
+          quux: new Set(["foo"]),
+          grault: {},
+        },
+      },
+    }, {
+      foo: {
+        bar: {
+          baz: true,
+          qux: [1, 2],
+          grault: {
+            garply: false,
+          },
+        },
+        corge: "deno",
+        [Symbol.for("deepmerge.test")]: true,
+      },
+    }),
+    {
+      foo: {
+        bar: {
+          quux: new Set(["foo"]),
+          baz: true,
+          qux: [1, 2],
+          grault: {
+            garply: false,
+          },
+        },
+        corge: "deno",
+        [Symbol.for("deepmerge.test")]: true,
+      },
+    },
+  );
+});
+
+Deno.test("deepMerge: handle circular references", () => {
+  const expected = { foo: true } as { foo: boolean; bar: unknown };
+  expected.bar = expected;
+  assertEquals(deepMerge({}, expected), expected);
 });

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -312,3 +312,37 @@ Deno.test("deepMerge: handle circular references", () => {
   expected.bar = expected;
   assertEquals(deepMerge({}, expected), expected);
 });
+
+Deno.test("deepMerge: target object is not modified", () => {
+  const record = {
+    foo: {
+      bar: true,
+    },
+    baz: [1, 2, 3],
+    quux: new Set([1, 2, 3]),
+  };
+  assertEquals(
+    deepMerge(record, {
+      foo: {
+        qux: false,
+      },
+      baz: [4, 5, 6],
+      quux: new Set([4, 5, 6]),
+    }, { arrays: "merge", sets: "merge" }),
+    {
+      foo: {
+        bar: true,
+        qux: false,
+      },
+      baz: [1, 2, 3, 4, 5, 6],
+      quux: new Set([1, 2, 3, 4, 5, 6]),
+    },
+  );
+  assertEquals(record, {
+    foo: {
+      bar: true,
+    },
+    baz: [1, 2, 3],
+    quux: new Set([1, 2, 3]),
+  });
+});

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -1,0 +1,189 @@
+import { assertEquals } from "../testing/asserts.ts";
+
+Deno.test("deepMerge: simple merge", () => {
+  assertEquals(deepMerge({
+    foo:true
+  }, {
+    bar:true
+  }), {
+    foo:true,
+    bar:true
+  })
+})
+
+Deno.test("deepMerge: symbol merge", () => {
+  assertEquals(deepMerge({}, {
+    [Symbol.for("deepmerge.test")]:true
+  }), {
+    [Symbol.for("deepmerge.test")]:true
+  })
+})
+
+Deno.test("deepMerge: ignore non enumerable", () => {
+  assertEquals(deepMerge({}, Object.defineProperties({}, {
+    foo:{enumerable:false, value:true},
+    bar:{enumerable:true, value:true}
+  })), {
+    bar:true
+  })
+})
+
+Deno.test("deepMerge: include non enumerable", () => {
+  assertEquals(deepMerge({}, Object.defineProperties({}, {
+    foo:{enumerable:false, value:true},
+    bar:{enumerable:true, value:true}
+  }), {includeNonEnumerable:true}), {
+    foo:true,
+    bar:true
+  })
+})
+
+Deno.test("deepMerge: nested merge", () => {
+  assertEquals(deepMerge({
+    foo:{
+      bar:true
+    }
+  }, {
+    foo:{
+      baz:true,
+      quux:{}
+    },
+    qux:true
+  }), {
+    foo:{
+      bar:true,
+      baz:true,
+      quux:{}
+    },
+    qux:true
+  })
+})
+
+Deno.test("deepMerge: override target (non-mergeable source)", () => {
+  assertEquals(deepMerge({
+    foo:{
+      bar:true
+    }
+  }, {
+    foo:true
+  }), {
+    foo:true
+  })
+})
+
+Deno.test("deepMerge: override target (non-mergeable destination #1)", () => {
+  const CustomClass = class {}
+  assertEquals(deepMerge({
+    foo:new CustomClass()
+  }, {
+    foo:true
+  }), {
+    foo:true
+  })
+})
+
+Deno.test("deepMerge: override target (non-mergeable destination #2)", () => {
+  assertEquals(deepMerge({
+    foo:[]
+  }, {
+    foo:true
+  }), {
+    foo:true
+  })
+})
+
+Deno.test("deepMerge: primitive types handling", () => {
+  const CustomClass = class {}
+  const expected = {
+    boolean:true,
+    null:null,
+    undefined:undefined,
+    number:1,
+    bigint:1n,
+    string:"string",
+    symbol:Symbol.for("deepmerge.test"),
+    object:{foo:true},
+    regexp:/regex/,
+    date:new Date(),
+    function() {},
+    async async() {},
+    arrow:() => {},
+    class:new CustomClass(),
+  }
+  assertEquals(deepMerge({
+    boolean:false,
+    null:undefined,
+    undefined:null,
+    number:-1,
+    bigint:-1n,
+    string:"foo",
+    symbol:Symbol(),
+    object:null,
+    regexp:/foo/,
+    date:new Date(0),
+    function:function () {},
+    async: async function() {},
+    arrow: () => {},
+    class:null,
+  }, expected), expected)
+})
+
+Deno.test("deepMerge: array merge (replace)", () => {
+  assertEquals(deepMerge({
+    foo:[1, 2, 3]
+  }, {
+    foo:[4, 5, 6]
+  }), {
+    foo:[4, 5, 6]
+  })
+})
+
+Deno.test("deepMerge: array merge (concat)", () => {
+  assertEquals(deepMerge({
+    foo:[1, 2, 3]
+  }, {
+    foo:[4, 5, 6]
+  }, {arrays:"concat"}), {
+    foo:[1, 2, 3, 4, 5, 6]
+  })
+})
+
+Deno.test("deepMerge: maps merge (replace)", () => {
+  assertEquals(deepMerge({
+    map:new Map([["foo", true]])
+  }, {
+    map:new Map([["bar", true]])
+  }), {
+    map:new Map([["bar", true]])
+  })
+})
+
+Deno.test("deepMerge: maps merge (concat)", () => {
+  assertEquals(deepMerge({
+    map:new Map([["foo", true]])
+  }, {
+    map:new Map([["bar", true]])
+  }, {maps:"concat"}), {
+    map:new Map([["foo", true], ["bar", true]])
+  })
+})
+
+Deno.test("deepMerge: sets merge (replace)", () => {
+  assertEquals(deepMerge({
+    set:new Set(["foo"])
+  }, {
+    set:new Set(["bar"])
+  }), {
+    set:new Set(["bar"])
+  })
+})
+
+Deno.test("deepMerge: sets merge (concat)", () => {
+  assertEquals(deepMerge({
+    set:new Set(["foo"])
+  }, {
+    set:new Set(["bar"])
+  }, {sets:"concat"}), {
+    set:new Set(["foo", "bar"])
+  })
+})


### PR DESCRIPTION
This implements `deepMerge`, which merges deeply two records together into the first one.

```ts
deepMerge({           // {
  foo: {              //   foo: {
    bar: true,        //     bar: true,
  },                  //     baz: true,
}, {                  //     quux: {},
  foo: {              //   },
    baz: true,        //   qux: true,
    quux: {},         // }
  },
  qux: true,
})
```

For convenience, a few options are proposed to handle edge cases:
- `arrays`, `sets` and `maps` can change their merging strategy from `"replace"` to `"concat"`. In the latter mode, values from both records will be kept
- `includeNonEnumerable` can be used to include properties and symbols which have an hidden visibility

Additional implementation notes:
- All `PropertyKey` types are supported (including `symbol`)
- Built-ins (like `RegExp`, `Date`, ...) and user classes won't be treated as objects, so the recursive merging won't apply on them (instead their reference is just replaced in target record) 

Ref:  #1065

____

- [x] Typings
  - [x] Basic typing
  - [x] Improved maps, arrays, sets typing
  - [x] Probably missing a recursive typing somewhere
  - [x] Handle merging strategy to reflect correct typing
- [x] Add signature for `Partial<T> : T` 
- [x] Change default to `merge` instead
- [x] Add example to comment and `README.md`  
- [x] Rename typing in PascalCase instead and export the options one
- [x] First clone the target object to avoid mutating in place
- [x] Improve prototype check 