### PR TITLE
feat(collections/running_reduce): Change `initialValue` to optional

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -839,8 +839,8 @@ assert(numbers.includes(random as number));
 ### runningReduce
 
 Calls the given reducer on each element of the given collection, passing it's
-result as the accumulator to the next respective call, starting with the given
-initialValue. Returns all intermediate accumulator results.
+result as the accumulator to the next respective call. If initialValue is given, 
+starting with that value. Returns all intermediate accumulator results.
 
 Example:
 
@@ -849,7 +849,12 @@ import { runningReduce } from "https://deno.land/std@$STD_VERSION/collections/mo
 import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
 const numbers = [1, 2, 3, 4, 5];
-const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);
+const sumSteps = runningReduce(numbers, (sum, current) => sum + current);
 
 assertEquals(sumSteps, [1, 3, 6, 10, 15]);
+
+const numbers = [1, 2, 3, 4, 5]
+const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 5);
+
+assertEquals(result, [6, 8, 11, 15, 20]);
 ```

--- a/collections/README.md
+++ b/collections/README.md
@@ -839,7 +839,7 @@ assert(numbers.includes(random as number));
 ### runningReduce
 
 Calls the given reducer on each element of the given collection, passing it's
-result as the accumulator to the next respective call. If initialValue is given, 
+result as the accumulator to the next respective call. If initialValue is given,
 starting with that value. Returns all intermediate accumulator results.
 
 Example:
@@ -853,8 +853,12 @@ const result = runningReduce(firstNumbers, (sum, current) => sum + current);
 
 assertEquals(result, [1, 3, 6, 10, 15]);
 
-const secondNumbers = [1, 2, 3, 4, 5]
-const resultWithInitialValue = runningReduce(secondNumbers, (sum, current) => sum + current, 5);
+const secondNumbers = [1, 2, 3, 4, 5];
+const resultWithInitialValue = runningReduce(
+  secondNumbers,
+  (sum, current) => sum + current,
+  5,
+);
 
 assertEquals(resultWithInitialValue, [6, 8, 11, 15, 20]);
 ```

--- a/collections/README.md
+++ b/collections/README.md
@@ -848,13 +848,13 @@ Example:
 import { runningReduce } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
 import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
-const numbers = [1, 2, 3, 4, 5];
-const sumSteps = runningReduce(numbers, (sum, current) => sum + current);
+const firstNumbers = [1, 2, 3, 4, 5];
+const result = runningReduce(firstNumbers, (sum, current) => sum + current);
 
-assertEquals(sumSteps, [1, 3, 6, 10, 15]);
+assertEquals(result, [1, 3, 6, 10, 15]);
 
-const numbers = [1, 2, 3, 4, 5]
-const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 5);
+const secondNumbers = [1, 2, 3, 4, 5]
+const resultWithInitialValue = runningReduce(secondNumbers, (sum, current) => sum + current, 5);
 
-assertEquals(result, [6, 8, 11, 15, 20]);
+assertEquals(resultWithInitialValue, [6, 8, 11, 15, 20]);
 ```

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -3,8 +3,8 @@
 
 /**
  * Calls the given reducer on each element of the given collection, passing it's
- * result as the accumulator to the next respective call, starting with the given
- * initialValue. Returns all intermediate accumulator results.
+ * result as the accumulator to the next respective call. If initialValue is given,
+ * starting with that value. Returns all intermediate accumulator results.
  *
  * Example:
  *
@@ -13,16 +13,35 @@
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * const numbers = [1, 2, 3, 4, 5];
- * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);
+ * const sumSteps = runningReduce(numbers, (sum, current) => sum + current);
  *
  * assertEquals(sumSteps, [1, 3, 6, 10, 15]);
+ *
+ * const numbers = [1, 2, 3, 4, 5]
+ * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 5);
+ *
+ * assertEquals(result, [6, 8, 11, 15, 20]);
  * ```
  */
-export function runningReduce<T, O>(
+export function runningReduce<T>(
   array: readonly T[],
-  reducer: (accumulator: O, current: T) => O,
-  initialValue: O,
-): O[] {
-  let currentResult = initialValue;
+  reducer: (accumulator: T, current: T) => T,
+  initialValue?: T,
+): T[] {
+  let currentResult: T;
+
+  if (!initialValue) {
+    switch (typeof array[0]) {
+      case "string":
+        currentResult = "" as unknown as T;
+        break;
+      case "number":
+        currentResult = 0 as unknown as T;
+        break;
+    }
+  } else {
+    currentResult = initialValue;
+  }
+
   return array.map((el) => currentResult = reducer(currentResult, el));
 }

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -12,15 +12,15 @@
  * import { runningReduce } from "https://deno.land/std@$STD_VERSION/collections/mod.ts";
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
- * const numbers = [1, 2, 3, 4, 5];
- * const sumSteps = runningReduce(numbers, (sum, current) => sum + current);
+ * const firstNumbers = [1, 2, 3, 4, 5];
+ * const result = runningReduce(firstNumbers, (sum, current) => sum + current);
  *
- * assertEquals(sumSteps, [1, 3, 6, 10, 15]);
+ * assertEquals(result, [1, 3, 6, 10, 15]);
  *
- * const numbers = [1, 2, 3, 4, 5]
- * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 5);
+ * const secondNumbers = [1, 2, 3, 4, 5]
+ * const resultWithInitialValue = runningReduce(secondNumbers, (sum, current) => sum + current, 5);
  *
