### PR TITLE
feat(node): add wasi module

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -53,7 +53,7 @@ Deno standard library as it's a compatibility module.
 - [x] util/types _partly_
 - [ ] v8
 - [ ] vm
-- [ ] wasi
+- [x] wasi
 - [ ] webcrypto
 - [ ] worker_threads
 - [ ] zlib

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -28,6 +28,7 @@ import tty from "./tty.ts";
 import vm from "./vm.ts";
 import url from "./url.ts";
 import util from "./util.ts";
+import wasi from "./wasi.ts";
 
 // TODO(kt3k): add these modules when implemented
 // import cluster from "./cluster.ts";
@@ -73,4 +74,5 @@ export default {
   util,
   vm,
   zlib: {},
+  wasi,
 } as Record<string, unknown>;

--- a/node/wasi.ts
+++ b/node/wasi.ts
@@ -1,0 +1,3 @@
+import Context from "../wasi/snapshot_preview1.ts";
+
+export const WASI = Context

--- a/node/wasi.ts
+++ b/node/wasi.ts
@@ -1,3 +1,5 @@
 import Context from "../wasi/snapshot_preview1.ts";
 
 export const WASI = Context;
+
+export default { WASI };

--- a/node/wasi.ts
+++ b/node/wasi.ts
@@ -1,3 +1,3 @@
 import Context from "../wasi/snapshot_preview1.ts";
 
-export const WASI = Context
+export const WASI = Context;


### PR DESCRIPTION
since [Node.js WASI](https://nodejs.org/api/wasi.html#wasiinitializeinstance) is 1:1 to Deno WASI API, we can just re-export `Context`