### PR TITLE
fix (collections/maxWith,minWith): improve handling of arrays containing undefined

### DIFF
--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -25,10 +25,12 @@ export function maxWith<T>(
   comparator: (a: T, b: T) => number,
 ): T | undefined {
   let max: T | undefined = undefined;
+  let isFirst = true;
 
   for (const current of array) {
-    if (max === undefined || comparator(current, max) > 0) {
+    if (isFirst || comparator(current, <T> max) > 0) {
       max = current;
+      isFirst = false;
     }
   }
 

--- a/collections/max_with_test.ts
+++ b/collections/max_with_test.ts
@@ -76,3 +76,24 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "[collections/maxWith] array containing undefined",
+  fn() {
+    maxWithTest(
+      [
+        [undefined, undefined, 1],
+        (a, b) => {
+          if (a === undefined) {
+            return 1;
+          }
+          if (b === undefined) {
+            return -1;
+          }
+          return 0;
+        },
+      ],
+      undefined,
+    );
+  },
+});

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -20,10 +20,12 @@ export function minWith<T>(
   comparator: (a: T, b: T) => number,
 ): T | undefined {
   let min: T | undefined = undefined;
+  let isFirst = true;
 
   for (const current of array) {
-    if (min === undefined || comparator(current, min) < 0) {
+    if (isFirst || comparator(current, <T> min) < 0) {
       min = current;
+      isFirst = false;
     }
   }
 

--- a/collections/min_with_test.ts
+++ b/collections/min_with_test.ts
@@ -69,3 +69,24 @@ Deno.test({
     minWithTest([["John", "Kim", "Kim"], (a, b) => a.length - b.length], "Kim");
   },
 });
+
+Deno.test({
+  name: "[collections/minWith] array containing undefined",
+  fn() {
+    minWithTest(
+      [
+        [undefined, undefined, 1],
+        (a, b) => {
+          if (a === undefined) {
+            return -1;
+          }
+          if (b === undefined) {
+            return 1;
+          }
+          return 0;
+        },
+      ],
+      undefined,
+    );
+  },
+});


### PR DESCRIPTION
In the case of a comparator that returns undefined as the maximum or minimum value, the value returned depends on the order of the array.
This is a pretty edge case, but I've fixed it.

```ts
const comparator = (a, b) => {
  if (a === undefined) {
    return 1;
  }
  if (b === undefined) {
    return -1;
  }
  return 0;
};
// current implementation:
maxWith([undefined, 1, undefined], comparator) //=> undefined (correct)
maxWith([undefined, undefined, 1], comparator) //=> 1 (wrong)
```