### PR TITLE
ci: fix reference error in node ci

### DIFF
--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -230,9 +230,7 @@ export async function assertCallbackErrorUncaught(
     cmd: [
       Deno.execPath(),
       "eval",
-      // TODO(kt3k): Uncomment the below option when
-      // https://github.com/denoland/deno/issues/13026 is resolved.
-      // "--no-check", // Running TSC for every one of these tests would take way too long
+      "--no-check", // Running TSC for every one of these tests would take way too long
       "--unstable",
       `${prelude ?? ""}
 

--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -230,7 +230,9 @@ export async function assertCallbackErrorUncaught(
     cmd: [
       Deno.execPath(),
       "eval",
-      "--no-check", // Running TSC for every one of these tests would take way too long
+      // TODO(kt3k): Uncomment the below option when
+      // https://github.com/denoland/deno/issues/13026 is resolved.
+      // "--no-check", // Running TSC for every one of these tests would take way too long
       "--unstable",
       `${prelude ?? ""}
 

--- a/node/internal_binding/_node.ts
+++ b/node/internal_binding/_node.ts
@@ -5,13 +5,13 @@
  * https://github.com/nodejs/node/blob/3b72788afb7365e10ae1e97c71d1f60ee29f09f2/src/node.h#L728-L738
  */
 export enum Encodings {
-  ASCII,
-  UTF8,
-  BASE64,
-  UCS2,
-  BINARY,
-  HEX,
-  BUFFER,
-  BASE64URL,
-  LATIN1 = BINARY,
+  ASCII, // 0
+  UTF8, // 1
+  BASE64, // 2
+  UCS2, // 3
+  BINARY, // 4
+  HEX, // 5
+  BUFFER, // 6
+  BASE64URL, // 7
+  LATIN1 = 4 // 4 = BINARY,
 }

--- a/node/internal_binding/_node.ts
+++ b/node/internal_binding/_node.ts
@@ -13,5 +13,5 @@ export enum Encodings {
   HEX, // 5
   BUFFER, // 6
   BASE64URL, // 7
-  LATIN1 = 4 // 4 = BINARY,
+  LATIN1 = 4, // 4 = BINARY
 }


### PR DESCRIPTION
Now the CI is blocked by the reference error in `node/internal_binding/_node.ts` (cf: https://github.com/denoland/deno_std/runs/4466763309?check_suite_focus=true ), which is probably caused by https://github.com/denoland/deno/pull/13025

~~The issue seems only happening with swc. This PR works around it by using tsc for transpiling the problematic enum~~

This PR works around the issue by avoiding using enum reference in enum definition.

reference: transpiled result in playground https://www.typescriptlang.org/play?ssl=11&ssc=1&pln=11&pc=4#code/KYDwDg9gTgLgBMAdgVwLZwKKIMYQCYCWiA5gM5wDec1AUNQIIDKAwgJKsA0cA9N3AAzU4dOAFUAKgDEAHF15wAjEJEAhJhgBsAFjl8ATMuqjmjPbrgBmQ3BWsAcvQBKATXNbrACQwANcwFZrFVFJSQxHcw1A9W1RRwAZcwB2azj6cXslAF44d3l3bNsHFw4aAF9qIA