### PR TITLE
Adding shim for perf_hooks in deno

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -33,7 +33,7 @@ deno standard library as it's a compatibility module.
 - [x] path
 - [x] path/posix
 - [x] path/win32
-- [ ] perf_hooks
+- [x] perf_hooks
 - [x] process _partly_
 - [x] querystring
 - [ ] readline

--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -1,4 +1,4 @@
-import { notImplemented } from './_utils'
+import { notImplemented } from "./_utils.ts";
 
 const { PerformanceObserver, PerformanceEntry, performance: shimPerformance } =
   globalThis as typeof globalThis & {
@@ -22,7 +22,9 @@ const performance: Partial<Performance> & {
   timeOrigin: shimPerformance.timeOrigin,
 };
 
-const monitorEventLoopDelay = notImplemented("monitorEventLoopDelay from performance");
+const monitorEventLoopDelay = notImplemented(
+  "monitorEventLoopDelay from performance",
+);
 
 export default {
   performance,

--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -1,5 +1,44 @@
-export const { performance, PerformanceEntry } = globalThis as
-  & typeof globalThis
-  & {
+function unimplemented(functionName: string) {
+  throw new Error(
+    `Node.js performance method ${functionName} is not currently supported by JSPM core in the browser`,
+  );
+}
+
+const { PerformanceObserver, PerformanceEntry, performance: shimPerformance } =
+  globalThis as typeof globalThis & {
     PerformanceEntry: PerformanceEntry;
+    PerformanceObserver: PerformanceObserver;
   };
+const constants = {};
+
+const performance: Partial<Performance> & {
+  eventLoopUtilization: void;
+  nodeTiming: Record<string, string>;
+  timerify: void;
+} = {
+  clearMarks: shimPerformance.clearMarks,
+  eventLoopUtilization: unimplemented("eventLoopUtilization"),
+  mark: shimPerformance.mark,
+  measure: shimPerformance.measure,
+  nodeTiming: {},
+  now: shimPerformance.now,
+  timerify: unimplemented("timerify"),
+  timeOrigin: shimPerformance.timeOrigin,
+};
+
+const monitorEventLoopDelay = unimplemented("monitorEventLoopDelay");
+
+export default {
+  performance,
+  PerformanceObserver,
+  monitorEventLoopDelay,
+  constants,
+};
+
+export {
+  constants,
+  monitorEventLoopDelay,
+  performance,
+  PerformanceEntry,
+  PerformanceObserver,
+};

--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -3,28 +3,36 @@ import { notImplemented } from "./_utils.ts";
 const { PerformanceObserver, PerformanceEntry, performance: shimPerformance } =
   globalThis as typeof globalThis & {
     PerformanceEntry: PerformanceEntry;
-    PerformanceObserver: PerformanceObserver;
+    // deno-lint-ignore no-explicit-any
+    PerformanceObserver: any;
   };
 const constants = {};
 
 const performance: Partial<Performance> & {
-  eventLoopUtilization: void;
+  // deno-lint-ignore no-explicit-any
+  eventLoopUtilization: any;
   nodeTiming: Record<string, string>;
-  timerify: void;
+  // deno-lint-ignore no-explicit-any
+  timerify: any;
+  // deno-lint-ignore no-explicit-any
+  timeOrigin: any;
 } = {
   clearMarks: shimPerformance.clearMarks,
-  eventLoopUtilization: notImplemented("eventLoopUtilization from performance"),
+  eventLoopUtilization: () =>
+    notImplemented("eventLoopUtilization from performance"),
   mark: shimPerformance.mark,
   measure: shimPerformance.measure,
   nodeTiming: {},
   now: shimPerformance.now,
-  timerify: notImplemented("timerify from performance"),
-  timeOrigin: shimPerformance.timeOrigin,
+  timerify: () => notImplemented("timerify from performance"),
+  // deno-lint-ignore no-explicit-any
+  timeOrigin: (shimPerformance as any).timeOrigin,
 };
 
-const monitorEventLoopDelay = notImplemented(
-  "monitorEventLoopDelay from performance",
-);
+const monitorEventLoopDelay = () =>
+  notImplemented(
+    "monitorEventLoopDelay from performance",
+  );
 
 export default {
   performance,

--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -1,8 +1,4 @@
-function unimplemented(functionName: string) {
-  throw new Error(
-    `Node.js performance method ${functionName} is not currently supported by JSPM core in the browser`,
-  );
-}
+import { notImplemented } from './_utils'
 
 const { PerformanceObserver, PerformanceEntry, performance: shimPerformance } =
   globalThis as typeof globalThis & {
@@ -17,16 +13,16 @@ const performance: Partial<Performance> & {
   timerify: void;
 } = {
   clearMarks: shimPerformance.clearMarks,
-  eventLoopUtilization: unimplemented("eventLoopUtilization"),
+  eventLoopUtilization: notImplemented("eventLoopUtilization from performance"),
   mark: shimPerformance.mark,
   measure: shimPerformance.measure,
   nodeTiming: {},
   now: shimPerformance.now,
-  timerify: unimplemented("timerify"),
+  timerify: notImplemented("timerify from performance"),
   timeOrigin: shimPerformance.timeOrigin,
 };
 
-const monitorEventLoopDelay = unimplemented("monitorEventLoopDelay");
+const monitorEventLoopDelay = notImplemented("monitorEventLoopDelay from performance");
 
 export default {
   performance,

--- a/node/perf_hooks_test.ts
+++ b/node/perf_hooks_test.ts
@@ -4,7 +4,9 @@ import { assertEquals } from "../testing/asserts.ts";
 Deno.test({
   name: "[perf_hooks] performance",
   fn() {
-    assertEquals(perfHooks.performance, performance);
+    assertEquals(perfHooks.performance.clearMarks, performance.clearMarks);
+    assertEquals(perfHooks.performance.mark, performance.mark);
+    assertEquals(perfHooks.performance.now, performance.now);
   },
 });
 


### PR DESCRIPTION
Just upstreaming the shims that we are trying to add into `jspm-core` 😄. Please let me know if there are any changes needed.