### PR TITLE
security(encoding/yaml): disable functions

### DIFF
--- a/encoding/_yaml/schema/extended.ts
+++ b/encoding/_yaml/schema/extended.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 import { Schema } from "../schema.ts";
-import { func, regexp, undefinedType } from "../type/mod.ts";
+import { regexp, undefinedType } from "../type/mod.ts";
 import { def } from "./default.ts";
 
 // Extends JS-YAML default schema with additional JavaScript types
 // It is not described in the YAML specification.
 export const extended = new Schema({
-  explicit: [func, regexp, undefinedType],
+  explicit: [regexp, undefinedType],
   include: [def],
 });


### PR DESCRIPTION
Which could allow arbitrary code execution when parsing YAML files with the extended schema, e.g:

## Example of misuse

```js
import { parse, EXTENDED_SCHEMA } from "https://deno.land/std/encoding/yaml.ts";

const data = parse(`
fun: !!js/function >
  console.log(Deno.core);
`, {schema: EXTENDED_SCHEMA});
console.log(data);
```

Will log `Deno.core`

## Proof of fix

```js
import { parse, EXTENDED_SCHEMA } from "https://raw.githubusercontent.com/denoland/deno_std/security/yaml-func-exec/encoding/yaml.ts";

const data = parse(`
fun: !!js/function >
  console.log(Deno.core);
`, {schema: EXTENDED_SCHEMA});
console.log(data);
```

Will throw with `Uncaught YAMLError: unknown tag !<tag:yaml.org,2002:js/function> at line 4, column 1:`

## Notes

- Reported by @ry0tak
- Impact: high (allows arbitrary JS execution)
- Probability: low (requires using `EXTENDED_SCHEMA` which is uncommon) and parsing untrusted YAML files