### PR TITLE
doc: Adds an explanation about how to test markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ maintainers):
 - test with Deno canary on Linux
 - test with Deno canary on macOS
 
-_Code Examples in Markdown Files_:
+_Typechecking code in in Markdown files_:
 
 If you want to run `deno test --doc x.md` you will need to specify the flag 
 `--import-map=test_import_map.json`, this import map is in the root of deno_std.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ maintainers):
 _Code Examples in Markdown Files_:
 
 If you want to run `deno test --doc x.md` you will need to specify the flag 
-`--import-map=test_import_map.json`, this import map is in the root of deno_std
+`--import-map=test_import_map.json`, this import map is in the root of deno_std.
 
 _For maintainers_:
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ maintainers):
 - test with Deno canary on Linux
 - test with Deno canary on macOS
 
+_Code Examples in Markdown Files_:
+
+If you want to run `deno test --doc x.md` you will need to specify the flag 
+`--import-map=test_import_map.json`, this import map is in the root of deno_std
+
 _For maintainers_:
 
 To release a new version a tag in the form of `x.y.z` should be added.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ maintainers):
 
 _Typechecking code in Markdown files_:
 
-If you want to run `deno test --doc x.md` you will need to specify the flag 
+If you want to run `deno test --doc x.md` you will need to specify the flag
 `--import-map=test_import_map.json`, this import map is in the root of deno_std.
 
 _For maintainers_:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ maintainers):
 - test with Deno canary on Linux
 - test with Deno canary on macOS
 
-_Typechecking code in in Markdown files_:
+_Typechecking code in Markdown files_:
 
 If you want to run `deno test --doc x.md` you will need to specify the flag 
 `--import-map=test_import_map.json`, this import map is in the root of deno_std.


### PR DESCRIPTION
This is good to document for modules such as `collections` who have a `README.md` with examples.