### PR TITLE
feat(node/fs): implement `fs.rm` and `fs.rmSync`

### DIFF
--- a/node/_fs/_fs_rm.ts
+++ b/node/_fs/_fs_rm.ts
@@ -1,0 +1,50 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+type rmOptions = {
+  force?: boolean;
+  maxRetries?: number;
+  recursive?: boolean;
+  retryDelay?: number;
+};
+
+type rmCallback = (err?: Error) => void;
+
+export function rm(path: string | URL, callback: rmCallback): void;
+export function rm(
+  path: string | URL,
+  options: rmOptions,
+  callback: rmCallback,
+): void;
+export function rm(
+  path: string | URL,
+  optionsOrCallback: rmOptions | rmCallback,
+  maybeCallback?: rmCallback,
+) {
+  const callback = typeof optionsOrCallback === "function"
+    ? optionsOrCallback
+    : maybeCallback;
+  const options = typeof optionsOrCallback === "object"
+    ? optionsOrCallback
+    : undefined;
+
+  if (!callback) throw new Error("No callback function supplied");
+
+  Deno.remove(path, { recursive: options?.recursive })
+    .then((_) => callback(), (err) => {
+      if (options?.force && err instanceof Deno.errors.NotFound) {
+        callback();
+      } else {
+        callback(err);
+      }
+    });
+}
+
+export function rmSync(path: string | URL, options?: rmOptions) {
+  try {
+    Deno.removeSync(path, { recursive: options?.recursive });
+  } catch (err) {
+    if (options?.force && err instanceof Deno.errors.NotFound) {
+      return;
+    }
+    throw err;
+  }
+}

