### PR TITLE
fix(testing): show special characters in assertEquals results

### DIFF
--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -235,6 +235,20 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
  * @param B Expected string
  */
 export function diffstr(A: string, B: string) {
+  function unescape(string: string): string {
+    // unescape invisible characters.
+    // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences
+    return string
+      .replaceAll("\b", "\\b")
+      .replaceAll("\f", "\\f")
+      .replaceAll("\t", "\\t")
+      .replaceAll("\v", "\\v")
+      .replaceAll( // does not remove line breaks
+        /\r\n|\r|\n/g,
+        (str) => str === "\r" ? "\\r" : str === "\n" ? "\\n\n" : "\\r\\n\r\n",
+      );
+  }
+
   function tokenize(string: string, { wordDiff = false } = {}): string[] {
     if (wordDiff) {
       // Split string on whitespace symbols
@@ -296,7 +310,11 @@ export function diffstr(A: string, B: string) {
   }
 
   // Compute multi-line diff
-  const diffResult = diff(tokenize(`${A}\n`), tokenize(`${B}\n`));
+  const diffResult = diff(
+    tokenize(`${unescape(A)}\n`),
+    tokenize(`${unescape(B)}\n`),
+  );
+
   const added = [], removed = [];
   for (const result of diffResult) {
     if (result.type === DiffType.added) {

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -118,30 +118,45 @@ Deno.test({
       [..."abxde"].join("\n"),
     );
     assertEquals(diffResult, [
-      { type: "common", value: "a\n" },
-      { type: "common", value: "b\n" },
-      { type: "added", value: "x\n" },
-      {
-        type: "removed",
-        value: "c\n",
-        details: [{ type: "removed", value: "c" }, {
-          type: "common",
-          value: "\n",
-        }],
-      },
-      { type: "common", value: "d\n" },
+      { type: "common", value: "a\\n\n" },
+      { type: "common", value: "b\\n\n" },
       {
         type: "added",
-        value: "e\n",
+        value: "x\\n\n",
         details: [
-          {
-            type: "added",
-            value: "e",
-          },
-          {
-            type: "common",
-            value: "\n",
-          },
+          { type: "added", value: "x" },
+          { type: "common", value: "\\" },
+          { type: "common", value: "n" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "added",
+        value: "d\\n\n",
+        details: [
+          { type: "common", value: "d" },
+          { type: "added", value: "\\" },
+          { type: "added", value: "n" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      { type: "added", value: "e\n" },
+      {
+        type: "removed",
+        value: "c\\n\n",
+        details: [
+          { type: "removed", value: "c" },
+          { type: "common", value: "\\" },
+          { type: "common", value: "n" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "removed",
+        value: "d\n",
+        details: [
+          { type: "common", value: "d" },
+          { type: "common", value: "\n" },
         ],
       },
     ]);
@@ -225,6 +240,47 @@ Deno.test({
           { type: "common", value: "\n" },
         ],
       },
+    ]);
+  },
+});
+
+Deno.test({
+  name: `"\\b\\f\\r\\t\\v\\n" vs "\\r\\n" (diffstr)`,
+  fn(): void {
+    const diffResult = diffstr("\b\f\r\t\v\n", "\r\n");
+    assertEquals(diffResult, [
+      {
+        type: "removed",
+        value: "\\b\\f\\r\\t\\v\\n\n",
+        details: [
+          { type: "common", value: "\\" },
+          { type: "removed", value: "b" },
+          { type: "removed", value: "\\" },
+          { type: "removed", value: "f" },
+          { type: "removed", value: "\\" },
+          { type: "common", value: "r" },
+          { type: "common", value: "\\" },
+          { type: "removed", value: "t" },
+          { type: "removed", value: "\\" },
+          { type: "removed", value: "v" },
+          { type: "removed", value: "\\" },
+          { type: "common", value: "n" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "added",
+        value: "\\r\\n\r\n",
+        details: [
+          { type: "common", value: "\\" },
+          { type: "common", value: "r" },
+          { type: "common", value: "\\" },
+          { type: "common", value: "n" },
+          { type: "added", value: "\r" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      { type: "common", value: "\n" },
     ]);
   },
 });

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1023,12 +1023,13 @@ Deno.test("assert diff formatting (strings)", () => {
     },
     undefined,
     `
-    a
-    b
-${green("+   x")}
-${red("-   c")}
-    d
+    a\\n
+    b\\n
+${green("+   x")}\\n
+${green("+   d")}\\n
 ${green("+   e")}
+${red("-   c")}\\n
+${red("-   d")}
 `,
   );
 });


### PR DESCRIPTION
closes #1444

The display after the change is as follows.
![image](https://user-images.githubusercontent.com/40050810/138547656-5e3a3d41-cc83-4b82-8229-e71b974588b0.png)
![image](https://user-images.githubusercontent.com/40050810/138547661-5185623c-77b3-4e8d-b871-71868dac8121.png)
