### PR TITLE
fix(collections): Prevent prototype merge in collections/deep_merge.ts

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -2,9 +2,9 @@
 
 // deno-lint-ignore-file ban-types
 
-import { hasOwnProperty } from "../_util/has_own_property.ts";
-
 import { filterInPlace } from "./_utils.ts";
+
+const { hasOwn } = Object;
 
 /**
  * Merges the two given Records, recursively merging any nested Records with
@@ -73,7 +73,7 @@ export function deepMerge<
 
     const a = record[key] as ResultMember;
 
-    if (!(hasOwnProperty(other, key))) {
+    if (!(hasOwn(other, key))) {
       result[key] = a;
 
       continue;

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -73,7 +73,7 @@ export function deepMerge<
 
     const a = record[key] as ResultMember;
 
-    if (!(hasOwn(other, key))) {
+    if (!hasOwn(other, key)) {
       result[key] = a;
 
       continue;

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -2,6 +2,8 @@
 
 // deno-lint-ignore-file ban-types
 
+import { hasOwnProperty } from "../_util/has_own_property.ts";
+
 import { filterInPlace } from "./_utils.ts";
 
 /**
@@ -71,7 +73,7 @@ export function deepMerge<
 
     const a = record[key] as ResultMember;
 
-    if (!(key in other)) {
+    if (!(hasOwnProperty(other, key))) {
       result[key] = a;
 
       continue;

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -65,6 +65,20 @@ Deno.test("deepMerge: nested merge", () => {
   );
 });
 
+Deno.test("deepMerge: prevent prototype merge", () => {
+  assertEquals(
+    deepMerge({
+      constructor: undefined,
+    }, {
+      foo: true,
+    }),
+    {
+      constructor: undefined,
+      foo: true,
+    }
+  );
+});
+
 Deno.test("deepMerge: override target (non-mergeable source)", () => {
   assertEquals(
     deepMerge({

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -75,7 +75,7 @@ Deno.test("deepMerge: prevent prototype merge", () => {
     {
       constructor: undefined,
       foo: true,
-    }
+    },
   );
 });
 


### PR DESCRIPTION
The use of the `in` operator to check for the existence of properties is causing unexpected merging in objects with the same property names as `Object.prototype`. This PR fixes it by changing it to use `Object.prototype.hasOwnProperty`.

Expected behavior:

```ts
assertEquals(
  deepMerge({
    constructor: undefined,
  }, {
    foo: true,
  }),
  {
    constructor: undefined,
    foo: true,
  }
);
```

Actual behavior:

```ts
assertEquals(
  deepMerge({
    constructor: undefined,
  }, {
    foo: true,
  }),
  {
    constructor: Object.prototype.constructor,
    foo: true,
  }
);
```
