### PR TITLE
docs(http): adhere to deno style guide in `std/http` module

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -100,4 +100,4 @@ let response: Response = {};
 deleteCookie(response, "deno", { path: "/", domain: "deno.land" });
 ```
 
-**Note**: At the moment multiple `Set-Cookie` in a `Response` is not handled.
+> Note: At the moment multiple `Set-Cookie` in a `Response` is not handled.

--- a/http/_io.ts
+++ b/http/_io.ts
@@ -116,13 +116,15 @@ export function chunkedBodyReader(h: Headers, r: BufReader): Deno.Reader {
   return { read };
 }
 
-function isProhibidedForTrailer(key: string): boolean {
+function isProhibitedForTrailer(key: string): boolean {
   const s = new Set(["transfer-encoding", "content-length", "trailer"]);
   return s.has(key.toLowerCase());
 }
 
-/** Read trailer headers from reader and append values to headers. "trailer"
- * field will be deleted. */
+/**
+ * Read trailer headers from reader and append values to headers. "trailer"
+ * field will be deleted.
+ */
 export async function readTrailers(
   headers: Headers,
   r: BufReader,
@@ -163,7 +165,7 @@ function parseTrailer(field: string | null): Headers | undefined {
   if (trailerNames.length === 0) {
     throw new Deno.errors.InvalidData("Empty trailer header.");
   }
-  const prohibited = trailerNames.filter((k) => isProhibidedForTrailer(k));
+  const prohibited = trailerNames.filter((k) => isProhibitedForTrailer(k));
   if (prohibited.length > 0) {
     throw new Deno.errors.InvalidData(
       `Prohibited trailer names: ${Deno.inspect(prohibited)}.`,
@@ -190,8 +192,10 @@ export async function writeChunkedBody(
   await w.write(endChunk);
 }
 
-/** Write trailer headers to writer. It should mostly should be called after
- * `writeResponse()`. */
+/**
+ * Write trailer headers to writer. It should mostly should be called after
+ * `writeResponse()`.
+ */
 export async function writeTrailers(
   w: Deno.Writer,
   headers: Headers,
@@ -210,7 +214,7 @@ export async function writeTrailers(
   const writer = BufWriter.create(w);
   const trailerNames = trailer.split(",").map((s) => s.trim().toLowerCase());
   const prohibitedTrailers = trailerNames.filter((k) =>
-    isProhibidedForTrailer(k)
+    isProhibitedForTrailer(k)
   );
   if (prohibitedTrailers.length > 0) {
     throw new TypeError(
@@ -241,7 +245,7 @@ export async function writeResponse(
   const writer = BufWriter.create(w);
   if (statusText === null) {
     throw new Deno.errors.InvalidData(
-      "Empty statusText (explicitely pass an empty string if this was intentional)",
+      "Empty statusText (explicitly pass an empty string if this was intentional)",
     );
   }
   if (!r.body) {

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-/** Create dummy Deno.Conn object with given base properties. */
+/** Create dummy `Deno.Conn` object with given base properties. */
 export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
   return {
     localAddr: {

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-/** Create dummy Deno.Conn object with given base properties */
+/** Create dummy Deno.Conn object with given base properties. */
 export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
   return {
     localAddr: {

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -184,8 +184,6 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
 
 /**
  * Set the cookie header properly in the Response.
- * @param res An object which has a headers property.
- * @param cookie Cookie to set.
  *
  * Example:
  *
@@ -196,6 +194,9 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
  * setCookie(response, { name: 'deno', value: 'runtime',
  *   httpOnly: true, secure: true, maxAge: 2, domain: "deno.land" });
  * ```
