### PR TITLE
chore(http/file_server): migrate to serve and serveTls

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -6,7 +6,7 @@
 // https://github.com/indexzero/http-server/blob/master/test/http-server-test.js
 
 import { extname, posix } from "../path/mod.ts";
-import { listenAndServe, listenAndServeTls } from "./server.ts";
+import { serve, serveTls } from "./server.ts";
 import { Status, STATUS_TEXT } from "./http_status.ts";
 import { parse } from "../flags/mod.ts";
 import { assert } from "../_util/assert.ts";
@@ -690,9 +690,9 @@ function main(): void {
 
   if (keyFile || certFile) {
     proto += "s";
-    listenAndServeTls(addr, certFile, keyFile, handler);
+    serveTls(handler, { addr, certFile, keyFile });
   } else {
-    listenAndServe(addr, handler);
+    serve(handler, { addr });
   }
 
   console.log(


### PR DESCRIPTION
`listenAndServe` and `listenAndServeTls` have been deprecated in v0.114.0. This PR migrates them to `serve` and `serveTls`, which are new APIs.