### PR TITLE
fix (collections/includesValue): prevent enumerable prototype check

### DIFF
--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -21,7 +21,10 @@ export function includesValue<T>(
   value: T,
 ): boolean {
   for (const i in record) {
-    if (record[i] === value || Number.isNaN(value) && Number.isNaN(record[i])) {
+    if (
+      Object.hasOwn(record, i) &&
+      (record[i] === value || Number.isNaN(value) && Number.isNaN(record[i]))
+    ) {
       return true;
     }
   }

--- a/collections/includes_value_test.ts
+++ b/collections/includes_value_test.ts
@@ -101,3 +101,14 @@ Deno.test("[collections/includesValue] Works with NaN", () => {
 
   assert(actual);
 });
+
+Deno.test("[collections/includesValue] prevent enumerable prototype check", () => {
+  class Foo {}
+  // @ts-ignore: for test
+  Foo.prototype.a = "hello";
+  const input = new Foo() as Record<string, string>;
+
+  const actual = includesValue(input, "hello");
+
+  assert(!actual);
+});


### PR DESCRIPTION
Add an `Object.hasOwn()` check to the `for...in` loop to prevent enumeration of keys that exist in prototype.

before:
```ts
Object.prototype.a = "hello";
includesValue({}, "hello"); // => true
```
after fix:
```ts
Object.prototype.a = "hello";
includesValue({}, "hello"); // => false
```