### PR TITLE
fix(collections): Prevent calling `Object.prototype.__proto__` on non-Deno platforms in collections/deep_merge.ts

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -70,6 +70,11 @@ export function deepMerge<
 
   // Iterate through each key of other object and use correct merging strategy
   for (const key of keys) {
+    // Skip preventing Object.prototype.__proto__ accessor property calls on non-Deno platforms
+    if (key === "__proto__") {
+      continue;
+    }
+
     type ResultMember = Result[typeof key];
 
     const a = record[key] as ResultMember;

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -70,7 +70,7 @@ export function deepMerge<
 
   // Iterate through each key of other object and use correct merging strategy
   for (const key of keys) {
-    // Skip preventing Object.prototype.__proto__ accessor property calls on non-Deno platforms
+    // Skip to prevent Object.prototype.__proto__ accessor property calls on non-Deno platforms
     if (key === "__proto__") {
       continue;
     }

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -79,6 +79,35 @@ Deno.test("deepMerge: prevent prototype merge", () => {
   );
 });
 
+Deno.test("deepMerge: prevent calling Object.prototype.__proto__ accessor property", () => {
+  Object.defineProperty(Object.prototype, "__proto__", {
+    get() {
+      throw new Error("Unexpected Object.prototype.__proto__ getter property call");
+    },
+    set() {
+      throw new Error("Unexpected Object.prototype.__proto__ setter property call");
+    },
+    configurable: true,
+  });
+  try {
+    assertEquals(
+      deepMerge({
+        foo: true,
+      }, {
+        bar: true,
+        ["__proto__"]: {},
+      }),
+      {
+        foo: true,
+        bar: true,
+      },
+    );
+  } finally {
+    // deno-lint-ignore no-explicit-any
+    delete (Object.prototype as any).__proto__;
+  }
+});
+
 Deno.test("deepMerge: override target (non-mergeable source)", () => {
   assertEquals(
     deepMerge({

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -82,10 +82,14 @@ Deno.test("deepMerge: prevent prototype merge", () => {
 Deno.test("deepMerge: prevent calling Object.prototype.__proto__ accessor property", () => {
   Object.defineProperty(Object.prototype, "__proto__", {
     get() {
-      throw new Error("Unexpected Object.prototype.__proto__ getter property call");
+      throw new Error(
+        "Unexpected Object.prototype.__proto__ getter property call",
+      );
     },
     set() {
-      throw new Error("Unexpected Object.prototype.__proto__ setter property call");
+      throw new Error(
+        "Unexpected Object.prototype.__proto__ setter property call",
+      );
     },
     configurable: true,
   });


### PR DESCRIPTION
On Deno, `Object.prototype.__proto__` has been removed, but not always on other platforms. As long as it is explicitly marked as browser compatible, it should be fixed.