### PR TITLE
docs: change CI rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno: [1.x, canary]
+        deno: [canary]
         os: [macOS-latest, ubuntu-latest, windows-2019]
 
     steps:
@@ -28,13 +28,8 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
-      - name: Run tests release
-        if: matrix.deno != 'canary'
-        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json
-
       - name: Run tests canary
-        if: matrix.deno == 'canary'
-        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json --ignore=_wasm_crypto/_build.ts,crypto/_benches,encoding/_yaml/example,examples/chat/server.ts,examples/echo_server.ts,examples/cat.ts,examples/gist.ts,examples/curl.ts,hash/_wasm/build.ts,http/bench.ts,http/bench_legacy.ts,http/racing_server.ts,http/testdata,node/cli.ts,node/_tools,node/testdata,node/_module,wasi/snapshot_preview1_test_runner.ts
+        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json
 
       - name: Type check browser compatible modules
         shell: bash

--- a/README.md
+++ b/README.md
@@ -90,22 +90,15 @@ For contributions to the Node compatibility library please check the
 
 _About CI checks_:
 
-We currently have 9 checks on CI. You need to pass the following 6 checks for
-your PR to be accepted:
-
-- test with Deno 1.x on Windows
-- test with Deno 1.x on Linux
-- test with Deno 1.x on macOS
-- lint
-- wasm crypto check
-- CLA
-
-You don't need to pass the following 3 checks (These are informative checks for
-maintainers):
+We currently have 6 checks on CI. Each PR should pass all of these checks to be
+accepted.
 
 - test with Deno canary on Windows
 - test with Deno canary on Linux
 - test with Deno canary on macOS
+- lint
+- wasm crypto check
+- CLA
 
 _Typechecking code in Markdown files_:
 


### PR DESCRIPTION
We discussed this internally, and decided to try only run canary CI for a while.

The reasons of this change are:
- We had problems in some recent releases because canary CI wasn't passing at the time of release
- Merging with red status confuses people (and caused a mistake)
- The latest released Deno is compatible with the latest tag of std, and it doesn't need to compatible with std's main

The downside of this change is (probably) that we can't merge PRs in std when CLI canary accidentally broke something in std.

This is an experimental attempt. I think we'll revisit this after several releases.

related: #1279 #870 denoland/deno#9801

previous change: #1209