### PR TITLE
feat(bytes): switch equals to simd for large byte arrays

### DIFF
--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -1,0 +1,41 @@
+/** Check whether binary arrays are equal to each other using 8-bit comparisons.
+ * @private
+ * @param a first array to check equality
+ * @param b second array to check equality
+ */
+export function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < b.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** Check whether binary arrays are equal to each other using 32-bit comparisons.
+ * @private
+ * @param a first array to check equality
+ * @param b second array to check equality
+ */
+export function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  const len = a.length;
+  const compressable = Math.floor(len / 4);
+  const compressedA = new Uint32Array(a.buffer, 0, compressable);
+  const compressedB = new Uint32Array(b.buffer, 0, compressable);
+  for (let i = compressable * 4; i < len; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  for (let i = 0; i < compressedA.length; i++) {
+    if (compressedA[i] !== compressedB[i]) return false;
+  }
+  return true;
+}
+
+/** Check whether binary arrays are equal to each other.
+ * @param a first array to check equality
+ * @param b second array to check equality
+ */
+export function equals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length < 1000) return equalsNaive(a, b);
+  return equalsSimd(a, b);
+}

--- a/bytes/equals_bench.ts
+++ b/bytes/equals_bench.ts
@@ -1,7 +1,4 @@
-import {
-  bench,
-  runBenchmarks,
-} from "../testing/bench.ts";
+import { bench, runBenchmarks } from "../testing/bench.ts";
 
 function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
@@ -73,4 +70,3 @@ bench({
 });
 
 runBenchmarks();
-

--- a/bytes/equals_bench.ts
+++ b/bytes/equals_bench.ts
@@ -1,0 +1,76 @@
+import {
+  bench,
+  runBenchmarks,
+} from "../testing/bench.ts";
+
+function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < b.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  const len = a.length;
+  const compressable = Math.floor(len / 4);
+  const compressedA = new Uint32Array(a.buffer, 0, compressable);
+  const compressedB = new Uint32Array(b.buffer, 0, compressable);
+  for (let i = compressable * 4; i < len; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  for (let i = 0; i < compressedA.length; i++) {
+    if (compressedA[i] !== compressedB[i]) return false;
+  }
+  return true;
+}
+
+function rand(n: number): number {
+  return Math.floor(Math.random() * n);
+}
+
+function randArr(len: number): Uint8Array {
+  const arr = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    arr[i] = rand(256);
+  }
+  return arr;
+}
+
+console.log("generating benchmarks...");
+const testCases: [Uint8Array, Uint8Array][] = [];
+// CHANGE THESE
+const len = 10000;
+const nCases = 10000;
+for (let i = 0; i < nCases; i++) {
+  const arr1 = randArr(len);
+  const arr2 = randArr(len);
+  testCases.push([arr1, arr1.slice(0)]);
+  testCases.push([arr1, arr2]);
+}
+
+bench({
+  name: "bench old equals",
+  func(b): void {
+    b.start();
+    for (const [a, b] of testCases) {
+      equalsNaive(a, b);
+    }
+    b.stop();
+  },
+});
+
+bench({
+  name: "bench simd equals",
+  func(b): void {
+    b.start();
+    for (const [a, b] of testCases) {
+      equalsSimd(a, b);
+    }
+    b.stop();
+  },
+});
+
+runBenchmarks();
+

--- a/bytes/equals_bench.ts
+++ b/bytes/equals_bench.ts
@@ -1,39 +1,5 @@
 import { bench, runBenchmarks } from "../testing/bench.ts";
-
-function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < b.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
-function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  const len = a.length;
-  const compressable = Math.floor(len / 4);
-  const compressedA = new Uint32Array(a.buffer, 0, compressable);
-  const compressedB = new Uint32Array(b.buffer, 0, compressable);
-  for (let i = compressable * 4; i < len; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  for (let i = 0; i < compressedA.length; i++) {
-    if (compressedA[i] !== compressedB[i]) return false;
-  }
-  return true;
-}
-
-function rand(n: number): number {
-  return Math.floor(Math.random() * n);
-}
-
-function randArr(len: number): Uint8Array {
-  const arr = new Uint8Array(len);
-  for (let i = 0; i < len; i++) {
-    arr[i] = rand(256);
-  }
-  return arr;
-}
+import { equalsNaive, equalsSimd } from "./equals.ts";
 
 console.log("generating benchmarks...");
 const testCases: [Uint8Array, Uint8Array][] = [];
