### PR TITLE
node: add nextTick helper module

### DIFF
--- a/node/_next_tick.ts
+++ b/node/_next_tick.ts
@@ -1,0 +1,25 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// FIXME(bartlomieju): currently this implementation is buggy
+// See:
+// - https://github.com/denoland/deno_std/issues/1482
+// - https://github.com/denoland/deno/issues/12735
+
+/** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
+export function nextTick(this: unknown, cb: () => void): void;
+export function nextTick<T extends Array<unknown>>(
+  this: unknown,
+  cb: (...args: T) => void,
+  ...args: T
+): void;
+export function nextTick<T extends Array<unknown>>(
+  this: unknown,
+  cb: (...args: T) => void,
+  ...args: T
+) {
+  if (args) {
+    queueMicrotask(() => cb.call(this, ...args));
+  } else {
+    queueMicrotask(cb);
+  }
+}

--- a/node/_stream/async_iterator.ts
+++ b/node/_stream/async_iterator.ts
@@ -4,6 +4,7 @@ import finished from "./end_of_stream.ts";
 import Readable from "./readable.ts";
 import type Stream from "./stream.ts";
 import { destroyer } from "./destroy.ts";
+import { nextTick } from "../_next_tick.ts";
 
 const kLastResolve = Symbol("lastResolve");
 const kLastReject = Symbol("lastReject");
@@ -56,7 +57,7 @@ function readAndResolve(iter: ReadableStreamAsyncIterator) {
 }
 
 function onReadable(iter: ReadableStreamAsyncIterator) {
-  queueMicrotask(() => readAndResolve(iter));
+  nextTick(() => readAndResolve(iter));
 }
 
 function wrapForNext(

--- a/node/_stream/duplex.ts
+++ b/node/_stream/duplex.ts
@@ -30,7 +30,7 @@ import {
   readableAddChunk,
 } from "./duplex_internal.ts";
 import { debuglog } from "../_util/_debuglog.ts";
-
+import { nextTick } from "../_next_tick.ts";
 export { errorOrDestroy } from "./duplex_internal.ts";
 
 let debug = debuglog("stream", (fn) => {
@@ -253,7 +253,7 @@ class Duplex extends Stream {
       }
 
       if (err) {
-        queueMicrotask(() => {
+        nextTick(() => {
           const r = this._readableState;
           const w = this._writableState;
 
@@ -271,7 +271,7 @@ class Duplex extends Stream {
           }
         });
       } else {
-        queueMicrotask(() => {
+        nextTick(() => {
           const r = this._readableState;
           const w = this._writableState;
 
@@ -329,7 +329,7 @@ class Duplex extends Stream {
         if (state.length) {
           emitReadable(this);
         } else if (!state.reading) {
-          queueMicrotask(() => nReadingNextTick(this));
+          nextTick(() => nReadingNextTick(this));
         }
       }
     }
@@ -480,7 +480,7 @@ class Duplex extends Stream {
     const res = super.removeAllListeners(ev);
 
     if (ev === "readable" || ev === undefined) {
-      queueMicrotask(() => updateReadableListening(this));
+      nextTick(() => updateReadableListening(this));
     }
 
     return res;
@@ -516,7 +516,7 @@ class Duplex extends Stream {
     const res = super.removeListener.call(this, ev, fn);
 
     if (ev === "readable") {
-      queueMicrotask(() => updateReadableListening(this));
+      nextTick(() => updateReadableListening(this));
     }
 
     // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
@@ -686,7 +686,7 @@ class Duplex extends Stream {
 
     if (typeof cb === "function") {
       if (err || state.finished) {
-        queueMicrotask(() => {
+        nextTick(() => {
           (cb as (error?: Error | undefined) => void)(err);
         });
       } else {

--- a/node/_stream/duplex.ts
+++ b/node/_stream/duplex.ts
@@ -329,7 +329,7 @@ class Duplex extends Stream {
         if (state.length) {
           emitReadable(this);
         } else if (!state.reading) {
-          nextTick(() => nReadingNextTick(this));
+          nextTick(nReadingNextTick, this);
         }
       }
     }
@@ -480,7 +480,7 @@ class Duplex extends Stream {
     const res = super.removeAllListeners(ev);
 
     if (ev === "readable" || ev === undefined) {
-      nextTick(() => updateReadableListening(this));
+      nextTick(updateReadableListening, this);
     }
 
     return res;
@@ -516,7 +516,7 @@ class Duplex extends Stream {
     const res = super.removeListener.call(this, ev, fn);
 
     if (ev === "readable") {
-      nextTick(() => updateReadableListening(this));
+      nextTick(updateReadableListening, this);
     }
 
     // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
@@ -686,9 +686,10 @@ class Duplex extends Stream {
 
     if (typeof cb === "function") {
       if (err || state.finished) {
-        nextTick(() => {
-          (cb as (error?: Error | undefined) => void)(err);
-        });
+        nextTick(
+          cb as (error?: Error | undefined) => void,
+          err,
+        );
       } else {
         state[kOnFinished].push(cb);
       }

--- a/node/_stream/duplex_internal.ts
+++ b/node/_stream/duplex_internal.ts
@@ -21,6 +21,7 @@ import {
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
 } from "../_errors.ts";
 import { debuglog } from "../_util/_debuglog.ts";
+import { nextTick } from "../_next_tick.ts";
 
 let debug = debuglog("stream", (fn) => {
   debug = fn;
@@ -32,7 +33,7 @@ export function endDuplex(stream: Duplex) {
   debug("endReadable", state.endEmitted);
   if (!state.endEmitted) {
     state.ended = true;
-    queueMicrotask(() => endReadableNT(state, stream));
+    nextTick(() => endReadableNT(state, stream));
   }
 }
 
@@ -47,7 +48,7 @@ function endReadableNT(state: ReadableState, stream: Duplex) {
     stream.emit("end");
 
     if (stream.writable && stream.allowHalfOpen === false) {
-      queueMicrotask(() => endWritableNT(stream));
+      nextTick(() => endWritableNT(stream));
     } else if (state.autoDestroy) {
       // In case of duplex streams we need a way to detect
       // if the writable side is ready for autoDestroy as well.
@@ -103,7 +104,7 @@ export function errorOrDestroy(
     }
 
     if (sync) {
-      queueMicrotask(() => {
+      nextTick(() => {
         if (w.errorEmitted || r.errorEmitted) {
           return;
         }
@@ -155,7 +156,7 @@ export function finishMaybe(
     if (state.pendingcb === 0 && needFinish(state)) {
       state.pendingcb++;
       if (sync) {
-        queueMicrotask(() => finish(stream, state));
+        nextTick(() => finish(stream, state));
       } else {
         finish(stream, state);
       }
@@ -191,7 +192,7 @@ export function onwrite(stream: Duplex, er?: Error | null) {
     }
 
     if (sync) {
-      queueMicrotask(() => onwriteError(stream, state, er, cb));
+      nextTick(() => onwriteError(stream, state, er, cb));
     } else {
       onwriteError(stream, state, er, cb);
     }
@@ -213,7 +214,7 @@ export function onwrite(stream: Duplex, er?: Error | null) {
           stream: stream as unknown as Writable,
           state,
         };
-        queueMicrotask(() =>
+        nextTick(() =>
           afterWriteTick(state.afterWriteTickInfo as AfterWriteTick)
         );
       }

--- a/node/_stream/duplex_internal.ts
+++ b/node/_stream/duplex_internal.ts
@@ -33,7 +33,7 @@ export function endDuplex(stream: Duplex) {
   debug("endReadable", state.endEmitted);
   if (!state.endEmitted) {
     state.ended = true;
-    nextTick(() => endReadableNT(state, stream));
+    nextTick(endReadableNT, state, stream);
   }
 }
 
@@ -48,7 +48,7 @@ function endReadableNT(state: ReadableState, stream: Duplex) {
     stream.emit("end");
 
     if (stream.writable && stream.allowHalfOpen === false) {
-      nextTick(() => endWritableNT(stream));
+      nextTick(endWritableNT, stream);
     } else if (state.autoDestroy) {
       // In case of duplex streams we need a way to detect
       // if the writable side is ready for autoDestroy as well.
@@ -156,7 +156,7 @@ export function finishMaybe(
     if (state.pendingcb === 0 && needFinish(state)) {
       state.pendingcb++;
       if (sync) {
-        nextTick(() => finish(stream, state));
+        nextTick(finish, stream, state);
       } else {
         finish(stream, state);
       }
@@ -192,7 +192,7 @@ export function onwrite(stream: Duplex, er?: Error | null) {
     }
 
     if (sync) {
-      nextTick(() => onwriteError(stream, state, er, cb));
+      nextTick(onwriteError, stream, state, er, cb);
     } else {
       onwriteError(stream, state, er, cb);
     }
@@ -214,9 +214,7 @@ export function onwrite(stream: Duplex, er?: Error | null) {
           stream: stream as unknown as Writable,
           state,
         };
-        nextTick(() =>
-          afterWriteTick(state.afterWriteTickInfo as AfterWriteTick)
-        );
+        nextTick(afterWriteTick, state.afterWriteTickInfo as AfterWriteTick);
       }
     } else {
       afterWrite(

--- a/node/_stream/end_of_stream.ts
+++ b/node/_stream/end_of_stream.ts
@@ -11,6 +11,7 @@ import {
   ERR_STREAM_PREMATURE_CLOSE,
   NodeErrorAbstraction,
 } from "../_errors.ts";
+import { nextTick } from "../_next_tick.ts";
 
 export type StreamImplementations = Duplex | Readable | Stream | Writable;
 

--- a/node/_stream/end_of_stream.ts
+++ b/node/_stream/end_of_stream.ts
@@ -218,7 +218,7 @@ export default function eos(
   );
 
   if (closed) {
-    queueMicrotask(callback);
+    nextTick(callback);
   }
 
   return function () {

--- a/node/_stream/from.ts
+++ b/node/_stream/from.ts
@@ -3,6 +3,7 @@ import { Buffer } from "../buffer.ts";
 import Readable from "./readable.ts";
 import type { ReadableOptions } from "./readable.ts";
 import { ERR_INVALID_ARG_TYPE, ERR_STREAM_NULL_VALUES } from "../_errors.ts";
+import { nextTick } from "../_next_tick.ts";
 
 export default function from(
   // deno-lint-ignore no-explicit-any
@@ -59,8 +60,8 @@ export default function from(
     if (needToClose) {
       needToClose = false;
       close().then(
-        () => queueMicrotask(() => cb(error)),
-        (e) => queueMicrotask(() => cb(error || e)),
+        () => nextTick(() => cb(error)),
+        (e) => nextTick(() => cb(error || e)),
       );
     } else {
       cb(error);

--- a/node/_stream/from.ts
+++ b/node/_stream/from.ts
@@ -60,8 +60,8 @@ export default function from(
     if (needToClose) {
       needToClose = false;
       close().then(
-        () => nextTick(() => cb(error)),
-        (e) => nextTick(() => cb(error || e)),
+        () => nextTick(cb, error),
+        (e) => nextTick(cb, error || e),
       );
     } else {
       cb(error);

--- a/node/_stream/readable.ts
+++ b/node/_stream/readable.ts
@@ -31,6 +31,7 @@ import Writable from "./writable.ts";
 import { errorOrDestroy as errorOrDestroyWritable } from "./writable_internal.ts";
 import Duplex, { errorOrDestroy as errorOrDestroyDuplex } from "./duplex.ts";
 import { debuglog } from "../_util/_debuglog.ts";
+import { nextTick } from "../_next_tick.ts";
 
 let debug = debuglog("stream", (fn) => {
   debug = fn;
@@ -273,7 +274,7 @@ class Readable extends Stream {
 
     const endFn = doEnd ? onend : unpipe;
     if (state.endEmitted) {
-      queueMicrotask(endFn);
+      nextTick(endFn);
     } else {
       this.once("end", endFn);
     }
@@ -451,7 +452,7 @@ class Readable extends Stream {
         if (state.length) {
           emitReadable(this);
         } else if (!state.reading) {
-          queueMicrotask(() => nReadingNextTick(this));
+          nextTick(() => nReadingNextTick(this));
         }
       }
     }
@@ -489,7 +490,7 @@ class Readable extends Stream {
     const res = super.removeListener.call(this, ev, fn);
 
     if (ev === "readable") {
-      queueMicrotask(() => updateReadableListening(this));
+      nextTick(() => updateReadableListening(this));
     }
 
     // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
@@ -617,7 +618,7 @@ class Readable extends Stream {
     const res = super.removeAllListeners(ev);
 
     if (ev === "readable" || ev === undefined) {
-      queueMicrotask(() => updateReadableListening(this));
+      nextTick(() => updateReadableListening(this));
     }
 
     return res;

--- a/node/_stream/readable.ts
+++ b/node/_stream/readable.ts
@@ -452,7 +452,7 @@ class Readable extends Stream {
         if (state.length) {
           emitReadable(this);
         } else if (!state.reading) {
-          nextTick(() => nReadingNextTick(this));
+          nextTick(nReadingNextTick, this);
         }
       }
     }
@@ -490,7 +490,7 @@ class Readable extends Stream {
     const res = super.removeListener.call(this, ev, fn);
 
     if (ev === "readable") {
-      nextTick(() => updateReadableListening(this));
+      nextTick(updateReadableListening, this);
     }
 
     // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
@@ -618,7 +618,7 @@ class Readable extends Stream {
     const res = super.removeAllListeners(ev);
 
     if (ev === "readable" || ev === undefined) {
-      nextTick(() => updateReadableListening(this));
+      nextTick(updateReadableListening, this);
     }
 
     return res;

--- a/node/_stream/readable_internal.ts
+++ b/node/_stream/readable_internal.ts
@@ -115,7 +115,7 @@ export function emitReadable(stream: Duplex | Readable) {
   if (!state.emittedReadable) {
     debug("emitReadable", state.flowing);
     state.emittedReadable = true;
-    nextTick(() => emitReadable_(stream));
+    nextTick(emitReadable_, stream);
   }
 }
 
@@ -139,7 +139,7 @@ export function endReadable(stream: Readable) {
   debug("endReadable", state.endEmitted);
   if (!state.endEmitted) {
     state.ended = true;
-    nextTick(() => endReadableNT(state, stream));
+    nextTick(endReadableNT, state, stream);
   }
 }
 

--- a/node/_stream/readable_internal.ts
+++ b/node/_stream/readable_internal.ts
@@ -11,6 +11,7 @@ import {
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
 } from "../_errors.ts";
 import { debuglog } from "../_util/_debuglog.ts";
+import { nextTick } from "../_next_tick.ts";
 
 let debug = debuglog("stream", (fn) => {
   debug = fn;
@@ -40,7 +41,7 @@ export function _destroy(
     }
 
     if (err) {
-      queueMicrotask(() => {
+      nextTick(() => {
         if (!r.errorEmitted) {
           r.errorEmitted = true;
           self.emit("error", err);
@@ -51,7 +52,7 @@ export function _destroy(
         }
       });
     } else {
-      queueMicrotask(() => {
+      nextTick(() => {
         r.closeEmitted = true;
         if (r.emitClose) {
           self.emit("close");
@@ -114,7 +115,7 @@ export function emitReadable(stream: Duplex | Readable) {
   if (!state.emittedReadable) {
     debug("emitReadable", state.flowing);
     state.emittedReadable = true;
-    queueMicrotask(() => emitReadable_(stream));
+    nextTick(() => emitReadable_(stream));
   }
 }
 
@@ -138,7 +139,7 @@ export function endReadable(stream: Readable) {
   debug("endReadable", state.endEmitted);
   if (!state.endEmitted) {
     state.ended = true;
-    queueMicrotask(() => endReadableNT(state, stream));
+    nextTick(() => endReadableNT(state, stream));
   }
 }
 
@@ -178,7 +179,7 @@ export function errorOrDestroy(
       r.errored = err;
     }
     if (sync) {
-      queueMicrotask(() => {
+      nextTick(() => {
         if (!r.errorEmitted) {
           r.errorEmitted = true;
           stream.emit("error", err);
@@ -249,7 +250,7 @@ export function howMuchToRead(n: number, state: ReadableState) {
 export function maybeReadMore(stream: Readable, state: ReadableState) {
   if (!state.readingMore && state.constructed) {
     state.readingMore = true;
-    queueMicrotask(() => maybeReadMore_(stream, state));
+    nextTick(() => maybeReadMore_(stream, state));
   }
 }
 
@@ -421,7 +422,7 @@ export function readableAddChunk(
 export function resume(stream: Duplex | Readable, state: ReadableState) {
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
-    queueMicrotask(() => resume_(stream, state));
+    nextTick(() => resume_(stream, state));
   }
 }
 

--- a/node/_stream/writable.ts
+++ b/node/_stream/writable.ts
@@ -248,7 +248,7 @@ class Writable extends Stream {
   destroy(err?: Error | null, cb?: () => void) {
     const state = this._writableState;
     if (!state.destroyed) {
-      nextTick(() => errorBuffer(state));
+      nextTick(errorBuffer, state);
     }
     destroy.call(this, err, cb);
     return this;
@@ -308,9 +308,10 @@ class Writable extends Stream {
 
     if (typeof cb === "function") {
       if (err || state.finished) {
-        nextTick(() => {
-          (cb as (error?: Error | undefined) => void)(err);
-        });
+        nextTick(
+          cb as (error?: Error | undefined) => void,
+          err,
+        );
       } else {
         state[kOnFinished].push(cb);
       }
@@ -405,7 +406,7 @@ class Writable extends Stream {
     }
 
     if (err) {
-      nextTick(() => cb(err));
+      nextTick(cb, err);
       errorOrDestroy(this, err, true);
       return false;
     }

--- a/node/_stream/writable.ts
+++ b/node/_stream/writable.ts
@@ -27,6 +27,7 @@ import {
   writeOrBuffer,
 } from "./writable_internal.ts";
 import type { Encodings } from "../_utils.ts";
+import { nextTick } from "../_next_tick.ts";
 
 export type WritableEncodings = Encodings | "buffer";
 
@@ -247,7 +248,7 @@ class Writable extends Stream {
   destroy(err?: Error | null, cb?: () => void) {
     const state = this._writableState;
     if (!state.destroyed) {
-      queueMicrotask(() => errorBuffer(state));
+      nextTick(() => errorBuffer(state));
     }
     destroy.call(this, err, cb);
     return this;
@@ -307,7 +308,7 @@ class Writable extends Stream {
 
     if (typeof cb === "function") {
       if (err || state.finished) {
-        queueMicrotask(() => {
+        nextTick(() => {
           (cb as (error?: Error | undefined) => void)(err);
         });
       } else {
@@ -404,7 +405,7 @@ class Writable extends Stream {
     }
 
     if (err) {
-      queueMicrotask(() => cb(err));
+      nextTick(() => cb(err));
       errorOrDestroy(this, err, true);
       return false;
     }

--- a/node/_stream/writable_internal.ts
+++ b/node/_stream/writable_internal.ts
@@ -4,6 +4,7 @@ import type Writable from "./writable.ts";
 import type { WritableState } from "./writable.ts";
 import { kDestroy } from "./symbols.ts";
 import { ERR_MULTIPLE_CALLBACK, ERR_STREAM_DESTROYED } from "../_errors.ts";
+import { nextTick } from "../_next_tick.ts";
 
 export type writeV = (
   // deno-lint-ignore no-explicit-any
@@ -44,7 +45,7 @@ function _destroy(
     }
 
     if (err) {
-      queueMicrotask(() => {
+      nextTick(() => {
         if (!w.errorEmitted) {
           w.errorEmitted = true;
           self.emit("error", err);
@@ -55,7 +56,7 @@ function _destroy(
         }
       });
     } else {
-      queueMicrotask(() => {
+      nextTick(() => {
         w.closeEmitted = true;
         if (w.emitClose) {
           self.emit("close");
@@ -248,7 +249,7 @@ export function errorOrDestroy(stream: Writable, err: Error, sync = false) {
       w.errored = err;
     }
     if (sync) {
-      queueMicrotask(() => {
+      nextTick(() => {
         if (w.errorEmitted) {
           return;
         }
@@ -294,7 +295,7 @@ export function finishMaybe(
     if (state.pendingcb === 0 && needFinish(state)) {
       state.pendingcb++;
       if (sync) {
-        queueMicrotask(() => finish(stream, state));
+        nextTick(() => finish(stream, state));
       } else {
         finish(stream, state);
       }
@@ -358,7 +359,7 @@ export function onwrite(stream: Writable, er?: Error | null) {
     }
 
     if (sync) {
-      queueMicrotask(() => onwriteError(stream, state, er, cb));
+      nextTick(() => onwriteError(stream, state, er, cb));
     } else {
       onwriteError(stream, state, er, cb);
     }
@@ -380,7 +381,7 @@ export function onwrite(stream: Writable, er?: Error | null) {
           stream,
           state,
         };
-        queueMicrotask(() =>
+        nextTick(() =>
           afterWriteTick(state.afterWriteTickInfo as AfterWriteTick)
         );
       }
@@ -408,7 +409,7 @@ export function prefinish(stream: Writable, state: WritableState) {
           state.prefinished = true;
           stream.emit("prefinish");
           state.pendingcb++;
-          queueMicrotask(() => finish(stream, state));
+          nextTick(() => finish(stream, state));
         }
       });
       state.sync = false;

--- a/node/_stream/writable_internal.ts
+++ b/node/_stream/writable_internal.ts
@@ -295,7 +295,7 @@ export function finishMaybe(
     if (state.pendingcb === 0 && needFinish(state)) {
       state.pendingcb++;
       if (sync) {
-        nextTick(() => finish(stream, state));
+        nextTick(finish, stream, state);
       } else {
         finish(stream, state);
       }
@@ -359,7 +359,7 @@ export function onwrite(stream: Writable, er?: Error | null) {
     }
 
     if (sync) {
-      nextTick(() => onwriteError(stream, state, er, cb));
+      nextTick(onwriteError, stream, state, er, cb);
     } else {
       onwriteError(stream, state, er, cb);
     }
@@ -381,8 +381,9 @@ export function onwrite(stream: Writable, er?: Error | null) {
           stream,
           state,
         };
-        nextTick(() =>
-          afterWriteTick(state.afterWriteTickInfo as AfterWriteTick)
+        nextTick(
+          afterWriteTick,
+          state.afterWriteTickInfo as AfterWriteTick,
         );
       }
     } else {
@@ -409,7 +410,7 @@ export function prefinish(stream: Writable, state: WritableState) {
           state.prefinished = true;
           stream.emit("prefinish");
           state.pendingcb++;
-          nextTick(() => finish(stream, state));
+          nextTick(finish, stream, state);
         }
       });
       state.sync = false;

--- a/node/_util/_util_callbackify.ts
+++ b/node/_util/_util_callbackify.ts
@@ -22,6 +22,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // These are simplified versions of the "real" errors in Node.
+
+import { nextTick } from "../_next_tick.ts";
+
 class NodeFalsyValueRejectionError extends Error {
   public reason: unknown;
   public code = "ERR_FALSY_VALUE_REJECTION";
@@ -101,11 +104,11 @@ function callbackify<ResultT>(
     };
     original.apply(this, args).then(
       (ret: unknown) => {
-        queueMicrotask(cb.bind(this, null, ret));
+        nextTick(cb.bind(this, null, ret));
       },
       (rej: unknown) => {
         rej = rej || new NodeFalsyValueRejectionError(rej);
-        queueMicrotask(cb.bind(this, rej));
+        nextTick(cb.bind(this, rej));
       },
     );
   };

--- a/node/child_process.ts
+++ b/node/child_process.ts
@@ -10,7 +10,7 @@ import { deferred } from "../async/deferred.ts";
 import { iterateReader, writeAll } from "../streams/conversion.ts";
 import { isWindows } from "../_util/os.ts";
 import { Buffer } from "./buffer.ts";
-
+import { nextTick } from "./_next_tick.ts";
 export class ChildProcess extends EventEmitter {
   /**
    * The exit code of the child process. This property will be `null` until the child process exits.
@@ -119,7 +119,7 @@ export class ChildProcess extends EventEmitter {
       this.stdio[1] = this.stdout;
       this.stdio[2] = this.stderr;
 
-      queueMicrotask(() => {
+      nextTick(() => {
         this.emit("spawn");
         this.#spawned.resolve();
       });
@@ -192,7 +192,7 @@ export class ChildProcess extends EventEmitter {
   }
 
   private _handleError(err: unknown): void {
-    queueMicrotask(() => {
+    nextTick(() => {
       this.emit("error", err); // TODO(uki00a) Convert `err` into nodejs's `SystemError` class.
     });
   }

--- a/node/process.ts
+++ b/node/process.ts
@@ -10,6 +10,8 @@ import { validateString } from "./_validators.ts";
 import { ERR_INVALID_ARG_TYPE } from "./_errors.ts";
 import { getOptionValue } from "./_options.ts";
 import { assert } from "../_util/assert.ts";
+import { nextTick } from "./_next_tick.ts";
+export { nextTick } from "./_next_tick.ts";
 
 const notImplementedEvents = [
   "beforeExit",
@@ -68,25 +70,6 @@ export const env: Record<string, string> = new Proxy({}, {
 
 /** https://nodejs.org/api/process.html#process_process_exit_code */
 export const exit = Deno.exit;
