### PR TITLE
fix(testing): `assertEquals` now considers constructors equal if one is nullable and the other is `Object`

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -146,7 +146,7 @@ export function equal(c: unknown, d: unknown): boolean {
       return true;
     }
     if (a && typeof a === "object" && b && typeof b === "object") {
-      if (a && b && (a.constructor !== b.constructor)) {
+      if (a && b && !constructorsEqual(a, b)) {
         return false;
       }
       if (a instanceof WeakMap || b instanceof WeakMap) {
@@ -209,6 +209,13 @@ export function equal(c: unknown, d: unknown): boolean {
     }
     return false;
   })(c, d);
+}
+
+// deno-lint-ignore ban-types
+function constructorsEqual(a: object, b: object) {
+  return a.constructor === b.constructor ||
+    a.constructor === Object && !b.constructor ||
+    !a.constructor && b.constructor === Object;
 }
 
 /** Make an assertion, error will be thrown if `expr` does not have truthy value. */

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -941,6 +941,17 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
   );
 });
 
+Deno.test("assertEquals compares objects structurally if one object's constructor is undefined and the other is Object", () => {
+  const a = Object.create(null);
+  a.prop = "test";
+  const b = {
+    prop: "test",
+  };
+
+  assertEquals(a, b);
+  assertEquals(b, a);
+});
+
 Deno.test("assertEquals diff for differently ordered objects", () => {
   assertThrows(
     () => {


### PR DESCRIPTION
As discussed.