### PR TITLE
feat(node): barebones express compatibility

### DIFF
--- a/node/buffer.ts
+++ b/node/buffer.ts
@@ -642,6 +642,26 @@ export class Buffer extends Uint8Array {
     return offset + 4;
   }
 }
+// Make Buffer static methods enumerable (so they can be copied by safe-buffer, etc...)
+for (
+  const prop of [
+    "alloc",
+    "allocUnsafe",
+    "byteLength",
+    "from",
+    "isBuffer",
+    "isEncoding",
+  ]
+) {
+  Reflect.defineProperty(Buffer, prop, { enumerable: true });
+}
+// Allow calling Buffer() without new (translate it to a Buffer.from call, for safe-buffer, etc..)
+const PBuffer = new Proxy(Buffer, {
+  apply(_target, _thisArg, args) {
+    // @ts-ignore tedious to replicate types ...
+    return Buffer.from(...args);
+  },
+});
 
 export const kMaxLength = 4294967296;
 export const kStringMaxLength = 536870888;
@@ -654,7 +674,7 @@ export const atob = globalThis.atob;
 export const btoa = globalThis.btoa;
 
 export default {
-  Buffer,
+  Buffer: PBuffer,
   kMaxLength,
   kStringMaxLength,
   constants,

--- a/node/http.ts
+++ b/node/http.ts
@@ -108,9 +108,17 @@ export class IncomingMessage {
   get httpVersion() {
     return "1.1";
   }
+  listeners(_key: string) {
+    return [];
+  }
+  resume() {
+  }
 
   get headers() {
     return this.req.headers;
+  }
+  get method() {
+    return this.req.method;
   }
 
   get url() {

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -66,4 +66,5 @@ export default {
   tty,
   url,
   util,
+  zlib: {},
 } as Record<string, unknown>;


### PR DESCRIPTION
Building off https://github.com/denoland/deno_std/pull/1383 which got `koa` working, this adds the minimal patches to get an `express` hello-world working

## Example

```
yarn add express
```

```js
import { createRequire } from "../deno_std/node/module.ts";
globalThis.require = createRequire(import.meta.url);

const express = require('express');
const app = express();

app.get('/', function (req, res) {
  res.send('Hello World')
})

app.listen(3000)
```