### PR TITLE
fix(node/_tools): Better error and output logging

### DIFF
--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -61,12 +61,12 @@ for await (const file of dir) {
       ]);
       test.close();
 
-      let stdout = decoder.decode(rawOutput);
-      if (rawOutput.length) console.log(stdout);
-      if (rawStderr.length) console.error(await decoder.decode(rawStderr));
+      let stderr = decoder.decode(rawStderr);
+      if (rawStderr.length) console.error(stderr);
+      if (rawOutput.length) console.log(decoder.decode(rawOutput));
 
       if (status.code !== 0) {
-        fail(stdout);
+        fail(stderr);
       }
     },
   });

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -1,6 +1,6 @@
 import { walk } from "../../fs/walk.ts";
 import { dirname, fromFileUrl, relative } from "../../path/mod.ts";
-import { assertEquals } from "../../testing/asserts.ts";
+import { assertEquals, fail } from "../../testing/asserts.ts";
 import { config, testList } from "./common.ts";
 
 /**
@@ -36,7 +36,9 @@ for await (const file of dir) {
   Deno.test({
     name: relative(testsFolder, file.path),
     fn: async () => {
-      const process = Deno.run({
+      // Pipe stdout in order to output each test result as Deno.test output
+      // That way the tests will respect the `--quiet` option when provided
+      const test = Deno.run({
         cwd: testsFolder,
         cmd: [
           "deno",
@@ -47,12 +49,23 @@ for await (const file of dir) {
           "require.ts",
           file.path,
         ],
+        stdout: "piped",
       });
 
-      const { code } = await process.status();
-      process.close();
+      const [rawOutput, status] = await Promise.all([
+        test.output(),
+        test.status(),
+      ]);
+      test.close();
 
-      assertEquals(code, 0);
+      let output = new TextDecoder().decode(rawOutput);
+      if (rawOutput.length) {
+        console.log(output);
+      }
+
+      if (status.code !== 0) {
+        fail(output);
+      }
     },
   });
 }


### PR DESCRIPTION
This patch pipes the output from the subprocess tests to `console.log` after the test has finished. That way the test output is marked as output of Deno.test and can be ignored by passing `--quiet` instead of going directly to stdout

Before and after with `--quiet`
![image](https://user-images.githubusercontent.com/42647963/139558878-f67327c8-30e7-4fcc-912c-2908c6c71673.png)
![image](https://user-images.githubusercontent.com/42647963/139558963-f4439e72-7a95-40ec-a6de-8981f483a9fa.png)

Aditionally, the output of a failed test will be passed to a `fail` call for easier debugging

Before and after
![image](https://user-images.githubusercontent.com/42647963/139559196-85d4da1a-8099-4d09-b77c-febfaa7f1a8f.png)
![image](https://user-images.githubusercontent.com/42647963/139559206-efe22523-8042-4097-a02e-a11e79f03908.png)
