### PR TITLE
chore(node): don't typecheck require module when running tests

### DIFF
--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -47,6 +47,7 @@ for await (const file of dir) {
           "-A",
           "--quiet",
           "--unstable",
+          "--no-check",
           "require.ts",
           file.path,
         ],


### PR DESCRIPTION
This change should speed up CI runs.