### PR TITLE
feat(statistics): Implement mean, median, and mode.

### DIFF
--- a/statistics/mean.ts
+++ b/statistics/mean.ts
@@ -1,0 +1,24 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns the arithmetic mean of the numbers in the given collection
+ *
+ * Example:
+ *
+ * ```ts
+ * const numbers = [ 4, 2, 9 ]
+ * assertEquals(mean(numbers), 5)
+ * ```
+ */
+export function mean(collection: Array<number>): number | undefined {
+  if (collection.length === 0) {
+    return undefined;
+  }
+
+  let total = 0;
+  for (const number of collection) {
+    total += number;
+  }
+
+  return total / collection.length;
+}

--- a/statistics/mean.ts
+++ b/statistics/mean.ts
@@ -6,6 +6,9 @@
  * Example:
  *
  * ```ts
+ * import { assertEquals } from "../testing/asserts.ts"
+ * import { mean } from "./mean.ts";
+ *
  * const numbers = [ 4, 2, 9 ]
  * assertEquals(mean(numbers), 5)
  * ```

--- a/statistics/mean_test.ts
+++ b/statistics/mean_test.ts
@@ -1,0 +1,43 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { mean } from "./mean.ts";
+
+Deno.test({
+  name: "[statistics/mean] empty array",
+  fn() {
+    assertEquals(mean([]), undefined);
+  },
+});
+
+Deno.test({
+  name: "[statistics/mean] single element",
+  fn() {
+    assertEquals(mean([1]), 1);
+    assertEquals(mean([5]), 5);
+  },
+});
+
+Deno.test({
+  name: "[statistics/mean] integer mean",
+  fn() {
+    assertEquals(mean([1, 3]), 2);
+    assertEquals(mean([20, 10, 5, 25]), 15);
+  },
+});
+
+Deno.test({
+  name: "[statistics/mean] decimal mean",
+  fn() {
+    assertEquals(mean([4, 1]), 2.5);
+    assertEquals(mean([10, 4, 1, 14]), 7.25);
+  },
+});
+
+Deno.test({
+  name: "[statistics/mean] irrational mean",
+  fn() {
+    assertEquals(mean([2, 1, 2])!.toFixed(3), "1.667");
+    assertEquals(mean([11, 5, 1])!.toFixed(3), "5.667");
+  },
+});

--- a/statistics/median.ts
+++ b/statistics/median.ts
@@ -6,6 +6,9 @@
  * Example:
  *
  * ```ts
+ * import { assertEquals } from "../testing/asserts.ts"
+ * import { median } from "./median.ts"
+ *
  * const numbers = [ 4, 2, 7 ]
  * assertEquals(median(numbers), 4)
  * ```

--- a/statistics/median.ts
+++ b/statistics/median.ts
@@ -1,0 +1,27 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns the arithmetic median of the numbers in the given collection
+ *
+ * Example:
+ *
+ * ```ts
+ * const numbers = [ 4, 2, 7 ]
+ * assertEquals(median(numbers), 4)
+ * ```
+ */
+export function median(collection: Array<number>): number | undefined {
+  if (collection.length === 0) {
+    return undefined;
+  }
+
+  const middle = Math.floor(collection.length / 2);
+  const values = Array.from(collection);
+  values.sort((a, b) => a - b);
+
+  if (values.length % 2 === 0) {
+    return (values[middle] + values[middle - 1]) / 2;
+  }
+
+  return values[middle];
+}

--- a/statistics/median_test.ts
+++ b/statistics/median_test.ts
@@ -1,0 +1,35 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { median } from "./median.ts";
+
+Deno.test({
+  name: "[statistics/median] empty array",
+  fn() {
+    assertEquals(median([]), undefined);
+  },
+});
+
+Deno.test({
+  name: "[statistics/median] single element",
+  fn() {
+    assertEquals(median([1]), 1);
+    assertEquals(median([5]), 5);
+  },
+});
+
+Deno.test({
+  name: "[statistics/median] even number of elements",
+  fn() {
+    assertEquals(median([3, 1]), 2);
+    assertEquals(median([10, 5, 25, 19]), 14.5);
+  },
+});
+
+Deno.test({
+  name: "[statistics/median] odd number of elements",
+  fn() {
+    assertEquals(median([12, 2, 5]), 5);
+    assertEquals(median([27, 13, 6, 1, 19]), 13);
+  },
+});

