### PR TITLE
chore(node/tools/setup): Make sure filenames are in the correct order before setting up

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -5,26 +5,26 @@
       "index.js"
     ],
     "parallel": [
-      "test-assert.js",
-      "test-assert-async.js"
+      "test-assert-async.js",
+      "test-assert.js"
     ]
   },
   "tests": {
     "parallel": [
-      "test-assert.js",
       "test-assert-async.js",
       "test-assert-fail.js",
+      "test-assert.js",
       "test-event-emitter-add-listeners.js",
       "test-event-emitter-check-listener-leaks.js",
+      "test-event-emitter-invalid-listener.js",
+      "test-event-emitter-listener-count.js",
       "test-event-emitter-listeners-side-effects.js",
+      "test-event-emitter-listeners.js",
       "test-event-emitter-max-listeners-warning-for-null.js",
       "test-event-emitter-max-listeners-warning-for-symbol.js",
       "test-event-emitter-max-listeners-warning.js",
       "test-event-emitter-max-listeners.js",
       "test-event-emitter-method-names.js",
-      "test-event-emitter-invalid-listener.js",
-      "test-event-emitter-listener-count.js",
-      "test-event-emitter-listeners.js",
       "test-event-emitter-once.js",
       "test-event-emitter-remove-all-listeners.js",
       "test-event-emitter-remove-listeners.js",

--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -68,7 +68,7 @@ function checkConfigTestFilesOrder() {
     );
   }
 
-  const ignoreCommonTests = config.ignore.parallel;
+  const ignoreCommonTests = config.ignore.common;
   const sortedIgnoreCommonTests = JSON.parse(JSON.stringify(ignoreCommonTests));
   sortedIgnoreCommonTests.sort();
   if (

--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -44,6 +44,45 @@ const decompressedSourcePath = join(
   NODE_FILE.replaceAll("NODE_VERSION", config.nodeVersion),
 );
 
+function checkConfigTestFilesOrder() {
+  const parallelTests = config.tests.parallel;
+  const sortedParallelTests = JSON.parse(JSON.stringify(parallelTests));
+  sortedParallelTests.sort();
+  if (JSON.stringify(parallelTests) !== JSON.stringify(sortedParallelTests)) {
+    throw new Error(
+      "File names in `config.tests.parallel` are not correct order.",
+    );
+  }
+
+  const ignoreParallelTests = config.ignore.parallel;
+  const sortedIgnoreParallelTests = JSON.parse(
+    JSON.stringify(ignoreParallelTests),
+  );
+  sortedIgnoreParallelTests.sort();
+  if (
+    JSON.stringify(ignoreParallelTests) !==
+      JSON.stringify(sortedIgnoreParallelTests)
+  ) {
+    throw new Error(
+      "File names in `config.ignore.parallel` are not correct order.",
+    );
+  }
+
+  const ignoreCommonTests = config.ignore.parallel;
+  const sortedIgnoreCommonTests = JSON.parse(JSON.stringify(ignoreCommonTests));
+  sortedIgnoreCommonTests.sort();
+  if (
+    JSON.stringify(ignoreCommonTests) !==
+      JSON.stringify(sortedIgnoreCommonTests)
+  ) {
+    throw new Error(
+      "File names in `config.ignore.common` are not correct order.",
+    );
+  }
+}
+
+checkConfigTestFilesOrder();
+
 /**
  * This will overwrite the file if found
  */


### PR DESCRIPTION
If file names are not in the correct order, it will be difficult to see which tests have already been added.