### PR TITLE
fix(http/file_server): don't require --allow-read for showing help message

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -369,9 +369,9 @@ async function serveDir(
   req: Request,
   dirPath: string,
   options: {
-    dotfiles: boolean,
-    target: string,
-  }
+    dotfiles: boolean;
+    target: string;
+  },
 ): Promise<Response> {
   const showDotfiles = options.dotfiles;
   const dirUrl = `/${posix.relative(options.target, dirPath)}`;
@@ -660,7 +660,10 @@ function main(): void {
 
       if (fileInfo.isDirectory) {
         if (dirListingEnabled) {
-          response = await serveDir(req, fsPath, { dotfiles: serverArgs.dotfiles, target });
+          response = await serveDir(req, fsPath, {
+            dotfiles: serverArgs.dotfiles,
+            target,
+          });
         } else {
           throw new Deno.errors.NotFound();
         }

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -338,9 +338,6 @@ Deno.test("printHelp", async function () {
       "run",
       "--no-check",
       "--quiet",
-      // TODO(ry) It ought to be possible to get the help output without
-      // --allow-read.
-      "--allow-read",
       "file_server.ts",
       "--help",
     ],


### PR DESCRIPTION
This PR updates `http/file_server.ts`. Now the file_server cli doesn't need `--allow-read` permission flag when `--help` flag is passed. (`read` permission was used during resolving the target. Now we resolve it after handling `--help`)