@@ -41,10 +7,13 @@ const testCases: [Uint8Array, Uint8Array][] = [];
 const len = 10000;
 const nCases = 10000;
 for (let i = 0; i < nCases; i++) {
-  const arr1 = randArr(len);
-  const arr2 = randArr(len);
+  const arr1 = crypto.getRandomValues(new Uint8Array(len));
+  const arr2 = crypto.getRandomValues(new Uint8Array(len));
+  const arr3 = arr1.slice(0);
+  arr3[arr3.length - 1] = arr1[arr1.length - 1] ^ 1;
   testCases.push([arr1, arr1.slice(0)]);
   testCases.push([arr1, arr2]);
+  testCases.push([arr1, arr3]);
 }
 
 bench({

--- a/bytes/mod.ts
+++ b/bytes/mod.ts
@@ -69,16 +69,36 @@ export function lastIndexOf(
   return -1;
 }
 
-/** Check whether binary arrays are equal to each other.
- * @param a first array to check equality
- * @param b second array to check equality
- */
-export function equals(a: Uint8Array, b: Uint8Array): boolean {
+function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < b.length; i++) {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  const len = a.length;
+  const compressable = Math.floor(len / 4);
+  const compressedA = new Uint32Array(a.buffer, 0, compressable);
+  const compressedB = new Uint32Array(b.buffer, 0, compressable);
+  for (let i = compressable * 4; i < len; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  for (let i = 0; i < compressedA.length; i++) {
+    if (compressedA[i] !== compressedB[i]) return false;
+  }
+  return true;
+}
+
+/** Check whether binary arrays are equal to each other.
+ * @param a first array to check equality
+ * @param b second array to check equality
+ */
+export function equals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length < 1000) return equalsNaive(a, b);
+  return equalsSimd(a, b);
 }
 
 /** Check whether binary array starts with prefix.

--- a/bytes/mod.ts
+++ b/bytes/mod.ts
@@ -69,38 +69,6 @@ export function lastIndexOf(
   return -1;
 }
 
-function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < b.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
-function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  const len = a.length;
-  const compressable = Math.floor(len / 4);
-  const compressedA = new Uint32Array(a.buffer, 0, compressable);
-  const compressedB = new Uint32Array(b.buffer, 0, compressable);
-  for (let i = compressable * 4; i < len; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  for (let i = 0; i < compressedA.length; i++) {
-    if (compressedA[i] !== compressedB[i]) return false;
-  }
-  return true;
-}
-
-/** Check whether binary arrays are equal to each other.
- * @param a first array to check equality
- * @param b second array to check equality
- */
-export function equals(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length < 1000) return equalsNaive(a, b);
-  return equalsSimd(a, b);
-}
-
 /** Check whether binary array starts with prefix.
  * @param source source array
  * @param prefix prefix array to check in source
@@ -209,3 +177,5 @@ export function copy(src: Uint8Array, dst: Uint8Array, off = 0): number {
 
 /** @deprecated */
 export { includes as contains };
+
+export { equals } from "./equals.ts";

--- a/bytes/test.ts
+++ b/bytes/test.ts
@@ -119,6 +119,40 @@ Deno.test("[bytes] equals", () => {
   assert(!v3);
 });
 
+function rand(n: number): number {
+  return Math.floor(Math.random() * n);
+}
+
+function randArr(len: number): Uint8Array {
+  const arr = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    arr[i] = rand(256);
+  }
+  return arr;
+}
+
+Deno.test("[bytes] equals randomized testing", () => {
+  // run tests before and after cutoff
+  for (let len = 995; len <= 1005; len ++) {
+    const arr1 = randArr(len);
+    const arr2 = randArr(len);
+    const arr3 = arr1.slice(0);
+    // the chance of arr1 equaling arr2 is basically 0
+    // but introduce an inequality at the end just in case
+    arr2[arr2.length - 1] = arr1[arr1.length - 1] ^ 1;
+    // arr3 is arr1 but with an inequality in the very last element
+    // this is to test the equality check when length isn't a multiple of 4
+    arr3[arr3.length - 1] ^= 1;
+    // arrays with same underlying ArrayBuffer should be equal
+    assert(equals(arr1, arr1));
+    // equal arrays with different underlying ArrayBuffers should be equal
+    assert(equals(arr1, arr1.slice(0)));
+    // inequal arrays should be inequal
+    assert(!equals(arr1, arr2));
+    assert(!equals(arr1, arr3));
+  }
+});
+
 Deno.test("[bytes] startsWith", () => {
   const v = startsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 1]));
   const v2 = startsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 2]));

