### PR TITLE
feat(http/server): create Middleware type

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -41,6 +41,11 @@ export type Handler = (
 ) => Response | Promise<Response>;
 
 /**
+ * A definition for creating middleware
+ */
+export type Middleware = (next: Handler): Handler
+
+/**
  * Parse an address from a string.
  *
  * Throws a `TypeError` when the address is invalid.


### PR DESCRIPTION
This PR creates a type of `Middleware` in the `http/server` module, which frameworks can consume as a standardized interface for creating Middleware applications within Deno.

See https://github.com/denoland/deno_std/pull/768#issue-818064027 for more context. I'd like to kick the discussion off again since between that PR and this one, the std `http/server` has had a ground up rewirte. To quote the original PR:

> ### The Sales Pitch
> 
> I think it is critically important to provide middleware as a base in `std/http` because it gives a foundation for frameworks like Oak to build off of, but in a way to which other frameworks can benefit; "a rising tide lifts all boats" and all that. One area of contention in the Node ecosystem is that various frameworks exist, and yet all have to effectively re-implement the same set of middlewares over and over, as there is no centralised mechanism for middleware. Compare this to a language like Golang where middleware is an intrinsic part of the std library and we see frameworks building atop that, but also smaller libraries integrating with it in powerful ways which gives user's more choice and library/framework authors more power & expresivity.
