### PR TITLE
fix (collections): Add missing functions to mod.ts

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -1,16 +1,24 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+export * from "./associate_by.ts";
 export * from "./chunked.ts";
-export * from "./distinct_by.ts";
+export * from "./deep_merge.ts";
 export * from "./distinct.ts";
+export * from "./distinct_by.ts";
 export * from "./filter_entries.ts";
 export * from "./filter_keys.ts";
 export * from "./filter_values.ts";
 export * from "./find_last.ts";
+export * from "./find_last_index.ts";
 export * from "./group_by.ts";
 export * from "./intersect.ts";
 export * from "./map_entries.ts";
 export * from "./map_keys.ts";
+export * from "./map_not_nullish.ts";
 export * from "./map_values.ts";
 export * from "./partition.ts";
 export * from "./permutations.ts";
+export * from "./sort_by.ts";
+export * from "./union.ts";
+export * from "./unzip.ts";
+export * from "./zip.ts";


### PR DESCRIPTION
This adds functions to `collection`s `mod.ts` which I have forgotten to add when implementing them :see_no_evil:
