### PR TITLE
perf(fs): Parallelize `expandGlob`

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -151,11 +151,11 @@ export async function* expandGlob(
     // Advancing the list of current matches may introduce duplicates, so we
     // pass everything through this Map.
     const nextMatchMap: Map<string, WalkEntry> = new Map();
-    for (const currentMatch of currentMatches) {
+    await Promise.all(currentMatches.map(async (currentMatch) => {
       for await (const nextMatch of advanceMatch(currentMatch, segment)) {
         nextMatchMap.set(nextMatch.path, nextMatch);
       }
-    }
+    }));
     currentMatches = [...nextMatchMap.values()].sort(comparePath);
   }
   if (hasTrailingSep) {


### PR DESCRIPTION
In my use case, this change makes `expandGlob` x1.9 faster.