### PR TITLE
feat(http/file_server): add streaming support, fix empty file handling

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -285,9 +285,16 @@ Deno.test("checkURIEncodedPathTraversal", async function () {
 Deno.test("serveWithUnorthodoxFilename", async function () {
   await startFileServer();
   try {
-    const malformedRes = await fetch("http://localhost:4507/testdata/%");
-    assertEquals(malformedRes.status, 400);
-    await malformedRes.text(); // Consuming the body so that the test doesn't leak resources
+    let res = await fetch("http://localhost:4507/testdata/%");
+    assert(res.headers.has("access-control-allow-origin"));
+    assert(res.headers.has("access-control-allow-headers"));
+    assertEquals(res.status, 200);
+    let _ = await res.text();
+    res = await fetch("http://localhost:4507/testdata/test%20file.txt");
+    assert(res.headers.has("access-control-allow-origin"));
+    assert(res.headers.has("access-control-allow-headers"));
+    assertEquals(res.status, 200);
+    await res.text(); // Consuming the body so that the test doesn't leak resources
   } finally {
     await killFileServer();
   }


### PR DESCRIPTION
- Add support for streaming files for the file server using ``ReadableStream``. 
  Ranges made this a bit trickier. Without ranges, we could've simply used the new ``readableStreamFromReader`` function from the ``streams`` module to turn the file into a stream. I had to write my own ``ReadableStream``.
- Fix the issue with empty files introduced with #1028
  I also reverted the test ``"serveWithUnorthodoxFilename"`` to what it was before. The test should've catched the issue, but it was modified in that same PR to pass despite the bug.