### PR TITLE
fix(encoding/base64url): allow passing strings to `encode`

### DIFF
--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -29,11 +29,11 @@ function convertBase64ToBase64url(b64: string): string {
 }
 
 /**
- * Encodes a given Uint8Array into a base64url representation
- * @param uint8
+ * Encodes a given ArrayBuffer or string into a base64url representation
+ * @param data
  */
-export function encode(uint8: Uint8Array): string {
-  return convertBase64ToBase64url(base64.encode(uint8));
+export function encode(data: ArrayBuffer | string): string {
+  return convertBase64ToBase64url(base64.encode(data));
 }
 
 /**

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -27,6 +27,12 @@ const testsetInvalid = [
   "PDw/Pz8+Pg==",
 ];
 
+Deno.test("[encoding/base64url] testBase64urlEncodeString", () => {
+  for (const [input, output] of testsetString) {
+    assertEquals(encode(input), output);
+  }
+});
+
 Deno.test("[encoding/base64url] testBase64urlEncodeBinary", () => {
   for (const [input, output] of testsetBinary) {
     assertEquals(encode(input), output);


### PR DESCRIPTION
[`base64#encode`](https://deno.land/std@0.110.0/encoding/base64.ts#L15) takes `ArrayBuffer | string` as input, but `base64url#encode` only allows `UInt8Array`.

This makes it very inconvenient to encode JSON-stringified values, eg. `encode(JSON.stringify({ foo: 123 }))` currently does not work for `base64url`, but the corresponding function from `base64` works as intended.

This PR loosens the `base64url#encode` type to `ArrayBuffer | string` and adds a corresponding test for string values.