### PR TITLE
fix(fs/walk): dont throw when encountering a symlink to a file

### DIFF
--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -126,15 +126,18 @@ export async function* walk(
       assert(entry.name != null);
       let path = join(root, entry.name);
 
+      let isFile = entry.isFile;
+
       if (entry.isSymlink) {
         if (followSymlinks) {
           path = await Deno.realPath(path);
+          isFile = await Deno.lstat(path).then((s) => s.isFile);
         } else {
           continue;
         }
       }
 
-      if (entry.isFile) {
+      if (isFile) {
         if (includeFiles && include(path, exts, match, skip)) {
           yield { path, ...entry };
         }
@@ -187,15 +190,17 @@ export function* walkSync(
     assert(entry.name != null);
     let path = join(root, entry.name);
 
+    let isFile = entry.isFile;
     if (entry.isSymlink) {
       if (followSymlinks) {
         path = Deno.realPathSync(path);
+        isFile = Deno.lstatSync(path).isFile;
       } else {
         continue;
       }
     }
 
-    if (entry.isFile) {
+    if (isFile) {
       if (includeFiles && include(path, exts, match, skip)) {
         yield { path, ...entry };
       }

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -266,6 +266,23 @@ testWalk(
   },
 );
 
+// https://github.com/denoland/deno_std/issues/1358
+testWalk(
+  async (d: string) => {
+    await Deno.mkdir(d + "/a");
+    await touch(d + "/a/x");
+    await touch(d + "/a/y");
+    await touch(d + "/b");
+    await Deno.symlink(d + "/b", d + "/a/bb");
+  },
+  async function symlinkPointsToFile() {
+    assertReady(5);
+    const files = await walkArray("a", { followSymlinks: true });
+    assertEquals(files.length, 4);
+    assert(files.some((f): boolean => f.endsWith("/b")));
+  },
+);
+
 testWalk(
   async (d: string) => {
     await Deno.mkdir(d + "/a/b", { recursive: true });


### PR DESCRIPTION
Close #1358 