### PR TITLE
chore(node/_tools/test): Add `--only` flag to run specific tests

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -119,6 +119,23 @@ To run the tests you have set up, do the following:
 $ deno test --allow-read --allow-run node/_tools/test.ts
 ```
 
+If you want to run specific tests in a local environment, add `--only` flag to
+the `node/_tools/config.json` as follows:
+
+```json
+...
+  "tests": {
+    "parallel": [
+      ...
+      "test-event-emitter-add-listeners.js",
+      "test-event-emitter-check-listener-leaks.js --only",
+      "test-event-emitter-invalid-listener.js",
+      ...
+    ]
+  }
+...
+```
+
 The test should be passing with the latest deno, so if the test fails, try the
 following:
 

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -10,9 +10,13 @@ import { config, testList } from "./common.ts";
  * code for the test is reported, the test suite will fail immediately
  */
 
+const onlyFlagTestList = config.tests.parallel.filter((filename) =>
+  filename.match("--only")
+).map((filename) => new RegExp(filename.replace(/ --only/, "")));
+
 const dir = walk(fromFileUrl(new URL(config.suitesFolder, import.meta.url)), {
   includeDirs: false,
-  match: testList,
+  match: onlyFlagTestList.length ? onlyFlagTestList : testList,
 });
 
 const testsFolder = dirname(fromFileUrl(import.meta.url));


### PR DESCRIPTION
As the number of tests in `config.json` increases, it becomes more difficult to remove untargeted tests when we want to run a specific test in a local environment. (We can't even comment it out in a json file.)