### PR TITLE
feat(node/util): Add `util.isDate`

### DIFF
--- a/node/_tools/suites/parallel/test-util.js
+++ b/node/_tools/suites/parallel/test-util.js
@@ -71,8 +71,7 @@ assert.strictEqual(util.isDate(Date()), false);
 assert.strictEqual(util.isDate({}), false);
 assert.strictEqual(util.isDate([]), false);
 assert.strictEqual(util.isDate(new Error()), false);
-// TODO(wafuwafu13): Enable this.
-// assert.strictEqual(util.isDate(Object.create(Date.prototype)), false);
+assert.strictEqual(util.isDate(Object.create(Date.prototype)), false);
 
 // isError
 assert.strictEqual(util.isError(new Error()), true);

--- a/node/_tools/suites/parallel/test-util.js
+++ b/node/_tools/suites/parallel/test-util.js
@@ -62,16 +62,16 @@ assert.strictEqual(util.isRegExp(new Date()), false);
 // TODO(wafuwafu13): Enable this.
 // assert.strictEqual(util.isRegExp(Object.create(RegExp.prototype)), false);
 
-// TODO(wafuwafu13): Enable this when `isDate` is ready.
 // isDate
-// assert.strictEqual(util.isDate(new Date()), true);
-// assert.strictEqual(util.isDate(new Date(0), 'foo'), true);
+assert.strictEqual(util.isDate(new Date()), true);
+assert.strictEqual(util.isDate(new Date(0), 'foo'), true);
 // TODO(wafuwafu13): Enable this when "vm" is ready.
 // assert.strictEqual(util.isDate(new (context('Date'))()), true);
-// assert.strictEqual(util.isDate(Date()), false);
-// assert.strictEqual(util.isDate({}), false);
-// assert.strictEqual(util.isDate([]), false);
-// assert.strictEqual(util.isDate(new Error()), false);
+assert.strictEqual(util.isDate(Date()), false);
+assert.strictEqual(util.isDate({}), false);
+assert.strictEqual(util.isDate([]), false);
+assert.strictEqual(util.isDate(new Error()), false);
+// TODO(wafuwafu13): Enable this.
 // assert.strictEqual(util.isDate(Object.create(Date.prototype)), false);
 
 // isError
@@ -113,7 +113,6 @@ assert.strictEqual(util.isPrimitive(Infinity), true);
 assert.strictEqual(util.isPrimitive(NaN), true);
 assert.strictEqual(util.isPrimitive(Symbol('symbol')), true);
 
-// TODO(wafuwafu13): Enable this when `isBuffer` is ready.
 // isBuffer
 // assert.strictEqual(util.isBuffer('foo'), false);
 // assert.strictEqual(util.isBuffer(Buffer.from('foo')), true);

--- a/node/_tools/suites/parallel/test-util.js
+++ b/node/_tools/suites/parallel/test-util.js
@@ -112,6 +112,7 @@ assert.strictEqual(util.isPrimitive(Infinity), true);
 assert.strictEqual(util.isPrimitive(NaN), true);
 assert.strictEqual(util.isPrimitive(Symbol('symbol')), true);
 
+// TODO(wafuwafu13): Enable this when `isBuffer` is ready.
 // isBuffer
 // assert.strictEqual(util.isBuffer('foo'), false);
 // assert.strictEqual(util.isBuffer(Buffer.from('foo')), true);

--- a/node/util.ts
+++ b/node/util.ts
@@ -103,7 +103,7 @@ export function isRegExp(value: unknown): boolean {
   return value instanceof RegExp;
 }
 
-/** @deprecated - use `value instanceof Date` instead. */
+/** @deprecated */
 export function isDate(value: unknown): boolean {
   return types.isDate(value);
 }

--- a/node/util.ts
+++ b/node/util.ts
@@ -103,6 +103,11 @@ export function isRegExp(value: unknown): boolean {
   return value instanceof RegExp;
 }
 
+/** @deprecated - use `value instanceof Date` instead. */
+export function isDate(value: unknown): boolean {
+  return value instanceof Date;
+}
+
 /** @deprecated - use `value === null || (typeof value !== "object" && typeof value !== "function")` instead. */
 export function isPrimitive(value: unknown): boolean {
   return (
@@ -279,6 +284,7 @@ export default {
   isError,
   isFunction,
   isRegExp,
+  isDate,
   isPrimitive,
   getSystemErrorName,
   deprecate,

--- a/node/util.ts
+++ b/node/util.ts
@@ -105,7 +105,7 @@ export function isRegExp(value: unknown): boolean {
 
 /** @deprecated - use `value instanceof Date` instead. */
 export function isDate(value: unknown): boolean {
-  return value instanceof Date;
+  return types.isDate(value);
 }
 
 /** @deprecated - use `value === null || (typeof value !== "object" && typeof value !== "function")` instead. */


### PR DESCRIPTION
part of: https://github.com/denoland/deno_std/issues/911

[`types`](https://github.com/nodejs/node/blob/6e1629786fe16058e0f12bc1613fae7734bff9b0/lib/util.js#L367) is come from [internalBinding](https://github.com/nodejs/node/blob/6e1629786fe16058e0f12bc1613fae7734bff9b0/lib/internal/util/types.js#L58) but we actually don't touch V8 APIs directly in std/node so [simulating the behavior in typescript](https://github.com/denoland/deno_std/blob/e72289d02705b7ee75227c599f95c17ffe6aeb44/node/_util/_util_types.ts#L90).

