### PR TITLE
docs(README): add note about ci checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ For contributions to the Node compatibility library please check the
 
 _About CI checks_:
 
-We currently have 9 checks on CI. You need to pass the following 6 checks for your PR to be accepted:
+We currently have 9 checks on CI. You need to pass the following 6 checks for
+your PR to be accepted:
 
 - test with Deno 1.x on Windows
 - test with Deno 1.x on Linux
@@ -99,7 +100,9 @@ We currently have 9 checks on CI. You need to pass the following 6 checks for yo
 - wasm crypto check
 - CLA
 
-You don't need to pass the following 3 checks (These are informative checks for maintainers):
+You don't need to pass the following 3 checks (These are informative checks for
+maintainers):
+
 - test with Deno canary on Windows
 - test with Deno canary on Linux
 - test with Deno canary on macOS

--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ Ensure there is a related issue and it is referenced in the PR text.
 For contributions to the Node compatibility library please check the
 [`std/node` contributing guide](./node/README.md)
 
+_About CI checks_:
+
+We currently have 9 checks on CI. You need to pass the following 6 checks for your PR to be accepted:
+
+- test with Deno 1.x on Windows
+- test with Deno 1.x on Linux
+- test with Deno 1.x on macOS
+- lint
+- wasm crypto check
+- CLA
+
+You don't need to pass the following 3 checks (These are informative checks for maintainers):
+- test with Deno canary on Windows
+- test with Deno canary on Linux
+- test with Deno canary on macOS
+
 _For maintainers_:
 
 To release a new version a tag in the form of `x.y.z` should be added.


### PR DESCRIPTION
I talked with @ry and we decided to keep running canary CI because we want to know the breakage as soon as possible. But we don't require them passing for the PR to be accepted. This PR tries to clarify that for the contributors.

closes #870 
closes #1174