### PR TITLE
chore: wrap examples in fenced code blocks

### DIFF
--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -14,9 +14,13 @@ export interface Deferred<T> extends Promise<T> {
 /** Creates a Promise with the `reject` and `resolve` functions
  * placed as methods on the promise object itself. It allows you to do:
  *
+ * ```ts
+ *     import { deferred } from "./deferred.ts";
+ *
  *     const p = deferred<number>();
  *     // ...
  *     p.resolve(42);
+ * ```
  */
 export function deferred<T>(): Deferred<T> {
   let methods;

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -57,6 +57,9 @@ class AsyncIterableClone<T> implements AsyncIterable<T> {
  *
  * Example:
  *
+ * ```ts
+ *     import { tee } from "./tee.ts";
+ *
  *     const gen = async function* gen() {
  *       yield 1;
  *       yield 2;
@@ -76,6 +79,7 @@ class AsyncIterableClone<T> implements AsyncIterable<T> {
  *         console.log(n); // => 1, 2, 3
  *       }
  *     })();
+ * ```
  */
 export function tee<T, N extends number = 2>(
   src: AsyncIterable<T>,

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -364,17 +364,21 @@ export interface ParseOptions extends ReadOptions {
 
   /** Parse function for rows.
    * Example:
-   *     const r = await parseFile('a,b,c\ne,f,g\n', {
+   * ```ts
+   *     import { parse } from "./csv.ts";
+   *     const r = await parse('a,b,c\ne,f,g\n', {
    *      columns: ["this", "is", "sparta"],
-   *       parse: (e: Record<string, unknown>) => {
+   *       parse: (_e: unknown) => {
+   *         const e = _e as { this: unknown, is: unknown, sparta: unknown };
    *         return { super: e.this, street: e.is, fighter: e.sparta };
    *       }
    *     });
    * // output
-   * [
-   *   { super: "a", street: "b", fighter: "c" },
-   *   { super: "e", street: "f", fighter: "g" }
-   * ]
+   * // [
+   * //   { super: "a", street: "b", fighter: "c" },
+   * //   { super: "e", street: "f", fighter: "g" }
+   * // ]
+   * ```
    */
   parse?: (input: unknown) => unknown;
 }

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -14,12 +14,14 @@ export interface ArgParsingOptions {
   /** When `true`, populate the result `_` with everything before the `--` and
    * the result `['--']` with everything after the `--`. Here's an example:
    *
+   * ```ts
    *      // $ deno run example.ts -- a arg1
    *      import { parse } from "./mod.ts";
    *      console.dir(parse(Deno.args, { "--": false }));
    *      // output: { _: [ "a", "arg1" ] }
    *      console.dir(parse(Deno.args, { "--": true }));
    *      // output: { _: [], --: [ "a", "arg1" ] }
+   * ```
    *
    * Defaults to `false`.
    */
@@ -94,7 +96,10 @@ function hasKey(obj: NestedMapping, keys: string[]): boolean {
 /** Take a set of command line arguments, with an optional set of options, and
  * return an object representation of those argument.
  *
+ * ```ts
+ *      import { parse } from "./mod.ts";
  *      const parsedArgs = parse(Deno.args);
+ * ```
  */
 export function parse(
   args: string[],

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -2,14 +2,18 @@
 // A module to print ANSI terminal colors. Inspired by chalk, kleur, and colors
 // on npm.
 //
-// ```
-// import { bgBlue, red, bold } from "https://deno.land/std/fmt/colors.ts";
-// console.log(bgBlue(red(bold("Hello world!"))));
-// ```
-//
-// This module supports `NO_COLOR` environmental variable disabling any coloring
-// if `NO_COLOR` is set.
-//
+
+/**
+ * ```ts
+ * import { bgBlue, red, bold } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * console.log(bgBlue(red(bold("Hello world!"))));
+ * ```
+ *
+ * This module supports `NO_COLOR` environmental variable disabling any coloring
+ * if `NO_COLOR` is set.
+ *
+ * @module
+ */
 // This module is browser compatible.
 
 // deno-lint-ignore no-explicit-any
@@ -441,8 +445,11 @@ export function bgRgb8(str: string, color: number): string {
  *
  * To produce the color magenta:
  *
+ * ```ts
+ *      import { rgb24 } from "./colors.ts";
  *      rgb24("foo", 0xff00ff);
  *      rgb24("foo", {r: 255, g: 0, b: 255});
+ * ```
  * @param str text color to apply 24bit rgb to
  * @param color code
  */
@@ -478,8 +485,11 @@ export function rgb24(str: string, color: number | Rgb): string {
  *
  * To produce the color magenta:
  *
+ * ```ts
+ *      import { bgRgb24 } from "./colors.ts";
  *      bgRgb24("foo", 0xff00ff);
  *      bgRgb24("foo", {r: 255, g: 0, b: 255});
+ * ```
  * @param str text color to apply 24bit rgb to
  * @param color code
  */

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -65,10 +65,12 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * syntax.
  *
  * Example:
- *
+ * ```ts
+ *      import { expandGlob } from "./expand_glob.ts";
  *      for await (const file of expandGlob("**\/*.ts")) {
  *        console.log(file);
  *      }
+ * ```
  */
 export async function* expandGlob(
   glob: string,
@@ -173,9 +175,12 @@ export async function* expandGlob(
  *
  * Example:
  *
+ * ```ts
+ *      import { expandGlobSync } from "./expand_glob.ts";
  *      for (const file of expandGlobSync("**\/*.ts")) {
  *        console.log(file);
  *      }
+ * ```
  */
 export function* expandGlobSync(
   glob: string,

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -91,10 +91,15 @@ export interface WalkEntry extends Deno.DirEntry {
  * - skip?: RegExp[];
  *
  *
+ * ```ts
+ *       import { walk } from "./walk.ts";
+ *       import { assert } from "../testing/asserts.ts";
+ *
  *       for await (const entry of walk(".")) {
  *         console.log(entry.path);
  *         assert(entry.isFile);
  *       }
+ * ```
  */
 export async function* walk(
   root: string,

--- a/io/streams.ts
+++ b/io/streams.ts
@@ -13,17 +13,24 @@ function isCloser(value: unknown): value is Deno.Closer {
 
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
- *      // Server-sent events: Send runtime metrics to the client every second.
- *      request.respond({
- *        headers: new Headers({ "Content-Type": "text/event-stream" }),
- *        body: readerFromIterable((async function* () {
- *          while (true) {
- *            await new Promise((r) => setTimeout(r, 1000));
- *            const message = `data: ${JSON.stringify(Deno.metrics())}\n\n`;
- *            yield new TextEncoder().encode(message);
- *          }
- *        })()),
- *      });
+ * ```ts
+ *      import { readerFromIterable } from "./streams.ts";
+ *      import { serve } from "../http/server_legacy.ts";
+ *
+ *      for await (const request of serve({ port: 8000 })) {
+ *        // Server-sent events: Send runtime metrics to the client every second.
+ *        request.respond({
+ *          headers: new Headers({ "Content-Type": "text/event-stream" }),
+ *          body: readerFromIterable((async function* () {
+ *            while (true) {
+ *              await new Promise((r) => setTimeout(r, 1000));
+ *              const message = `data: ${JSON.stringify(Deno.metrics())}\n\n`;
+ *              yield new TextEncoder().encode(message);
+ *            }
+ *          })()),
+ *        });
+ *      }
+ * ```
  */
 export function readerFromIterable(
   iterable: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
@@ -135,6 +142,9 @@ export function writableStreamFromWriter(
 
 /** Create a `ReadableStream` from any kind of iterable.
  *
+ * ```ts
+ *      import { readableStreamFromIterable } from "./streams.ts";
+ *
  *      const r1 = readableStreamFromIterable(["foo, bar, baz"]);
  *      const r2 = readableStreamFromIterable((async function* () {
  *        await new Promise(((r) => setTimeout(r, 1000)));
@@ -144,7 +154,8 @@ export function writableStreamFromWriter(
  *        await new Promise(((r) => setTimeout(r, 1000)));
  *        yield "baz";
  *      })());
-*/
+ * ```
+ */
 export function readableStreamFromIterable<T>(
   iterable: Iterable<T> | AsyncIterable<T>,
 ): ReadableStream<T> {

--- a/node/module.ts
+++ b/node/module.ts
@@ -524,10 +524,13 @@ class Module {
    * with `node_modules` lookup and `index.js` lookup support.
    * Also injects available Node.js builtin module polyfills.
    *
+   * ```ts
+   *     import { createRequire } from "./module.ts";
    *     const require = createRequire(import.meta.url);
    *     const fs = require("fs");
    *     const leftPad = require("left-pad");
    *     const cjsModule = require("./cjs_mod");
+   * ```
    *
    * @param filename path or URL to current module
    * @return Require function to import CJS modules

--- a/path/common.ts
+++ b/path/common.ts
@@ -6,13 +6,14 @@ import { SEP } from "./separator.ts";
 /** Determines the common path from a set of paths, using an optional separator,
  * which defaults to the OS default separator.
  *
- *       import { common } from "https://deno.land/std/path/mod.ts";
+ * ```ts
+ *       import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
  *       const p = common([
  *         "./deno/std/path/mod.ts",
  *         "./deno/std/fs/mod.ts",
  *       ]);
  *       console.log(p); // "./deno/std/"
- *
+ * ```
  */
 export function common(paths: string[], sep = SEP): string {
   const [first = "", ...remaining] = paths;

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -478,7 +478,10 @@ export function parse(path: string): ParsedPath {
 /**
  * Converts a file URL to a path string.
  *
+ * ```ts
+ *      import { fromFileUrl } from "./posix.ts";
  *      fromFileUrl("file:///home/foo"); // "/home/foo"
+ * ```
  * @param url of a file URL
  */
 export function fromFileUrl(url: string | URL): string {
@@ -494,7 +497,10 @@ export function fromFileUrl(url: string | URL): string {
 /**
  * Converts a path string to a file URL.
  *
+ * ```ts
+ *      import { toFileUrl } from "./posix.ts";
  *      toFileUrl("/home/foo"); // new URL("file:///home/foo")
+ * ```
  * @param path to convert to file URL
  */
 export function toFileUrl(path: string): URL {

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -957,9 +957,12 @@ export function parse(path: string): ParsedPath {
 /**
  * Converts a file URL to a path string.
  *
+ * ```ts
+ *      import { fromFileUrl } from "./win32.ts";
  *      fromFileUrl("file:///home/foo"); // "\\home\\foo"
  *      fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"
  *      fromFileUrl("file://localhost/home/foo"); // "\\\\localhost\\home\\foo"
+ * ```
  * @param url of a file URL
  */
 export function fromFileUrl(url: string | URL): string {
@@ -982,9 +985,12 @@ export function fromFileUrl(url: string | URL): string {
 /**
  * Converts a path string to a file URL.
  *
+ * ```ts
+ *      import { toFileUrl } from "./win32.ts";
  *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
  *      toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")
  *      toFileUrl("\\\\127.0.0.1\\home\\foo"); // new URL("file://127.0.0.1/home/foo")
+ * ```
  * @param path to convert to file URL
  */
 export function toFileUrl(path: string): URL {

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -29,12 +29,15 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
 /** Attempts to grant a set of permissions, resolving with the descriptors of
  * the permissions that are granted.
  *
+ * ```ts
+ *      import { grant } from "./mod.ts";
  *      const perms = await grant({ name: "net" }, { name: "read" });
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
  *      } else {
  *        // notify user of missing permissions
  *      }
+ * ```
  *
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions. */
@@ -44,12 +47,15 @@ export async function grant(
 /** Attempts to grant a set of permissions, resolving with the descriptors of
  * the permissions that are granted.
  *
+ * ```ts
+ *      import { grant } from "./mod.ts";
  *      const perms = await grant([{ name: "net" }, { name: "read" }]);
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
  *      } else {
  *        // notify user of missing permissions
  *      }
+ * ```
  *
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions. */
@@ -78,7 +84,10 @@ export async function grant(
 
 /** Attempts to grant a set of permissions or rejects.
  *
+ * ```ts
+ *      import { grantOrThrow } from "./mod.ts";
  *      await grantOrThrow({ name: "env" }, { name: "net" });
+ * ```
  *
  * If the permission can be prompted for, the function will attempt to prompt.
  * If any of the permissions are denied, the function will reject for the first
@@ -89,7 +98,10 @@ export async function grantOrThrow(
 ): Promise<void>;
 /** Attempts to grant a set of permissions or rejects.
  *
+ * ```ts
+ *      import { grantOrThrow } from "./mod.ts";
  *      await grantOrThrow([{ name: "env" }, { name: "net" }]);
+ * ```
  *
  * If the permission can be prompted for, the function will attempt to prompt.
  * If any of the permissions are denied, the function will reject mentioning the

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -9,6 +9,9 @@ export type Disposable = { dispose: () => void };
  *
  * Example:
  *
+ * ```ts
+ *       import { signal } from "./mod.ts";
+ *
  *       const sig = signal(Deno.Signal.SIGUSR1, Deno.Signal.SIGINT);
  *       setTimeout(() => {}, 5000); // Prevents exiting immediately
  *
@@ -18,6 +21,7 @@ export type Disposable = { dispose: () => void };
  *
  *       // At some other point in your code when finished listening:
  *       sig.dispose();
+ * ```
  *
  * @param signos - one or more `Deno.Signal`s to await on
  */
@@ -51,10 +55,14 @@ export function signal(
 /**
  * Registers a callback function to be called on triggering of a signal event.
  *
+ * ```ts
+ *       import { onSignal } from "./mod.ts";
+ *
  *       const handle = onSignal(Deno.Signal.SIGINT, () => {
  *         console.log('Received SIGINT');
  *         handle.dispose();  // de-register from receiving further events
  *       });
+ * ```
  *
  * @param signo One of Deno.Signal (e.g. Deno.Signal.SIGINT)
  * @param callback Callback function triggered upon signal event


### PR DESCRIPTION
Wraps all examples in fenced code blocks so that they can be tested with `deno test --doc`.