### PR TITLE
feat (node/crypto) add `randomInt`

### DIFF
--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,6 +1,49 @@
 import randomBytes from "./randomBytes.ts";
 import { Buffer } from "../buffer.ts";
 
+export default function randomFill(
+  buf: Buffer,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+export default function randomFill(
+  buf: Buffer,
+  offset: number,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+export default function randomFill(
+  buf: Buffer,
+  offset: number,
+  size: number,
+  cb: (err: Error | null, buf?: Buffer) => void,
+): void;
+
+export default function randomFill(
+  buf: Buffer,
+  // deno-lint-ignore no-explicit-any
+  offset?: any,
+  // deno-lint-ignore no-explicit-any
+  size?: any,
+  cb?: (err: Error | null, buf?: Buffer) => void,
+) {
+  if (size + offset > buf.length) {
+    throw new RangeError(
+      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(size +
+        offset)}.`,
+    );
+  }
+
+  const buffer = buf as Buffer;
+  const callback = cb as (err: Error | null, buf?: Buffer) => void;
+  const trueOffset = 0 | offset;
+  const trueSize = buffer.length - trueOffset;
+
+  randomBytes(size, (err, buf) => {
+    if (err) return callback(err as Error);
+    buffer.copy(buf as Buffer, trueOffset, 0, trueSize);
+    callback(null, buffer);
+  });
+}
+
 export function randomFillSync(buffer: Buffer, offset = 0, size?: number) {
   if (size === undefined) {
     size = buffer.length - offset;

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -28,7 +28,7 @@ export default function randomFill(
   let trueSize = buf.length - trueOffset;
 
   if (size !== undefined) {
-    trueSize = size as number
+    trueSize = size as number;
   }
 
   if (trueSize + trueOffset > buf.length) {

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -19,28 +19,29 @@ export default function randomFill(
 
 export default function randomFill(
   buf: Buffer,
-  // deno-lint-ignore no-explicit-any
-  offset?: any,
-  // deno-lint-ignore no-explicit-any
-  size?: any,
+  offset?: number | ((err: Error | null, buf?: Buffer) => void),
+  size?: number | ((err: Error | null, buf?: Buffer) => void),
   cb?: (err: Error | null, buf?: Buffer) => void,
 ) {
-  if (size + offset > buf.length) {
+  const callback = cb as (err: Error | null, buf?: Buffer) => void;
+  const trueOffset = offset as unknown as number | 0;
+  let trueSize = buf.length - trueOffset;
+
+  if (size !== undefined) {
+    trueSize = size as number
+  }
+
+  if (trueSize + trueOffset > buf.length) {
     throw new RangeError(
-      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(size +
-        offset)}.`,
+      `The value of "size + offset" is out of range. It must be <= ${buf.length}. Received ${(trueSize +
+        trueOffset)}.`,
     );
   }
 
-  const buffer = buf as Buffer;
-  const callback = cb as (err: Error | null, buf?: Buffer) => void;
-  const trueOffset = 0 | offset;
-  const trueSize = buffer.length - trueOffset;
-
-  randomBytes(size, (err, buf) => {
+  randomBytes(trueSize, (err, buf) => {
     if (err) return callback(err as Error);
-    buffer.copy(buf as Buffer, trueOffset, 0, trueSize);
-    callback(null, buffer);
+    buf?.copy(buf as Buffer, trueOffset, 0, trueSize);
+    callback(null, buf);
   });
 }
 

--- a/node/_crypto/randomFill.ts
+++ b/node/_crypto/randomFill.ts
@@ -1,0 +1,17 @@
+import randomBytes from "./randomBytes.ts";
+import { Buffer } from "../buffer.ts";
+
+export function randomFillSync(buffer: Buffer, offset = 0, size?: number) {
+  if (size === undefined) {
+    size = buffer.length - offset;
+  }
+
+  if (size + offset > buffer.length) {
+    throw new RangeError(
+      `The value of "size + offset" is out of range. It must be <= ${buffer.length}. Received ${(size +
+        offset)}.`,
+    );
+  }
+
+  randomBytes(size).copy(buffer, offset, 0, size);
+}

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,0 +1,34 @@
+import { Buffer } from "../buffer.ts";
+import { randomFillSync } from "./randomFill.ts";
+import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+
+const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
+const validateZero = (buf: Buffer) => {
+  buf.forEach((val) => assertEquals(val, 0));
+};
+
+Deno.test("[node/crypto.randomFillSync] Complete fill, explicit size", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf, undefined, 10);
+  validateNonZero(buf);
+});
+
+Deno.test("[randomFillSync] Complete fill", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf);
+  validateNonZero(buf);
+});
+
+Deno.test("[node/crypto.randomFillSync] Fill beginning, explicit offset+size", () => {
+  const buf = Buffer.alloc(10);
+  randomFillSync(buf, 0, 5);
+  validateNonZero(buf);
+
+  const untouched = buf.slice(5);
+  assertEquals(untouched.length, 5);
+  validateZero(untouched);
+});
+
+Deno.test("[node/crypto.randomFillSync] Invalid offst/size", () => {
+  assertThrows(() => randomFillSync(Buffer.alloc(10), 1, 10));
+});

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,11 +1,21 @@
 import { Buffer } from "../buffer.ts";
