### PR TITLE
fix(stream/web): default export with variable name

### DIFF
--- a/node/stream/web.ts
+++ b/node/stream/web.ts
@@ -28,7 +28,7 @@ export {
   _WritableStreamDefaultWriter as WritableStreamDefaultWriter,
 };
 
-export default {
+const streams = {
   ReadableStream,
   ReadableStreamDefaultReader,
   ReadableByteStreamController,
@@ -43,3 +43,5 @@ export default {
   TextEncoderStream,
   TextDecoderStream,
 };
+
+export default streams;


### PR DESCRIPTION
Importing `stream/web.ts` like this:

```ts
import streams from 'https://deno.land/std@0.113.0/node/stream/web.ts'
```

results in this:

```
error: Uncaught SyntaxError: The requested module 'https://deno.land/std@0.113.0/node/stream/web.ts' does not provide an export named 'default'
import streams from 'https://deno.land/std@0.113.0/node/stream/web.ts'
```

this PR fixes this, by using a variable name for a default export:

```sh
$ deno eval 'import streams from "https://denopkg.com/talentlessguy/deno_std@feat-stream-web-default-export-with-var-name/node/stream/web.ts"; console.log(streams)'
{
  ReadableStream: [Function: ReadableStream],
  ReadableStreamDefaultReader: [Function: ReadableStreamDefaultReader],
  ReadableByteStreamController: [Function: ReadableByteStreamController],
  ReadableStreamDefaultController: [Function: ReadableStreamDefaultController],
  TransformStream: [Function: TransformStream],
  TransformStreamDefaultController: [Function: TransformStreamDefaultController],
  WritableStream: [Function: WritableStream],
  WritableStreamDefaultWriter: [Function: WritableStreamDefaultWriter],
  WritableStreamDefaultController: [Function: WritableStreamDefaultController],
  ByteLengthQueuingStrategy: [Function: ByteLengthQueuingStrategy],
  CountQueuingStrategy: [Function: CountQueuingStrategy],
  TextEncoderStream: [Function: TextEncoderStream],
  TextDecoderStream: [Function: TextDecoderStream]
}
```