### PR TITLE
BREAKING(fs): deprecate exists and existsSync

### DIFF
--- a/fs/README.md
+++ b/fs/README.md
@@ -95,17 +95,7 @@ format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
 
 ### exists
 
-Test whether or not the given path exists by checking with the file system.
-
-```ts
-import {
-  exists,
-  existsSync,
-} from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
-
-exists("./foo"); // returns a Promise<boolean>
-existsSync("./foo"); // returns boolean
-```
+This function is now deprecated.
 
 ### move
 

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 /**
  * Test whether or not the given path exists by checking with the file system
+ * @deprecated Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
+ * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
  */
 export async function exists(filePath: string): Promise<boolean> {
   try {
@@ -17,6 +19,8 @@ export async function exists(filePath: string): Promise<boolean> {
 
 /**
  * Test whether or not the given path exists by checking with the file system
+ * @deprecated Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
+ * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
  */
 export function existsSync(filePath: string): boolean {
   try {


### PR DESCRIPTION
This PR deprecates `fs.exists` and `fs.existsSync`. See https://github.com/denoland/deno_std/issues/1216#issuecomment-937722077 for the context

closes #1216