### PR TITLE
feat(io/streams): Propagate cancel in readableStreamFromIterable()

### DIFF
--- a/io/streams.ts
+++ b/io/streams.ts
@@ -146,14 +146,34 @@ export function writableStreamFromWriter(
  *      import { readableStreamFromIterable } from "./streams.ts";
  *
  *      const r1 = readableStreamFromIterable(["foo, bar, baz"]);
- *      const r2 = readableStreamFromIterable((async function* () {
+ *      const r2 = readableStreamFromIterable(async function* () {
  *        await new Promise(((r) => setTimeout(r, 1000)));
  *        yield "foo";
  *        await new Promise(((r) => setTimeout(r, 1000)));
  *        yield "bar";
  *        await new Promise(((r) => setTimeout(r, 1000)));
  *        yield "baz";
- *      })());
+ *      }());
+ * ```
+ *
+ * If the produced iterator (`iterable[Symbol.asyncIterator]()` or
+ * `iterable[Symbol.iterator]()`) is a generator, or more specifically is found
+ * to have a `.throw()` method on it, that will be called upon
+ * `readableStream.cancel()`. This is the case for the second input type above:
+ *
+ * ```ts
+ * import { readableStreamFromIterable } from "./streams.ts";
+ *
+ * const r3 = readableStreamFromIterable(async function* () {
+ *   try {
+ *     yield "foo";
+ *   } catch (error) {
+ *     console.log(error); // Error: Cancelled by consumer.
+ *   }
+ * }());
+ * const reader = r3.getReader();
+ * console.log(await reader.read()); // { value: "foo", done: false }
+ * await reader.cancel(new Error("Cancelled by consumer."));
  * ```
  */
 export function readableStreamFromIterable<T>(
@@ -165,11 +185,17 @@ export function readableStreamFromIterable<T>(
   return new ReadableStream({
     async pull(controller) {
       const { value, done } = await iterator.next();
-
       if (done) {
         controller.close();
       } else {
         controller.enqueue(value);
+      }
+    },
+    async cancel(reason) {
+      if (typeof iterator.throw == "function") {
+        try {
+          await iterator.throw(reason);
+        } catch { /* `iterator.throw()` always throws on site. We catch it. */ }
       }
     },
   });

--- a/io/streams_test.ts
+++ b/io/streams_test.ts
@@ -308,6 +308,22 @@ Deno.test("[io] readableStreamFromIterable() generator", async function () {
   assertEquals(readStrings, strings);
 });
 
+Deno.test("[io] readableStreamFromIterable() cancel", async function () {
+  let generatorError = null;
+  const readable = readableStreamFromIterable(async function* () {
+    try {
+      yield "foo";
+    } catch (error) {
+      generatorError = error;
+    }
+  }());
+  const reader = readable.getReader();
+  assertEquals(await reader.read(), { value: "foo", done: false });
+  const cancelReason = new Error("Cancelled by consumer.");
+  await reader.cancel(cancelReason);
+  assertEquals(generatorError, cancelReason);
+});
+
 class MockReaderCloser implements Deno.Reader, Deno.Closer {
   chunks: Uint8Array[] = [];
   closeCall = 0;


### PR DESCRIPTION
Passes readable stream cancellations to the underlying iterator when applicable.
```ts
const readable = readableStreamFromIterable(async function* () {
  try {
    yield "foo";
  } catch (error) {
    console.log(error); // Error: Cancelled by consumer.
  }
}());
const reader = readable.getReader();
console.log(await reader.read()); // { value: "foo", done: false }
await reader.cancel(new Error("Cancelled by consumer."));
```