### PR TITLE
fix(docs): Added correct plural case for word "title"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Before opening a PR make sure to:
 
 Give the PR a descriptive title.
 
-Examples of good title:
+Examples of good titles:
 
 - fix(http): Fix race condition in server
 - docs(fmt): Update docstrings
 - feat(log): Handle nested messages
 
-Examples of bad title:
+Examples of bad titles:
 
 - fix #7123
 - update docs


### PR DESCRIPTION
No production code changed

This is a minor edit to documentation in order to fix a grammar issue.