--- a/statistics/mode.ts
+++ b/statistics/mode.ts
@@ -6,6 +6,9 @@
  * Example:
  *
  * ```ts
+ * import { assertEquals } from "../testing/asserts.ts"
+ * import { mode } from "./mode.ts"
+ *
  * const numbers = [ 4, 2, 7, 4 ]
  * assertEquals(mode(numbers), 4)
  * ```

--- a/statistics/mode.ts
+++ b/statistics/mode.ts
@@ -1,0 +1,37 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns the arithmetic mode(s) of the numbers in the given collection
+ *
+ * Example:
+ *
+ * ```ts
+ * const numbers = [ 4, 2, 7, 4 ]
+ * assertEquals(mode(numbers), 4)
+ * ```
+ */
+export function mode(collection: Array<number>): Set<number> | undefined {
+  if (collection.length === 0) {
+    return undefined;
+  }
+
+  const counter: Record<number, number> = {};
+  counter[collection[0]] = 1;
+  const maxes = new Set([collection[0]]);
+  let maxCount = 1;
+
+  for (let i = 1; i < collection.length; i++) {
+    const number = collection[i];
+    counter[number] = (counter[number] || 0) + 1;
+
+    if (counter[number] === maxCount) {
+      maxes.add(number);
+    } else if (counter[number] > maxCount) {
+      maxes.clear();
+      maxes.add(number);
+      maxCount = counter[number];
+    }
+  }
+
+  return maxes;
+}

--- a/statistics/mode_test.ts
+++ b/statistics/mode_test.ts
@@ -33,6 +33,6 @@ Deno.test({
     assertEquals(mode([2, 4]), new Set([2, 4]));
     assertEquals(mode([1, 8, 1, 8]), new Set([1, 8]));
     assertEquals(mode([8, 20, 20, 9, 20, 8, 8, 9]), new Set([8, 20]));
-    assertEquals(mode([1, 3, 4, 5, 3, 1, 4]), new Set([1, 3, 4]))
+    assertEquals(mode([1, 3, 4, 5, 3, 1, 4]), new Set([1, 3, 4]));
   },
 });

--- a/statistics/mode_test.ts
+++ b/statistics/mode_test.ts
@@ -1,0 +1,38 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { mode } from "./mode.ts";
+
+Deno.test({
+  name: "[statistics/mode] empty array",
+  fn() {
+    assertEquals(mode([]), undefined);
+  },
+});
+
+Deno.test({
+  name: "[statistics/mode] single element",
+  fn() {
+    assertEquals(mode([1]), new Set([1]));
+    assertEquals(mode([5]), new Set([5]));
+  },
+});
+
+Deno.test({
+  name: "[statistics/mode] one mode",
+  fn() {
+    assertEquals(mode([2, 2]), new Set([2]));
+    assertEquals(mode([1, 5, 7, 9, 7]), new Set([7]));
+    assertEquals(mode([8, 20, 20, 9, 20, 8]), new Set([20]));
+  },
+});
+
+Deno.test({
+  name: "[statistics/mode] multiple modes",
+  fn() {
+    assertEquals(mode([2, 4]), new Set([2, 4]));
+    assertEquals(mode([1, 8, 1, 8]), new Set([1, 8]));
+    assertEquals(mode([8, 20, 20, 9, 20, 8, 8, 9]), new Set([8, 20]));
+    assertEquals(mode([1, 3, 4, 5, 3, 1, 4]), new Set([1, 3, 4]))
+  },
+});


### PR DESCRIPTION
This PR is a proposal / proof-of-concept to add a `statistics` module to the standard library.

Whilst discussing with @LionC on Discord about the implementation of the std/collections `average` function, he suggested that it may make sense to break out a new statistics module for all the central tendency functions (mean, median, and mode).

I prefer this approach for the following (completely subjective) reasons:
- Including a function to calculate the arithmetic mean without functions for median and mode feels like an incomplete API. (if a user wants to write an application that uses primitive statistics functions, they can use the built in `average` function but would have to either roll their own median and mode functions or download a 3rd party library?)
- Location of the `average` function in the `collections` module seems a bit clunky because it operates strictly on arrays of `number`s, rather than generic collections like every other function does.

NOTE: mean and median are relatively straight forward implementations. However, how we implement mode should probably be discussed in a bit more detail. Do we want to return a Set here? An array? If an array, in what order? Or do we just want to return a single mode?

I have included the version which returns a Set in the PR. Here are some pros / cons off the top of my head:

Pros
- Supports multi-modes.
- Does not suggest any sort of order to the output.
- Internally, gives us performant (O(1)) look ups / insertions. (and returning directly means we don't have to copy to an Array)

Cons
- It is an awkward API to work with (in the case of a single mode, how would the user extract that single value?)