### PR TITLE
docs(http): reduce friction for windows users r.e. `0.0.0.0`

### DIFF
--- a/examples/echo_server.ts
+++ b/examples/echo_server.ts
@@ -1,9 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { copy } from "../io/util.ts";
+
 const hostname = "0.0.0.0";
 const port = 8080;
 const listener = Deno.listen({ hostname, port });
-console.log(`Listening on ${hostname}:${port}`);
+
+console.log(`Listening on http://localhost:${port}`);
+
 for await (const conn of listener) {
   copy(conn, conn);
 }

--- a/examples/echo_server_test.ts
+++ b/examples/echo_server_test.ts
@@ -22,7 +22,7 @@ Deno.test("[examples/echo_server]", async () => {
     assertNotEquals(message, null);
     assertStrictEquals(
       decoder.decode((message as ReadLineResult).line).trim(),
-      "Listening on 0.0.0.0:8080",
+      "Listening on http://localhost:8080",
     );
 
     conn = await Deno.connect({ hostname: "127.0.0.1", port: 8080 });

--- a/http/README.md
+++ b/http/README.md
@@ -36,7 +36,7 @@ A small program for serving local files over HTTP.
 
 ```sh
 deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
-> HTTP server listening on http://0.0.0.0:4507/
+> HTTP server listening on http://localhost:4507/
 ```
 
 ## Cookie

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -681,7 +681,11 @@ function main(): void {
     listenAndServe(addr, handler);
   }
 
-  console.log(`${proto.toUpperCase()} server listening on ${proto}://${addr}/`);
+  console.log(
+    `${proto.toUpperCase()} server listening on ${proto}://${
+      addr.replace("0.0.0.0", "localhost")
+    }/`,
+  );
 }
 
 if (import.meta.main) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -92,12 +92,12 @@ export interface ServerInit {
    * Optionally specifies the address to listen on, in the form
    * "host:port".
    *
-   * If the port is omitted, ":80" is used by default for HTTP when invoking
-   * non-TLS methods such as `Server.listenAndServe`, and ":443" is
+   * If the port is omitted, `:80` is used by default for HTTP when invoking
+   * non-TLS methods such as `Server.listenAndServe`, and `:443` is
    * used by default for HTTPS when invoking TLS methods such as
-   * `server.listenAndServeTls`.
+   * `Server.listenAndServeTls`.
    *
-   * If the host is omitted, the non-routable meta-address "0.0.0.0" is used.
+   * If the host is omitted, the non-routable meta-address `0.0.0.0` is used.
    */
   addr?: string;
 
@@ -163,6 +163,8 @@ export class Server {
    * const server = new Server({ handler });
    * const listener = Deno.listen({ port: 4505 });
    *
+   * console.log("server listening on http://localhost:4505");
+   *
    * await server.serve(listener);
    * ```
    *
@@ -192,7 +194,11 @@ export class Server {
    * Create a listener on the server, accept incoming connections, and handle
    * requests on these connections with the given handler.
    *
-   * If the server was constructed without an address, ":80" is used.
+   * If the server was constructed with the port omitted from the address, `:80`
+   * is used.
+   *
+   * If the server was constructed with the host omitted from the address, the
+   * non-routable meta-address `0.0.0.0` is used.
    *
    * Throws a server closed error if the server has been closed.
    *
@@ -209,6 +215,9 @@ export class Server {
    * };
    *
    * const server = new Server({ addr, handler });
+   *
+   * console.log("server listening on http://localhost:4505");
+   *
    * await server.listenAndServe();
    * ```
    */
@@ -232,7 +241,11 @@ export class Server {
    * Create a listener on the server, accept incoming connections, upgrade them
    * to TLS, and handle requests on these connections with the given handler.
    *
-   * If the server was constructed without an address, ":443" is used.
+   * If the server was constructed with the port omitted from the address, `:443`
+   * is used.
+   *
+   * If the server was constructed with the host omitted from the address, the
+   * non-routable meta-address `0.0.0.0` is used.
    *
    * Throws a server closed error if the server has been closed.
    *
@@ -252,6 +265,8 @@ export class Server {
    *
    * const certFile = "/path/to/certFile.crt";
    * const keyFile = "/path/to/keyFile.key";
+   *
+   * console.log("server listening on https://localhost:4505");
    *
    * await server.listenAndServeTls(certFile, keyFile);
    * ```
@@ -526,6 +541,8 @@ export interface ServeInit {
  *
  * const listener = Deno.listen({ port: 4505 });
  *
+ * console.log("server listening on http://localhost:4505");
+ *
  * await serve(listener, (request) => {
  *   const body = `Your user-agent is:\n\n${request.headers.get(
  *     "user-agent",
@@ -558,12 +575,17 @@ export async function serve(
  * incoming connections, and handles requests on these connections with the
  * given handler.
  *
- * If the server was constructed without an address, ":80" is used.
+ * If the port is omitted from the address, `:80` is used.
+ *
+ * If the host is omitted from the address, the non-routable meta-address
+ * `0.0.0.0` is used.
  *
  * ```ts
  * import { listenAndServe } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *
  * const addr = ":4505";
+ *
+ * console.log("server listening on http://localhost:4505");
  *
  * await listenAndServe(addr, (request) => {
  *   const body = `Your user-agent is:\n\n${request.headers.get(
@@ -597,7 +619,10 @@ export async function listenAndServe(
  * incoming connections, upgrades them to TLS, and handles requests on these
  * connections with the given handler.
  *
- * If the server was constructed without an address, ":443" is used.
+ * If the port is omitted from the address, `:443` is used.
+ *
+ * If the host is omitted from the address, the non-routable meta-address
+ * `0.0.0.0` is used.
  *
  * ```ts
  * import { listenAndServeTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
@@ -605,6 +630,8 @@ export async function listenAndServe(
  * const addr = ":4505";
  * const certFile = "/path/to/certFile.crt";
  * const keyFile = "/path/to/keyFile.key";
+ *
+ * console.log("server listening on http://localhost:4505");
  *
  * await listenAndServeTls(addr, certFile, keyFile, (request) => {
  *   const body = `Your user-agent is:\n\n${request.headers.get(

--- a/http/testdata/simple_https_server.ts
+++ b/http/testdata/simple_https_server.ts
@@ -11,6 +11,6 @@ const keyFile = join(moduleDir, "tls/localhost.key");
 const encoder = new TextEncoder();
 const body = encoder.encode("Hello HTTPS!");
 
-console.log(`Simple HTTPS server listening on https://${addr}`);
+console.log(`Simple HTTPS server listening on https://localhost:4505`);
 
 await listenAndServeTls(addr, certFile, keyFile, () => new Response(body));

--- a/http/testdata/simple_server.ts
+++ b/http/testdata/simple_server.ts
@@ -4,6 +4,6 @@ import { listenAndServe } from "../server.ts";
 
 const addr = "0.0.0.0:4504";
 
-console.log(`Simple server listening on http://${addr}`);
+console.log(`Simple server listening on http://localhost:4504`);
 
 await listenAndServe(addr, () => new Response());

--- a/http/testdata/simple_server_legacy.ts
+++ b/http/testdata/simple_server_legacy.ts
@@ -3,7 +3,9 @@
 import { serve } from "../server_legacy.ts";
 
 const addr = "0.0.0.0:4502";
-console.log(`Simple server listening on ${addr}`);
+
+console.log(`Simple server listening on http://localhost:4502`);
+
 for await (const req of serve(addr)) {
   req.respond({});
 }


### PR DESCRIPTION
Fixes #1165

Attempt to reduce friction for windows users r.e. `0.0.0.0` by opting to use `localhost` in logged statements.

Related to https://github.com/denoland/deno/pull/11938. As noted by @kt3k:

> Listening this address works for all platforms, but the browsers on windows don't work with the address 0.0.0.0, and that's been causing the confusions to Windows users of several tools (ref: denoland/deno_std#1165, denoland/deployctl#63, kt3k/packup#10)