### PR TITLE
feat(collections): add average

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -455,3 +455,17 @@ console.assert(
   ],
 );
 ```
+
+### average
+
+Returns an average value of elements in the array
+
+```ts
+import { average } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const numbers = [5, 6, 7, 8, 9];
+const avg = average(numbers);
+
+assertEquals(avg, 7);
+```

--- a/collections/average.ts
+++ b/collections/average.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns an average value of elements in the array
+ *
+ * Example:
+ *
+ * ```ts
+ * import { average } from "./average.ts"
+ * import { assertEquals } from "../testing/asserts.ts";
+ *
+ * const numbers = [5, 6, 7, 8, 9];
+ * const avg = average(numbers);
+ *
+ * assertEquals(avg, 7);
+ * ```
+ */
+export function average(collection: Array<number>): number | undefined {
+  if (collection.length === 0) {
+    return;
+  }
+
+  let sum = 0;
+
+  for (const num of collection) {
+    sum += num;
+  }
+
+  return sum / collection.length;
+}

--- a/collections/average_test.ts
+++ b/collections/average_test.ts
@@ -1,0 +1,60 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { average } from "./average.ts";
+
+Deno.test("[collections/average] empty array", () => {
+  const input: Array<number> = [];
+
+  const actual = average(input);
+
+  assertEquals(actual, undefined);
+});
+
+Deno.test("[collections/average] array with single element", () => {
+  const input = [0];
+
+  const actual = average(input);
+
+  assertEquals(actual, 0);
+});
+
+Deno.test("[collections/average] array with positive numbers", () => {
+  const input = [1, 2, 3, 4, 5];
+
+  const actual = average(input);
+
+  assertEquals(actual, 3);
+});
+
+Deno.test("[collections/average] array with negative numbers", () => {
+  const input = [-1, -2, -3, -4, -5];
+
+  const actual = average(input);
+
+  assertEquals(actual, -3);
+});
+
+Deno.test("[collections/average] array with NaN", () => {
+  const input = [1, 2, 3, 4, 5, NaN];
+
+  const actual = average(input);
+
+  assertEquals(actual, NaN);
+});
+
+Deno.test("[collections/average] array with Infinity", () => {
+  const input = [1, 2, 3, 4, 5, Infinity];
+
+  const actual = average(input);
+
+  assertEquals(actual, Infinity);
+});
+
+Deno.test("[collections/average] array with duplicate numbers", () => {
+  const input = [1, 1, 1, 1, 1];
+
+  const actual = average(input);
+
+  assertEquals(actual, 1);
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -23,3 +23,4 @@ export * from "./sort_by.ts";
 export * from "./union.ts";
 export * from "./unzip.ts";
 export * from "./zip.ts";
+export * from "./average.ts";


### PR DESCRIPTION
Implemented the `average` method in the collection module. ref: https://github.com/denoland/deno_std/issues/1065

Types are declare based on [this comment](https://github.com/denoland/deno_std/pull/978#issuecomment-866126420)

Let me know if I should add any specific test cases.