### PR TITLE
chore(node): show the command to repeat single test

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -132,28 +132,10 @@ $ deno test --allow-read --allow-run node/_tools/test.ts
 If you want to run specific tests in a local environment, try one of the
 following:
 
-- Use `node/_tools/require.ts` as follows(recommended):
+- Use `node/_tools/require.ts` as follows:
 
 ```zsh
 $ deno run -A --unstable node/_tools/require.ts /Abs/path/to/deno_std/node/_tools/suites/parallel/test-event-emitter-check-listener-leaks.js
-```
-
-- Add `--only` flag to the `node/_tools/config.json`.
-
-```json
-...
-  "tests": {
-    ...
-    "parallel": [
-      ...
-      "test-event-emitter-add-listeners.js",
-      "test-event-emitter-check-listener-leaks.js --only",
-      "test-event-emitter-invalid-listener.js",
-      ...
-    ]
-    ...
-  }
-...
 ```
 
 The test should be passing with the latest deno, so if the test fails, try the

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -1,5 +1,6 @@
 import { walk } from "../../fs/walk.ts";
-import { dirname, fromFileUrl, relative } from "../../path/mod.ts";
+import { magenta } from "../../fmt/colors.ts";
+import { dirname, fromFileUrl, join, relative } from "../../path/mod.ts";
 import { fail } from "../../testing/asserts.ts";
 import { config, testList } from "./common.ts";
 
@@ -10,26 +11,10 @@ import { config, testList } from "./common.ts";
  * code for the test is reported, the test suite will fail immediately
  */
 
-const onlyFlagTestList: RegExp[] = [];
-
-function makeOnlyFlagTestList(testLists: Array<string[]>) {
-  for (const testList of testLists) {
-    const hasOnlyFlagTestList = testList.filter((filename) =>
-      filename.match("--only")
-    ).map((filename) => new RegExp(filename.replace(/ --only/, "")));
-    onlyFlagTestList.push(...hasOnlyFlagTestList);
-  }
-}
-
-makeOnlyFlagTestList([
-  ...Object.keys(config.tests).map((suite) => config.tests[suite]),
-]);
-
 const dir = walk(fromFileUrl(new URL(config.suitesFolder, import.meta.url)), {
   includeDirs: false,
-  match: onlyFlagTestList.length ? onlyFlagTestList : testList,
+  match: testList,
 });
-
 const testsFolder = dirname(fromFileUrl(import.meta.url));
 const decoder = new TextDecoder();
 
@@ -37,20 +22,20 @@ for await (const file of dir) {
   Deno.test({
     name: relative(testsFolder, file.path),
     fn: async () => {
+      const cmd = [
+        Deno.execPath(),
+        "run",
+        "-A",
+        "--quiet",
+        "--unstable",
+        "--no-check",
+        join("node", "_tools", "require.ts"),
+        file.path,
+      ];
       // Pipe stdout in order to output each test result as Deno.test output
       // That way the tests will respect the `--quiet` option when provided
       const test = Deno.run({
-        cwd: testsFolder,
-        cmd: [
-          Deno.execPath(),
-          "run",
-          "-A",
-          "--quiet",
-          "--unstable",
-          "--no-check",
-          "require.ts",
-          file.path,
-        ],
+        cmd,
         stderr: "piped",
         stdout: "piped",
       });
@@ -67,6 +52,11 @@ for await (const file of dir) {
       if (rawOutput.length) console.log(decoder.decode(rawOutput));
 
       if (status.code !== 0) {
+        console.log(`Error: "${file.path}" failed`);
+        console.log(
+          "You can repeat only this test with the command:",
+          magenta(cmd.join(" ")),
+        );
         fail(stderr);
       }
     },


### PR DESCRIPTION
With this change the test results show the command to repeat the failed single test file of node.js compat testing.

<img width="1440" alt="スクリーンショット 2021-12-05 15 20 45" src="https://user-images.githubusercontent.com/613956/144736215-97461bad-6020-4617-aee0-e3ace6c261bb.png">

This command is more efficient than `--only` feature of `node/_tools/test.ts` because of less overhead in the execution. So I now deleted `--only` feature of test runner to promote this method of running single test case.

cc @wafuwafu13 