### PR TITLE
fix(node/util/inspect): Validate invalid options

### DIFF
--- a/node/_tools/suites/parallel/test-util-inspect.js
+++ b/node/_tools/suites/parallel/test-util-inspect.js
@@ -1556,27 +1556,25 @@ if (typeof Symbol !== 'undefined') {
     JSON.stringify(oldOptions)
   );
 
-  // TODO(wafuwafu13): Fix
-  // assert.throws(() => {
-  //   util.inspect.defaultOptions = null;
-  // }, {
-  //   code: 'ERR_INVALID_ARG_TYPE',
-  //   name: 'TypeError',
-  //   message: 'The "options" argument must be of type object. ' +
-  //            'Received null'
-  // }
-  // );
+  assert.throws(() => {
+    util.inspect.defaultOptions = null;
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options" argument must be of type object. ' +
+             'Received null'
+  }
+  );
 
-  // TODO(wafuwafu13): Fix
-  // assert.throws(() => {
-  //   util.inspect.defaultOptions = 'bad';
-  // }, {
-  //   code: 'ERR_INVALID_ARG_TYPE',
-  //   name: 'TypeError',
-  //   message: 'The "options" argument must be of type object. ' +
-  //            "Received type string ('bad')"
-  // }
-  // );
+  assert.throws(() => {
+    util.inspect.defaultOptions = 'bad';
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options" argument must be of type object. ' +
+             "Received type string ('bad')"
+  }
+  );
 }
 
 util.inspect(process);

--- a/node/internal/util/inspect.js
+++ b/node/internal/util/inspect.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import * as types from "./types.ts";
-import { validateString } from "../validators.js";
+import { validateObject, validateString } from "../validators.js";
 
 import {
   ALL_PROPERTIES,
@@ -216,8 +216,7 @@ Object.defineProperty(inspect, "defaultOptions", {
     return inspectDefaultOptions;
   },
   set(options) {
-    // TODO(wafuwafu13): Validate
-    // validateObject(options, 'options');
+    validateObject(options, "options");
     return Object.assign(inspectDefaultOptions, options);
   },
 });


### PR DESCRIPTION
`validateObject` is added when https://github.com/denoland/deno_std/pull/1632 is merged.