- * assertEquals(result, [6, 8, 11, 15, 20]);
+ * assertEquals(resultWithInitialValue, [6, 8, 11, 15, 20]);
  * ```
  */
 export function runningReduce<T>(

--- a/collections/running_reduce_test.ts
+++ b/collections/running_reduce_test.ts
@@ -7,7 +7,7 @@ Deno.test({
   name: "[collections/runningReduce] no mutation",
   fn() {
     const numbers = [1, 2, 3, 4, 5];
-    runningReduce(numbers, (sum, current) => sum + current, 0);
+    runningReduce(numbers, (sum, current) => sum + current);
 
     assertEquals(numbers, [1, 2, 3, 4, 5]);
   },
@@ -17,6 +17,16 @@ Deno.test({
   name: "[collections/runningReduce] array of numbers",
   fn() {
     const numbers = [1, 2, 3, 4, 5];
+    const result = runningReduce(numbers, (sum, current) => sum + current);
+
+    assertEquals(result, [1, 3, 6, 10, 15]);
+  },
+});
+
+Deno.test({
+  name: "[collections/runningReduce] array of numbers with initialValue 0",
+  fn() {
+    const numbers = [1, 2, 3, 4, 5];
     const result = runningReduce(numbers, (sum, current) => sum + current, 0);
 
     assertEquals(result, [1, 3, 6, 10, 15]);
@@ -24,7 +34,27 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[collections/runningReduce] array of numbers with initialValue",
+  fn() {
+    const numbers = [1, 2, 3, 4, 5];
+    const result = runningReduce(numbers, (sum, current) => sum + current, 5);
+
+    assertEquals(result, [6, 8, 11, 15, 20]);
+  },
+});
+
+Deno.test({
   name: "[collections/runningReduce] array of strings",
+  fn() {
+    const strings = ["a", "b", "c", "d", "e"];
+    const result = runningReduce(strings, (str, current) => str + current);
+
+    assertEquals(result, ["a", "ab", "abc", "abcd", "abcde"]);
+  },
+});
+
+Deno.test({
+  name: `[collections/runningReduce] array of strings with initialValue ""`,
   fn() {
     const strings = ["a", "b", "c", "d", "e"];
     const result = runningReduce(strings, (str, current) => str + current, "");
@@ -34,10 +64,55 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[collections/runningReduce] empty input",
+  name: "[collections/runningReduce] array of strings with initialValue",
   fn() {
-    const result = runningReduce([], (sum, current) => sum + current, 0);
+    const strings = ["a", "b", "c", "d", "e"];
+    const result = runningReduce(
+      strings,
+      (str, current) => str + current,
+      "foo",
+    );
+
+    assertEquals(result, ["fooa", "fooab", "fooabc", "fooabcd", "fooabcde"]);
+  },
+});
+
+Deno.test({
+  name: "[collections/runningReduce] empty array",
+  fn() {
+    const result = runningReduce(
+      [],
+      (sum, current) => (sum + current) as never,
+    );
 
     assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: "[collections/runningReduce] array of strings and number",
+  fn() {
+    const result = runningReduce(
+      [1, "foo", 2, "bar"],
+      // deno-lint-ignore no-explicit-any
+      (sum: any, current: any) => sum + current,
+    );
+
+    assertEquals(result, [1, "1foo", "1foo2", "1foo2bar"]);
+  },
+});
+
+Deno.test({
+  name:
+    "[collections/runningReduce] array of strings and number with initialValue",
+  fn() {
+    const result = runningReduce(
+      [1, "foo", 2, "bar"],
+      // deno-lint-ignore no-explicit-any
+      (sum: any, current: any) => sum + current,
+      5,
+    );
+
+    assertEquals(result, [6, "6foo", "6foo2", "6foo2bar"]);
   },
 });


### PR DESCRIPTION
[kotlin.collections/running-reduce](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/running-reduce.html#runningreduce) has no optional specification of `initialValue` and 
 [JavaScript/Array/reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) can optionally specify `initialValue`.