### PR TITLE
docs: update Node.js builtin list, alias sys to util

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -9,6 +9,8 @@ deno standard library as it's a compatibility module.
 ## Supported Builtins
 
 - [x] assert _partly_
+- [x] assert/strict _partly_
+- [ ] async_hooks
 - [x] buffer
 - [x] child_process _partly_
 - [ ] cluster
@@ -16,31 +18,42 @@ deno standard library as it's a compatibility module.
 - [x] constants _partly_
 - [x] crypto _partly_
 - [ ] dgram
+- [ ] diagnostics_channel
 - [ ] dns
 - [x] events
 - [x] fs _partly_
+- [x] fs/promises _partly_
 - [ ] http
 - [ ] http2
 - [ ] https
+- [ ] inspector
 - [x] module
 - [ ] net
 - [x] os _partly_
 - [x] path
+- [x] path/posix
+- [x] path/win32
 - [ ] perf_hooks
 - [x] process _partly_
 - [x] querystring
 - [ ] readline
 - [ ] repl
 - [x] stream
+- [x] stream/promises
+- [ ] stream/web
 - [x] string_decoder
-- [ ] sys
+- [x] sys
 - [x] timers
+- [x] timers/promises
 - [ ] tls
+- [ ] trace_events
 - [x] tty _partly_
 - [x] url
 - [x] util _partly_
-- ~~v8~~ _can't implement_
+- [x] util/types _partly_
+- [ ] v8
 - [ ] vm
+- [ ] wasi
 - [ ] worker_threads
 - [ ] zlib
 

--- a/node/sys.ts
+++ b/node/sys.ts
@@ -1,0 +1,2 @@
+export * from './util.ts';
+export { default } from './util.ts';

--- a/node/sys.ts
+++ b/node/sys.ts
@@ -1,2 +1,2 @@
-export * from './util.ts';
-export { default } from './util.ts';
+export * from "./util.ts";
+export { default } from "./util.ts";


### PR DESCRIPTION
This updates the Node.js builtin list assuming #1083, #1084, #1085 land.

It also aliases sys to util and extends the list to include the newest Node.js builtins.