### PR TITLE
feat(testing/asserts): Add assertThrows() overload to receive error

### DIFF
--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -17,14 +17,13 @@ Deno.test("[async] delay with abort", async function () {
   const { signal } = abort;
   const delayedPromise = delay(100, { signal });
   setTimeout(() => abort.abort(), 0);
-  const result = await assertRejects(
+  await assertRejects(
     () => delayedPromise,
     DOMException,
     "Delay was aborted",
   );
 
   const diff = new Date().getTime() - start.getTime();
-  assert(result === undefined);
   assert(diff < 100);
 });
 

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -32,20 +32,15 @@ Deno.test("[async] pooledMap errors", async function () {
     return n;
   }
   const mappedNumbers: number[] = [];
-  let error: unknown;
   await assertRejects(async () => {
-    try {
-      for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
-        mappedNumbers.push(m);
-      }
-    } catch (e) {
-      error = e;
-      throw e;
+    for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
+      mappedNumbers.push(m);
     }
-  }, AggregateError);
+  }, (error: Error) => {
+    assert(error instanceof AggregateError);
+    assertEquals(error.errors.length, 2);
+    assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
+    assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
+  });
   assertEquals(mappedNumbers, [3]);
-  assert(error instanceof AggregateError);
-  assertEquals(error.errors.length, 2);
-  assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
-  assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
 });

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -474,23 +474,17 @@ for (const t of testCases) {
       }
       let actual;
       if (t.Error) {
-        let err;
         await assertRejects(async () => {
-          try {
-            await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
-              separator,
-              comment: comment,
-              trimLeadingSpace: trim,
-              fieldsPerRecord: fieldsPerRec,
-              lazyQuotes: lazyquote,
-            });
-          } catch (e) {
-            err = e;
-            throw e;
-          }
+          await readMatrix(new BufReader(new StringReader(t.Input ?? "")), {
+            separator,
+            comment: comment,
+            trimLeadingSpace: trim,
+            fieldsPerRecord: fieldsPerRec,
+            lazyQuotes: lazyquote,
+          });
+        }, (error: Error) => {
+          assertEquals(error, t.Error);
         });
