### PR TITLE
fix(collections): intersect does not handle duplicate values in head properly

### DIFF
--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -19,16 +19,13 @@ import { filterInPlace } from "./_utils.ts";
  * ```
  */
 export function intersect<T>(...arrays: (readonly T[])[]): T[] {
-  if (arrays.length === 0) {
-    return [];
-  }
-
   const [originalHead, ...tail] = arrays;
-  const head = [...originalHead];
+  const head = [...new Set(originalHead)];
   const tailSets = tail.map((it) => new Set(it));
 
   for (const set of tailSets) {
     filterInPlace(head, (it) => set.has(it));
+    if (head.length === 0) return head;
   }
 
   return head;

--- a/collections/intersect_test.ts
+++ b/collections/intersect_test.ts
@@ -62,6 +62,14 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[collections/intersect] duplicates",
+  fn() {
+    intersectTest([["a", "b", "c", "b"], ["b", "c"]], ["b", "c"]);
+    intersectTest([["a", "b"], ["b", "b", "c", "c"]], ["a", "b"]);
+  },
+});
+
+Deno.test({
   name: "[collections/intersect] more than two inputs",
   fn() {
     intersectTest(

--- a/collections/intersect_test.ts
+++ b/collections/intersect_test.ts
@@ -65,7 +65,7 @@ Deno.test({
   name: "[collections/intersect] duplicates",
   fn() {
     intersectTest([["a", "b", "c", "b"], ["b", "c"]], ["b", "c"]);
-    intersectTest([["a", "b"], ["b", "b", "c", "c"]], ["a", "b"]);
+    intersectTest([["a", "b"], ["b", "b", "c", "c"]], ["b"]);
   },
 });
 


### PR DESCRIPTION
One would expect `intersection` to be commutative.