### PR TITLE
fix(toml): parse declaration correctly

### DIFF
--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -73,7 +73,7 @@ class Dumper {
         } else {
           // this is a complex array, use the inline format.
           const str = value.map((x) => this.#printAsInlineValue(x)).join(",");
-          out.push(`${prop} = [${str}]`);
+          out.push(`${this.#declaration([prop])}[${str}]`);
         }
       } else if (typeof value === "object") {
         out.push("");
@@ -210,7 +210,7 @@ class Dumper {
     return `${this.#declaration(keys)}${this.#printDate(value)}`;
   }
   #format(): string[] {
-    const rDeclaration = /(.*)\s=/;
+    const rDeclaration = /^(".*"|[^=]*)\s=/;
     const out = [];
     for (let i = 0; i < this.output.length; i++) {
       const l = this.output[i];

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -210,7 +210,7 @@ class Dumper {
     return `${this.#declaration(keys)}${this.#printDate(value)}`;
   }
   #format(): string[] {
-    const rDeclaration = /^(".*"|[^=]*)\s=/;
+    const rDeclaration = /^(\".*\"|[^=]*)\s=/;
     const out = [];
     for (let i = 0; i < this.output.length; i++) {
       const l = this.output[i];

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -526,15 +526,15 @@ Deno.test({
         },
       },
     };
-    const expected = `emptyArray = []
-mixedArray1 = [1,{b = 2}]
-mixedArray2 = [{b = 2},1]
+    const expected = `emptyArray   = []
+mixedArray1  = [1,{b = 2}]
+mixedArray2  = [{b = 2},1]
 nestedArray1 = [[{b = 1}]]
 nestedArray2 = [[[{b = 1}]]]
 nestedArray3 = [[],[{b = 1}]]
 
 [deepNested.a]
-b = [1,{c = 2,d = [{e = 3},true]}]
+b            = [1,{c = 2,d = [{e = 3},true]}]
 `;
     const actual = stringify(src);
     assertEquals(actual, expected);
@@ -671,5 +671,22 @@ Deno.test({
       Error,
       "Contains invalid whitespaces: `\\u3000`",
     );
+  },
+});
+
+// https://github.com/denoland/deno_std/issues/1067#issuecomment-907740319
+Deno.test({
+  name: "[TOML] object value contains '='",
+  fn(): void {
+    const src = {
+      "a": "a = 1",
+      "helloooooooo": 1,
+    };
+
+    const actual = stringify(src);
+    const expected = `a            = "a = 1"
+helloooooooo = 1
+`;
+    assertEquals(actual, expected);
   },
 });


### PR DESCRIPTION
This PR contains two parts.
1. origin regexp couldn't match the key correctly, see https://github.com/denoland/deno_std/issues/1067#issuecomment-907740319
2. fixes wrong test https://github.com/denoland/deno_std/blob/bfe8b128164d295bad9eb9f73250ced55b07cf4b/encoding/toml_test.ts#L513-L542