### PR TITLE
feat(collections): add filterNotNullish

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -455,3 +455,17 @@ console.assert(
   ],
 );
 ```
+
+### filterNotNullish
+
+Returns all elements in the given collection that are neither `null` or
+`undefined`
+
+```ts
+import { filterNotNullish } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const middleNames = [null, "William", undefined, "Martha"];
+
+assertEquals(filterNotNullish(middleNames), ["William", "Martha"]);
+```

--- a/collections/filter_not_nullish.ts
+++ b/collections/filter_not_nullish.ts
@@ -1,0 +1,23 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Returns all elements in the given collection that are neither `null` or `undefined`
+ *
+ * Example:
+ *
+ * ```ts
+ * import { filterNotNullish } from "./filter_not_nullish.ts";
+ * import { assertEquals } from "../testing/asserts.ts";
+ *
+ * const middleNames = [ null, 'William', undefined, 'Martha' ]
+ *
+ * assertEquals(filterNotNullish(middleNames), [ 'William', 'Martha' ])
+ * ```
+ */
+export function filterNotNullish<T>(
+  array: readonly T[],
+): NonNullable<T>[] {
+  return array.filter((it) => it !== undefined && it !== null) as NonNullable<
+    T
+  >[];
+}

--- a/collections/filter_not_nullish_test.ts
+++ b/collections/filter_not_nullish_test.ts
@@ -1,0 +1,57 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { filterNotNullish } from "./filter_not_nullish.ts";
+
+function filterNotNullishTest<T>(
+  input: [Array<T>],
+  expected: Array<T>,
+  message?: string,
+) {
+  const actual = filterNotNullish(...input);
+  assertEquals(actual, expected, message);
+}
+
+Deno.test({
+  name: "[collections/filterNotNullish] remove nullish values",
+  fn() {
+    filterNotNullishTest([[1, 2, 3, undefined, null]], [1, 2, 3]);
+  },
+});
+
+Deno.test({
+  name: "[collections/filterNotNullish] no mutation",
+  fn() {
+    const input = [1, 2, 3, 4];
+    filterNotNullish(input);
+
+    assertEquals(input, [1, 2, 3, 4]);
+  },
+});
+
+Deno.test({
+  name: "[collections/filterNotNullish] empty input",
+  fn() {
+    filterNotNullishTest([[]], []);
+  },
+});
+
+Deno.test({
+  name: "[collections/filterNotNullish] mixed types",
+  fn() {
+    filterNotNullishTest(
+      [[1, "Kim", true, { name: "Kim" }, ["Kim"], undefined, null]],
+      [1, "Kim", true, { name: "Kim" }, ["Kim"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "[collections/filterNotNullish] keep falsy values",
+  fn() {
+    filterNotNullishTest(
+      [[0, "", false, {}, [], undefined, null]],
+      [0, "", false, {}, []],
+    );
+  },
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -23,3 +23,4 @@ export * from "./sort_by.ts";
 export * from "./union.ts";
 export * from "./unzip.ts";
 export * from "./zip.ts";
+export * from "./filter_not_nullish.ts";


### PR DESCRIPTION
This PR adds `filterNotNullish` to the `collections` module