--- a/bytes/test.ts
+++ b/bytes/test.ts
@@ -133,7 +133,7 @@ function randArr(len: number): Uint8Array {
 
 Deno.test("[bytes] equals randomized testing", () => {
   // run tests before and after cutoff
-  for (let len = 995; len <= 1005; len ++) {
+  for (let len = 995; len <= 1005; len++) {
     const arr1 = randArr(len);
     const arr2 = randArr(len);
     const arr3 = arr1.slice(0);

--- a/bytes/test.ts
+++ b/bytes/test.ts
@@ -119,23 +119,11 @@ Deno.test("[bytes] equals", () => {
   assert(!v3);
 });
 
-function rand(n: number): number {
-  return Math.floor(Math.random() * n);
-}
-
-function randArr(len: number): Uint8Array {
-  const arr = new Uint8Array(len);
-  for (let i = 0; i < len; i++) {
-    arr[i] = rand(256);
-  }
-  return arr;
-}
-
 Deno.test("[bytes] equals randomized testing", () => {
   // run tests before and after cutoff
   for (let len = 995; len <= 1005; len++) {
-    const arr1 = randArr(len);
-    const arr2 = randArr(len);
+    const arr1 = crypto.getRandomValues(new Uint8Array(len));
+    const arr2 = crypto.getRandomValues(new Uint8Array(len));
     const arr3 = arr1.slice(0);
     // the chance of arr1 equaling arr2 is basically 0
     // but introduce an inequality at the end just in case


### PR DESCRIPTION
For large `Uint8Array`s, it's faster to make `Uint32Array`s from the underlying `ArrayBuffer`s and compare those instead of the original `Uint8Array`s. I've used the following benchmarking code and found the cutoff to be at around 1000 elements on my machine:
```ts
import {
  bench,
  runBenchmarks,
} from "https://deno.land/std@0.110.0/testing/bench.ts";

function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
  if (a.length !== b.length) return false;
  for (let i = 0; i < b.length; i++) {
    if (a[i] !== b[i]) return false;
  }
  return true;
}

function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
  if (a.length !== b.length) return false;
  const len = a.length;
  const compressable = Math.floor(len / 4);
  const compressedA = new Uint32Array(a.buffer, 0, compressable);
  const compressedB = new Uint32Array(b.buffer, 0, compressable);
  for (let i = compressable * 4; i < len; i++) {
    if (a[i] !== b[i]) return false;
  }
  for (let i = 0; i < compressedA.length; i++) {
    if (compressedA[i] !== compressedB[i]) return false;
  }
  return true;
}

function rand(n: number): number {
  return Math.floor(Math.random() * n);
}

function randArr(len: number): Uint8Array {
  let arr = new Uint8Array(len);
  for (let i = 0; i < len; i++) {
    arr[i] = rand(256);
  }
  return arr;
}

console.log("generating benchmarks...");
const testCases: [Uint8Array, Uint8Array][] = [];
// CHANGE THESE
const len = 2000;
const nCases = 10000;
for (let i = 0; i < nCases; i++) {
  const arr1 = randArr(len);
  const arr2 = randArr(len);
  testCases.push([arr1, arr1.slice(0)]);
  testCases.push([arr1, arr2]);
}

bench({
  name: "bench old equals",
  func(b): void {
    b.start();
    for (const [a, b] of testCases) {
      equalsNaive(a, b);
    }
    b.stop();
  },
});

bench({
  name: "bench simd equals",
  func(b): void {
    b.start();
    for (const [a, b] of testCases) {
      equalsSimd(a, b);
    }
    b.stop();
  },
});

runBenchmarks();
```
For reference, here's the results I get with 100k arrays of length 10k:
```
benchmark bench old equals ...
    1194ms
benchmark bench simd equals ...
    502ms
```