### PR TITLE
feat(node): add helpers for determining CJS/ESM loader

### DIFF
--- a/node/module.ts
+++ b/node/module.ts
@@ -1188,7 +1188,7 @@ export function resolveMainPath(main: string): undefined | string {
   // Note extension resolution for the main entry point can be deprecated in a
   // future major.
   // Module._findPath is monkey-patchable here.
-  let mainPath = Module._findPath(path.resolve(main), null, true);
+  let mainPath = Module._findPath(path.resolve(main), [], true);
   if (!mainPath) {
     return;
   }


### PR DESCRIPTION
These two helpers are not really part of `module` module,
instead they are part of `lib/internal/modules/run_main.js` in Node.

They are however crucial to determining which loader should
be used and I didn't want to rewrite all of this functionality in Rust if it's 
already available in `node/module.ts`.