### PR TITLE
Fix `NaN` handling in `collections/sortBy` ( closes #1092 )

### DIFF
--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -36,6 +36,16 @@ export function sortBy<T>(
     const selectedA = selector(a);
     const selectedB = selector(b);
 
+    if (typeof selectedA === "number") {
+      if (Number.isNaN(selectedA)) {
+        return 1;
+      }
+
+      if (Number.isNaN(selectedB)) {
+        return -1;
+      }
+    }
+
     if (selectedA > selectedB) {
       return 1;
     }

--- a/collections/sort_by_test.ts
+++ b/collections/sort_by_test.ts
@@ -97,6 +97,68 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[collections/sortBy] special number values",
+  fn() {
+    sortByTest(
+      [
+        [
+          1,
+          Number.POSITIVE_INFINITY,
+          2,
+          Number.NEGATIVE_INFINITY,
+          3,
+          Number.NaN,
+          4,
+          Number.NaN,
+        ],
+        (it) => it,
+      ],
+      [
+        Number.NEGATIVE_INFINITY,
+        1,
+        2,
+        3,
+        4,
+        Number.POSITIVE_INFINITY,
+        Number.NaN,
+        Number.NaN,
+      ],
+    );
+    sortByTest(
+      [
+        [
+          Number.NaN,
+          1,
+          Number.POSITIVE_INFINITY,
+          Number.NaN,
+          7,
+          Number.NEGATIVE_INFINITY,
+          Number.NaN,
+          2,
+          6,
+          5,
+          9,
+        ],
+        (it) => it,
+      ],
+      [
+        Number.NEGATIVE_INFINITY,
+        1,
+        2,
+        5,
+        6,
+        7,
+        9,
+        Number.POSITIVE_INFINITY,
+        Number.NaN,
+        Number.NaN,
+        Number.NaN,
+      ],
+    );
+  },
+});
+
+Deno.test({
   name: "[collections/sortBy] sortings",
   fn() {
     const testArray = [


### PR DESCRIPTION
This fixes `NaN` handling in `sortBy` as mentioned in #1092 by adding a simple explicit check. Also adds two tests for that behaviour.
