### PR TITLE
fix(datetime/tests): use expected date in assertion

### DIFF
--- a/datetime/test_2021_12_31.ts
+++ b/datetime/test_2021_12_31.ts
@@ -5,5 +5,5 @@ import { assertEquals } from "../testing/asserts.ts";
 Deno.test("The date is 2021-12-31", () => {
   const d = new Date();
   d.setHours(0, 0, 0, 0);
-  assertEquals(d, new Date(2021, 11, 31));
+  assertEquals(d, new Date(2021, 12, 31));
 });


### PR DESCRIPTION
I think this should be the correct assertion given the test's title and the [parameter in the ci](https://github.com/denoland/deno_std/blob/main/.github/workflows/ci.yml#L43).