### PR TITLE
fix(node): Use denoflate to decompress Node test folder

### DIFF
--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -1,4 +1,4 @@
-import { gunzip } from "https://deno.land/x/compress@v0.3.9/gzip/gzip.ts";
+import { gunzip } from "https://deno.land/x/denoflate@1.2.1/mod.ts";
 import { Untar } from "../../archive/tar.ts";
 import { walk } from "../../fs/walk.ts";
 import {


### PR DESCRIPTION
Closes #1298 

`compress` seems to have been kinda abandoned, so I just opted to replace it with `denoflate`, solving some ugly TypeScript errors in the process