### PR TITLE
chore(node/events): remove unnecessary @ts-ignore comments

### DIFF
--- a/node/events.ts
+++ b/node/events.ts
@@ -96,13 +96,9 @@ export class EventEmitter {
     this.checkListenerArgument(listener);
     this.emit("newListener", eventName, this.unwrapListener(listener));
     if (this.hasListeners(eventName)) {
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
       let listeners = this._events[eventName];
       if (!Array.isArray(listeners)) {
         listeners = [listeners];
-        // deno-lint-ignore ban-ts-comment
-        // @ts-ignore
         this._events[eventName] = listeners;
       }
 
@@ -112,8 +108,6 @@ export class EventEmitter {
         listeners.push(listener);
       }
     } else {
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
       this._events[eventName] = listener;
     }
     const max = this.getMaxListeners();
@@ -149,10 +143,8 @@ export class EventEmitter {
         this.emit(EventEmitter.errorMonitor, ...args);
       }
 
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
-      const listeners = ensureArray<GenericFunction>(this._events[eventName])
-        .slice(); // We copy with slice() so array is not mutated during emit
+      const listeners = ensureArray(this._events[eventName]!)
+        .slice() as Array<GenericFunction>; // We copy with slice() so array is not mutated during emit
       for (const listener of listeners) {
         try {
           listener.apply(this, args);
@@ -196,8 +188,6 @@ export class EventEmitter {
    */
   public listenerCount(eventName: string | symbol): number {
     if (this.hasListeners(eventName)) {
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
       const maybeListeners = this._events[eventName];
       return Array.isArray(maybeListeners) ? maybeListeners.length : 1;
     } else {
@@ -221,8 +211,6 @@ export class EventEmitter {
       return [];
     }
 
-    // deno-lint-ignore ban-ts-comment
-    // @ts-ignore
     const eventListeners = target._events[eventName];
     if (Array.isArray(eventListeners)) {
       return unwrap
@@ -387,8 +375,6 @@ export class EventEmitter {
 
     if (eventName) {
       if (this.hasListeners(eventName)) {
-        // deno-lint-ignore ban-ts-comment
-        // @ts-ignore
         const listeners = ensureArray(this._events[eventName]).slice()
           .reverse();
         for (const listener of listeners) {
@@ -420,8 +406,6 @@ export class EventEmitter {
   ): this {
     this.checkListenerArgument(listener);
     if (this.hasListeners(eventName)) {
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
       const maybeArr = this._events[eventName];
 
       assert(maybeArr);
@@ -442,13 +426,9 @@ export class EventEmitter {
       if (listenerIndex >= 0) {
         arr.splice(listenerIndex, 1);
         if (arr.length === 0) {
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           delete this._events[eventName];
         } else if (arr.length === 1) {
           // If there is only one listener, an array is not necessary.
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           this._events[eventName] = arr[0];
         }
 
@@ -642,8 +622,6 @@ export class EventEmitter {
   }
 
   private warnIfNeeded(eventName: string | symbol, warning: Error): void {
-    // deno-lint-ignore ban-ts-comment
-    // @ts-ignore
     const listeners = this._events[eventName];
     if (listeners.warned) {
       return;
@@ -663,8 +641,6 @@ export class EventEmitter {
   }
 
   private hasListeners(eventName: string | symbol): boolean {
-    // deno-lint-ignore ban-ts-comment
-    // @ts-ignore
     return this._events && Boolean(this._events[eventName]);
   }
 }


### PR DESCRIPTION
TypeScript v4.4 (which is used in Deno v1.14) now supports symbols as index signatures. This eliminates the need for some `@ts-ignore` comments in `node/events.ts`. This PR removes such unnecessary comments.