### PR TITLE
chore(node): Implement `internal/errors`

### DIFF
--- a/node/_tools/suites/parallel/test-util.js
+++ b/node/_tools/suites/parallel/test-util.js
@@ -31,8 +31,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
-// TODO(wafuwafu13): Enable this when "internal/errors" is ready.
-// const errors = require('internal/errors');
+const errors = require('internal/errors');
 // TODO(wafuwafu13): Enable this when "vm" is ready.
 // const context = require('vm').runInNewContext;
 
@@ -189,11 +188,10 @@ assert.strictEqual(util.isFunction('string'), false);
     util.types.isNativeError(Object.create(Error.prototype)),
     false
   );
-  // TODO(wafuwafu13): Enable this when "internal/errors" is ready.
-  // assert.strictEqual(
-  //   util.types.isNativeError(new errors.codes.ERR_IPC_CHANNEL_CLOSED()),
-  //   true
-  // );
+  assert.strictEqual(
+    util.types.isNativeError(new errors.codes.ERR_IPC_CHANNEL_CLOSED()),
+    true
+  );
 }
 
 // TODO(wafuwafu13): Enable this.

--- a/node/internal/errors.ts
+++ b/node/internal/errors.ts
@@ -1,0 +1,10 @@
+// Copyright Node.js contributors. All rights reserved. MIT License.
+import { ERR_IPC_CHANNEL_CLOSED } from "../_errors.ts";
+
+export const codes = {
+  ERR_IPC_CHANNEL_CLOSED,
+};
+
+export default {
+  codes,
+};

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -9,7 +9,7 @@ import dns from "./dns.ts";
 import events from "./events.ts";
 import fs from "./fs.ts";
 import fsPromises from "./fs/promises.ts";
-import errors from "./internal/errors.ts";
+import internalErrors from "./internal/errors.ts";
 import internalUtilInspect from "./internal/util/inspect.js";
 import internalReadlineUtils from "./internal/readline/utils.js";
 import http from "./http.ts";
@@ -58,7 +58,7 @@ export default {
   http,
   "internal/readline/utils": internalReadlineUtils,
   "internal/util/inspect": internalUtilInspect,
-  "internal/errors": errors,
+  "internal/errors": internalErrors,
   net,
   os,
   path,

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -9,6 +9,7 @@ import dns from "./dns.ts";
 import events from "./events.ts";
 import fs from "./fs.ts";
 import fsPromises from "./fs/promises.ts";
+import errors from "./internal/errors.ts";
 import internalUtilInspect from "./internal/util/inspect.js";
 import internalReadlineUtils from "./internal/readline/utils.js";
 import http from "./http.ts";
@@ -57,6 +58,7 @@ export default {
   http,
   "internal/readline/utils": internalReadlineUtils,
   "internal/util/inspect": internalUtilInspect,
+  "internal/errors": errors,
   net,
   os,
   path,


### PR DESCRIPTION
Errors defined in [`nodejs/node/lib/internal/errors`](https://github.com/nodejs/node/blob/afe460ec9e30add944056760a01d1185c6aac276/lib/internal/errors.js#L390-L408) are implemented in [`node/_errors.ts`](https://github.com/denoland/deno_std/blob/main/node/_errors.ts) and work correctly, but can't import `internal/errors` in test file like `test-util.js`.