### PR TITLE
ci: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# github folder and all project root files (readme, license, general config, etc.)
+.github/      @bartlomieju @kt3k
+/*            @bartlomieju @kt3k
+
+# deno std
+_util/        @bartlomieju @kt3k
+_wasm_crypto/ @bartlomieju @kt3k
+archive/      @bartlomieju @kt3k
+async/        @bartlomieju @kt3k
+bytes/        @bartlomieju @kt3k
+collections/  @bartlomieju @kt3k
+crypto/       @bartlomieju @kt3k
+datetime/     @bartlomieju @kt3k
+encoding/     @bartlomieju @kt3k
+examples/     @bartlomieju @kt3k
+flags/        @bartlomieju @kt3k
+fmt/          @bartlomieju @kt3k
+fs/           @bartlomieju @kt3k
+hash/         @bartlomieju @kt3k
+http/         @bartlomieju @kt3k
+io/           @bartlomieju @kt3k
+log/          @bartlomieju @kt3k
+mime/         @bartlomieju @kt3k
+node/         @bartlomieju @kt3k
+node/         @bartlomieju @kt3k
+path/         @bartlomieju @kt3k
+permissions/  @bartlomieju @kt3k
+signal/       @bartlomieju @kt3k
+streams/      @bartlomieju @kt3k
+testing/      @bartlomieju @kt3k
+textproto/    @bartlomieju @kt3k
+uuid/         @bartlomieju @kt3k
+wasi/         @bartlomieju @kt3k
+ws/           @bartlomieju @kt3k


### PR DESCRIPTION
Closes #1472

<div type='discussions-op-text'>

<sup>Originally posted by **bartlomieju** October 26, 2021</sup>
We should have a bot that automatically requests a review from one of maintainers for PRs.

In the beginning it could assign either me or kt3k</div>

This uses [GitHub's codeowners feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), which automatically request a review from maintainers depending on which files were edited. In addition, the UI will also display which reviewers will be mandated when browsing files directly on GitHub:
<img src="https://user-images.githubusercontent.com/22963968/141213445-974f4b58-fa19-4079-bc9f-dca3810feccf.png" width="200">

I'll leave bartlomieju and kt3k as suggested in initial issue
