### PR TITLE
feat(async): Add abort signal to delay

### DIFF
--- a/async/delay.ts
+++ b/async/delay.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+export interface DelayOptions {
+  signal?: AbortSignal;
+}
+
 /* Resolves after the given number of milliseconds. */
-export function delay(ms: number, signal?: AbortSignal): Promise<void> {
+export function delay(ms: number, options: DelayOptions = {}): Promise<void> {
+  const { signal } = options;
   return new Promise((resolve, reject): void => {
     const abort = () => {
       clearTimeout(i);

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -1,9 +1,13 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 /* Resolves after the given number of milliseconds. */
-export function delay(ms: number): Promise<void> {
-  return new Promise((res): number =>
-    setTimeout((): void => {
+export function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((res): void => {
+    const done = () => {
+      clearTimeout(i);
+      signal?.removeEventListener("abort", done);
       res();
-    }, ms)
-  );
+    };
+    const i = setTimeout(done, ms);
+    signal?.addEventListener("abort", done, { once: true });
+  });
 }

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -1,13 +1,16 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 /* Resolves after the given number of milliseconds. */
 export function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((res): void => {
-    const done = () => {
+  return new Promise((resolve, reject): void => {
+    const abort = () => {
       clearTimeout(i);
-      signal?.removeEventListener("abort", done);
-      res();
+      reject(new DOMException("Delay was aborted.", "AbortError"));
+    };
+    const done = () => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
     };
     const i = setTimeout(done, ms);
-    signal?.addEventListener("abort", done, { once: true });
+    signal?.addEventListener("abort", abort, { once: true });
   });
 }

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { delay } from "./delay.ts";
-import { assert } from "../testing/asserts.ts";
+import { assert, assertThrowsAsync } from "../testing/asserts.ts";
 
 Deno.test("[async] delay", async function () {
   const start = new Date();
@@ -17,7 +17,8 @@ Deno.test("[async] delay with abort", async function () {
   const { signal } = abort;
   const delayedPromise = delay(100, signal);
   setTimeout(() => abort.abort(), 0);
-  const result = await delayedPromise;
+  const result = await assertThrowsAsync(() => delayedPromise, DOMException, "Delay was aborted");
+
   const diff = new Date().getTime() - start.getTime();
   assert(result === undefined);
   assert(diff < 100);

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -10,3 +10,39 @@ Deno.test("[async] delay", async function () {
   assert(result === undefined);
   assert(diff >= 100);
 });
+
+Deno.test("[async] delay with abort", async function () {
+  const start = new Date();
+  const abort = new AbortController();
+  const { signal } = abort;
+  const delayedPromise = delay(100, signal);
+  setTimeout(() => abort.abort(), 0);
+  const result = await delayedPromise;
+  const diff = new Date().getTime() - start.getTime();
+  assert(result === undefined);
+  assert(diff < 100);
+});
+
+Deno.test("[async] delay with non-aborted signal", async function () {
+  const start = new Date();
+  const abort = new AbortController();
+  const { signal } = abort;
+  const delayedPromise = delay(100, signal);
+  // abort.abort()
+  const result = await delayedPromise;
+  const diff = new Date().getTime() - start.getTime();
+  assert(result === undefined);
+  assert(diff >= 100);
+});
+
+Deno.test("[async] delay with signal aborted after delay", async function () {
+  const start = new Date();
+  const abort = new AbortController();
+  const { signal } = abort;
+  const delayedPromise = delay(100, signal);
+  const result = await delayedPromise;
+  abort.abort();
+  const diff = new Date().getTime() - start.getTime();
+  assert(result === undefined);
+  assert(diff >= 100);
+});

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { delay } from "./delay.ts";
-import { assert, assertThrowsAsync } from "../testing/asserts.ts";
+import { assert, assertRejects } from "../testing/asserts.ts";
 
 Deno.test("[async] delay", async function () {
   const start = new Date();
@@ -17,7 +17,7 @@ Deno.test("[async] delay with abort", async function () {
   const { signal } = abort;
   const delayedPromise = delay(100, signal);
   setTimeout(() => abort.abort(), 0);
-  const result = await assertThrowsAsync(() => delayedPromise, DOMException, "Delay was aborted");
+  const result = await assertRejects(() => delayedPromise, DOMException, "Delay was aborted");
 
   const diff = new Date().getTime() - start.getTime();
   assert(result === undefined);

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -15,9 +15,13 @@ Deno.test("[async] delay with abort", async function () {
   const start = new Date();
   const abort = new AbortController();
   const { signal } = abort;
-  const delayedPromise = delay(100, signal);
+  const delayedPromise = delay(100, { signal });
   setTimeout(() => abort.abort(), 0);
-  const result = await assertRejects(() => delayedPromise, DOMException, "Delay was aborted");
+  const result = await assertRejects(
+    () => delayedPromise,
+    DOMException,
+    "Delay was aborted",
+  );
 
   const diff = new Date().getTime() - start.getTime();
   assert(result === undefined);
@@ -28,7 +32,7 @@ Deno.test("[async] delay with non-aborted signal", async function () {
   const start = new Date();
   const abort = new AbortController();
   const { signal } = abort;
-  const delayedPromise = delay(100, signal);
+  const delayedPromise = delay(100, { signal });
   // abort.abort()
   const result = await delayedPromise;
   const diff = new Date().getTime() - start.getTime();
@@ -40,7 +44,7 @@ Deno.test("[async] delay with signal aborted after delay", async function () {
   const start = new Date();
   const abort = new AbortController();
   const { signal } = abort;
-  const delayedPromise = delay(100, signal);
+  const delayedPromise = delay(100, { signal });
   const result = await delayedPromise;
   abort.abort();
   const diff = new Date().getTime() - start.getTime();


### PR DESCRIPTION
This is a non-breaking change which adds an optional `signal?: AbortSignal` to the delay function.

3 new tests were added which test that:

1. The abort stops the timeout and immediately resolves the delay promise
2. Not aborting the signal behaves as normal
3. Aborting after the delay has already completed does not result in an error

Fixes #1129