### PR TITLE
fix(node): @ts-ignore Error.captureStackTrace()

### DIFF
--- a/node/_errors.ts
+++ b/node/_errors.ts
@@ -59,6 +59,7 @@ export function hideStackFrames(fn: GenericFunction) {
 
 const captureLargerStackTrace = hideStackFrames(
   function captureLargerStackTrace(err) {
+    // @ts-ignore this function is not available in lib.dom.d.ts
     Error.captureStackTrace(err);
 
     return err;

--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -526,6 +526,7 @@ export class AssertionError extends Error {
       this.operator = operator;
     }
 
+    // @ts-ignore this function is not available in lib.dom.d.ts
     Error.captureStackTrace(this, stackStartFn || stackStartFunction);
     // Create error message including the error code in the name.
     this.stack;

--- a/node/process.ts
+++ b/node/process.ts
@@ -260,6 +260,7 @@ function createWarningObject(
     warningErr.detail = detail;
   }
 
+  // @ts-ignore this function is not available in lib.dom.d.ts
   Error.captureStackTrace(warningErr, ctor || process.emitWarning);
 
   return warningErr;


### PR DESCRIPTION
This call is not present in lib.dom.d.ts. As such, we should @ts-ignore
it.

Fixes #1523