### PR TITLE
perf: use `Array.from` instead of `new Array`

### DIFF
--- a/archive/tar_test.ts
+++ b/archive/tar_test.ts
@@ -100,7 +100,7 @@ Deno.test("appendFileWithLongNameToTarArchive", async function (): Promise<
   void
 > {
   // 9 * 15 + 13 = 148 bytes
-  const fileName = new Array(10).join("long-file-name/") + "file-name.txt";
+  const fileName = "long-file-name/".repeat(10) + "file-name.txt";
   const text = "hello tar world!";
 
   // create a tar archive

--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -31,7 +31,7 @@ export function chunk<T>(array: readonly T[], size: number): T[][] {
     return [];
   }
 
-  const ret = new Array(Math.ceil(array.length / size));
+  const ret = Array.from<T[]>({ length: Math.ceil(array.length / size) });
   let readIndex = 0;
   let writeIndex = 0;
 

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -26,8 +26,8 @@
 export function unzip<T, U>(pairs: readonly [T, U][]): [T[], U[]] {
   const { length } = pairs;
   const ret: [T[], U[]] = [
-    new Array(length),
-    new Array(length),
+    Array.from({ length: length }),
+    Array.from({ length: length }),
   ];
 
   pairs.forEach(([first, second], index) => {

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -26,8 +26,8 @@
 export function unzip<T, U>(pairs: readonly [T, U][]): [T[], U[]] {
   const { length } = pairs;
   const ret: [T[], U[]] = [
-    Array.from({ length: length }),
-    Array.from({ length: length }),
+    Array.from({ length }),
+    Array.from({ length }),
   ];
 
   pairs.forEach(([first, second], index) => {

--- a/collections/without_all_test.ts
+++ b/collections/without_all_test.ts
@@ -55,6 +55,10 @@ Deno.test({
 Deno.test({
   name: "[collection/withoutAll] leaves duplicate elements",
   fn() {
-    withoutAllTest(new Array(110).fill(3), [1], new Array(110).fill(3));
+    withoutAllTest(
+      Array.from({ length: 110 }, () => 3),
+      [1],
+      Array.from({ length: 110 }, () => 3),
+    );
   },
 });

--- a/encoding/_yaml/dumper/dumper.ts
+++ b/encoding/_yaml/dumper/dumper.ts
@@ -872,7 +872,7 @@ function getDuplicateReferences(
   for (let index = 0; index < length; index += 1) {
     state.duplicates.push(objects[duplicatesIndexes[index]]);
   }
-  state.usedDuplicates = new Array(length);
+  state.usedDuplicates = Array.from({ length: length });
 }
 
 export function dump(input: Any, options?: DumperStateOptions): string {

--- a/encoding/_yaml/dumper/dumper.ts
+++ b/encoding/_yaml/dumper/dumper.ts
@@ -872,7 +872,7 @@ function getDuplicateReferences(
   for (let index = 0; index < length; index += 1) {
     state.duplicates.push(objects[duplicatesIndexes[index]]);
   }
-  state.usedDuplicates = Array.from({ length: length });
+  state.usedDuplicates = Array.from({ length });
 }
 
 export function dump(input: Any, options?: DumperStateOptions): string {

--- a/encoding/_yaml/loader/loader.ts
+++ b/encoding/_yaml/loader/loader.ts
@@ -150,8 +150,8 @@ function charFromCodepoint(c: number): string {
   );
 }
 
-const simpleEscapeCheck = new Array(256); // integer, for fast access
-const simpleEscapeMap = new Array(256);
+const simpleEscapeCheck = Array.from<number>({ length: 256 }); // integer, for fast access
+const simpleEscapeMap = Array.from<string>({ length: 256 });
 for (let i = 0; i < 256; i++) {
   simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
   simpleEscapeMap[i] = simpleEscapeSequence(i);

--- a/encoding/_yaml/type/pairs.ts
+++ b/encoding/_yaml/type/pairs.ts
@@ -9,7 +9,7 @@ import type { Any } from "../utils.ts";
 const _toString = Object.prototype.toString;
 
 function resolveYamlPairs(data: Any[][]): boolean {
-  const result = new Array(data.length);
+  const result = Array.from({ length: data.length });
 
   for (let index = 0; index < data.length; index++) {
     const pair = data[index];
@@ -29,7 +29,7 @@ function resolveYamlPairs(data: Any[][]): boolean {
 function constructYamlPairs(data: string): Any[] {
   if (data === null) return [];
 
-  const result = new Array(data.length);
+  const result = Array.from({ length: data.length });
 
   for (let index = 0; index < data.length; index += 1) {
     const pair = data[index];

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -59,7 +59,7 @@ class Printf {
   constructor(format: string, ...args: unknown[]) {
     this.format = format;
     this.args = args;
-    this.haveSeen = new Array(args.length);
+    this.haveSeen = Array.from({ length: args.length });
     this.i = 0;
   }
 

--- a/hash/_wasm/wasm.js
+++ b/hash/_wasm/wasm.js
@@ -23,7 +23,7 @@ function getStringFromWasm0(ptr, len) {
   return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 }
 
-const heap = new Array(32).fill(undefined);
+const heap = Array.from({ length: 32 });
 
 heap.push(undefined, null, true, false);
 

--- a/io/util.ts
+++ b/io/util.ts
@@ -91,7 +91,10 @@ export async function readLong(buf: BufReader): Promise<number | null> {
  * @param d The number to be sliced
  * @param dest The sliced array
  */
-export function sliceLongToBytes(d: number, dest = new Array(8)): number[] {
+export function sliceLongToBytes(
+  d: number,
+  dest = Array.from<number>({ length: 8 }),
+): number[] {
   let big = BigInt(d);
   for (let i = 0; i < 8; i++) {
     dest[7 - i] = Number(big & 0xffn);

--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -79,7 +79,10 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
   const offset = N;
   const delta = M - N;
   const size = M + N + 1;
-  const fp = new Array(size).fill({ y: -1 });
+  const fp: FarthestPoint[] = Array.from(
+    { length: size },
+    () => ({ y: -1, id: -1 }),
+  );
   /**
    * INFO:
    * This buffer is used to save memory and improve performance.

--- a/testing/bench_test.ts
+++ b/testing/bench_test.ts
@@ -40,7 +40,7 @@ Deno.test({
     });
 
     bench(async function promiseAllFetchDenolandX10(b) {
-      const urls = new Array(10).fill("https://deno.land/");
+      const urls = Array.from({ length: 10 }, () => "https://deno.land/");
       b.start();
       await Promise.all(
         urls.map(

--- a/uuid/_common.ts
+++ b/uuid/_common.ts
@@ -42,7 +42,7 @@ export function uuidToBytes(uuid: string): number[] {
  */
 export function stringToBytes(str: string): number[] {
   str = unescape(encodeURIComponent(str));
-  const bytes = new Array(str.length);
+  const bytes = Array.from<number>({ length: str.length });
   for (let i = 0; i < str.length; i++) {
     bytes[i] = str.charCodeAt(i);
   }


### PR DESCRIPTION
This PR replaces instances of `new Array(n)` with `Array.from({ length: n })`.

This has 2 main benefits:

1. **Performance:**
   `new Array(n)` [**_always_** results in holey arrays](https://v8.dev/blog/elements-kinds#avoid-creating-holes).
   This results in very bad deoptimizations from the V8 engine.

   > Once the array is marked as holey, it remains holey forever — even if all its elements are present later!

   This can have serious performance implications for end-users. (see `chunk` and `unzip` for the most worrying instances of this)

2. **Type-safety:**
   `new Array()` returns `any[]` by default.
   This results in unsafe code which can lead to runtime errors.
   `Array.from` returns `unknown[]` by default, which ensures type-safety.

   While making this PR I discovered one bug in [`_diff.ts`](https://github.com/denoland/deno_std/blob/b15a2c285c6775373d4b5520610ec156d66cd73c/testing/_diff.ts#L82) in which a required property was missing from elements added on creation.
   All other usages of `new Array()` were implicitly `any[]`.