### PR TITLE
refactor(node/url): Move `toPathIfFileURL` to internal

### DIFF
--- a/node/internal/fs/utils.js
+++ b/node/internal/fs/utils.js
@@ -18,7 +18,7 @@ import {
   isUint8Array,
 } from "../util/types.ts";
 import { once } from "../util.ts";
-import { toPathIfFileURL } from "../../url.ts";
+import { toPathIfFileURL } from "../url.ts";
 import {
   validateAbortSignal,
   validateBoolean,

--- a/node/internal/url.ts
+++ b/node/internal/url.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "../url.ts";
+
+export function toPathIfFileURL(fileURLOrPath: string | URL) {
+  if (!(fileURLOrPath instanceof URL)) {
+    return fileURLOrPath;
+  }
+  return fileURLToPath(fileURLOrPath);
+}
+
+export default {
+  toPathIfFileURL,
+};

--- a/node/url.ts
+++ b/node/url.ts
@@ -188,13 +188,6 @@ function getPathFromURLPosix(url: URL): string {
   return decodeURIComponent(pathname);
 }
 
-export function toPathIfFileURL(fileURLOrPath: string | URL) {
-  if (!(fileURLOrPath instanceof URL)) {
-    return fileURLOrPath;
-  }
-  return fileURLToPath(fileURLOrPath);
-}
-
 /**
  *  The following characters are percent-encoded when converting from file path
  *  to URL:
@@ -332,7 +325,6 @@ export default {
   format,
   fileURLToPath,
   pathToFileURL,
-  toPathIfFileURL,
   urlToHttpOptions,
   URL,
 };


### PR DESCRIPTION
[toPathIfFileURL](https://github.com/nodejs/node/blob/d81f328aa5b02397f7eac99389f28b951366c438/lib/internal/url.js#L1548) is not public API.