### PR TITLE
feat(collections): Add `associatewith`

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -38,6 +38,25 @@ assertEquals(usersById, {
 });
 ```
 
+## associateWith
+
+Builds a new Record using the given array as keys and choosing a value for each
+key using the given selector.
+
+```ts
+import { associateWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const names = ["Kim", "Lara", "Jonathan"];
+const namesToLength = associateWith(names, (it) => it.length);
+
+assertEquals(namesToLength, {
+  "Kim": 3,
+  "Lara": 4,
+  "Jonathan": 8,
+});
+```
+
 ### chunk
 
 Splits the given array into chunks of the given size and returns them.

--- a/collections/README.md
+++ b/collections/README.md
@@ -41,7 +41,8 @@ assertEquals(usersById, {
 ## associateWith
 
 Builds a new Record using the given array as keys and choosing a value for each
-key using the given selector.
+key using the given selector. If any of two pairs would have the same value the
+latest on will be used (overriding the ones before it).
 
 ```ts
 import { associateWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -1,0 +1,37 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Builds a new Record using the given array as keys and choosing a value for each
+ * key using the given selector.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { associateWith } from "./associate_with.ts"
+ * import { assertEquals } from "../testing/asserts.ts";
+ *
+ * const names = [ 'Kim', 'Lara', 'Jonathan' ]
+ * const namesToLength = associateWith(names, it => it.length)
+ *
+ * assertEquals(namesToLength, {
+ *   'Kim': 3,
+ *   'Lara': 4,
+ *   'Jonathan': 8,
+ * })
+ *
+ * ```
+ */
+export function associateWith<T>(
+  array: readonly string[],
+  selector: (key: string) => T,
+): Record<string, T> {
+  const ret: Record<string, T> = {};
+
+  for (const element of array) {
+    const selectedValue = selector(element);
+
+    ret[element] = selectedValue;
+  }
+
+  return ret;
+}

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -18,7 +18,6 @@
  *   'Lara': 4,
  *   'Jonathan': 8,
  * })
- *
  * ```
  */
 export function associateWith<T>(

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -2,7 +2,8 @@
 
 /**
  * Builds a new Record using the given array as keys and choosing a value for each
- * key using the given selector.
+ * key using the given selector. If any of two pairs would have the same value
+ * the latest on will be used (overriding the ones before it).
  *
  * Example:
  *

--- a/collections/associate_with_test.ts
+++ b/collections/associate_with_test.ts
@@ -79,3 +79,21 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "[collections/associateWith] duplicate keys",
+  fn() {
+    associateWithTest(
+      [
+        ["Kim", "Marija", "Karl", "Jonathan", "Marija"],
+        (it) => it.charAt(0),
+      ],
+      {
+        "Jonathan": "J",
+        "Karl": "K",
+        "Kim": "K",
+        "Marija": "M",
+      },
+    );
+  },
+});

--- a/collections/associate_with_test.ts
+++ b/collections/associate_with_test.ts
@@ -1,0 +1,81 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { associateWith } from "./associate_with.ts";
+
+function associateWithTest<T>(
+  input: [readonly string[], (el: string) => T],
+  expected: { [x: string]: T },
+  message?: string,
+) {
+  const actual = associateWith(...input);
+  assertEquals(actual, expected, message);
+}
+
+Deno.test({
+  name: "[collections/associateWith] no mutation",
+  fn() {
+    const arrayA = ["Foo", "Bar"];
+    associateWith(arrayA, (it) => it.charAt(0));
+
+    assertEquals(arrayA, ["Foo", "Bar"]);
+  },
+});
+
+Deno.test({
+  name: "[collections/associateWith] empty input",
+  fn() {
+    associateWithTest([[], () => "abc"], {});
+  },
+});
+
+Deno.test({
+  name: "[collections/associateWith] associates",
+  fn() {
+    associateWithTest<number>(
+      [
+        [
+          "Kim",
+          "Lara",
+          "Jonathan",
+        ],
+        (it) => it.length,
+      ],
+      {
+        "Kim": 3,
+        "Lara": 4,
+        "Jonathan": 8,
+      },
+    );
+    associateWithTest(
+      [
+        [
+          "Kim@example.org",
+          "Lara@example.org",
+          "Jonathan@example.org",
+        ],
+        (it) => it.replace("org", "com"),
+      ],
+      {
+        "Kim@example.org": "Kim@example.com",
+        "Lara@example.org": "Lara@example.com",
+        "Jonathan@example.org": "Jonathan@example.com",
+      },
+    );
+    associateWithTest<boolean>(
+      [
+        [
+          "Kim",
+          "Lara",
+          "Jonathan",
+        ],
+        (it) => /m/.test(it),
+      ],
+      {
+        "Kim": true,
+        "Lara": false,
+        "Jonathan": false,
+      },
+    );
+  },
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 export * from "./associate_by.ts";
+export * from "./associate_with.ts";
 export * from "./chunk.ts";
 export * from "./deep_merge.ts";
 export * from "./distinct.ts";


### PR DESCRIPTION
Builds a new Record using the given array as keys and choosing a value for each key using the given selector.

```ts
import { associateWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";

const names = ["Kim", "Lara", "Jonathan"];
const namesToLength = associateWith(names, (it) => it.length);

assertEquals(namesToLength, {
  "Kim": 3,
  "Lara": 4,
  "Jonathan": 8,
});
```

Related https://github.com/denoland/deno_std/issues/1173