### PR TITLE
chore(node/util): Convert `internal/util/inspect.js` to TypeScript

### DIFF
--- a/node/_validators.ts
+++ b/node/_validators.ts
@@ -76,19 +76,28 @@ export const validateUint32 = hideStackFrames(
   },
 );
 
-export function validateString(value: unknown, name: string) {
+export function validateString(
+  value: unknown,
+  name: string,
+): asserts value is string {
   if (typeof value !== "string") {
     throw new ERR_INVALID_ARG_TYPE(name, "string", value);
   }
 }
 
-export function validateNumber(value: unknown, name: string) {
+export function validateNumber(
+  value: unknown,
+  name: string,
+): asserts value is number {
   if (typeof value !== "number") {
     throw new ERR_INVALID_ARG_TYPE(name, "number", value);
   }
 }
 
-export function validateBoolean(value: unknown, name: string) {
+export function validateBoolean(
+  value: unknown,
+  name: string,
+): asserts value is boolean {
   if (typeof value !== "boolean") {
     throw new ERR_INVALID_ARG_TYPE(name, "boolean", value);
   }

--- a/node/internal/util/inspect.ts
+++ b/node/internal/util/inspect.ts
@@ -43,9 +43,9 @@ export function getStringWidth(str: string, removeControlChars = true): number {
   str = str.normalize("NFC");
   for (const char of str[Symbol.iterator]()) {
     const code = char.codePointAt(0);
-    if (isFullWidthCodePoint(code!)) {
+    if (code && isFullWidthCodePoint(code)) {
       width += 2;
-    } else if (!isZeroWidthCodePoint(code!)) {
+    } else if (code && !isZeroWidthCodePoint(code)) {
       width++;
     }
   }

--- a/node/internal/util/inspect.ts
+++ b/node/internal/util/inspect.ts
@@ -34,7 +34,7 @@ const ansi = new RegExp(ansiPattern, "g");
 /**
  * Returns the number of columns required to display the given string.
  */
-export function getStringWidth(str, removeControlChars = true) {
+export function getStringWidth(str: string, removeControlChars = true): number {
   let width = 0;
 
   if (removeControlChars) {
@@ -43,9 +43,9 @@ export function getStringWidth(str, removeControlChars = true) {
   str = str.normalize("NFC");
   for (const char of str[Symbol.iterator]()) {
     const code = char.codePointAt(0);
-    if (isFullWidthCodePoint(code)) {
+    if (isFullWidthCodePoint(code!)) {
       width += 2;
-    } else if (!isZeroWidthCodePoint(code)) {
+    } else if (!isZeroWidthCodePoint(code!)) {
       width++;
     }
   }
@@ -57,7 +57,7 @@ export function getStringWidth(str, removeControlChars = true) {
  * Returns true if the character represented by a given
  * Unicode code point is full-width. Otherwise returns false.
  */
-const isFullWidthCodePoint = (code) => {
+const isFullWidthCodePoint = (code: number): boolean => {
   // Code points are partially derived from:
   // https://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
   return code >= 0x1100 && (
@@ -95,7 +95,7 @@ const isFullWidthCodePoint = (code) => {
   );
 };
 
-const isZeroWidthCodePoint = (code) => {
+const isZeroWidthCodePoint = (code: number): boolean => {
   return code <= 0x1F || // C0 control codes
     (code >= 0x7F && code <= 0x9F) || // C1 control codes
     (code >= 0x300 && code <= 0x36F) || // Combining Diacritical Marks
@@ -110,7 +110,7 @@ const isZeroWidthCodePoint = (code) => {
 /**
  * Remove all VT control characters. Use to estimate displayed string width.
  */
-export function stripVTControlCharacters(str) {
+export function stripVTControlCharacters(str: unknown): string {
   validateString(str, "str");
 
   return str.replace(ansi, "");

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -10,7 +10,7 @@ import events from "./events.ts";
 import fs from "./fs.ts";
 import fsPromises from "./fs/promises.ts";
 import internalErrors from "./internal/errors.ts";
-import internalUtilInspect from "./internal/util/inspect.js";
+import internalUtilInspect from "./internal/util/inspect.ts";
 import internalReadlineUtils from "./internal/readline/utils.js";
 import http from "./http.ts";
 import net from "./net.ts";

--- a/node/util.ts
+++ b/node/util.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import { promisify } from "./_util/_util_promisify.ts";
 import { callbackify } from "./_util/_util_callbackify.ts";
-import { stripVTControlCharacters } from "./internal/util/inspect.js";
+import { stripVTControlCharacters } from "./internal/util/inspect.ts";
 import { ERR_INVALID_ARG_TYPE, ERR_OUT_OF_RANGE, errorMap } from "./_errors.ts";
 import * as types from "./_util/_util_types.ts";
 import { Buffer } from "./buffer.ts";


### PR DESCRIPTION
I want to define `util.inspect` written in TS at `internal/util/inspect`. ( https://github.com/denoland/deno_std/pull/1592 is in progress.)