### PR TITLE
docs(crypto): Updated README.md exaples

### DIFF
--- a/crypto/README.md
+++ b/crypto/README.md
@@ -6,8 +6,15 @@
 import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
 
 // This will delegate to the runtime's WebCrypto implementation.
-console.log(await crypto.subtle.digest("SHA-384", new TextEncoder().encode("hello world")));
+console.log(
+  await crypto.subtle.digest(
+    "SHA-384",
+    new TextEncoder().encode("hello world"),
+  ),
+);
 
 // This will use a bundled WASM/Rust implementation.
-console.log(await crypto.subtle.digest("BLAKE3", new TextEncoder().encode("hello world")));
+console.log(
+  await crypto.subtle.digest("BLAKE3", new TextEncoder().encode("hello world")),
+);
 ```


### PR DESCRIPTION
Updated the README.md examples of the crypto module to encode the string since the crypto.suble.digest function does no longer take a string.