### PR TITLE
feat(collections): add filterValuesNotNullish

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -509,3 +509,24 @@ console.assert(
   ],
 );
 ```
+
+### filterValuesNotNullish
+
+Returns a new collection with all entries of the given collection except the
+ones that have a nullish value
+
+```ts
+import { filterValuesNotNullish } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const values = {
+  x: null,
+  y: undefined,
+  z: "hi",
+};
+
+assertEquals(
+  filterValuesNotNullish(values),
+  { z: "hi" },
+);
+```

--- a/collections/filter_values_not_nullish.ts
+++ b/collections/filter_values_not_nullish.ts
@@ -1,0 +1,34 @@
+/**
+ * Returns a new collection with all entries of the given collection except the ones that have a nullish value
+ *
+ * ```ts
+ * import { filterValuesNotNullish } from "./filter_values_not_nullish.ts";
+ * import { assertEquals } from "../testing/asserts.ts";
+ *
+ * const values = {
+ *   x: null,
+ *   y: undefined,
+ *   z: "hi",
+ * }
+ *
+ * assertEquals(
+ *   filterValuesNotNullish(values),
+ *   { z: "hi" }
+ * )
+ * ```
+ */
+export function filterValuesNotNullish<T>(
+  record: Record<string, T>,
+): Record<string, NonNullable<T>> {
+  const filteredRecord: Record<string, NonNullable<T>> = {};
+
+  for (const i in record) {
+    if (record[i] === null || record[i] === undefined) {
+      // This needs to be empty for code to work
+    } else {
+      filteredRecord[i] = record[i] as NonNullable<T>;
+    }
+  }
+
+  return filteredRecord;
+}

--- a/collections/filter_values_not_nullish_test.ts
+++ b/collections/filter_values_not_nullish_test.ts
@@ -1,0 +1,64 @@
+import { filterValuesNotNullish } from "./filter_values_not_nullish.ts";
+import { assertEquals } from "../testing/asserts.ts";
+
+Deno.test("[collections/filterValuesNotNullish] Example code", () => {
+  const values = {
+    x: null,
+    y: undefined,
+    z: "hi",
+  };
+
+  const actual = filterValuesNotNullish(values);
+
+  assertEquals(actual, { z: "hi" });
+});
+
+Deno.test("[collections/filterValuesNotNullish] No mutation", () => {
+  const values = {
+    x: null,
+    y: undefined,
+    z: "hi",
+  };
+
+  const actual = filterValuesNotNullish(values);
+
+  assertEquals(actual, { z: "hi" });
+  assertEquals(values, {
+    x: null,
+    y: undefined,
+    z: "hi",
+  });
+});
+
+Deno.test("[collections/filterValuesNotNullish] Empty input", () => {
+  const values = {};
+
+  const actual = filterValuesNotNullish(values);
+
+  assertEquals(actual, {});
+});
+
+Deno.test("[collections/filterValuesNotNullish] No nullish values returns the same object", () => {
+  const values = {
+    x: 32,
+    y: 40,
+    z: "hello",
+  };
+
+  const actual = filterValuesNotNullish(values);
+
+  assertEquals(actual, values);
+});
+
+Deno.test("[collections/filterValuesNotNullish] All values being nullish returns empty object", () => {
+  const values = {
+    x: null,
+    y: undefined,
+    z: undefined,
+    four: null,
+  };
+
+  const actual = filterValuesNotNullish(values);
+
+  assertEquals(actual, {});
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -26,3 +26,4 @@ export * from "./union.ts";
 export * from "./without_all.ts";
 export * from "./unzip.ts";
 export * from "./zip.ts";
+export * from "./filter_values_not_nullish.ts";


### PR DESCRIPTION
There are a few things I'd like to bring up regarding this:
- The name is kinda long/wordy, I don't really have any better ideas but if anyone has I'd appreciate if they could share it.
- In the current implementation I'm not sure how to get rid of the typecast, as even tho its as "type-guarded" as can be, TS still doesn't recognize it as NonNullable
- I've followed the nullish coalescing operator, which only considers(to my knowledge) `null` and `undefined` as nullish, I'm not sure if that's a problem/if that's what the function was intended to do originally.