### PR TITLE
fix(async): let async exception of `deadline` can be caught

### DIFF
--- a/async/deadline.ts
+++ b/async/deadline.ts
@@ -13,6 +13,5 @@ export class DeadlineError extends Error {
 export function deadline<T>(p: Promise<T>, delay: number): Promise<T> {
   const d = deferred<never>();
   const t = setTimeout(() => d.reject(new DeadlineError()), delay);
-  p.finally(() => clearTimeout(t));
-  return Promise.race([p, d]);
+  return Promise.race([p, d]).finally(() => clearTimeout(t));
 }

--- a/async/deadline_test.ts
+++ b/async/deadline_test.ts
@@ -24,7 +24,7 @@ Deno.test("[async] deadline: thrown when promise is rejected", async () => {
   const t = setTimeout(() => p.reject(new Error("booom")), 100);
   await assertThrowsAsync(
     async () => {
-      await deadline(p, 100);
+      await deadline(p, 1000);
     },
     Error,
     "booom",

--- a/async/deadline_test.ts
+++ b/async/deadline_test.ts
@@ -18,3 +18,16 @@ Deno.test("[async] deadline: throws DeadlineError", async () => {
   }, DeadlineError);
   clearTimeout(t);
 });
+
+Deno.test("[async] deadline: thrown when promise is rejected", async () => {
+  const p = deferred();
+  const t = setTimeout(() => p.reject(new Error("booom")), 100);
+  await assertThrowsAsync(
+    async () => {
+      await deadline(p, 100);
+    },
+    Error,
+    "booom",
+  );
+  clearTimeout(t);
+});


### PR DESCRIPTION
```ts
try {
  await deadline(Promise.reject("booom"), 20);
} catch (error) {
  console.log(`catch error: ${error}`);
}
```

will crash:

```plain
catch error: booom
error: Uncaught (in promise) booom
```