### PR TITLE
feature(node/crypto): add randomFillSync an randomFill

### DIFF
--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,6 +1,49 @@
 import randomBytes from "./randomBytes.ts";
 import { Buffer } from "../buffer.ts";
 
+export default function randomFill(
+  buf: Buffer,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+export default function randomFill(
+  buf: Buffer,
+  offset: number,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+export default function randomFill(
+  buf: Buffer,
+  offset: number,
+  size: number,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+
+export default function randomFill(
+  buf: Buffer,
+  // deno-lint-ignore no-explicit-any
+  offset?: any,
+  // deno-lint-ignore no-explicit-any
+  size?: any,
+  cb?: (err: Error | null, buf?: Buffer) => void,
+) {
+  if (size + offset > buf.length) {
+    throw new RangeError(
+      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(size +
+        offset)}.`,
+    );
+  }
+
+  const buffer = buf as Buffer;
+  const callback = cb as (err: Error | null, buf?: Buffer) => void;
+  const trueOffset = 0 | offset;
+  const trueSize = buffer.length - trueOffset;
+
+  randomBytes(size, (err, buf) => {
+    if (err) return callback(err as Error);
+    buffer.copy(buf as Buffer, trueOffset, 0, trueSize);
+    callback(null, buffer);
+  });
+}
+
 export function randomFillSync(buffer: Buffer, offset = 0, size?: number) {
   if (size === undefined) {
     size = buffer.length - offset;

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -28,7 +28,7 @@ export default function randomFill(
   let trueSize = buf.length - trueOffset;
 
   if (size !== undefined) {
-    trueSize = size as number
+    trueSize = size as number;
   }
 
   if (trueSize + trueOffset > buf.length) {

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -25,27 +25,27 @@ function assertSize(size: number, offset: number, length: number) {
 
 export default function randomFill(
   buf: Buffer,
-  cb: (err: Error | null, buf?: Buffer) => void,
+  cb: (err: Error | null, buf: Buffer) => void,
 ): void;
 
 export default function randomFill(
   buf: Buffer,
   offset: number,
-  cb: ((err: Error | null, buf?: Buffer) => void),
+  cb: ((err: Error | null, buf: Buffer) => void),
 ): void;
 
 export default function randomFill(
   buf: Buffer,
   offset: number,
   size: number,
-  cb: (err: Error | null, buf?: Buffer) => void,
+  cb: (err: Error | null, buf: Buffer) => void,
 ): void;
 
 export default function randomFill(
   buf: Buffer,
-  offset?: number | ((err: Error | null, buf?: Buffer) => void),
-  size?: number | ((err: Error | null, buf?: Buffer) => void),
-  cb?: ((err: Error | null, buf?: Buffer) => void),
+  offset?: number | ((err: Error | null, buf: Buffer) => void),
+  size?: number | ((err: Error | null, buf: Buffer) => void),
+  cb?: ((err: Error | null, buf: Buffer) => void),
 ): void {
   if (typeof offset === "function") {
     cb = offset;
@@ -60,7 +60,7 @@ export default function randomFill(
   assertSize(size as number, offset as number, buf.length);
 
   randomBytes(size as number, (err, bytes) => {
-    if (err) return cb!(err);
+    if (err) return cb!(err, buf);
     bytes?.copy(buf, offset as number);
     cb!(null, buf);
   });

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -19,28 +19,29 @@ export default function randomFill(
 
 export default function randomFill(
   buf: Buffer,
-  // deno-lint-ignore no-explicit-any
-  offset?: any,
-  // deno-lint-ignore no-explicit-any
-  size?: any,
+  offset?: number | ((err: Error | null, buf?: Buffer) => void),
+  size?: number | ((err: Error | null, buf?: Buffer) => void),
   cb?: (err: Error | null, buf?: Buffer) => void,
 ) {
-  if (size + offset > buf.length) {
+  const callback = cb as (err: Error | null, buf?: Buffer) => void;
+  const trueOffset = offset as unknown as number | 0;
+  let trueSize = buf.length - trueOffset;
+
+  if (size !== undefined) {
+    trueSize = size as number
+  }
+
+  if (trueSize + trueOffset > buf.length) {
     throw new RangeError(
-      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(size +
-        offset)}.`,
+      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(trueSize +
+        trueOffset)}.`,
     );
   }
 
-  const buffer = buf as Buffer;
-  const callback = cb as (err: Error | null, buf?: Buffer) => void;
-  const trueOffset = 0 | offset;
-  const trueSize = buffer.length - trueOffset;
-
-  randomBytes(size, (err, buf) => {
+  randomBytes(trueSize, (err, buf) => {
     if (err) return callback(err as Error);
-    buffer.copy(buf as Buffer, trueOffset, 0, trueSize);
-    callback(null, buffer);
+    buf?.copy(buf as Buffer, trueOffset, 0, trueSize);
+    callback(null, buf);
   });
 }
 

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,4 +1,4 @@
-import randomBytes,{MAX_SIZE as kMaxUint32} from "./randomBytes.ts";
+import randomBytes, { MAX_SIZE as kMaxUint32 } from "./randomBytes.ts";
 import { Buffer } from "../buffer.ts";
 
 const kBufferMaxLength = 0x7fffffff;

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,0 +1,17 @@
+import randomBytes from "./randomBytes.ts";
+import { Buffer } from "../buffer.ts";
+
+export function randomFillSync(buffer: Buffer, offset = 0, size?: number) {
+  if (size === undefined) {
+    size = buffer.length - offset;
+  }
+
+  if (size + offset > buffer.length) {
+    throw new RangeError(
+      `The value of "size + offset" is out of range. It must be <= ${buffer.length}. Received ${(size +
+        offset)}.`,
+    );
+  }
+
+  randomBytes(size).copy(buffer, offset, 0, size);
+}

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,7 +1,6 @@
-import randomBytes from "./randomBytes.ts";
+import randomBytes,{MAX_SIZE as kMaxUint32} from "./randomBytes.ts";
 import { Buffer } from "../buffer.ts";
 
-const kMaxUint32 = Math.pow(2, 32) - 1;
 const kBufferMaxLength = 0x7fffffff;
 
 function assertOffset(offset: number, length: number) {

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,0 +1,34 @@
+import { Buffer } from "../buffer.ts";
+import { randomFillSync } from "./randomFill.ts";
+import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+
+const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
+const validateZero = (buf: Buffer) => {
+  buf.forEach((val) => assertEquals(val, 0));
+};
+
+Deno.test("[node/crypto.randomFillSync] Complete fill, explicit size", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf, undefined, 10);
+  validateNonZero(buf);
+});
+
+Deno.test("[randomFillSync] Complete fill", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf);
+  validateNonZero(buf);
+});
+
+Deno.test("[node/crypto.randomFillSync] Fill beginning, explicit offset+size", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf, 0, 5);
+  validateNonZero(buf);
+
+  const untouched = buf.slice(5);
+  assertEquals(untouched.length, 5);
+  validateZero(untouched);
+});
+
+Deno.test("[node/crypto.randomFillSync] Invalid offst/size", () => {
+  assertThrows(() => randomFillSync(Buffer.alloc(10), 1, 10));
+});

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,11 +1,21 @@
 import { Buffer } from "../buffer.ts";
-import { randomFillSync } from "./randomFill.ts";
+import randomFill, { randomFillSync } from "./randomFill.ts";
 import { assertEquals, assertThrows } from "../../testing/asserts.ts";
 
 const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
 const validateZero = (buf: Buffer) => {
   buf.forEach((val) => assertEquals(val, 0));
 };
+
+Deno.test("[node/crypto.randomFill]", () => {
+  const buf = Buffer.alloc(10);
+  const before = buf.toString("hex");
+
+  randomFill(buf, 5, 5, (_err, bufTwo) => {
+    const after = bufTwo?.toString("hex");
+    assertEquals(before.slice(0, 10), after?.slice(0, 10));
+  });
+});
 
 Deno.test("[node/crypto.randomFillSync] Complete fill, explicit size", () => {
   const buf = Buffer.alloc(10);

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,8 +1,15 @@
 import { Buffer } from "../buffer.ts";
 import randomFill, { randomFillSync } from "./randomFill.ts";
-import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "../../testing/asserts.ts";
 
-const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
+const validateNonZero = (buf: Buffer) => {
+  if (!buf.some((ch) => ch > 0)) throw new Error("Error");
+};
+
 const validateZero = (buf: Buffer) => {
   buf.forEach((val) => assertEquals(val, 0));
 };
@@ -15,6 +22,15 @@ Deno.test("[node/crypto.randomFill]", () => {
     const after = bufTwo?.toString("hex");
     assertEquals(before.slice(0, 10), after?.slice(0, 10));
   });
+});
+
+Deno.test("[node/crypto.randomFillSync]", () => {
+  const buf = Buffer.alloc(10);
+  const before = buf.toString("hex");
+
+  const after = randomFillSync(buf, 5, 5);
+
+  assertNotEquals(before, after);
 });
 
 Deno.test("[node/crypto.randomFillSync] Complete fill, explicit size", () => {

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,9 +1,6 @@
 import { Buffer } from "../buffer.ts";
 import randomFill, { randomFillSync } from "./randomFill.ts";
-import {
-  assertEquals,
-  assertThrows,
-} from "../../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../../testing/asserts.ts";
 
 const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
 const validateZero = (buf: Buffer) => {

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "../buffer.ts";
 import randomFill, { randomFillSync } from "./randomFill.ts";
-import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "../../testing/asserts.ts";
 
 const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
 const validateZero = (buf: Buffer) => {
@@ -13,7 +17,7 @@ Deno.test("[node/crypto.randomFill]", () => {
 
   randomFill(buf, 5, 5, (_err, bufTwo) => {
     const after = bufTwo?.toString("hex");
-    assertEquals(before.slice(0, 10), after?.slice(0, 10));
+    assertNotEquals(before.slice(0, 10), after?.slice(0, 10));
   });
 });
 

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -2,7 +2,6 @@ import { Buffer } from "../buffer.ts";
 import randomFill, { randomFillSync } from "./randomFill.ts";
 import {
   assertEquals,
-  assertNotEquals,
   assertThrows,
 } from "../../testing/asserts.ts";
 
@@ -17,7 +16,7 @@ Deno.test("[node/crypto.randomFill]", () => {
 
   randomFill(buf, 5, 5, (_err, bufTwo) => {
     const after = bufTwo?.toString("hex");
-    assertNotEquals(before.slice(0, 10), after?.slice(0, 10));
+    assertEquals(before.slice(0, 10), after?.slice(0, 10));
   });
 });
 

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
+import { randomFillSync } from "./_crypto/randomFill.ts";
 import {
   crypto as wasmCrypto,
   DigestAlgorithm,
@@ -158,6 +159,7 @@ export default {
   Hash,
   createHash,
   getHashes,
+  randomFillSync,
   pbkdf2,
   pbkdf2Sync,
   randomBytes,
@@ -169,6 +171,7 @@ export default {
 export {
   pbkdf2,
   pbkdf2Sync,
+  randomFillSync,
   randomBytes,
   randomUUID,
   scrypt,

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
-import { randomFillSync } from "./_crypto/randomFill.ts";
+import randomFill, { randomFillSync } from "./_crypto/randomFill.ts";
 import {
   crypto as wasmCrypto,
   DigestAlgorithm,
@@ -171,8 +171,9 @@ export default {
 export {
   pbkdf2,
   pbkdf2Sync,
-  randomFillSync,
   randomBytes,
+  randomFill,
+  randomFillSync,
   randomUUID,
   scrypt,
   scryptSync,

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -159,6 +159,7 @@ export default {
   Hash,
   createHash,
   getHashes,
+  randomFill,
   randomFillSync,
   pbkdf2,
   pbkdf2Sync,


### PR DESCRIPTION
Reference: https://nodejs.org/api/crypto.html#crypto_crypto_randomfillsync_buffer_offset_size
Adds and exports `randomFillSync` and `randomFill` function.


- [x] I have added tests
- [x]  I have run deno fmt and deno lint