### PR TITLE
fix(node/buffer): fix toString with base64 encoding

### DIFF
--- a/node/buffer.ts
+++ b/node/buffer.ts
@@ -437,7 +437,7 @@ export class Buffer extends Uint8Array {
 
     const b = this.subarray(start, end);
     if (encoding === "hex") return new TextDecoder().decode(hex.encode(b));
-    if (encoding === "base64") return base64.encode(b.buffer);
+    if (encoding === "base64") return base64.encode(b);
 
     return new TextDecoder(encoding).decode(b);
   }

--- a/node/buffer_test.ts
+++ b/node/buffer_test.ts
@@ -434,6 +434,14 @@ Deno.test({
 });
 
 Deno.test({
+  name: "Buffer to string base64 with start and end specified",
+  fn() {
+    const buffer = Buffer.from("deno land deno land deno land");
+    assertEquals(buffer.toString("base64", 10, 19), "ZGVubyBsYW5k");
+  },
+});
+
+Deno.test({
   name: "Buffer to string hex",
   fn() {
     for (const encoding of ["hex", "HEX"]) {

--- a/node/string_decoder_test.ts
+++ b/node/string_decoder_test.ts
@@ -47,12 +47,12 @@ Deno.test({
     let decoder;
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("E1", "hex")), "4Q==");
-    assertEquals(decoder.end(), "4QAA");
+    assertEquals(decoder.write(Buffer.from("E1", "hex")), "");
+    assertEquals(decoder.end(), "4Q==");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("E18B", "hex")), "4Ys=");
-    assertEquals(decoder.end(), "4YsA");
+    assertEquals(decoder.write(Buffer.from("E18B", "hex")), "");
+    assertEquals(decoder.end(), "4Ys=");
 
     decoder = new StringDecoder("base64");
     assertEquals(decoder.write(Buffer.from("\ufffd")), "77+9");
@@ -66,16 +66,16 @@ Deno.test({
     assertEquals(decoder.end(), "");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("EFBFBDE2", "hex")), "77+94g==");
-    assertEquals(decoder.end(), "4gAA");
+    assertEquals(decoder.write(Buffer.from("EFBFBDE2", "hex")), "77+9");
+    assertEquals(decoder.end(), "4g==");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.write(Buffer.from("F1", "hex")), "8Q==");
+    assertEquals(decoder.write(Buffer.from("F1", "hex")), "");
     assertEquals(decoder.write(Buffer.from("41F2", "hex")), "8UHy");
     assertEquals(decoder.end(), "");
 
     decoder = new StringDecoder("base64");
-    assertEquals(decoder.text(Buffer.from([0x41]), 2), "QQ==");
+    assertEquals(decoder.text(Buffer.from([0x41]), 2), "");
   },
 });
 


### PR DESCRIPTION
This PR fixes `toString` method of Buffer of `std/node`.

Currently `toString` with base64 encoding always uses underlying array buffer (b.buffer) as the source data, which means the method isn't actually slicing the data even when `start` and `end` are passed.

This PR fixes the above.

---
The change in canary accidentally revealed this bug as `Deno.readFile()` now returns Uint8Array with `arr.byteLength !== arr.buffer.byteLength`

closes #1290