### PR TITLE
fix(fmt): print with rounding taken into account

### DIFF
--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -503,12 +503,6 @@ class Printf {
    * @param fractional
    * @param precision
    * @returns tuple of fractional and round
-   * ```ts
-   * //inner of class Printf
-   * assertEquals(this.roundFractionToPrecision("3",3), ["300",false]);
-   * assertEquals(this.roundFractionToPrecision("33456",3), ["335",false]);
-   * assertEquals(this.roundFractionToPrecision("99999",3), ["000",true]);
-   * ```
    */
   roundFractionToPrecision(
     fractional: string,

--- a/fmt/printf_test.ts
+++ b/fmt/printf_test.ts
@@ -108,6 +108,8 @@ Deno.test("testFloate", function (): void {
   assertEquals(S("%e", -4.1), "-4.100000e+00");
   assertEquals(S("%e", Number.MAX_SAFE_INTEGER), "9.007199e+15");
   assertEquals(S("%e", Number.MIN_SAFE_INTEGER), "-9.007199e+15");
+  assertEquals(S("%.3e", 1.9999), "2.000e+00");
+  assertEquals(S("%.3e", 29.99999), "3.000e+01");
 });
 Deno.test("testFloatE", function (): void {
   assertEquals(S("%E", 4), "4.000000E+00");
@@ -146,6 +148,8 @@ Deno.test("testFloatfF", function (): void {
     S("%F", Number.MAX_VALUE),
     "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000",
   );
+  assertEquals(S("%.3f", 0.9999), "1.000");
+  assertEquals(S("%.3f", 1.9999), "2.000");
 });
 
 Deno.test("testString", function (): void {


### PR DESCRIPTION
Currently `printf` behaves as seen in the following block.
```ts
import {printf} from "https://deno.land/std/fmt/printf.ts";
printf("%.3f",0.9999);
//it print 0.000
printf("%.1f\n",0.99);
//it print 0.0
printf("%.3f\n",1.9999);
//it print 1.000
```
The reason for this behavior is that `roundFractionToPrecision` ignores the carry.
so, I fixed it.