### PR TITLE
BREAKING(http): update `serve` API

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -530,13 +530,7 @@ export class Server {
 export interface ServeInit {
   /**
    * Optionally specifies the address to listen on, in the form
-   * "host:port". The default is ":8000".
-   *
-   * If the port is omitted, `:80` is used by default for HTTP when invoking
-   * without `tls` options, and `:443` is
-   * used by default for HTTPS when invoking with `tls` options.
-   *
-   * If the host is omitted, the non-routable meta-address `0.0.0.0` is used.
+   * "host:port".
    */
   addr?: string;
 

--- a/http/server.ts
+++ b/http/server.ts
@@ -593,18 +593,29 @@ export async function serveListener(
   return await server.serve(listener);
 }
 
-/** Serve HTTP requests with the given handler
+/** Serve HTTP requests with the given handler.
+ *
+ * You can specifies `addr` option, which is the address to listen on,
+ * in the form "host:port". The default is "0.0.0.0:8000".
+ *
+ * The below example serves with the port 8000.
  *
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * serve((_req) => new Response("Hello, world"));
  * ```
  *
+ * You can change the listening address by `addr` option. The below example
+ * serves with the port 3000.
+ *
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * console.log("server is starting at localhost:3000");
  * serve((_req) => new Response("Hello, world"), { addr: ":3000" });
  * ```
+ *
+ * If `tls` option is specified, then the server serves with TLS connections with the
+ * given certificates.
  *
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
@@ -615,6 +626,9 @@ export async function serveListener(
  *   tls: { certFile, keyFile },
  * });
  * ```
+ *
+ * @param handler The handler for individual HTTP requests.
+ * @param options Optional serve options. See `ServeInit` documentation for details.
  */
 export async function serve(
   handler: Handler,

--- a/http/server.ts
+++ b/http/server.ts
@@ -754,8 +754,7 @@ export async function listenAndServe(
  * @param handler The handler for individual HTTP requests.
  * @param options Optional serve options.
  *
- * @deprecated Use `serve` instead. `serve` supports `tls` options, which starts the server with
- * TLS connections.
+ * @deprecated Use `serveTls` instead.
  */
 export async function listenAndServeTls(
   addr: string,

--- a/http/server.ts
+++ b/http/server.ts
@@ -669,6 +669,8 @@ export async function serveTls(
 }
 
 /**
+ * @deprecated Use `serve` instead.
+ *
  * Constructs a server, creates a listener on the given address, accepts
  * incoming connections, and handles requests on these connections with the
  * given handler.
@@ -697,8 +699,6 @@ export async function serveTls(
  * @param addr The address to listen on.
  * @param handler The handler for individual HTTP requests.
  * @param options Optional serve options.
- *
- * @deprecated Use `serve` instead.
  */
 export async function listenAndServe(
   addr: string,
@@ -715,6 +715,8 @@ export async function listenAndServe(
 }
 
 /**
+ * @deprecated Use `serveTls` instead.
+ *
  * Constructs a server, creates a listener on the given address, accepts
  * incoming connections, upgrades them to TLS, and handles requests on these
  * connections with the given handler.
@@ -747,8 +749,6 @@ export async function listenAndServe(
  * @param keyFile The path to the file containing the TLS private key.
  * @param handler The handler for individual HTTP requests.
  * @param options Optional serve options.
- *
- * @deprecated Use `serveTls` instead.
  */
 export async function listenAndServeTls(
   addr: string,

--- a/http/server.ts
+++ b/http/server.ts
@@ -537,13 +537,13 @@ export interface ServeInit {
  * handles requests on these connections with the given handler.
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serveListener } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *
  * const listener = Deno.listen({ port: 4505 });
  *
  * console.log("server listening on http://localhost:4505");
  *
- * await serve(listener, (request) => {
+ * await serveListener(listener, (request) => {
  *   const body = `Your user-agent is:\n\n${request.headers.get(
  *     "user-agent",
  *   ) ?? "Unknown"}`;
@@ -556,7 +556,7 @@ export interface ServeInit {
  * @param handler The handler for individual HTTP requests.
  * @param options Optional serve options.
  */
-export async function serve(
+export async function serveListener(
   listener: Deno.Listener,
   handler: Handler,
   options?: ServeInit,
@@ -568,6 +568,13 @@ export async function serve(
   }
 
   return await server.serve(listener);
+}
+
+/** Serve HTTP requests on port 8000 */
+export async function serve(handler: Handler): Promise<void> {
+  const addr = ":8000";
+  const server = new Server({ addr, handler });
+  return await server.listenAndServe();
 }
 
 /**

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -5,6 +5,7 @@ import {
   serve,
   serveListener,
   Server,
+  serveTls,
 } from "./server.ts";
 import { mockConn as createMockConn } from "./_mock_conn.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
@@ -352,19 +353,17 @@ Deno.test("serve should not throw if abort when the server is already closed", a
   }
 });
 
-Deno.test("serve (with tls options) should not throw if abort when the server is already closed", async () => {
+Deno.test("serveTls should not throw if abort when the server is already closed", async () => {
   const addr = "localhost:4505";
   const certFile = join(testdataDir, "tls/localhost.crt");
   const keyFile = join(testdataDir, "tls/localhost.key");
   const handler = () => new Response();
   const abortController = new AbortController();
 
-  const servePromise = serve(handler, {
+  const servePromise = serveTls(handler, {
     addr,
-    tls: {
-      certFile,
-      keyFile,
-    },
+    certFile,
+    keyFile,
     signal: abortController.signal,
   });
 
@@ -712,12 +711,10 @@ Deno.test(`Server.listenAndServeTls should handle requests`, async () => {
   const handler = () => new Response(body, { status });
   const abortController = new AbortController();
 
-  const servePromise = serve(handler, {
+  const servePromise = serveTls(handler, {
     addr,
-    tls: {
-      certFile,
-      keyFile,
-    },
+    certFile,
+    keyFile,
     signal: abortController.signal,
   });
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -2,8 +2,7 @@
 import {
   _parseAddrFromStr,
   ConnInfo,
-  listenAndServe,
-  listenAndServeTls,
+  serve,
   serveListener,
   Server,
 } from "./server.ts";
@@ -334,12 +333,13 @@ Deno.test("serve should not throw if abort when the server is already closed", a
   }
 });
 
-Deno.test("listenAndServe should not throw if abort when the server is already closed", async () => {
+Deno.test("serve should not throw if abort when the server is already closed", async () => {
   const addr = "localhost:4505";
   const handler = () => new Response();
   const abortController = new AbortController();
 
-  const servePromise = listenAndServe(addr, handler, {
+  const servePromise = serve(handler, {
+    addr,
     signal: abortController.signal,
   });
 
@@ -352,14 +352,19 @@ Deno.test("listenAndServe should not throw if abort when the server is already c
   }
 });
 
-Deno.test("listenAndServeTls should not throw if abort when the server is already closed", async () => {
+Deno.test("serve (with tls options) should not throw if abort when the server is already closed", async () => {
   const addr = "localhost:4505";
   const certFile = join(testdataDir, "tls/localhost.crt");
   const keyFile = join(testdataDir, "tls/localhost.key");
   const handler = () => new Response();
   const abortController = new AbortController();
 
-  const servePromise = listenAndServeTls(addr, certFile, keyFile, handler, {
+  const servePromise = serve(handler, {
+    addr,
+    tls: {
+      certFile,
+      keyFile,
+    },
     signal: abortController.signal,
   });
 
@@ -617,7 +622,7 @@ Deno.test(`serve should handle requests`, async () => {
   }
 });
 
-Deno.test(`listenAndServe should handle requests`, async () => {
+Deno.test(`serve should handle requests`, async () => {
   const addr = "localhost:4505";
   const url = `http://${addr}`;
   const status = 418;
@@ -627,7 +632,8 @@ Deno.test(`listenAndServe should handle requests`, async () => {
   const handler = () => new Response(body, { status });
   const abortController = new AbortController();
 
-  const servePromise = listenAndServe(addr, handler, {
+  const servePromise = serve(handler, {
+    addr,
     signal: abortController.signal,
   });
 
@@ -641,19 +647,22 @@ Deno.test(`listenAndServe should handle requests`, async () => {
   }
 });
 
-Deno.test(`listenAndServe should handle websocket requests`, async () => {
+Deno.test(`serve should handle websocket requests`, async () => {
   const addr = "localhost:4505";
   const url = `ws://${addr}`;
   const message = `${url} - Hello Deno on WebSocket!`;
 
   const abortController = new AbortController();
 
-  const servePromise = listenAndServe(addr, (request) => {
+  const servePromise = serve((request) => {
     const { socket, response } = Deno.upgradeWebSocket(request);
     // Return the received message as it is
     socket.onmessage = (event) => socket.send(event.data);
     return response;
-  }, abortController);
+  }, {
+    addr,
+    signal: abortController.signal,
+  });
 
   const ws = new WebSocket(url);
   try {
@@ -683,7 +692,12 @@ Deno.test(`Server.listenAndServeTls should handle requests`, async () => {
   const handler = () => new Response(body, { status });
   const abortController = new AbortController();
 
-  const servePromise = listenAndServeTls(addr, certFile, keyFile, handler, {
+  const servePromise = serve(handler, {
+    addr,
+    tls: {
+      certFile,
+      keyFile,
+    },
     signal: abortController.signal,
   });
 
@@ -982,7 +996,8 @@ Deno.test("Server should be able to parse IPV6 addresses", async () => {
   const handler = () => new Response(body, { status });
   const abortController = new AbortController();
 
-  const servePromise = listenAndServe(addr, handler, {
+  const servePromise = serve(handler, {
+    addr,
     signal: abortController.signal,
   });
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -647,6 +647,26 @@ Deno.test(`serve should handle requests`, async () => {
   }
 });
 
+Deno.test(`serve listens on the port 8000 by default`, async () => {
+  const url = "http://localhost:8000";
+  const body = "Hello from port 8000";
+
+  const handler = () => new Response(body);
+  const abortController = new AbortController();
+
+  const servePromise = serve(handler, {
+    signal: abortController.signal,
+  });
+
+  try {
+    const response = await fetch(url);
+    assertEquals(await response.text(), body);
+  } finally {
+    abortController.abort();
+    await servePromise;
+  }
+});
+
 Deno.test(`serve should handle websocket requests`, async () => {
   const addr = "localhost:4505";
   const url = `ws://${addr}`;

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -4,7 +4,7 @@ import {
   ConnInfo,
   listenAndServe,
   listenAndServeTls,
-  serve,
+  serveListener,
   Server,
 } from "./server.ts";
 import { mockConn as createMockConn } from "./_mock_conn.ts";
@@ -321,7 +321,7 @@ Deno.test("serve should not throw if abort when the server is already closed", a
   const handler = () => new Response();
   const abortController = new AbortController();
 
-  const servePromise = serve(listener, handler, {
+  const servePromise = serveListener(listener, handler, {
     signal: abortController.signal,
   });
 
@@ -603,7 +603,7 @@ Deno.test(`serve should handle requests`, async () => {
   const handler = () => new Response(body, { status });
   const abortController = new AbortController();
 
-  const servePromise = serve(listener, handler, {
+  const servePromise = serveListener(listener, handler, {
     signal: abortController.signal,
   });
 


### PR DESCRIPTION
This PR supersedes #1478

This PR updates the APIs in `http/server.ts`.

`serve` now has the following signature:

```ts
async function serve(
  handler: Handler,
  options: ServeInit = {},
): Promise<void>;
```

And `ServeInit` has `addr`, `signal` (for aborting), `tls` options. The addr defaults to ":8000", so the example given in #1478 like the below works:

```ts
import { serve } from "https://deno.land/std/http/server.ts";
serve(req => new Response("Hello world"));
```

(http server starting with the port 8000 by default may look strange, but this has prior examples such as python's http.server, Django, etc. ref: https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers . Alternative default port might be 3000, 8008, 8080, etc)

This `serve` covers the use cases of `listenAndServe` and `listenAndServeTls`. So this PR also deprecates these APIs.

The original `serve` now becomes `serveListener`.