### PR TITLE
feat(collections): add minBy

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -455,3 +455,23 @@ console.assert(
   ],
 );
 ```
+
+### minBy
+
+Returns the first element that is the smallest value of the given function or
+undefined if there are no elements
+
+```ts
+import { minBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const people = [
+  { name: "Anna", age: 34 },
+  { name: "Kim", age: 42 },
+  { name: "John", age: 23 },
+];
+
+const personWithMinAge = minBy(people, (i) => i.age);
+
+assertEquals(personWithMinAge, { name: "John", age: 23 });
+```

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -1,0 +1,40 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns the first element that is the smallest value of the given function or undefined if there are no elements.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { minBy } from "./min_by.ts";
+ * import { assertEquals } from "../testing/asserts.ts"
+ *
+ * const people = [
+ *     { name: 'Anna', age: 34 },
+ *     { name: 'Kim', age: 42 },
+ *     { name: 'John', age: 23 },
+ * ];
+ *
+ * const personWithMinAge = minBy(people, i => i.age);
+ *
+ * assertEquals(personWithMinAge, { name: 'John', age: 23 });
+ * ```
+ */
+export function minBy<T>(
+  collection: readonly T[],
+  selector: ((el: T) => number) | ((el: T) => string),
+): T | undefined {
+  let min: T | undefined = undefined;
+  let minValue: ReturnType<typeof selector> | undefined = undefined;
+
+  for (const current of collection) {
+    const currentValue = selector(current);
+
+    if (minValue === undefined || currentValue < minValue) {
+      min = current;
+      minValue = currentValue;
+    }
+  }
+
+  return min;
+}

--- a/collections/min_by_test.ts
+++ b/collections/min_by_test.ts
@@ -1,0 +1,113 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { minBy } from "./min_by.ts";
+
+Deno.test("[collections/minBy] of array of input", () => {
+  const input = [
+    { name: "Kyle", age: 34 },
+    { name: "John", age: 42 },
+    { name: "Anna", age: 23 },
+  ];
+
+  const min = minBy(input, (i) => i.age);
+
+  assertEquals(min, { name: "Anna", age: 23 });
+});
+
+Deno.test("[collections/minBy] of array of input with mutation", () => {
+  const input = [
+    { name: "Kyle", age: 34 },
+    { name: "John", age: 42 },
+    { name: "Anna", age: 23 },
+  ];
+
+  const min = minBy(input, (i) => i.age - 10);
+
+  assertEquals(min, { name: "Anna", age: 23 });
+});
+
+Deno.test("[collections/minBy] of array of input with multiple min", () => {
+  const input = [
+    { name: "Kyle", age: 34 },
+    { name: "John", age: 42 },
+    { name: "Anna", age: 23 },
+    { name: "Anna", age: 23 },
+  ];
+
+  const min = minBy(input, (i) => i.age);
+
+  assertEquals(min, { name: "Anna", age: 23 });
+});
+
+Deno.test("[collections/minBy] of array of positive numbers", () => {
+  const input = [2, 3, 5];
+
+  const min = minBy(input, (i) => i);
+
+  assertEquals(min, 2);
+});
+
+Deno.test("[collections/minBy] of array of negative numbers", () => {
+  const input = [-2, -3, -5];
+
+  const min = minBy(input, (i) => i);
+
+  assertEquals(min, -5);
+});
+
+Deno.test("[collections/minBy] of array of strings", () => {
+  const input = ["Kyle", "John", "Anna"];
+
+  const min = minBy(input, (i: string) => i);
+
+  assertEquals(min, "Anna");
+});
+
+Deno.test("[collections/minBy] of empty array", () => {
+  const input: number[] = [];
+
+  const min = minBy(input, (i) => i);
+
+  assertEquals(min, undefined);
+});
+
+Deno.test("[collections/minBy] of array of numbers with multiple min", () => {
+  const input = [2, 3, 5, 5];
+
+  const min = minBy(input, (i) => i);
+
+  assertEquals(min, 2);
+});
+
+Deno.test("[collections/minBy] of array of numbers with infinity", () => {
+  const input = [2, 3, 5, -Infinity];
+
+  const min = minBy(input, (i: number) => i);
+
+  assertEquals(min, -Infinity);
+});
+
+Deno.test("[collections/minBy] of array of numbers with NaN", () => {
+  const input = [2, 3, 5, NaN];
+
+  const min = minBy(input, (i) => i);
+
+  assertEquals(min, 2);
+});
+
+Deno.test("[collections/minBy] no mutation", () => {
+  const input = [2, 3, 5, NaN];
+
+  minBy(input, (i: number) => i);
+
+  assertEquals(input, [2, 3, 5, NaN]);
+});
+
+Deno.test("[collections/minBy] empty input", () => {
+  const input: Array<{ age: number }> = [];
+
+  const min = minBy(input, (i) => i.age);
+
+  assertEquals(min, undefined);
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -23,3 +23,4 @@ export * from "./sort_by.ts";
 export * from "./union.ts";
 export * from "./unzip.ts";
 export * from "./zip.ts";
+export * from "./min_by.ts";


### PR DESCRIPTION
Implemented the `minBy` method in the collection module. ref: https://github.com/denoland/deno_std/issues/1065

Types are declare based on [this comment](https://github.com/denoland/deno_std/pull/978#issuecomment-866126420)

Let me know if I should add any specific test cases.