### PR TITLE
docs (collections): Avoid using relative paths in import statements in code examples

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -97,7 +97,7 @@ For arrays, maps and sets, a merging strategy can be specified to either
 include non enumerable properties too.
 
 ```ts
-import { deepMerge } from "./deep_merge.ts";
+import { deepMerge } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
 import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 const a = { foo: true };
@@ -423,7 +423,7 @@ return undefined
 
 ```ts
 import { minOf } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 const inventory = [
   { name: "mustard", count: 2 },
@@ -510,8 +510,8 @@ collection, resulting in some undefined values if size is greater than 1.
 (Default: false)
 
 ```ts
-import { slidingWindows } from "./sliding_windows.ts";
-import { assertEquals } from "../testing/asserts.ts";
+import { slidingWindows } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 const numbers = [1, 2, 3, 4, 5];
 
 const windows = slidingWindows(numbers, 3);

--- a/collections/associate_by.ts
+++ b/collections/associate_by.ts
@@ -8,8 +8,8 @@
  * Example:
  *
  * ```ts
- * import { associateBy } from "./associate_by.ts"
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { associateBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const users = [
  *     { id: 'a2e', userName: 'Anna' },

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -8,8 +8,8 @@
  * Example:
  *
  * ```ts
- * import { associateWith } from "./associate_with.ts"
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { associateWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const names = [ 'Kim', 'Lara', 'Jonathan' ]
  * const namesToLength = associateWith(names, it => it.length)

--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { chunk } from "./chunk.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { chunk } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const words = [ 'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consetetur', 'sadipscing' ]
  * const chunks = chunk(words, 3)

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -17,8 +17,8 @@ const { hasOwn } = Object;
  * Example:
  *
  * ```ts
- * import { deepMerge } from "./deep_merge.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { deepMerge } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const a = {foo: true}
  * const b = {foo: {bar: true}}

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { distinct } from "./distinct.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { distinct } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 3, 2, 5, 2, 5 ]
  * const distinctNumbers = distinct(numbers)

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { distinctBy } from "./distinct_by.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { distinctBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const names = [ 'Anna', 'Kim', 'Arnold', 'Kate' ]
  * const exampleNamesByFirstLetter = distinctBy(names, it => it.charAt(0))

--- a/collections/drop_last_while.ts
+++ b/collections/drop_last_while.ts
@@ -4,8 +4,8 @@
  *
  * Example:
  * ```ts
- * import { dropLastWhile } from "./drop_last_while.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { dropLastWhile } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [22, 30, 44];
  *

--- a/collections/drop_while.ts
+++ b/collections/drop_while.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { dropWhile } from "./drop_while.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { dropWhile } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 3, 2, 5, 2, 5 ]
  * const dropWhileNumbers = dropWhile(numbers, i => i !== 2)

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { filterEntries } from "./filter_entries.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { filterEntries } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const menu = {
  *     'Salad': 11,

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { filterKeys } from "./filter_keys.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { filterKeys } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const menu = {
  *     'Salad': 11,

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { filterValues } from "./filter_values.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { filterValues } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * type Person = { age: number };
  *

--- a/collections/find_last.ts
+++ b/collections/find_last.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { findLast } from "./find_last.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { findLast } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 4, 2, 7 ]
  * const lastEvenNumber = findLast(numbers, it => it % 2 === 0)

--- a/collections/find_last_index.ts
+++ b/collections/find_last_index.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { findLastIndex } from "./find_last_index.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { findLastIndex } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 4, 2, 7 ]
  * const lastIndexNumber = findLastIndex(numbers, it => it % 2 === 0)

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { findSingle } from "./find_single.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { findSingle } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const bookings = [
  *     { month: 'January', active: false },

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { firstNotNullishOf } from "./first_not_nullish_of.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { firstNotNullishOf } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const tables = [
  *     { number: 11, order: null },

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { groupBy } from "./group_by.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { groupBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * type Person = {
  *   name: string;

--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -5,8 +5,8 @@
  *
  * Example:
  * ```ts
- * import { includesValue } from "./includes_value.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { includesValue } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const input = {
  *   first: 33,

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -8,8 +8,8 @@ import { filterInPlace } from "./_utils.ts";
  * Example:
  *
  * ```ts
- * import { intersect } from "./intersect.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { intersect } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const lisaInterests = [ 'Cooking', 'Music', 'Hiking' ]
  * const kimInterests = [ 'Music', 'Tennis', 'Cooking' ]

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { mapEntries } from "./map_entries.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { mapEntries } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const usersById = {
  *     'a2e': { name: 'Kim', age: 22 },

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -9,8 +9,8 @@
  * Example:
  *
  * ```ts
- * import { mapKeys } from "./map_keys.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { mapKeys } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const counts = { a: 5, b: 3, c: 8 }
  *

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { mapNotNullish } from "./map_not_nullish.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { mapNotNullish } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const people = [
  *     { middleName: null },

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { mapValues } from "./map_values.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { mapValues } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const usersById = {
  *     'a5ec': { name: 'Mischa' },

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { maxBy } from "./max_by.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { maxBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const people = [
  *     { name: 'Anna', age: 34 },

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -8,8 +8,8 @@
  * Example:
  *
  * ```ts
- * import { maxOf } from "./max_of.ts"
- * import { assertEquals } from "../testing/asserts.ts"
+ * import { maxOf } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts"
  *
  * const inventory = [
  *      { name: "mustard", count: 2 },

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -11,8 +11,8 @@
  * Example:
  *
  * ```ts
- * import { maxWith } from "./max_with.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { maxWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const people = ["Kim", "Anna", "John", "Arthur"];
  * const largestName = maxWith(people, (a, b) => a.length - b.length);

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { minBy } from "./min_by.ts";
- * import { assertEquals } from "../testing/asserts.ts"
+ * import { minBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts"
  *
  * const people = [
  *     { name: 'Anna', age: 34 },

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -8,8 +8,8 @@
  * Example:
  *
  * ```ts
- * import { minOf } from "./min_of.ts"
- * import { assertEquals } from "../testing/asserts.ts"
+ * import { minOf } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts"
  *
  * const inventory = [
  *      { name: "mustard", count: 2 },

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { minWith } from "./min_with.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { minWith } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const people = ["Kim", "Anna", "John"];
  * const smallestName = minWith(people, (a, b) => a.length - b.length);

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { partition } from "./partition.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { partition } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 5, 6, 7, 8, 9 ]
  * const [ even, odd ] = partition(numbers, it => it % 2 == 0)

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -8,8 +8,8 @@
  * Example:
  *
  * ```ts
- * import { permutations } from "./permutations.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { permutations } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 1, 2 ]
  * const windows = permutations(numbers)

--- a/collections/reduce_groups.ts
+++ b/collections/reduce_groups.ts
@@ -5,8 +5,8 @@ import { mapValues } from "./map_values.ts";
  * Applies the given reducer to each group in the given Grouping, returning the results together with the respective group keys
  *
  * ```ts
- * import { reduceGroups } from "./reduce_groups.ts"
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { reduceGroups } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const votes = {
  *     'Woody': [ 2, 3, 1, 4 ],

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -8,8 +8,8 @@ import { randomInteger } from "./_utils.ts";
  * Example:
  *
  * ```ts
- * import { sample } from "./sample.ts"
- * import { assert } from "../testing/asserts.ts";
+ * import { sample } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [1, 2, 3, 4];
  * const random = sample(numbers);

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -14,8 +14,8 @@
  * Example:
  *
  * ```ts
- * import { slidingWindows } from "./sliding_windows.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { slidingWindows } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  * const numbers = [1, 2, 3, 4, 5];
  *
  * const windows = slidingWindows(numbers, 3);

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { sortBy } from "./sort_by.ts"
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { sortBy } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const people = [
  *     { name: 'Anna', age: 34 },

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { sumOf } from "./sum_of.ts"
- * import { assertEquals } from "../testing/asserts.ts"
+ * import { sumOf } from "https://deno.land/std@$STD_VERSION/collections/mod.ts"
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts"
  *
  * const people = [
  *     { name: 'Anna', age: 34 },

--- a/collections/take_last_while.ts
+++ b/collections/take_last_while.ts
@@ -5,8 +5,8 @@
  *
  * Example:
  * ```ts
- * import { takeLastWhile } from "./take_last_while.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { takeLastWhile } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const arr = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/take_while.ts
+++ b/collections/take_while.ts
@@ -4,8 +4,8 @@
  *
  * Example:
  * ```ts
- * import { takeWhile } from "./take_while.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { takeWhile } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const arr = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { union } from "./union.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { union } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const soupIngredients = [ 'Pepper', 'Carrots', 'Leek' ]
  * const saladIngredients = [ 'Carrots', 'Radicchio', 'Pepper' ]

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -7,8 +7,8 @@
  * Example:
  *
  * ```ts
- * import { unzip } from "./unzip.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { unzip } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const parents = [
  *     [ 'Maria', 'Jeff' ],

--- a/collections/without_all.ts
+++ b/collections/without_all.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { withoutAll } from "./without_all.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { withoutAll } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const withoutList = withoutAll([2, 1, 2, 3], [1, 2]);
  *

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -6,8 +6,8 @@
  * Example:
  *
  * ```ts
- * import { zip } from "./zip.ts";
- * import { assertEquals } from "../testing/asserts.ts";
+ * import { zip } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [ 1, 2, 3, 4 ]
  * const letters = [ 'a', 'b', 'c', 'd' ]


### PR DESCRIPTION
Currently, relative paths are used in the import statement in some code examples.
Change this to import from https.