### PR TITLE
chore(node): skip broken test

### DIFF
--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -274,6 +274,9 @@ Deno.test({
 });
 
 Deno.test({
+  // TODO(kt3k): Enable this test. The failure of this test has been caused by
+  // https://github.com/denoland/deno/pull/12385
+  ignore: true,
   name: "[process] stdio",
   async fn() {
     const cwd = path.dirname(path.fromFileUrl(import.meta.url));


### PR DESCRIPTION
The `main` CI is now broken (probably caused by denoland/deno#12385). This PR skips the test case which causes the problem