### PR TITLE
chore: add faketime testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,19 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
+      - name: Install fakedate
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install faketime
+
       - name: Run tests canary
-        run: deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json --ignore=node/
+        run: |
+          deno test --doc --unstable --allow-all --coverage=./cov --import-map=test_import_map.json --config strict-ts44.tsconfig.json --ignore=node/
+
+      - name: Run test with the date 2021-12-31
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          faketime '2021-12-31' deno test --unstable --allow-all --import-map=test_import_map.json --config strict-ts44.tsconfig.json datetime/test_2021_12_31.ts
 
       - name: Type check browser compatible modules
         shell: bash

--- a/datetime/test_2021_12_31.ts
+++ b/datetime/test_2021_12_31.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// This file contains test cases which needs to be run at the specific date (2021-12-31)
+import { assertEquals } from "../testing/asserts.ts";
+
+Deno.test("The date is 2021-12-31", () => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  assertEquals(d, new Date(2021, 11, 31));
+});


### PR DESCRIPTION
This PR adds ability to run test with the specific date time. This is necessary for writing test for #1676