### PR TITLE
fix(node): fix string representation of node errors

### DIFF
--- a/node/_errors.ts
+++ b/node/_errors.ts
@@ -314,6 +314,9 @@ export class NodeSyntaxError extends NodeErrorAbstraction
   constructor(code: string, message: string) {
     super(SyntaxError.prototype.name, code, message);
     Object.setPrototypeOf(this, SyntaxError.prototype);
+    this.toString = function () {
+      return `${this.name} [${this.code}]: ${this.message}`;
+    };
   }
 }
 
@@ -321,6 +324,9 @@ export class NodeRangeError extends NodeErrorAbstraction {
   constructor(code: string, message: string) {
     super(RangeError.prototype.name, code, message);
     Object.setPrototypeOf(this, RangeError.prototype);
+    this.toString = function () {
+      return `${this.name} [${this.code}]: ${this.message}`;
+    };
   }
 }
 
@@ -328,6 +334,9 @@ export class NodeTypeError extends NodeErrorAbstraction implements TypeError {
   constructor(code: string, message: string) {
     super(TypeError.prototype.name, code, message);
     Object.setPrototypeOf(this, TypeError.prototype);
+    this.toString = function () {
+      return `${this.name} [${this.code}]: ${this.message}`;
+    };
   }
 }
 
@@ -335,6 +344,9 @@ export class NodeURIError extends NodeErrorAbstraction implements URIError {
   constructor(code: string, message: string) {
     super(URIError.prototype.name, code, message);
     Object.setPrototypeOf(this, URIError.prototype);
+    this.toString = function () {
+      return `${this.name} [${this.code}]: ${this.message}`;
+    };
   }
 }
 

--- a/node/_errors_test.ts
+++ b/node/_errors_test.ts
@@ -1,0 +1,35 @@
+import {
+  NodeRangeError,
+  NodeSyntaxError,
+  NodeTypeError,
+  NodeURIError,
+} from "./_errors.ts";
+import { assertEquals } from "../testing/asserts.ts";
+
+Deno.test("NodeSyntaxError string representation", () => {
+  assertEquals(
+    String(new NodeSyntaxError("CODE", "MESSAGE")),
+    "SyntaxError [CODE]: MESSAGE",
+  );
+});
+
+Deno.test("NodeRangeError string representation", () => {
+  assertEquals(
+    String(new NodeRangeError("CODE", "MESSAGE")),
+    "RangeError [CODE]: MESSAGE",
+  );
+});
+
+Deno.test("NodeTypeError string representation", () => {
+  assertEquals(
+    String(new NodeTypeError("CODE", "MESSAGE")),
+    "TypeError [CODE]: MESSAGE",
+  );
+});
+
+Deno.test("NodeURIError string representation", () => {
+  assertEquals(
+    String(new NodeURIError("CODE", "MESSAGE")),
+    "URIError [CODE]: MESSAGE",
+  );
+});


### PR DESCRIPTION
String representation of Node errors were wrong.

This might indirectly addresses the test failures of #1453