### PR TITLE
docs(testing): document assertRejects in README

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -31,13 +31,13 @@ pretty-printed diff of failing assertion.
   this function does. Also compares any errors thrown to an optional expected
   `Error` class and checks that the error `.message` includes an optional
   string.
-- `assertRejects()` - Expects the passed `fn` to be async and throw (or
-  return a `Promise` that rejects). If the `fn` does not throw or reject, this
-  function will throw asynchronously _(⚠️ assertion should be awaited or be the
-  return value of the test function to avoid any uncaught rejections which could
-  result in unexpected process exit)_. Also compares any errors thrown to an
-  optional expected `Error` class and checks that the error `.message` includes
-  an optional string.
+- `assertRejects()` - Expects the passed `fn` to be async and throw (or return a
+  `Promise` that rejects). If the `fn` does not throw or reject, this function
+  will throw asynchronously _(⚠️ assertion should be awaited or be the return
+  value of the test function to avoid any uncaught rejections which could result
+  in unexpected process exit)_. Also compares any errors thrown to an optional
+  expected `Error` class and checks that the error `.message` includes an
+  optional string.
 - `assertThrowsAsync()` - Deprecated. Use `assertRejects`.
 - `unimplemented()` - Use this to stub out methods that will throw when invoked.
 - `unreachable()` - Used to assert unreachable code.

--- a/testing/README.md
+++ b/testing/README.md
@@ -31,13 +31,14 @@ pretty-printed diff of failing assertion.
   this function does. Also compares any errors thrown to an optional expected
   `Error` class and checks that the error `.message` includes an optional
   string.
-- `assertThrowsAsync()` - Expects the passed `fn` to be async and throw (or
+- `assertRejects()` - Expects the passed `fn` to be async and throw (or
   return a `Promise` that rejects). If the `fn` does not throw or reject, this
   function will throw asynchronously _(⚠️ assertion should be awaited or be the
   return value of the test function to avoid any uncaught rejections which could
   result in unexpected process exit)_. Also compares any errors thrown to an
   optional expected `Error` class and checks that the error `.message` includes
   an optional string.
+- `assertThrowsAsync()` - Deprecated. Use `assertRejects`.
 - `unimplemented()` - Use this to stub out methods that will throw when invoked.
 - `unreachable()` - Used to assert unreachable code.
 


### PR DESCRIPTION
This PR continues the work of #1139. Updates `testing/README.md` following the change of #1101