### PR TITLE
fix(node/util): format no longer adds `"` around formatted strings.

### DIFF
--- a/node/util.ts
+++ b/node/util.ts
@@ -154,7 +154,7 @@ function circularRemover(): (key: string, value: unknown) => unknown {
 }
 
 function formatString(str: string) {
-  return `"${str.replace(/\\/, "\\\\").replace(/"/g, '\\"')}"`;
+  return `${str.replace(/\\/, "\\\\").replace(/"/g, '\\"')}`;
 }
 
 function thingToString(

--- a/node/util_test.ts
+++ b/node/util_test.ts
@@ -296,12 +296,12 @@ Deno.test("[util] format", () => {
     [10, 11],
   ], { hi: "hello" });
   const expected =
-    '[10, hi, null, undefined, NaN, Infinity, { hello: world }, [10, 11], hi: hello]';
+    "[10, hi, null, undefined, NaN, Infinity, { hello: world }, [10, 11], hi: hello]";
   assertEquals(util.format("%o", testData), expected);
   assertEquals(util.format("%O", testData), expected);
 
   const expected2 =
-    '[10, hi, null, undefined, NaN, Infinity, [Object], [Array], hi: hello]';
+    "[10, hi, null, undefined, NaN, Infinity, [Object], [Array], hi: hello]";
   assertEquals(util.format("%s", testData), expected2);
 
   assertEquals(

--- a/node/util_test.ts
+++ b/node/util_test.ts
@@ -296,12 +296,12 @@ Deno.test("[util] format", () => {
     [10, 11],
   ], { hi: "hello" });
   const expected =
-    '[10, "hi", null, undefined, NaN, Infinity, { hello: "world" }, [10, 11], hi: "hello"]';
+    '[10, hi, null, undefined, NaN, Infinity, { hello: world }, [10, 11], hi: hello]';
   assertEquals(util.format("%o", testData), expected);
   assertEquals(util.format("%O", testData), expected);
 
   const expected2 =
-    '[10, "hi", null, undefined, NaN, Infinity, [Object], [Array], hi: "hello"]';
+    '[10, hi, null, undefined, NaN, Infinity, [Object], [Array], hi: hello]';
   assertEquals(util.format("%s", testData), expected2);
 
   assertEquals(


### PR DESCRIPTION
This aligns that part of format with node, see this by running:

```bash
node -e "const Util = require('util'); console.log(Util.format('test %s this', 'thing'))"
```
and
```bash
deno eval -T "import * as Util from 'https://raw.githubusercontent.com/grian32/deno_std/util-fmt-fix/node/util.ts'; console.log(Util.format('test %s this', 'thing'))"
```

Partially fixes, but does not close #1087 