### PR TITLE
chore(.github): Specify Deno release version explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# The CLI release version specified below should be bumped just after a new one
+# publishes and just before cutting a new std release.
+# When doing this, ensure to:
+# - Reference the commit by hash so we aren't blocked on it publishing.
+# - Adapt to any breaking changes in CLI (`--unstable` or TypeScript).
+# - Remove accumulated `--ignore` entries from the canary tests.
+env:
+  DENO_VERSION_HASH: f27902e749fb3a78ca35a0dc41c9fc53cd2806e1 # 1.14.1
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -13,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno: [1.x, canary]
+        deno: [release, canary]
         os: [macOS-latest, ubuntu-latest, windows-2019]
 
     steps:
@@ -26,7 +35,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1.0.0
         with:
-          deno-version: ${{ matrix.deno }}
+          deno-version: ${{ matrix.deno == 'release' && env.DENO_VERSION_HASH || matrix.deno }}
 
       - name: Run tests release
         if: matrix.deno != 'canary'
@@ -34,7 +43,7 @@ jobs:
 
       - name: Run tests canary
         if: matrix.deno == 'canary'
-        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json --ignore=_wasm_crypto/_build.ts,crypto/_benches,encoding/_yaml/example,examples/chat/server.ts,examples/echo_server.ts,examples/cat.ts,examples/gist.ts,examples/curl.ts,hash/_wasm/build.ts,http/bench.ts,http/bench_legacy.ts,http/racing_server.ts,http/testdata,node/cli.ts,node/_tools,node/testdata,node/_module,wasi/snapshot_preview1_test_runner.ts
+        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json
 
       - name: Type check browser compatible modules
         shell: bash

--- a/node/buffer.ts
+++ b/node/buffer.ts
@@ -437,7 +437,7 @@ export class Buffer extends Uint8Array {
 
     const b = this.subarray(start, end);
     if (encoding === "hex") return new TextDecoder().decode(hex.encode(b));
-    if (encoding === "base64") return base64.encode(b.buffer);
+    if (encoding === "base64") return base64.encode(b);
 
     return new TextDecoder(encoding).decode(b);
   }

--- a/node/string_decoder_test.ts
+++ b/node/string_decoder_test.ts
@@ -47,12 +47,12 @@ Deno.test({
     let decoder;
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("E1", "hex")), "4Q==");
-    assertEquals(decoder.end(), "4QAA");
+    assertEquals(decoder.write(Buffer.from("E1", "hex")), "");
+    assertEquals(decoder.end(), "4Q==");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("E18B", "hex")), "4Ys=");
-    assertEquals(decoder.end(), "4YsA");
+    assertEquals(decoder.write(Buffer.from("E18B", "hex")), "");
+    assertEquals(decoder.end(), "4Ys=");
 
     decoder = new StringDecoder("base64");
     assertEquals(decoder.write(Buffer.from("\ufffd")), "77+9");
@@ -66,16 +66,16 @@ Deno.test({
     assertEquals(decoder.end(), "");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("EFBFBDE2", "hex")), "77+94g==");
-    assertEquals(decoder.end(), "4gAA");
+    assertEquals(decoder.write(Buffer.from("EFBFBDE2", "hex")), "77+9");
+    assertEquals(decoder.end(), "4g==");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("F1", "hex")), "8Q==");
+    assertEquals(decoder.write(Buffer.from("F1", "hex")), "");
     assertEquals(decoder.write(Buffer.from("41F2", "hex")), "8UHy");
     assertEquals(decoder.end(), "");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.text(Buffer.from([0x41]), 2), "QQ==");
+    assertEquals(decoder.text(Buffer.from([0x41]), 2), "");
   },
 });
 


### PR DESCRIPTION
Also remove outdated `--ignore` entries from canary tests.

- This should be bumped just after CLI release publishes and just before cutting a new std release.
- Breaking changes in CLI (`--unstable` or TypeScript) should be adapted to here when bumping this.
- Accumulated `--ignore` entries in canary tests should be flushed at this time also.

Closes #870.