### PR TITLE
feat(node/_error): Implement `ERR_INVALID_URL_SCHEME`

### DIFF
--- a/node/_errors.ts
+++ b/node/_errors.ts
@@ -2,7 +2,6 @@
 /** ********** NOT IMPLEMENTED
  * ERR_INVALID_MODULE_SPECIFIER
  * ERR_INVALID_PACKAGE_TARGET
- * ERR_INVALID_URL_SCHEME
  * ERR_MANIFEST_ASSERT_INTEGRITY
  * ERR_MODULE_NOT_FOUND
  * ERR_PACKAGE_PATH_NOT_EXPORTED
@@ -2393,5 +2392,18 @@ export class ERR_INVALID_URL extends NodeTypeError {
       `Invalid URL: ${input}`,
     );
     this.input = input;
+  }
+}
+
+export class ERR_INVALID_URL_SCHEME extends NodeTypeError {
+  constructor(expected: string | [string] | [string, string]) {
+    expected = Array.isArray(expected) ? expected : [expected];
+    const res = expected.length === 2
+      ? `one of scheme ${expected[0]} or ${expected[1]}`
+      : `of scheme ${expected[0]}`;
+    super(
+      "ERR_INVALID_URL_SCHEME",
+      `The URL must be ${res}`,
+    );
   }
 }

--- a/node/_tools/suites/parallel/test-url-fileurltopath.js
+++ b/node/_tools/suites/parallel/test-url-fileurltopath.js
@@ -21,11 +21,10 @@ function testInvalidArgs(...args) {
 // Input must be string or URL
 testInvalidArgs(null, undefined, 1, {}, true);
 
-// TODO(wafuwafu13): implement ERR_INVALID_URL_SCHEME
-// // Input must be a file URL
-// assert.throws(() => url.fileURLToPath('https://a/b/c'), {
-//   code: 'ERR_INVALID_URL_SCHEME'
-// });
+// Input must be a file URL
+assert.throws(() => url.fileURLToPath('https://a/b/c'), {
+  code: 'ERR_INVALID_URL_SCHEME'
+});
 
 {
   const withHost = new URL('file://host/a');

--- a/node/url.ts
+++ b/node/url.ts
@@ -23,6 +23,7 @@ import {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_FILE_URL_HOST,
   ERR_INVALID_FILE_URL_PATH,
+  ERR_INVALID_URL_SCHEME,
 } from "./_errors.ts";
 import {
   CHAR_BACKWARD_SLASH,
@@ -53,7 +54,7 @@ export function fileURLToPath(path: string | URL): string {
     throw new ERR_INVALID_ARG_TYPE("path", ["string", "URL"], path);
   }
   if (path.protocol !== "file:") {
-    throw new Deno.errors.InvalidData("invalid url scheme");
+    throw new ERR_INVALID_URL_SCHEME("file");
   }
   return isWindows ? getPathFromURLWin(path) : getPathFromURLPosix(path);
 }

--- a/node/url_test.ts
+++ b/node/url_test.ts
@@ -10,8 +10,6 @@ Deno.test({
   },
 });
 
-// todo(wafuwafu13) Add Windows and invalid case
-
 Deno.test({
   ignore: isWindows,
   name: "fileURLToPath",


### PR DESCRIPTION
Part of https://github.com/denoland/deno_std/issues/911

- Implement `ERR_INVALID_URL_SCHEME`
- Use `ERR_INVALID_URL_SCHEME`
- Remove TODO comment