-import { randomFillSync } from "./randomFill.ts";
+import randomFill, { randomFillSync } from "./randomFill.ts";
 import { assertEquals, assertThrows } from "../../testing/asserts.ts";
 
 const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
 const validateZero = (buf: Buffer) => {
   buf.forEach((val) => assertEquals(val, 0));
 };
+
+Deno.test("[node/crypto.randomFill]", () => {
+  const buf = Buffer.alloc(10);
+  const before = buf.toString("hex");
+
+  randomFill(buf, 5, 5, (_err, bufTwo) => {
+    const after = bufTwo?.toString("hex");
+    assertEquals(before.slice(0, 10), after?.slice(0, 10));
+  });
+});
 
 Deno.test("[node/crypto.randomFillSync] Complete fill, explicit size", () => {
   const buf = Buffer.alloc(10);

--- a/node/_crypto/randomFill_test.ts
+++ b/node/_crypto/randomFill_test.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "../buffer.ts";
 import randomFill, { randomFillSync } from "./randomFill.ts";
-import { assertEquals, assertThrows } from "../../testing/asserts.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "../../testing/asserts.ts";
 
 const validateNonZero = (buf: Buffer) => buf.some((ch) => ch > 0);
 const validateZero = (buf: Buffer) => {
@@ -13,7 +17,7 @@ Deno.test("[node/crypto.randomFill]", () => {
 
   randomFill(buf, 5, 5, (_err, bufTwo) => {
     const after = bufTwo?.toString("hex");
-    assertEquals(before.slice(0, 10), after?.slice(0, 10));
+    assertNotEquals(before.slice(0, 10), after?.slice(0, 10));
   });
 });
 

--- a/node/_crypto/randomInt.ts
+++ b/node/_crypto/randomInt.ts
@@ -1,0 +1,43 @@
+export default function randomInt(min: number): number;
+export default function randomInt(min: number, max?: number): number;
+export default function randomInt(
+  min: number,
+  cb?: ((err: Error | null, n?: number) => void) | number,
+): void;
+export default function randomInt(
+  min?: number,
+  max?: number,
+  cb?: (err: Error | null, n?: number) => void,
+): void;
+
+export default function randomInt(
+  min?: number,
+  max?: ((err: Error | null, n?: number) => void) | number,
+  cb?: (err: Error | null, n?: number) => void,
+): number | void {
+  if (min !== undefined && max === undefined) {
+    max = min;
+    min = 0;
+  }
+
+  if (Number(min as number) >= Number(max as number)) {
+    throw new Error("Min is bigger than Max!");
+  }
+
+  const randomBuffer = new Uint32Array(1);
+
+  crypto.getRandomValues(randomBuffer);
+
+  const randomNumber = randomBuffer[0] / (0xffffffff + 1);
+
+  min = Math.ceil(min as number);
+  max = Math.floor(max as number);
+  const result = Math.floor(randomNumber * (max - min + 1)) + min;
+
+  if (cb !== undefined) {
+    cb(null, result);
+    return;
+  }
+
+  return result;
+}

--- a/node/_crypto/randomInt_test.ts
+++ b/node/_crypto/randomInt_test.ts
@@ -1,0 +1,28 @@
+import randomInt from "./randomInt.ts";
+import { assert, assertThrows } from "../../testing/asserts.ts";
+
+const between = (x: number, min: number, max: number) => x >= min && x <= max;
+
+Deno.test("[node/crypto.randomInt] One Param: Max", () => {
+  assert(between(randomInt(55), 0, 55));
+});
+
+Deno.test("[node/crypto.randomInt] Two Params: Max and Min", () => {
+  assert(between(randomInt(40, 120), 40, 120));
+});
+
+Deno.test("[node/crypto.randomInt] Max and Callback", () => {
+  randomInt(3, (_err, val) => {
+    assert(between(val as number, 0, 3));
+  });
+});
+
+Deno.test("[node/crypto.randomInt] Min, Max and Callback", () => {
+  randomInt(3, 5, (_err, val) => {
+    assert(between(val as number, 3, 5));
+  });
+});
+
+Deno.test("[node/crypto.randomInt] Min is bigger than Max", () => {
+  assertThrows(() => randomInt(45, 34));
+});

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -2,6 +2,7 @@
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
 import randomFill, { randomFillSync } from "./_crypto/randomFill.ts";
+import randomInt from "./_crypto/randomInt.ts";
 import {
   crypto as wasmCrypto,
   DigestAlgorithm,
@@ -165,6 +166,7 @@ export default {
   pbkdf2Sync,
   randomBytes,
   scrypt,
+  randomInt,
   scryptSync,
   timingSafeEqual,
   randomUUID,
@@ -175,6 +177,7 @@ export {
   randomBytes,
   randomFill,
   randomFillSync,
+  randomInt,
   randomUUID,
   scrypt,
   scryptSync,

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
+import { randomFillSync } from "./_crypto/randomFill.ts";
 import {
   crypto as wasmCrypto,
   DigestAlgorithm,
@@ -158,6 +159,7 @@ export default {
   Hash,
   createHash,
   getHashes,
+  randomFillSync,
   pbkdf2,
   pbkdf2Sync,
   randomBytes,
@@ -169,6 +171,7 @@ export default {
 export {
   pbkdf2,
   pbkdf2Sync,
+  randomFillSync,
   randomBytes,
   randomUUID,
   scrypt,

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 import { default as randomBytes } from "./_crypto/randomBytes.ts";
-import { randomFillSync } from "./_crypto/randomFill.ts";
+import randomFill, { randomFillSync } from "./_crypto/randomFill.ts";
 import {
   crypto as wasmCrypto,
   DigestAlgorithm,
@@ -171,8 +171,9 @@ export default {
 export {
   pbkdf2,
   pbkdf2Sync,
-  randomFillSync,
   randomBytes,
+  randomFill,
+  randomFillSync,
   randomUUID,
   scrypt,
   scryptSync,

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -159,6 +159,7 @@ export default {
   Hash,
   createHash,
   getHashes,
+  randomFill,
   randomFillSync,
   pbkdf2,
   pbkdf2Sync,


### PR DESCRIPTION
Reference: https://nodejs.org/api/crypto.html#crypto_crypto_randomint_min_max_callback
Adds and exports `randomInt`.


- [x] I have added tests
- [x]  I have run deno fmt and deno lint