### PR TITLE
feat(node): export fs.Stats class

### DIFF
--- a/node/fs.ts
+++ b/node/fs.ts
@@ -35,6 +35,8 @@ import { utimes, utimesSync } from "./_fs/_fs_utimes.ts";
 import { watch, watchFile } from "./_fs/_fs_watch.ts";
 import { writeFile, writeFileSync } from "./_fs/_fs_writeFile.ts";
 
+import { Stats } from "./internal/fs/utils.js";
+
 import * as promises from "./fs/promises.ts";
 
 const {
@@ -102,6 +104,7 @@ export default {
   rm,
   rmSync,
   stat,
+  Stats,
   statSync,
   symlink,
   symlinkSync,
@@ -177,6 +180,7 @@ export {
   rmdirSync,
   rmSync,
   stat,
+  Stats,
   statSync,
   symlink,
   symlinkSync,

--- a/node/internal/fs/utils.js
+++ b/node/internal/fs/utils.js
@@ -508,7 +508,7 @@ BigIntStats.prototype._checkModeProperty = function (property) {
   return (this.mode & BigInt(S_IFMT)) === BigInt(property);
 };
 
-function Stats(
+export function Stats(
   dev,
   mode,
   nlink,


### PR DESCRIPTION
This PR exports `fs.Stats` class, which is a part of public Node.js API. https://nodejs.org/api/fs.html#class-fsstats

closes #1689 