### PR TITLE
fix(node/http): improve http.Server compatibility

### DIFF
--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -1,0 +1,54 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { deferred } from "../async/deferred.ts";
+import EventEmitter from "./events.ts";
+import http from "./http.ts";
+
+Deno.test("[node/http listen]", async () => {
+  {
+    const server = http.createServer();
+    assertEquals(0, EventEmitter.listenerCount(server, "request"));
+  }
+
+  {
+    const server = http.createServer(() => {});
+    assertEquals(1, EventEmitter.listenerCount(server, "request"));
+  }
+
+  {
+    const promise = deferred<void>();
+    const server = http.createServer();
+
+    server.listen(() => {
+      server.close();
+      promise.resolve();
+    });
+
+    await promise;
+  }
+
+  {
+    const promise = deferred<void>();
+    const server = http.createServer();
+
+    server.listen().on("listening", () => {
+      server.close();
+      promise.resolve();
+    });
+
+    await promise;
+  }
+
+  for (const port of [0, -0, 0.0, "0", null, undefined]) {
+    const promise = deferred<void>();
+    const server = http.createServer();
+
+    server.listen(port, () => {
+      server.close();
+      promise.resolve();
+    });
+
+    await promise;
+  }
+});


### PR DESCRIPTION
The goal is to get http.Server in good enough shape to run Node's
benchmarks. Not quite there yet but getting closer.

This commit adds a few regression tests but those are expected to
eventually be subsumed by Node's own test suite.