### PR TITLE
feat(node): add mock zlib module

### DIFF
--- a/node/module_all.ts
+++ b/node/module_all.ts
@@ -52,6 +52,7 @@ import url from "./url.ts";
 import util from "./util.ts";
 import vm from "./vm.ts";
 import wasi from "./wasi.ts";
+import zlib from "./zlib.ts";
 
 // TODO(kt3k): add these modules when implemented
 // import cluster from "./cluster.ts";
@@ -61,7 +62,6 @@ import wasi from "./wasi.ts";
 // import sys from "./sys.ts";
 // import tls from "./tls.ts";
 // import workerThreads from "./worker_threads.ts";
-// import zlib from "./zlib.ts";
 
 // Canonical mapping of supported modules
 export default {
@@ -110,6 +110,6 @@ export default {
   url,
   util,
   vm,
-  zlib: {},
+  zlib,
   wasi,
 } as Record<string, unknown>;

--- a/node/zlib.ts
+++ b/node/zlib.ts
@@ -1,1 +1,187 @@
-throw new Error('"zlib" is not yet implemented.');
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { notImplemented } from "./_utils.ts";
+import { zlib as constants } from "./internal_binding/constants.ts";
+export class Options {
+  constructor() {
+    notImplemented();
+  }
+}
+export class BrotliOptions {
+  constructor() {
+    notImplemented();
+  }
+}
+export class BrotliCompress {
+  constructor() {
+    notImplemented();
+  }
+}
+export class BrotliDecompress {
+  constructor() {
+    notImplemented();
+  }
+}
+export class Deflate {
+  constructor() {
+    notImplemented();
+  }
+}
+export class DeflateRaw {
+  constructor() {
+    notImplemented();
+  }
+}
+export class Gunzip {
+  constructor() {
+    notImplemented();
+  }
+}
+export class Gzip {
+  constructor() {
+    notImplemented();
+  }
+}
+export class Inflate {
+  constructor() {
+    notImplemented();
+  }
+}
+export class InflateRaw {
+  constructor() {
+    notImplemented();
+  }
+}
+export class Unzip {
+  constructor() {
+    notImplemented();
+  }
+}
+export class ZlibBase {
+  constructor() {
+    notImplemented();
+  }
+}
+export { constants };
+export function createBrotliCompress() {
+  notImplemented();
+}
+export function createBrotliDecompress() {
+  notImplemented();
+}
+export function createDeflate() {
+  notImplemented();
+}
+export function createDeflateRaw() {
+  notImplemented();
+}
+export function createGunzip() {
+  notImplemented();
+}
+export function createGzip() {
+  notImplemented();
+}
+export function createInflate() {
+  notImplemented();
+}
+export function createInflateRaw() {
+  notImplemented();
+}
+export function createUnzip() {
+  notImplemented();
+}
+export function brotliCompress() {
+  notImplemented();
+}
+export function brotliCompressSync() {
+  notImplemented();
+}
+export function brotliDecompress() {
+  notImplemented();
+}
+export function brotliDecompressSync() {
+  notImplemented();
+}
+export function deflate() {
+  notImplemented();
+}
+export function deflateSync() {
+  notImplemented();
+}
+export function deflateRaw() {
+  notImplemented();
+}
+export function deflateRawSync() {
+  notImplemented();
+}
+export function gunzip() {
+  notImplemented();
+}
+export function gunzipSync() {
+  notImplemented();
+}
+export function gzip() {
+  notImplemented();
+}
+export function gzipSync() {
+  notImplemented();
+}
+export function inflate() {
+  notImplemented();
+}
+export function inflateSync() {
+  notImplemented();
+}
+export function inflateRaw() {
+  notImplemented();
+}
+export function inflateRawSync() {
+  notImplemented();
+}
+export function unzip() {
+  notImplemented();
+}
+export function unzipSync() {
+  notImplemented();
+}
+export default {
+  Options,
+  BrotliOptions,
+  BrotliCompress,
+  BrotliDecompress,
+  Deflate,
+  DeflateRaw,
+  Gunzip,
+  Gzip,
+  Inflate,
+  InflateRaw,
+  Unzip,
+  ZlibBase,
+  constants,
+  createBrotliCompress,
+  createBrotliDecompress,
+  createDeflate,
+  createDeflateRaw,
+  createGunzip,
+  createGzip,
+  createInflate,
+  createInflateRaw,
+  createUnzip,
+  brotliCompress,
+  brotliCompressSync,
+  brotliDecompress,
+  brotliDecompressSync,
+  deflate,
+  deflateSync,
+  deflateRaw,
+  deflateRawSync,
+  gunzip,
+  gunzipSync,
+  gzip,
+  gzipSync,
+  inflate,
+  inflateSync,
+  inflateRaw,
+  inflateRawSync,
+  unzip,
+  unzipSync,
+};


### PR DESCRIPTION
This PR adds mock implementation of `zlib` module in std/node.

Some module depeneds on `zlib`'s interfaces even without using its actual features. (e.g. This rollup plugin depends on zlib's interface even when its function is actually not used. ref: https://github.com/btd/rollup-plugin-visualizer/blob/a56a9061da9f8902ec1a7cfcbfef85d6e075b706/plugin/compress.ts ). This addition is useful for those situations.