+ * 
+ * @param res An object which has a headers property.
+ * @param cookie Cookie to set.
  */
 export function setCookie(res: { headers?: Headers }, cookie: Cookie): void {
   if (!res.headers) {

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -194,7 +194,7 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
  * setCookie(response, { name: 'deno', value: 'runtime',
  *   httpOnly: true, secure: true, maxAge: 2, domain: "deno.land" });
  * ```
- * 
+ *
  * @param res An object which has a headers property.
  * @param cookie Cookie to set.
  */

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -19,10 +19,12 @@ export interface Cookie {
   path?: string;
   /** Indicates if the cookie is made using SSL & HTTPS. */
   secure?: boolean;
-  /** Indicates that cookie is not accessible via JavaScript. **/
+  /** Indicates that cookie is not accessible via JavaScript. */
   httpOnly?: boolean;
-  /** Allows servers to assert that a cookie ought not to
-   * be sent along with cross-site requests. */
+  /**
+   * Allows servers to assert that a cookie ought not to
+   * be sent along with cross-site requests.
+   */
   sameSite?: "Strict" | "Lax" | "None";
   /** Additional key value pairs with the form "key=value" */
   unparsed?: string[];
@@ -96,7 +98,7 @@ function validateName(name: string | undefined | null): void {
 
 /**
  * Validate Path Value.
- * @see https://tools.ietf.org/html/rfc6265#section-4.1.2.4
+ * See {@link https://tools.ietf.org/html/rfc6265#section-4.1.2.4}.
  * @param path Path value.
  */
 function validatePath(path: string | null): void {
@@ -117,7 +119,7 @@ function validatePath(path: string | null): void {
 
 /**
  * Validate Cookie Value.
- * @see https://tools.ietf.org/html/rfc6265#section-4.1
+ * See {@link https://tools.ietf.org/html/rfc6265#section-4.1}.
  * @param value Cookie value.
  */
 function validateValue(name: string, value: string | null): void {
@@ -144,7 +146,7 @@ function validateValue(name: string, value: string | null): void {
 
 /**
  * Validate Cookie Domain.
- * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3
+ * See {@link https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3}.
  * @param domain Cookie domain.
  */
 function validateDomain(domain: string): void {
@@ -161,8 +163,8 @@ function validateDomain(domain: string): void {
 }
 
 /**
- * Parse the cookies of the Server Request
- * @param req An object which has a `headers` property
+ * Parse the cookies of the Server Request.
+ * @param req An object which has a `headers` property.
  */
 export function getCookies(req: { headers: Headers }): Record<string, string> {
   const cookie = req.headers.get("Cookie");
@@ -181,9 +183,9 @@ export function getCookies(req: { headers: Headers }): Record<string, string> {
 }
 
 /**
- * Set the cookie header properly in the Response
- * @param res An object which has a headers property
- * @param cookie Cookie to set
+ * Set the cookie header properly in the Response.
+ * @param res An object which has a headers property.
+ * @param cookie Cookie to set.
  *
  * Example:
  *
@@ -209,14 +211,22 @@ export function setCookie(res: { headers?: Headers }, cookie: Cookie): void {
 }
 
 /**
- *  Set the cookie header properly in the Response to delete it
- * @param res Server Response
- * @param name Name of the cookie to Delete
+ * Set the cookie header properly in the Response to delete it.
+ *
  * Example:
  *
- *     deleteCookie(res,'foo');
- *     deleteCookie(res,'foo', {path:'/demo'});
- *     deleteCookie(res,'foo', {domain:'deno.land'});
+ * ```ts
+ * import { deleteCookie } from "./cookie.ts";
+ *
+ * const response = new Response("");
+ *
+ * deleteCookie(response, "foo");
+ * deleteCookie(response, "foo", { path: "/demo" });
+ * deleteCookie(response, "foo", { domain: "deno.land" });
+ * ```
+ *
+ * @param res Server Response.
+ * @param name Name of the cookie to Delete.
  */
 export function deleteCookie(
   res: { headers?: Headers },

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -234,9 +234,9 @@ function fileLenToString(len: number): string {
 }
 
 /**
- * Returns an HTTP Response with the requested file as the body
- * @param req The server request context used to cleanup the file handle
- * @param filePath Path of the file to serve
+ * Returns an HTTP Response with the requested file as the body.
+ * @param req The server request context used to cleanup the file handle.
+ * @param filePath Path of the file to serve.
  */
 export async function serveFile(
   req: Request,

--- a/http/server.ts
+++ b/http/server.ts
@@ -1,47 +1,29 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { delay } from "../async/mod.ts";
 
-/**
- * Thrown by Server after it has been closed.
- */
+/** Thrown by Server after it has been closed. */
 const ERROR_SERVER_CLOSED = "Server closed";
 
-/**
- * Thrown when parsing an invalid address string.
- */
+/** Thrown when parsing an invalid address string. */
 const ERROR_ADDRESS_INVALID = "Invalid address";
 
-/**
- * Default port for serving HTTP.
- */
+/** Default port for serving HTTP. */
 const HTTP_PORT = 80;
 
-/**
- * Default port for serving HTTPS.
- */
+/** Default port for serving HTTPS. */
 const HTTPS_PORT = 443;
 
-/**
- * Initial backoff delay of 5ms following a temporary accept failure.
- */
+/** Initial backoff delay of 5ms following a temporary accept failure. */
 const INITIAL_ACCEPT_BACKOFF_DELAY = 5;
 
-/**
- * Max backoff delay of 1s following a temporary accept failure.
- */
+/** Max backoff delay of 1s following a temporary accept failure. */
 const MAX_ACCEPT_BACKOFF_DELAY = 1000;
 
-/**
- * Information about the connection a request arrived on.
- */
+/** Information about the connection a request arrived on. */
 export interface ConnInfo {
-  /**
-   * The local address of the connection.
-   */
+  /** The local address of the connection. */
   readonly localAddr: Deno.Addr;
-  /**
-   * The remote address of the connection.
-   */
+  /** The remote address of the connection. */
   readonly remoteAddr: Deno.Addr;
 }
 
@@ -61,6 +43,8 @@ export type Handler = (
 /**
  * Parse an address from a string.
  *
+ * Throws a `TypeError` when the address is invalid.
+ *
  * ```ts
  * import { _parseAddrFromStr } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *
@@ -68,11 +52,9 @@ export type Handler = (
  * const listenOptions = _parseAddrFromStr(addr);
  * ```
  *
- * @param {string} addr The address string to parse.
- * @param {number} defaultPort Default port when not included in the address string.
- * @return {Deno.ListenOptions} The parsed address.
- * @throws {TypeError} When the address is invalid.
- * @private
+ * @param addr The address string to parse.
+ * @param defaultPort Default port when not included in the address string.
+ * @return The parsed address.
  */
 export function _parseAddrFromStr(
   addr: string,
@@ -104,9 +86,7 @@ export function _parseAddrFromStr(
   };
 }
 
-/**
- * Options for running an HTTP server.
- */
+/** Options for running an HTTP server. */
 export interface ServerInit {
   /**
    * Optionally specifies the address to listen on, in the form
@@ -121,15 +101,11 @@ export interface ServerInit {
    */
   addr?: string;
 
-  /**
-   * The handler to invoke for individual HTTP requests.
-   */
+  /** The handler to invoke for individual HTTP requests. */
   handler: Handler;
 }
 
-/**
- * Used to construct an HTTP server.
- */
+/** Used to construct an HTTP server. */
 export class Server {
   #addr?: string;
   #handler: Handler;
@@ -155,7 +131,7 @@ export class Server {
    * const server = new Server({ addr, handler });
    * ```
    *
-   * @param {ServerInit} serverInit Options for running an HTTP server.
+   * @param serverInit Options for running an HTTP server.
    */
   constructor(serverInit: ServerInit) {
     this.#addr = serverInit.addr;
@@ -190,8 +166,7 @@ export class Server {
    * await server.serve(listener);
    * ```
    *
-   * @param {Deno.Listener} listener The listener to accept connections from.
-   * @throws {Deno.errors.Http} When the server has already been closed.
+   * @param listener The listener to accept connections from.
    */
   async serve(listener: Deno.Listener): Promise<void> {
     if (this.#closed) {
@@ -236,8 +211,6 @@ export class Server {
    * const server = new Server({ addr, handler });
    * await server.listenAndServe();
    * ```
-   *
-   * @throws {Deno.errors.Http} When the server has already been closed.
    */
   async listenAndServe(): Promise<void> {
     if (this.#closed) {
@@ -283,9 +256,8 @@ export class Server {
    * await server.listenAndServeTls(certFile, keyFile);
    * ```
    *
-   * @param {string} certFile The path to the file containing the TLS certificate.
-   * @param {string} keyFile The path to the file containing the TLS private key.
-   * @throws {Deno.errors.Http} When the server has already been closed.
+   * @param certFile The path to the file containing the TLS certificate.
+   * @param keyFile The path to the file containing the TLS private key.
    */
   async listenAndServeTls(certFile: string, keyFile: string): Promise<void> {
     if (this.#closed) {
@@ -311,8 +283,6 @@ export class Server {
    * Immediately close the server listeners and associated HTTP connections.
    *
    * Throws a server closed error if called after the server has been closed.
-   *
-   * @throws {Deno.errors.Http} When the server has already been closed.
    */
   close(): void {
     if (this.#closed) {
@@ -338,16 +308,12 @@ export class Server {
     this.#httpConnections.clear();
   }
 
-  /**
-   * Get whether the server is closed.
-   */
+  /** Get whether the server is closed. */
   get closed(): boolean {
     return this.#closed;
   }
 
-  /**
-   * Get the list of network addresses the server is listening on.
-   */
+  /** Get the list of network addresses the server is listening on. */
   get addrs(): Deno.Addr[] {
     return Array.from(this.#listeners).map((listener) => listener.addr);
   }
@@ -355,10 +321,9 @@ export class Server {
   /**
    * Responds to an HTTP request.
    *
-   * @param {Deno.RequestEvent} requestEvent The HTTP request to respond to.
-   * @param {Deno.HttpConn} httpCon The HTTP connection to yield requests from.
-   * @param {ConnInfo} connInfo Information about the underlying connection.
-   * @private
+   * @param requestEvent The HTTP request to respond to.
+   * @param httpCon The HTTP connection to yield requests from.
+   * @param connInfo Information about the underlying connection.
    */
   async #respond(
     requestEvent: Deno.RequestEvent,
@@ -388,9 +353,8 @@ export class Server {
   /**
    * Serves all HTTP requests on a single connection.
    *
-   * @param {Deno.HttpConn} httpConn The HTTP connection to yield requests from.
-   * @param {ConnInfo} connInfo Information about the underlying connection.
-   * @private
+   * @param httpConn The HTTP connection to yield requests from.
+   * @param connInfo Information about the underlying connection.
    */
   async #serveHttp(
     httpConn: Deno.HttpConn,
@@ -423,8 +387,7 @@ export class Server {
   /**
    * Accepts all connections on a single network listener.
    *
-   * @param {Deno.Listener} listener The listener to accept connections from.
-   * @private
+   * @param listener The listener to accept connections from.
    */
   async #accept(
     listener: Deno.Listener,
@@ -499,8 +462,7 @@ export class Server {
   /**
    * Untracks and closes an HTTP connection.
    *
-   * @param {Deno.HttpConn} httpConn The HTTP connection to close.
-   * @private
+   * @param httpConn The HTTP connection to close.
    */
   #closeHttpConn(httpConn: Deno.HttpConn): void {
     this.#untrackHttpConnection(httpConn);
@@ -515,8 +477,7 @@ export class Server {
   /**
    * Adds the listener to the internal tracking list.
    *
-   * @param {Deno.Listener} listener Listener to track.
-   * @private
+   * @param listener Listener to track.
    */
   #trackListener(listener: Deno.Listener): void {
     this.#listeners.add(listener);
@@ -525,8 +486,7 @@ export class Server {
   /**
    * Removes the listener from the internal tracking list.
    *
-   * @param {Deno.Listener} listener Listener to untrack.
-   * @private
+   * @param listener Listener to untrack.
    */
   #untrackListener(listener: Deno.Listener): void {
     this.#listeners.delete(listener);
@@ -535,8 +495,7 @@ export class Server {
   /**
    * Adds the HTTP connection to the internal tracking list.
    *
-   * @param {Deno.HttpConn} httpConn HTTP connection to track.
-   * @private
+   * @param httpConn HTTP connection to track.
    */
   #trackHttpConnection(httpConn: Deno.HttpConn): void {
     this.#httpConnections.add(httpConn);
@@ -545,21 +504,16 @@ export class Server {
   /**
    * Removes the HTTP connection from the internal tracking list.
    *
-   * @param {Deno.HttpConn} httpConn HTTP connection to untrack.
-   * @private
+   * @param httpConn HTTP connection to untrack.
    */
   #untrackHttpConnection(httpConn: Deno.HttpConn): void {
     this.#httpConnections.delete(httpConn);
   }
 }
 
-/**
- * Additional serve options.
- */
+/** Additional serve options. */
 export interface ServeInit {
-  /**
-   * An AbortSignal to close the server and all connections.
-   */
+  /** An AbortSignal to close the server and all connections. */
   signal?: AbortSignal;
 }
 
@@ -581,9 +535,9 @@ export interface ServeInit {
  * });
  * ```
  *
- * @param {Deno.Listener} listener The listener to accept connections from.
- * @param {Handler} handler The handler for individual HTTP requests.
- * @param {ServeInit} [options] Additional serve options.
+ * @param listener The listener to accept connections from.
+ * @param handler The handler for individual HTTP requests.
+ * @param options Optional serve options.
  */
 export async function serve(
   listener: Deno.Listener,
@@ -620,9 +574,9 @@ export async function serve(
  * });
  * ```
  *
- * @param {string} addr The address to listen on.
- * @param {Handler} handler The handler for individual HTTP requests.
- * @param {ServeInit} [options] Additional serve options.
+ * @param addr The address to listen on.
+ * @param handler The handler for individual HTTP requests.
+ * @param options Optional serve options.
  */
 export async function listenAndServe(
   addr: string,
@@ -661,11 +615,11 @@ export async function listenAndServe(
  * });
  * ```
  *
- * @param {string} addr The address to listen on.
- * @param {string} certFile The path to the file containing the TLS certificate.
- * @param {string} keyFile The path to the file containing the TLS private key.
- * @param {Handler} handler The handler for individual HTTP requests.
- * @param {ServeInit} [options] Additional serve options.
+ * @param addr The address to listen on.
+ * @param certFile The path to the file containing the TLS certificate.
+ * @param keyFile The path to the file containing the TLS private key.
+ * @param handler The handler for individual HTTP requests.
+ * @param options Optional serve options.
  */
 export async function listenAndServeTls(
   addr: string,

--- a/http/server_legacy.ts
+++ b/http/server_legacy.ts
@@ -270,14 +270,16 @@ export class Server implements AsyncIterable<ServerRequest> {
 }
 
 /**
- * Options for creating an HTTP server.
- *
  * @deprecated
+ *
+ * Options for creating an HTTP server.
  */
 export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
 
 /**
- * Create a HTTP server
+ * @deprecated
+ *
+ * Create an HTTP server.
  *
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server_legacy.ts";
@@ -288,8 +290,6 @@ export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
  *   req.respond({ body });
  * }
  * ```
- *
- * @deprecated
  */
 export function serve(addr: string | HTTPOptions): Server {
   if (typeof addr === "string") {
@@ -301,7 +301,9 @@ export function serve(addr: string | HTTPOptions): Server {
 }
 
 /**
- * Start an HTTP server with given options and request handler
+ * @deprecated
+ *
+ * Start an HTTP server with given options and request handler.
  *
  * ```ts
  * import { listenAndServe, ServerRequest } from "https://deno.land/std@$STD_VERSION/http/server_legacy.ts";
@@ -313,9 +315,8 @@ export function serve(addr: string | HTTPOptions): Server {
  * });
  * ```
  *
- * @param options Server configuration
- * @param handler Request handler
- * @deprecated
+ * @param options Server configuration.
+ * @param handler Request handler.
  */
 export async function listenAndServe(
   addr: string | HTTPOptions,
@@ -336,7 +337,9 @@ export async function listenAndServe(
 export type HTTPSOptions = Omit<Deno.ListenTlsOptions, "transport">;
 
 /**
- * Create an HTTPS server with given options
+ * @deprecated
+ *
+ * Create an HTTPS server with given options.
  *
  * ```ts
  * import { serveTLS } from "https://deno.land/std@$STD_VERSION/http/server_legacy.ts";
@@ -353,9 +356,8 @@ export type HTTPSOptions = Omit<Deno.ListenTlsOptions, "transport">;
  * }
  * ```
  *
- * @param options Server configuration
- * @return Async iterable server instance for incoming requests
- * @deprecated
+ * @param options Server configuration.
+ * @return Async iterable server instance for incoming requests.
  */
 export function serveTLS(options: HTTPSOptions): Server {
   const tlsOptions: Deno.ListenTlsOptions = {
@@ -367,7 +369,9 @@ export function serveTLS(options: HTTPSOptions): Server {
 }
 
 /**
- * Start an HTTPS server with given options and request handler
+ * @deprecated
+ *
+ * Start an HTTPS server with given options and request handler.
  *
  * ```ts
  * import { listenAndServeTLS } from "https://deno.land/std@$STD_VERSION/http/server_legacy.ts";
@@ -384,9 +388,8 @@ export function serveTLS(options: HTTPSOptions): Server {
  * });
  * ```
  *
- * @param options Server configuration
- * @param handler Request handler
- * @deprecated
+ * @param options Server configuration.
+ * @param handler Request handler.
  */
 export async function listenAndServeTLS(
   options: HTTPSOptions,
@@ -400,11 +403,11 @@ export async function listenAndServeTLS(
 }
 
 /**
+ * @deprecated
+ *
  * Interface of HTTP server response.
  * If body is a Reader, response would be chunked.
  * If body is a string, it would be UTF-8 encoded by default.
- *
- * @deprecated
  */
 export interface Response {
   status?: number;

--- a/http/server_legacy_test.ts
+++ b/http/server_legacy_test.ts
@@ -405,7 +405,7 @@ Deno.test({
       const s = await r.readLine();
       assert(s !== null && s.includes("server listening"));
       await delay(100);
-      // Reqeusts to the server and immediately closes the connection
+      // Requests to the server and immediately closes the connection
       const conn = await Deno.connect({ port: 4502 });
       await conn.write(new TextEncoder().encode("GET / HTTP/1.0\n\n"));
       conn.close();
@@ -682,7 +682,7 @@ Deno.test({
         "",
       ].join("\r\n")),
     );
-    // After sending the two requests, don't receive the reponses.
+    // After sending the two requests, don't receive the responses.
 
     // Closing the connection now.
     conn.close();


### PR DESCRIPTION
Following https://github.com/denoland/deno_std/pull/1128, this PR corrects the JSDoc syntax previously implemented to match the [style guide](https://deno.land/manual/contributing/style_guide) (apologies for not getting right first time!) and the supported syntax of <https://doc.deno.land/>.

In addition to correcting the docs in the `http/server.ts` module, I have also corrected/formatted docs in the rest of the `http` module for consistency. I haven't done the whole of std to keep the scope of this PR small and easily reviewable.

Compare [docs from this PR](https://doc.deno.land/https/raw.githubusercontent.com%2Fdenoland%2Fdeno_std%2Fd929a3a%2Fhttp%2Fmod.ts) with [current docs](https://doc.deno.land/https/raw.githubusercontent.com%2Fdenoland%2Fdeno_std%2Fmain%2Fhttp%2Fmod.ts).