### PR TITLE
fix(http): leak file resouce in file_server

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -286,6 +286,8 @@ export async function serveFile(
       const status = Status.NotModified;
       const statusText = STATUS_TEXT.get(status);
 
+      file.close();
+
       return new Response(null, {
         status,
         statusText,
@@ -322,6 +324,8 @@ export async function serveFile(
   ) {
     const status = Status.RequestedRangeNotSatisfiable;
     const statusText = STATUS_TEXT.get(status);
+
+    file.close();
 
     return new Response(statusText, {
       status,


### PR DESCRIPTION
If serveFile returns `Response` with a problem other than status 200 or status 206, there is a problem that the file is not closed. This PR fix the problem.
Becuase of running file_server as a independent process for tests, the tests didn't detect any resource leaks for a long time. So it add a test of the serveFile function.