### PR TITLE
feat(node): add mock inspector module

### DIFF
--- a/node/inspector.ts
+++ b/node/inspector.ts
@@ -1,0 +1,91 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+import { EventEmitter } from "./events.ts";
+import { notImplemented } from "./_utils.ts";
+
+const connectionSymbol = Symbol("connectionProperty");
+const messageCallbacksSymbol = Symbol("messageCallbacks");
+const nextIdSymbol = Symbol("nextId");
+const onMessageSymbol = Symbol("onMessage");
+
+class Session extends EventEmitter {
+  [connectionSymbol]: null;
+  [nextIdSymbol]: number;
+  [messageCallbacksSymbol]: Map<string, (e: Error) => void>;
+
+  constructor() {
+    super();
+    notImplemented();
+  }
+
+  /** Connects the session to the inspector back-end. */
+  connect() {
+    notImplemented();
+  }
+
+  /** Connects the session to the main thread
+   * inspector back-end. */
+  connectToMainThread() {
+    notImplemented();
+  }
+
+  [onMessageSymbol](_message: string) {
+    notImplemented();
+  }
+
+  /** Posts a message to the inspector back-end. */
+  post(
+    _method: string,
+    _params?: Record<string, unknown>,
+    _callback?: (...args: unknown[]) => void,
+  ): void {
+    notImplemented();
+  }
+
+  /** Immediately closes the session, all pending
+   * message callbacks will be called with an
+   * error.
+   */
+  disconnect() {
+    notImplemented();
+  }
+}
+
+/** Activates inspector on host and port.
+ * See https://nodejs.org/api/inspector.html#inspectoropenport-host-wait */
+function open(_port?: number, _host?: string, _wait?: boolean): void {
+  notImplemented();
+}
+
+/** Deactivate the inspector. Blocks until there are no active connections.
+ * See https://nodejs.org/api/inspector.html#inspectorclose */
+function close() {
+  notImplemented();
+}
+
+/** Return the URL of the active inspector, or undefined if there is none.
+ * See https://nodejs.org/api/inspector.html#inspectorurl */
+function url() {
+  // TODO(kt3k): returns undefined for now, which means the inspector is not activated.
+  return undefined;
+}
+
+/** Blocks until a client (existing or connected later) has sent Runtime.runIfWaitingForDebugger command.
+ * See https://nodejs.org/api/inspector.html#inspectorwaitfordebugger */
+function waitForDebugger() {
+  notImplemented();
+}
+
+const console = globalThis.console;
+
+export { close, console, open, Session, url, waitForDebugger };
+
+export default {
+  close,
+  console,
+  open,
+  Session,
+  url,
+  waitForDebugger,
+};

--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -25,6 +25,7 @@ import fs from "./fs.ts";
 import fsPromises from "./fs/promises.ts";
 import internalFsUtils from "./internal/fs/utils.js";
 import http from "./http.ts";
+import inspector from "./inspector.ts";
 import internalErrors from "./internal/errors.js";
 import internalReadlineUtils from "./internal/readline/utils.js";
 import internalStreamsAddAbortSignal from "./internal/streams/add-abort-signal.js";
@@ -81,6 +82,7 @@ export default {
   fs,
   "fs/promises": fsPromises,
   http,
+  inspector,
   "internal/errors": internalErrors,
   "internal/readline/utils": internalReadlineUtils,
   "internal/streams/add-abort-signal": internalStreamsAddAbortSignal,


### PR DESCRIPTION
This PR adds placeholder `inspector` module in std/node.

Some tools use `inspector` to check if there's active inspector automatically even when the user don't intend to use inspector (for example, ava does it https://github.com/avajs/ava/blob/c214512ddfd78530adf5f632974345396cc39e24/lib/cli.js#L121 ) This PR is useful for avoiding crashing the node compat mode in thoses cases.