-
-/** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
-export function nextTick(this: unknown, cb: () => void): void;
-export function nextTick<T extends Array<unknown>>(
-  this: unknown,
-  cb: (...args: T) => void,
-  ...args: T
-): void;
-export function nextTick<T extends Array<unknown>>(
-  this: unknown,
-  cb: (...args: T) => void,
-  ...args: T
-) {
-  if (args) {
-    queueMicrotask(() => cb.call(this, ...args));
-  } else {
-    queueMicrotask(cb);
-  }
-}
 
 /** https://nodejs.org/api/process.html#process_process_pid */
 export const pid = Deno.pid;
@@ -158,7 +141,7 @@ function createWritableStdioStream(writer: typeof Deno.stdout): _Writable {
       cb(err);
       this._undestroy();
       if (!this._writableState.emitClose) {
-        queueMicrotask(() => this.emit("close"));
+        nextTick(() => this.emit("close"));
       }
     },
   }) as _Writable;

--- a/node/process.ts
+++ b/node/process.ts
@@ -10,8 +10,7 @@ import { validateString } from "./_validators.ts";
 import { ERR_INVALID_ARG_TYPE } from "./_errors.ts";
 import { getOptionValue } from "./_options.ts";
 import { assert } from "../_util/assert.ts";
-import { nextTick } from "./_next_tick.ts";
-export { nextTick } from "./_next_tick.ts";
+import { nextTick as _nextTick } from "./_next_tick.ts";
 
 const notImplementedEvents = [
   "beforeExit",
@@ -51,6 +50,9 @@ export const chdir = Deno.chdir;
 
 /** https://nodejs.org/api/process.html#process_process_cwd */
 export const cwd = Deno.cwd;
+
+/** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
+export const nextTick = _nextTick;
 
 /**
  * https://nodejs.org/api/process.html#process_process_env
@@ -141,7 +143,7 @@ function createWritableStdioStream(writer: typeof Deno.stdout): _Writable {
       cb(err);
       this._undestroy();
       if (!this._writableState.emitClose) {
-        nextTick(() => this.emit("close"));
+        _nextTick(() => this.emit("close"));
       }
     },
   }) as _Writable;
@@ -379,7 +381,7 @@ class Process extends EventEmitter {
   mainModule: any = undefined;
 
   /** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
-  nextTick = nextTick;
+  nextTick = _nextTick;
 
   /** https://nodejs.org/api/process.html#process_process_events */
   on(event: "exit", listener: (code: number) => void): this;


### PR DESCRIPTION
Towards #1482

Added a helper module so `nextTick` can be used across `std/node` instead of using
`queueMicrotask` ad hoc. Still need to provide a proper polyfill.