### PR TITLE
chore: fix jsdoc for deprecated assertThrowsSync

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -778,9 +778,10 @@ export async function assertRejects<E extends Error = Error>(
  * If it does not, then it throws.  An error class and a string that should be
  * included in the error message can also be asserted.
  *
- * @deprecated
+ * @deprecated Use assertRejects instead.
  */
-export { assertRejects as assertThrowsAsync };
+export const assertThrowsAsync = assertRejects;
+
 
 /** Use this to stub out methods that will throw when invoked. */
 export function unimplemented(msg?: string): never {


### PR DESCRIPTION
As pointed in https://github.com/denoland/deno_std/issues/1562#issuecomment-969827702, IDE didn't show the deprecation information correctly with the current way of writing jsdoc unfortunately..

This PR fixes it, and now the IDE shows deprecation information correctly.
<img width="933" alt="スクリーンショット 2021-11-16 18 52 26" src="https://user-images.githubusercontent.com/613956/141963184-53142499-fe0c-4fa9-9202-c081f865c62c.png">


