### PR TITLE
fix(node): use hardcoded values for process.version and process.versions

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -92,12 +92,39 @@ export const pid = Deno.pid;
 /** https://nodejs.org/api/process.html#process_process_platform */
 export const platform = isWindows ? "win32" : Deno.build.os;
 
-/** https://nodejs.org/api/process.html#process_process_version */
-export const version = `v${Deno.version.deno}`;
+/**
+ * https://nodejs.org/api/process.html#process_process_version
+ *
+ * This value is hard coded to latest stable release of Node, as
+ * some packages are checking it for compatibility. Previously
+ * it pointed to Deno version, but that led to incompability
+ * with some packages.
+ */
+export const version = "v16.11.1";
 
-/** https://nodejs.org/api/process.html#process_process_versions */
+/**
+ * https://nodejs.org/api/process.html#process_process_versions
+ *
+ * This value is hard coded to latest stable release of Node, as
+ * some packages are checking it for compatibility. Previously
+ * it contained only output of `Deno.version`, but that led to incompability
+ * with some packages. Value of `v8` field is still taken from `Deno.version`.
+ */
 export const versions = {
-  node: Deno.version.deno,
+  node: "16.11.1",
+  uv: "1.42.0",
+  zlib: "1.2.11",
+  brotli: "1.0.9",
+  ares: "1.17.2",
+  modules: "93",
+  nghttp2: "1.45.1",
+  napi: "8",
+  llhttp: "6.0.4",
+  openssl: "1.1.1l",
+  cldr: "39.0",
+  icu: "69.1",
+  tz: "2021a",
+  unicode: "13.0",
   ...Deno.version,
 };
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -54,6 +54,24 @@ Deno.test({
     assertEquals(typeof process.version, "string");
     assertEquals(typeof process.versions, "object");
     assertEquals(typeof process.versions.node, "string");
+    assertEquals(typeof process.versions.v8, "string");
+    assertEquals(typeof process.versions.uv, "string");
+    assertEquals(typeof process.versions.zlib, "string");
+    assertEquals(typeof process.versions.brotli, "string");
+    assertEquals(typeof process.versions.ares, "string");
+    assertEquals(typeof process.versions.modules, "string");
+    assertEquals(typeof process.versions.nghttp2, "string");
+    assertEquals(typeof process.versions.napi, "string");
+    assertEquals(typeof process.versions.llhttp, "string");
+    assertEquals(typeof process.versions.openssl, "string");
+    assertEquals(typeof process.versions.cldr, "string");
+    assertEquals(typeof process.versions.icu, "string");
+    assertEquals(typeof process.versions.tz, "string");
+    assertEquals(typeof process.versions.unicode, "string");
+    // These two are not present in `process.versions` in Node, but we
+    // add them anyway
+    assertEquals(typeof process.versions.deno, "string");
+    assertEquals(typeof process.versions.typescript, "string");
   },
 });
 


### PR DESCRIPTION
This commit changes `process.version` and `process.versions` to use
hardcoded value of latest stable Node release, instead of shimming them 
with value of `Deno.version`. Doing so prevents incompatibilities with packages
that check Node version.

Fixes #1402