### PR TITLE
feat(std/node/stream): add partial support for `stream/web`

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -12,7 +12,7 @@ Deno standard library as it's a compatibility module.
 - [x] assert/strict _partly_
 - [ ] async_hooks
 - [x] buffer
-- [x] child*process \_partly*
+- [x] child_process \_partly_
 - [ ] cluster
 - [x] console _partly_
 - [x] constants _partly_
@@ -87,15 +87,15 @@ are stable:
 modules. It also sets supported globals.
 
 ```ts
-import { createRequire } from 'https://deno.land/std@$STD_VERSION/node/module.ts'
+import { createRequire } from "https://deno.land/std@$STD_VERSION/node/module.ts";
 
-const require = createRequire(import.meta.url)
+const require = createRequire(import.meta.url);
 // Loads native module polyfill.
-const path = require('path')
+const path = require("path");
 // Loads extensionless module.
-const cjsModule = require('./my_mod')
+const cjsModule = require("./my_mod");
 // Visits node_modules.
-const leftPad = require('left-pad')
+const leftPad = require("left-pad");
 ```
 
 ## Contributing

--- a/node/README.md
+++ b/node/README.md
@@ -12,7 +12,7 @@ Deno standard library as it's a compatibility module.
 - [x] assert/strict _partly_
 - [ ] async_hooks
 - [x] buffer
-- [x] child_process \_partly_
+- [x] child_process _partly_
 - [ ] cluster
 - [x] console _partly_
 - [x] constants _partly_

--- a/node/README.md
+++ b/node/README.md
@@ -12,7 +12,7 @@ Deno standard library as it's a compatibility module.
 - [x] assert/strict _partly_
 - [ ] async_hooks
 - [x] buffer
-- [x] child_process _partly_
+- [x] child*process \_partly*
 - [ ] cluster
 - [x] console _partly_
 - [x] constants _partly_
@@ -40,7 +40,7 @@ Deno standard library as it's a compatibility module.
 - [ ] repl
 - [x] stream
 - [x] stream/promises
-- [ ] stream/web
+- [x] stream/web _partly_
 - [x] string_decoder
 - [x] sys
 - [x] timers
@@ -87,15 +87,15 @@ are stable:
 modules. It also sets supported globals.
 
 ```ts
-import { createRequire } from "https://deno.land/std@$STD_VERSION/node/module.ts";
+import { createRequire } from 'https://deno.land/std@$STD_VERSION/node/module.ts'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 // Loads native module polyfill.
-const path = require("path");
+const path = require('path')
 // Loads extensionless module.
-const cjsModule = require("./my_mod");
+const cjsModule = require('./my_mod')
 // Visits node_modules.
-const leftPad = require("left-pad");
+const leftPad = require('left-pad')
 ```
 
 ## Contributing

--- a/node/stream/web.ts
+++ b/node/stream/web.ts
@@ -1,0 +1,17 @@
+const {
+  ReadableStream,
+  ReadableStreamDefaultReader,
+  ReadableStreamDefaultController,
+  WritableStream,
+  WritableStreamDefaultWriter,
+  TransformStream,
+} = globalThis;
+
+export {
+  ReadableStream,
+  ReadableStreamDefaultController,
+  ReadableStreamDefaultReader,
+  TransformStream,
+  WritableStream,
+  WritableStreamDefaultWriter,
+};


### PR DESCRIPTION
this pull request adds partial support for the experimental `stream/web` API from Node.js which is basically re-exports browser APIs.

Some of the APIs aren't in Deno yet so I have added only the ones present in Deno.

Ref: https://nodejs.org/api/webstreams.html#webstreams_class_readablestreambyobreader

Closes https://github.com/alephjs/esm.sh/issues/163