-
-        assertEquals(err, t.Error);
       } else {
         actual = await readMatrix(
           new BufReader(new StringReader(t.Input ?? "")),

--- a/testing/README.md
+++ b/testing/README.md
@@ -31,13 +31,11 @@ pretty-printed diff of failing assertion.
   this function does. Also compares any errors thrown to an optional expected
   `Error` class and checks that the error `.message` includes an optional
   string.
-- `assertRejects()` - Expects the passed `fn` to be async and throw (or return a
-  `Promise` that rejects). If the `fn` does not throw or reject, this function
-  will throw asynchronously _(⚠️ assertion should be awaited or be the return
-  value of the test function to avoid any uncaught rejections which could result
-  in unexpected process exit)_. Also compares any errors thrown to an optional
-  expected `Error` class and checks that the error `.message` includes an
-  optional string.
+- `assertRejects()` - Expects the passed `fn` to be async and throw and return a
+  `Promise` that rejects. If the `fn` does not throw or reject, this function
+  will reject _(⚠️ you should normally await this assertion)_. Also optionally
+  accepts an Error class which the expected error must be an instance of, and a
+  string which must be a substring of the error's `.message`.
 - `assertThrowsAsync()` - Deprecated. Use `assertRejects`.
 - `unimplemented()` - Use this to stub out methods that will throw when invoked.
 - `unreachable()` - Used to assert unreachable code.

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -612,7 +612,7 @@ export function assertThrows(
 ): void;
 export function assertThrows(
   fn: () => unknown,
-  errorCallback?: (e: Error) => unknown,
+  errorCallback: (e: Error) => unknown,
   msg?: string,
 ): void;
 export function assertThrows(
@@ -688,7 +688,7 @@ export function assertRejects(
 ): Promise<void>;
 export function assertRejects(
   fn: () => Promise<unknown>,
-  errorCallback?: (e: Error) => unknown,
+  errorCallback: (e: Error) => unknown,
   msg?: string,
 ): Promise<void>;
 export async function assertRejects(

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -599,16 +599,47 @@ export function fail(msg?: string): never {
 
 /**
  * Executes a function, expecting it to throw.  If it does not, then it
- * throws.  An error class and a string that should be included in the
- * error message can also be asserted.
+ * throws. An error class and a string that should be included in the
+ * error message can also be asserted. Or you can pass a
+ * callback which will be passed the error, usually to apply some custom
+ * assertions on it.
  */
-export function assertThrows<T = void>(
-  fn: () => T,
+export function assertThrows(
+  fn: () => unknown,
   ErrorClass?: Constructor,
-  msgIncludes = "",
+  msgIncludes?: string,
+  msg?: string,
+): void;
+export function assertThrows(
+  fn: () => unknown,
+  errorCallback?: (e: Error) => unknown,
+  msg?: string,
+): void;
+export function assertThrows(
+  fn: () => unknown,
+  errorClassOrCallback?: Constructor | ((e: Error) => unknown),
+  msgIncludesOrMsg?: string,
   msg?: string,
 ): void {
+  let ErrorClass;
+  let msgIncludes;
+  let errorCallback;
+  if (
+    errorClassOrCallback == null ||
+    errorClassOrCallback.prototype instanceof Error ||
+    errorClassOrCallback.prototype === Error.prototype
+  ) {
+    ErrorClass = errorClassOrCallback;
+    msgIncludes = msgIncludesOrMsg;
+    errorCallback = null;
+  } else {
+    ErrorClass = null;
+    msgIncludes = null;
+    errorCallback = errorClassOrCallback as (e: Error) => unknown;
+    msg = msgIncludesOrMsg;
+  }
   let doesThrow = false;
+  let error = null;
   try {
     fn();
   } catch (e) {
@@ -631,25 +662,60 @@ export function assertThrows<T = void>(
       throw new AssertionError(msg);
     }
     doesThrow = true;
+    error = e;
   }
   if (!doesThrow) {
     msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
     throw new AssertionError(msg);
   }
+  if (typeof errorCallback == "function") {
+    errorCallback(error);
+  }
 }
 
 /**
  * Executes a function which returns a promise, expecting it to throw or reject.
- * If it does not, then it throws.  An error class and a string that should be
- * included in the error message can also be asserted.
+ * If it does not, then it throws. An error class and a string that should be
+ * included in the error message can also be asserted. Or you can pass a
+ * callback which will be passed the error, usually to apply some custom
+ * assertions on it.
  */
-export async function assertRejects<T = void>(
-  fn: () => Promise<T>,
+export function assertRejects(
+  fn: () => Promise<unknown>,
   ErrorClass?: Constructor,
-  msgIncludes = "",
+  msgIncludes?: string,
+  msg?: string,
+): Promise<void>;
+export function assertRejects(
+  fn: () => Promise<unknown>,
+  errorCallback?: (e: Error) => unknown,
+  msg?: string,
+): Promise<void>;
+export async function assertRejects(
+  fn: () => Promise<unknown>,
+  errorClassOrCallback?: Constructor | ((e: Error) => unknown),
+  msgIncludesOrMsg?: string,
   msg?: string,
 ): Promise<void> {
+  let ErrorClass;
+  let msgIncludes;
+  let errorCallback;
+  if (
+    errorClassOrCallback == null ||
+    errorClassOrCallback.prototype instanceof Error ||
+    errorClassOrCallback.prototype === Error.prototype
+  ) {
+    ErrorClass = errorClassOrCallback;
+    msgIncludes = msgIncludesOrMsg;
+    errorCallback = null;
+  } else {
+    ErrorClass = null;
+    msgIncludes = null;
+    errorCallback = errorClassOrCallback as (e: Error) => unknown;
+    msg = msgIncludesOrMsg;
+  }
   let doesThrow = false;
+  let error = null;
   try {
     await fn();
   } catch (e) {
@@ -672,10 +738,14 @@ export async function assertRejects<T = void>(
       throw new AssertionError(msg);
     }
     doesThrow = true;
+    error = e;
   }
   if (!doesThrow) {
     msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
     throw new AssertionError(msg);
+  }
+  if (typeof errorCallback == "function") {
+    errorCallback(error);
   }
 }
 

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -629,9 +629,33 @@ Deno.test("testingAssertThrowsWithReturnType", () => {
   });
 });
 
-Deno.test("testingAssertThrowsAsyncWithReturnType", () => {
-  assertRejects(() => {
+Deno.test("testingAssertRejectsWithReturnType", async () => {
+  await assertRejects(() => {
     throw new Error();
+  });
+});
+
+Deno.test("testingAssertThrowsWithErrorCallback", () => {
+  assertThrows(() => {
+    throw new AggregateError([new Error("foo"), new Error("bar")], "baz");
+  }, (error: Error) => {
+    assert(error instanceof AggregateError);
+    assertEquals(error.message, "baz");
+    assertEquals(error.errors.length, 2);
+    assertStringIncludes(error.errors[0].stack, "Error: foo");
+    assertStringIncludes(error.errors[1].stack, "Error: bar");
+  });
+});
+
+Deno.test("testingAssertRejectsWithErrorCallback", async () => {
+  await assertRejects(() => {
+    throw new AggregateError([new Error("foo"), new Error("bar")], "baz");
+  }, (error: Error) => {
+    assert(error instanceof AggregateError);
+    assertEquals(error.message, "baz");
+    assertEquals(error.errors.length, 2);
+    assertStringIncludes(error.errors[0].stack, "Error: foo");
+    assertStringIncludes(error.errors[1].stack, "Error: bar");
   });
 });
 


### PR DESCRIPTION
Returning the error is useful.