### PR TITLE
fix(http/server): addr defaults to 127.0.0.1 on Windows, else 0.0.0.0 (#1165)

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -59,7 +59,8 @@ export type Handler = (
 ) => Response | Promise<Response>;
 
 /**
- * Parse an address from a string.
+ * Parse an address from a string. When only the port is given, the hostname
+ * defaults to 127.0.0.1
  *
  * ```ts
  * import { _parseAddrFromStr } from "https://deno.land/std@$STD_VERSION/http/server.ts";
@@ -78,7 +79,7 @@ export function _parseAddrFromStr(
   addr: string,
   defaultPort = HTTP_PORT,
 ): Deno.ListenOptions {
-  const host = addr.startsWith(":") ? `0.0.0.0${addr}` : addr;
+  const host = addr.startsWith(":") ? `127.0.0.1${addr}` : addr;
 
   let url: URL;
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -156,7 +156,7 @@ Deno.test("_parseAddrFromStr should throw an error if the address string contain
 Deno.test("_parseAddrFromStr should parse port only address strings", () => {
   const addr = _parseAddrFromStr(":4505");
   assertEquals(addr.port, 4505);
-  assertEquals(addr.hostname, "0.0.0.0");
+  assertEquals(addr.hostname, "127.0.0.1");
 });
 
 Deno.test("_parseAddrFromStr should parse host only address strings using the default HTTP port", () => {


### PR DESCRIPTION
# Problem

When using `_parseAddrFromStr(addr: string)` the default hostname address defaults to `0.0.0.0`, which works on Mac/Linux, but not on Windows as described here: #1165. This problem affects the majority of developers (41.2%) that use Windows as their main OS, given the Stack Overflow Survey 2021. The current workaround for Window users is to manually edit their hosts file: `C:\Windows\System32\Drivers\etc\hosts`.

# Solution

This PR contains a fix for address defaults by adding a simple if statement checking whether the OS is windows and if so use `127.0.0.1` (which works on Windows) instead of `0.0.0.0`. This slightly improves the developer experience for Window users.

I've also updated the comments and the test for `_parseAddrFromStr(addr: string)`.