### PR TITLE
feat(collections/running_reduce): Support `currentIndex`

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -693,21 +693,6 @@ const numbers = [1, 2, 3, 4, 5];
 const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);
 
 assertEquals(sumSteps, [1, 3, 6, 10, 15]);
-
-const strings = ["a", "b", "c", "d", "e"];
-const sumStepsWithCurrentIndex = runningReduce(
-  strings,
-  (sum, current, currentIndex) => sum + current + currentIndex,
-  "",
-);
-
-assertEquals(sumStepsWithCurrentIndex, [
-  "a0",
-  "a0b1",
-  "a0b1c2",
-  "a0b1c2d3",
-  "a0b1c2d3e4",
-]);
 ```
 
 ### sample

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -16,21 +16,6 @@
  * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);
  *
  * assertEquals(sumSteps, [1, 3, 6, 10, 15]);
- *
- * const strings = ["a", "b", "c", "d", "e"];
- * const sumStepsWithCurrentIndex = runningReduce(
- *   strings,
- *   (sum, current, currentIndex) => sum + current + currentIndex,
- *   "",
- * );
- *
- * assertEquals(sumStepsWithCurrentIndex, [
- *   "a0",
- *   "a0b1",
- *   "a0b1c2",
- *   "a0b1c2d3",
- *   "a0b1c2d3e4",
- * ]);
  * ```
  */
 export function runningReduce<T, O>(


### PR DESCRIPTION
Both [JavaScript/reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) and [Kotlin/runningReduceIndexed](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/running-reduce-indexed.html) support `currentIndex`.