### PR TITLE
feat(toml): Align keys by optional

### DIFF
--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -19,6 +19,10 @@ enum ArrayType {
   MIXED,
 }
 
+export interface FormatOptions {
+  keyAlignment?: boolean;
+}
+
 class Dumper {
   maxPad = 0;
   srcObject: Record<string, unknown>;
@@ -27,10 +31,10 @@ class Dumper {
   constructor(srcObjc: Record<string, unknown>) {
     this.srcObject = srcObjc;
   }
-  dump(): string[] {
+  dump(fmtOptions: FormatOptions = {}): string[] {
     // deno-lint-ignore no-explicit-any
     this.output = this.#printObject(this.srcObject as any);
-    this.output = this.#format();
+    this.output = this.#format(fmtOptions);
     return this.output;
   }
   #printObject(obj: Record<string, unknown>, keys: string[] = []): string[] {
@@ -209,7 +213,8 @@ class Dumper {
   #dateDeclaration(keys: string[], value: Date): string {
     return `${this.#declaration(keys)}${this.#printDate(value)}`;
   }
-  #format(): string[] {
+  #format(options: FormatOptions = {}): string[] {
+    const { keyAlignment = false } = options;
     const rDeclaration = /^(\".*\"|[^=]*)\s=/;
     const out = [];
     for (let i = 0; i < this.output.length; i++) {
@@ -223,9 +228,13 @@ class Dumper {
         }
         out.push(l);
       } else {
-        const m = rDeclaration.exec(l);
-        if (m) {
-          out.push(l.replace(m[1], m[1].padEnd(this.maxPad)));
+        if (keyAlignment) {
+          const m = rDeclaration.exec(l);
+          if (m) {
+            out.push(l.replace(m[1], m[1].padEnd(this.maxPad)));
+          } else {
+            out.push(l);
+          }
         } else {
           out.push(l);
         }
@@ -246,7 +255,12 @@ class Dumper {
 /**
  * Stringify dumps source object into TOML string and returns it.
  * @param srcObj
+ * @param [fmtOptions] format options
+ * @param [fmtOptions.keyAlignment] whether to algin key
  */
-export function stringify(srcObj: Record<string, unknown>): string {
-  return new Dumper(srcObj).dump().join("\n");
+export function stringify(
+  srcObj: Record<string, unknown>,
+  fmtOptions?: FormatOptions,
+): string {
+  return new Dumper(srcObj).dump(fmtOptions).join("\n");
 }

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -448,62 +448,62 @@ Deno.test({
       bool: true,
       bool2: false,
     };
-    const expected = `deno    = "is"
-not     = "[node]"
-regex   = "<ic*s*>"
-NANI    = "何?!"
+    const expected = `deno = "is"
+not = "[node]"
+regex = "<ic*s*>"
+NANI = "何?!"
 comment = "Comment inside # the comment"
-int1    = 99
-int2    = 42
-int3    = 0
-int4    = -17
-int5    = 1000
-int6    = 5349221
-int7    = 12345
-flt1    = 1
-flt2    = 3.1415
-flt3    = -0.01
-flt4    = 5e+22
-flt5    = 1000000
-flt6    = -0.02
-flt7    = 6.626e-34
-odt1    = 1979-05-01T07:32:00.000
-odt2    = 1979-05-27T07:32:00.000
-odt3    = 1979-05-27T07:32:00.999
-odt4    = 1979-05-27T07:32:00.000
-ld1     = 1979-05-27T00:00:00.000
-reg     = "/foo[bar]/"
-sf1     = inf
-sf2     = inf
-sf3     = -inf
-sf4     = NaN
-sf5     = NaN
-sf6     = NaN
-data    = [["gamma","delta"],[1,2]]
-hosts   = ["alpha","omega"]
-bool    = true
-bool2   = false
+int1 = 99
+int2 = 42
+int3 = 0
+int4 = -17
+int5 = 1000
+int6 = 5349221
+int7 = 12345
+flt1 = 1
+flt2 = 3.1415
+flt3 = -0.01
+flt4 = 5e+22
+flt5 = 1000000
+flt6 = -0.02
+flt7 = 6.626e-34
+odt1 = 1979-05-01T07:32:00.000
+odt2 = 1979-05-27T07:32:00.000
+odt3 = 1979-05-27T07:32:00.999
+odt4 = 1979-05-27T07:32:00.000
+ld1 = 1979-05-27T00:00:00.000
+reg = "/foo[bar]/"
+sf1 = inf
+sf2 = inf
+sf3 = -inf
+sf4 = NaN
+sf5 = NaN
+sf6 = NaN
+data = [["gamma","delta"],[1,2]]
+hosts = ["alpha","omega"]
+bool = true
+bool2 = false
 
 [foo]
-bar     = "deno"
+bar = "deno"
 
 [this.is]
-nested  = "denonono"
+nested = "denonono"
 
 ["https://deno.land/std"]
-"$"     = "doller"
+"$" = "doller"
 
 ["##".deno."https://deno.land"]
-proto   = "https"
-":80"   = "port"
+proto = "https"
+":80" = "port"
 
 [[arrayObjects]]
-stuff   = "in"
+stuff = "in"
 
 [[arrayObjects]]
 
 [[arrayObjects]]
-the     = "array"
+the = "array"
 `;
     const actual = stringify(src);
     assertEquals(actual, expected);
@@ -526,15 +526,15 @@ Deno.test({
         },
       },
     };
-    const expected = `emptyArray   = []
-mixedArray1  = [1,{b = 2}]
-mixedArray2  = [{b = 2},1]
+    const expected = `emptyArray = []
+mixedArray1 = [1,{b = 2}]
+mixedArray2 = [{b = 2},1]
 nestedArray1 = [[{b = 1}]]
 nestedArray2 = [[[{b = 1}]]]
 nestedArray3 = [[],[{b = 1}]]
 
 [deepNested.a]
-b            = [1,{c = 2,d = [{e = 3},true]}]
+b = [1,{c = 2,d = [{e = 3},true]}]
 `;
     const actual = stringify(src);
     assertEquals(actual, expected);
@@ -554,8 +554,8 @@ Deno.test({
     };
     const expected = `
 "\\"" = "\\""
-"'"  = "'"
-" "  = " "
+"'" = "'"
+" " = " "
 "\\\\" = "\\\\"
 "\\n" = "\\n"
 "\\t" = "\\t"
@@ -684,8 +684,29 @@ Deno.test({
     };
 
     const actual = stringify(src);
-    const expected = `a            = "a = 1"
+    const expected = `a = "a = 1"
 helloooooooo = 1
+`;
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "[TOML] stringfy with key alignment",
+  fn(): void {
+    const src = {
+      "a": 1,
+      "aa": 1,
+      "aaa": 1,
+      "aaaa": 1,
+      "aaaaa": 1,
+    };
+    const actual = stringify(src, { keyAlignment: true });
+    const expected = `a     = 1
+aa    = 1
+aaa   = 1
+aaaa  = 1
+aaaaa = 1
 `;
     assertEquals(actual, expected);
   },

--- a/encoding/toml_test.ts
+++ b/encoding/toml_test.ts
@@ -683,8 +683,8 @@ Deno.test({
       "helloooooooo": 1,
     };
 
-    const actual = stringify(src);
-    const expected = `a = "a = 1"
+    const actual = stringify(src, { keyAlignment: true });
+    const expected = `a            = "a = 1"
 helloooooooo = 1
 `;
     assertEquals(actual, expected);


### PR DESCRIPTION
now function `stringfy` will not align keys by default, and you could pass `{ keyAlignment : true }` to function `stringfy` as second parameter to align keys.
```ts
return stringfy(srcObj);
/*
key : value
keykey : value
keykeykey : value
*/

return stringfy(srcObj, { keyAlignment : true });
/*
key       : value
keykey    : value
keykeykey : value
*/
```

Close #1067 

