### PR TITLE
fix(node/process): warn on not implemented event instead of throw

### DIFF
--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -23,6 +23,11 @@ export function notImplemented(msg?: string): never {
   throw new Error(message);
 }
 
+export function warnNotImplemented(msg?: string): void {
+  const message = msg ? `Not implemented: ${msg}` : "Not implemented";
+  console.warn(message);
+}
+
 export type _TextDecoder = typeof TextDecoder.prototype;
 export const _TextDecoder = TextDecoder;
 

--- a/node/process.ts
+++ b/node/process.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
-import { notImplemented } from "./_utils.ts";
+import { warnNotImplemented } from "./_utils.ts";
 import { EventEmitter } from "./events.ts";
 import { fromFileUrl } from "../path/mod.ts";
 import { isWindows } from "../_util/os.ts";
@@ -385,14 +385,12 @@ class Process extends EventEmitter {
   //deno-lint-ignore ban-types
   on(event: "exit", listener: (code: number) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
-  on(event: typeof notImplementedEvents[number], listener: Function): never;
+  on(event: typeof notImplementedEvents[number], listener: Function): this;
   //deno-lint-ignore no-explicit-any
   on(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
-      notImplemented(`process.on("${event}")`);
-    }
-
-    if (event.startsWith("SIG")) {
+      warnNotImplemented(`process.on("${event}")`);
+    } else if (event.startsWith("SIG")) {
       Deno.addSignalListener(event as Deno.Signal, listener);
     } else {
       super.on(event, listener);
@@ -404,14 +402,12 @@ class Process extends EventEmitter {
   //deno-lint-ignore ban-types
   off(event: "exit", listener: (code: number) => void): this;
   off(event: string, listener: (...args: any[]) => void): this;
-  off(event: typeof notImplementedEvents[number], listener: Function): never;
+  off(event: typeof notImplementedEvents[number], listener: Function): this;
   //deno-lint-ignore no-explicit-any
   off(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
-      notImplemented(`process.off("${event}")`);
-    }
-
-    if (event.startsWith("SIG")) {
+      warnNotImplemented(`process.off("${event}")`);
+    } else if (event.startsWith("SIG")) {
       Deno.removeSignalListener(event as Deno.Signal, listener);
     } else {
       super.off(event, listener);
@@ -426,20 +422,21 @@ class Process extends EventEmitter {
   /** https://nodejs.org/api/process.html#process_process_platform */
   platform = platform;
 
-  removeAllListeners(event: string): never {
-    notImplemented(`process.removeAllListeners("${event}")`);
+  removeAllListeners(eventName?: string | symbol): this {
+    return super.removeAllListeners(eventName);
   }
 
   removeListener(
     event: typeof notImplementedEvents[number],
     //deno-lint-ignore ban-types
     listener: Function,
-  ): never;
+  ): this;
   removeListener(event: "exit", listener: (code: number) => void): this;
   //deno-lint-ignore no-explicit-any
   removeListener(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
-      notImplemented(`process.removeListener("${event}")`);
+      warnNotImplemented(`process.removeListener("${event}")`);
+      return this;
     }
 
     super.removeListener("exit", listener);

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -374,7 +374,7 @@ Deno.test("process.on, process.off, process.removeListener doesn't throw on unim
     "uncaughtException",
     "uncaughtExceptionMonitor",
     "unhandledRejection",
-  ]
+  ];
   const handler = () => {};
   events.forEach((ev) => {
     process.on(ev, handler);

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -119,13 +119,6 @@ Deno.test({
   name: "process.on",
   async fn() {
     assertEquals(typeof process.on, "function");
-    assertThrows(
-      () => {
-        process.on("uncaughtException", (_err: Error) => {});
-      },
-      Error,
-      "implemented",
-    );
 
     let triggered = false;
     process.on("exit", () => {
@@ -369,4 +362,24 @@ Deno.test({
   },
   sanitizeResources: false,
   sanitizeOps: false,
+});
+
+Deno.test("process.on, process.off, process.removeListener doesn't throw on unimplemented events", () => {
+  const events = [
+    "beforeExit",
+    "disconnect",
+    "message",
+    "multipleResolves",
+    "rejectionHandled",
+    "uncaughtException",
+    "uncaughtExceptionMonitor",
+    "unhandledRejection",
+  ]
+  const handler = () => {};
+  events.forEach((ev) => {
+    process.on(ev, handler);
+    process.off(ev, handler);
+    process.on(ev, handler);
+    process.removeListener(ev, handler);
+  });
 });


### PR DESCRIPTION
This PR changes the handling of not implemented events in process object. Currently it throws on notImplemented events but this PR changes it to just show the warnings about it.

This enables some of npm modules running in Deno compat mode (e.g. mocha)