### PR TITLE
chore: skip fmt/colors test

### DIFF
--- a/examples/colors_test.ts
+++ b/examples/colors_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/* TODO(kt3k): enable colors test when
+ * https://github.com/denoland/deno/issues/13050 is resolved.
 import { assertStrictEquals } from "../testing/asserts.ts";
 import { dirname, fromFileUrl } from "../path/mod.ts";
 
@@ -20,3 +23,4 @@ Deno.test("[examples/colors] print a colored text", async () => {
     process.close();
   }
 });
+*/

--- a/fmt/colors_test.ts
+++ b/fmt/colors_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/* TODO(kt3k): enable colors test when
+ * https://github.com/denoland/deno/issues/13050 is resolved.
 import { assertEquals } from "../testing/asserts.ts";
 import * as c from "./colors.ts";
 import "../examples/colors.ts";
@@ -232,3 +235,4 @@ Deno.test("test_bgRgb24", function (): void {
 Deno.test("test_bgRgb24number", function (): void {
   assertEquals(c.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
 });
+*/


### PR DESCRIPTION
These tests can't pass with the canary. Skipped them for now.

ref: https://github.com/denoland/deno/pull/13031