### PR TITLE
fix(node): use async read for stdin

### DIFF
--- a/node/_process/streams.ts
+++ b/node/_process/streams.ts
@@ -38,6 +38,8 @@ export const stdin = new Readable({
     const p = Buffer.alloc(size || 16 * 1024);
     Deno.stdin.read(p).then((length) => {
       this.push(length === null ? null : p.slice(0, length));
+    }, (error) => {
+      this.destroy(error);
     });
   },
 }) as _Readable;

--- a/node/_process/streams.ts
+++ b/node/_process/streams.ts
@@ -36,8 +36,9 @@ export const stdin = new Readable({
   emitClose: false,
   read(this: Readable, size: number) {
     const p = Buffer.alloc(size || 16 * 1024);
-    const length = Deno.stdin.readSync(p);
-    this.push(length === null ? null : p.slice(0, length));
+    Deno.stdin.read(p).then((length) => {
+      this.push(length === null ? null : p.slice(0, length));
+    });
   },
 }) as _Readable;
 stdin.on("close", () => Deno.stdin.close());


### PR DESCRIPTION
This change makes [`enquirer`](https://github.com/enquirer/enquirer) work in compat mode.