--- a/node/_fs/_fs_rm_test.ts
+++ b/node/_fs/_fs_rm_test.ts
@@ -1,0 +1,158 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+  fail,
+} from "../../testing/asserts.ts";
+import { rm, rmSync } from "./_fs_rm.ts";
+import { closeSync, existsSync } from "../fs.ts";
+import { join } from "../../path/mod.ts";
+import { isWindows } from "../../_util/os.ts";
+
+Deno.test({
+  name: "ASYNC: removing empty folder",
+  async fn() {
+    const dir = Deno.makeTempDirSync();
+    await new Promise<void>((resolve, reject) => {
+      rm(dir, (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    })
+      .then(() => assertEquals(existsSync(dir), false), () => fail())
+      .finally(() => {
+        if (existsSync(dir)) Deno.removeSync(dir);
+      });
+  },
+});
+
+function closeRes(before: Deno.ResourceMap, after: Deno.ResourceMap) {
+  for (const key in after) {
+    if (!before[key]) {
+      try {
+        closeSync(Number(key));
+      } catch (error) {
+        return error;
+      }
+    }
+  }
+}
+
+Deno.test({
+  name: "ASYNC: removing non-empty folder",
+  async fn() {
+    const rBefore = Deno.resources();
+    const dir = Deno.makeTempDirSync();
+    Deno.createSync(join(dir, "file1.txt"));
+    Deno.createSync(join(dir, "file2.txt"));
+    Deno.mkdirSync(join(dir, "some_dir"));
+    Deno.createSync(join(dir, "some_dir", "file.txt"));
+    await new Promise<void>((resolve, reject) => {
+      rm(dir, { recursive: true }, (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    })
+      .then(() => assertEquals(existsSync(dir), false), () => fail())
+      .finally(() => {
+        if (existsSync(dir)) Deno.removeSync(dir, { recursive: true });
+        const rAfter = Deno.resources();
+        closeRes(rBefore, rAfter);
+      });
+  },
+  ignore: isWindows,
+});
+
+Deno.test({
+  name: "ASYNC: removing a file",
+  async fn() {
+    const file = Deno.makeTempFileSync();
+    await new Promise<void>((resolve, reject) => {
+      rm(file, (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+
+    assertEquals(existsSync(file), false);
+  },
+});
+
+Deno.test({
+  name: "ASYNC: remove should fail if target does not exist",
+  async fn() {
+    const removePromise = new Promise<void>((resolve, reject) => {
+      rm("/path/to/noexist.text", (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+    await assertRejects(() => removePromise, Error);
+  },
+});
+
+Deno.test({
+  name:
+    "ASYNC: remove should not fail if target does not exist and force option is true",
+  async fn() {
+    await new Promise<void>((resolve, reject) => {
+      rm("/path/to/noexist.text", { force: true }, (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "SYNC: removing empty folder",
+  fn() {
+    const dir = Deno.makeTempDirSync();
+    rmSync(dir);
+    assertEquals(existsSync(dir), false);
+  },
+});
+
+Deno.test({
+  name: "SYNC: removing non-empty folder",
+  fn() {
+    const rBefore = Deno.resources();
+    const dir = Deno.makeTempDirSync();
+    Deno.createSync(join(dir, "file1.txt"));
+    Deno.createSync(join(dir, "file2.txt"));
+    Deno.mkdirSync(join(dir, "some_dir"));
+    Deno.createSync(join(dir, "some_dir", "file.txt"));
+    rmSync(dir, { recursive: true });
+    assertEquals(existsSync(dir), false);
+    // closing resources
+    const rAfter = Deno.resources();
+    closeRes(rBefore, rAfter);
+  },
+  ignore: isWindows,
+});
+
+Deno.test({
+  name: "SYNC: removing a file",
+  fn() {
+    const file = Deno.makeTempFileSync();
+
+    rmSync(file);
+
+    assertEquals(existsSync(file), false);
+  },
+});
+
+Deno.test({
+  name: "SYNC: remove should fail if target does not exist",
+  fn() {
+    assertThrows(() => rmSync("/path/to/noexist.text"), Error);
+  },
+});
+
+Deno.test({
+  name:
+    "SYNC: remove should not fail if target does not exist and force option is true",
+  fn() {
+    rmSync("/path/to/noexist.text", { force: true });
+  },
+});

--- a/node/fs.ts
+++ b/node/fs.ts
@@ -25,6 +25,7 @@ import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
 import { realpath, realpathSync } from "./_fs/_fs_realpath.ts";
 import { rename, renameSync } from "./_fs/_fs_rename.ts";
 import { rmdir, rmdirSync } from "./_fs/_fs_rmdir.ts";
+import { rm, rmSync } from "./_fs/_fs_rm.ts";
 import { stat, statSync } from "./_fs/_fs_stat.ts";
 import { symlink, symlinkSync } from "./_fs/_fs_symlink.ts";
 import { truncate, truncateSync } from "./_fs/_fs_truncate.ts";
@@ -86,6 +87,8 @@ export default {
   renameSync,
   rmdir,
   rmdirSync,
+  rm,
+  rmSync,
   stat,
   statSync,
   symlink,
@@ -151,8 +154,10 @@ export {
   realpathSync,
   rename,
   renameSync,
+  rm,
   rmdir,
   rmdirSync,
+  rmSync,
   stat,
   statSync,
   symlink,

--- a/node/fs/_fs_rm_test.ts
+++ b/node/fs/_fs_rm_test.ts
@@ -1,0 +1,73 @@
+import { assertEquals, assertRejects, fail } from "../../testing/asserts.ts";
+import { rm } from "./promises.ts";
+import { closeSync, existsSync } from "../fs.ts";
+import { join } from "../../path/mod.ts";
+import { isWindows } from "../../_util/os.ts";
+
+Deno.test({
+  name: "ASYNC: removing empty folder",
+  async fn() {
+    const dir = Deno.makeTempDirSync();
+    await rm(dir)
+      .then(() => assertEquals(existsSync(dir), false), () => fail())
+      .finally(() => {
+        if (existsSync(dir)) Deno.removeSync(dir);
+      });
+  },
+});
+
+function closeRes(before: Deno.ResourceMap, after: Deno.ResourceMap) {
+  for (const key in after) {
+    if (!before[key]) {
+      try {
+        closeSync(Number(key));
+      } catch (error) {
+        return error;
+      }
+    }
+  }
+}
+
+Deno.test({
+  name: "removing non-empty folder",
+  async fn() {
+    const rBefore = Deno.resources();
+    const dir = Deno.makeTempDirSync();
+    Deno.createSync(join(dir, "file1.txt"));
+    Deno.createSync(join(dir, "file2.txt"));
+    Deno.mkdirSync(join(dir, "some_dir"));
+    Deno.createSync(join(dir, "some_dir", "file.txt"));
+    await rm(dir, { recursive: true })
+      .then(() => assertEquals(existsSync(dir), false), () => fail())
+      .finally(() => {
+        if (existsSync(dir)) Deno.removeSync(dir, { recursive: true });
+        const rAfter = Deno.resources();
+        closeRes(rBefore, rAfter);
+      });
+  },
+  ignore: isWindows,
+});
+
+Deno.test({
+  name: "removing a file",
+  async fn() {
+    const file = Deno.makeTempFileSync();
+    await rm(file);
+    assertEquals(existsSync(file), false);
+  },
+});
+
+Deno.test({
+  name: "remove should fail if target does not exist",
+  async fn() {
+    await assertRejects(() => rm("/path/to/noexist.text"), Error);
+  },
+});
+
+Deno.test({
+  name:
+    "remove should not fail if target does not exist and force option is true",
+  async fn() {
+    await rm("/path/to/noexist.text", { force: true });
+  },
+});

--- a/node/fs/promises.ts
+++ b/node/fs/promises.ts
@@ -7,7 +7,7 @@ export const open = promisify(fs.open);
 // export const opendir = promisify(fs.opendir);
 export const rename = promisify(fs.rename);
 export const truncate = promisify(fs.truncate);
-// export const rm = promisify(fs.rm);
+export const rm = promisify(fs.rm);
 export const rmdir = promisify(fs.rmdir);
 export const mkdir = promisify(fs.mkdir);
 export const readdir = promisify(fs.readdir);
@@ -35,7 +35,7 @@ export default {
   // opendir,
   rename,
   truncate,
-  // rm,
+  rm,
   rmdir,
   mkdir,
   readdir,


### PR DESCRIPTION
this is a part of https://github.com/denoland/deno_std/pull/1564;

`fs.rmSync` need by https://github.com/nodejs/node/blob/master/test/common/tmpdir.js#L8