### PR TITLE
Return code 304 based on If-Modified-Since Header

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -286,8 +286,14 @@ export async function serveFile(
     headers.set("etag", simpleEtag);
 
     // If a `if-node-match` header is present and the value matches the tag return 304
+    // If a `if-modified-since` header is present and the value is bigger than
+    // the access timestamp value return 304
     const ifNoneMatch = req.headers.get("if-none-match");
-    if (ifNoneMatch && ifNoneMatch === simpleEtag) {
+    const ifModifiedSince = req.headers.get("if-modified-since");
+    if (
+      (ifNoneMatch && ifNoneMatch === simpleEtag) || (ifModifiedSince &&
+        fileInfo.mtime.getTime() < (new Date(ifModifiedSince).getTime() + 1000))
+    ) {
       response.status = 304;
       response.statusText = "Not Modified";
       return response;

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -285,13 +285,14 @@ export async function serveFile(
     );
     headers.set("etag", simpleEtag);
 
-    // If a `if-node-match` header is present and the value matches the tag return 304
-    // If a `if-modified-since` header is present and the value is bigger than
-    // the access timestamp value return 304
+    // If a `if-none-match` header is present and the value matches the tag or
+    // if a `if-modified-since` header is present and the value is bigger than
+    // the access timestamp value, then return 304
     const ifNoneMatch = req.headers.get("if-none-match");
     const ifModifiedSince = req.headers.get("if-modified-since");
     if (
-      (ifNoneMatch && ifNoneMatch === simpleEtag) || (ifModifiedSince &&
+      (ifNoneMatch && ifNoneMatch === simpleEtag) ||
+      (ifNoneMatch === null && ifModifiedSince &&
         fileInfo.mtime.getTime() < (new Date(ifModifiedSince).getTime() + 1000))
     ) {
       response.status = 304;


### PR DESCRIPTION
The If-Modified-Since request HTTP header makes the request conditional: the server will send back the requested resource, with a 200 status, only if it has been last modified after the given date. If the resource has not been modified since, the response will be a 304 without any body; the Last-Modified response header of a previous request will contain the date of last modification. Unlike If-Unmodified-Since, If-Modified-Since can only be used with a GET or HEAD.

When used in combination with If-None-Match, it is ignored, unless the server doesn't support If-None-Match.

The most common use case is to update a cached entity that has no associated ETag.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since