### PR TITLE
chore: deprecate std/hash

### DIFF
--- a/hash/README.md
+++ b/hash/README.md
@@ -1,3 +1,9 @@
+# std/hash is deprecated
+
+`std/hash` is deprecated now. Use Web Crypto API or std/crypto instead.
+
+---
+
 # std/hash
 
 hash is module to provide interfaces for hash functions.

--- a/hash/mod.ts
+++ b/hash/mod.ts
@@ -3,7 +3,9 @@
 import { Hash } from "./_wasm/hash.ts";
 import type { Hasher } from "./hasher.ts";
 
+/** @deprecated */
 export type { Hasher } from "./hasher.ts";
+/** @deprecated */
 export const supportedAlgorithms = [
   "md2",
   "md4",
@@ -25,11 +27,13 @@ export const supportedAlgorithms = [
   "keccak512",
   "blake3",
 ] as const;
+/** @deprecated */
 export type SupportedAlgorithm = typeof supportedAlgorithms[number];
 /**
  * Creates a new `Hash` instance.
  *
  * @param algorithm name of hash algorithm to use
+ * @deprecated
  */
 export function createHash(algorithm: SupportedAlgorithm): Hasher {
   return new Hash(algorithm as string);


### PR DESCRIPTION
We decided to deprecate std/hash in favor of std/crypto (ref: https://github.com/denoland/deno_std/pull/1025 ), but we didn't mention that in README.

This PR explicitly adds the deprecation notice in hash/README and also adds `@deprecated` tags in jsdocs.