### PR TITLE
chore(collections): Clean up sort_by code and add BigInt selector tests.

### DIFF
--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -24,26 +24,16 @@
  */
 export function sortBy<T>(
   array: Array<T>,
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: ((el: T) => number | string | bigint | Date),
 ): Array<T> {
-  const ret = Array.from(array);
-
-  return ret.sort((a, b) => {
+  return Array.from(array).sort((a, b) => {
     const selectedA = selector(a);
     const selectedB = selector(b);
 
-    if (selectedA > selectedB) {
-      return 1;
+    if (selectedA === selectedB) {
+      return 0;
     }
 
-    if (selectedA < selectedB) {
-      return -1;
-    }
-
-    return 0;
+    return selectedA > selectedB ? 1 : -1;
   });
 }

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import { Selector } from "./types.ts";
+
 /**
  * Returns all elements in the given collection, sorted by their result using the given selector
  *
@@ -25,10 +27,10 @@
 export function sortBy<T>(
   array: Array<T>,
   selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    | Selector<T, number>
+    | Selector<T, string>
+    | Selector<T, bigint>
+    | Selector<T, Date>,
 ): Array<T> {
   return Array.from(array).sort((a, b) => {
     const selectedA = selector(a);

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -24,7 +24,11 @@
  */
 export function sortBy<T>(
   array: Array<T>,
-  selector: ((el: T) => number | string | bigint | Date),
+  selector:
+    | ((el: T) => number)
+    | ((el: T) => string)
+    | ((el: T) => bigint)
+    | ((el: T) => Date),
 ): Array<T> {
   return Array.from(array).sort((a, b) => {
     const selectedA = selector(a);

--- a/collections/sort_by_test.ts
+++ b/collections/sort_by_test.ts
@@ -2,14 +2,15 @@
 
 import { assertEquals } from "../testing/asserts.ts";
 import { sortBy } from "./sort_by.ts";
+import { Selector } from "./types.ts";
 
 function sortByTest<T>(
   input: [
     Array<T>,
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    | Selector<T, number>
+    | Selector<T, string>
+    | Selector<T, bigint>
+    | Selector<T, Date>,
   ],
   expected: Array<T>,
   message?: string,

--- a/collections/sort_by_test.ts
+++ b/collections/sort_by_test.ts
@@ -6,10 +6,7 @@ import { sortBy } from "./sort_by.ts";
 function sortByTest<T>(
   input: [
     Array<T>,
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    ((el: T) => number | string | bigint | Date),
   ],
   expected: Array<T>,
   message?: string,
@@ -83,6 +80,21 @@ Deno.test({
         { name: "build", stage: 1 },
         { name: "deploy", stage: 4 },
         { name: "test", stage: 2 },
+      ],
+    );
+    sortByTest(
+      [
+        [
+          "9007199254740999",
+          "9007199254740991",
+          "9007199254740995",
+        ],
+        (it) => BigInt(it),
+      ],
+      [
+        "9007199254740991",
+        "9007199254740995",
+        "9007199254740999",
       ],
     );
     sortByTest(

--- a/collections/sort_by_test.ts
+++ b/collections/sort_by_test.ts
@@ -6,7 +6,10 @@ import { sortBy } from "./sort_by.ts";
 function sortByTest<T>(
   input: [
     Array<T>,
-    ((el: T) => number | string | bigint | Date),
+    | ((el: T) => number)
+    | ((el: T) => string)
+    | ((el: T) => bigint)
+    | ((el: T) => Date),
   ],
   expected: Array<T>,
   message?: string,


### PR DESCRIPTION
This changeset updates the new `sort_by` function to be slightly more compact / idiomatic (imo). I also added tests for functions that return `bigint`s being provided for the `selector` parameter.