### PR TITLE
chore(node/_tools): enable node.js test filtering

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -129,13 +129,26 @@ To run the tests you have set up, do the following:
 $ deno test --allow-read --allow-run node/_tools/test.ts
 ```
 
-If you want to run specific tests in a local environment, try one of the
-following:
+If you want to run specific Node.js test files, you can use the following
+command
 
-- Use `node/_tools/require.ts` as follows:
+```shellsession
+$ deno test -A node/_tools/test.ts -- <pattern-to-match>
+```
 
-```zsh
-$ deno run -A --unstable node/_tools/require.ts /Abs/path/to/deno_std/node/_tools/suites/parallel/test-event-emitter-check-listener-leaks.js
+For example, if you want to run only
+`node/_tools/suites/parallel/test-event-emitter-check-listener-leaks.js`, you
+can use:
+
+```shellsession
+$ deno test -A node/_tools/test.ts -- test-event-emitter-check-listener-leaks.js
+```
+
+If you want to run all test files which contains `event-emitter` in filename,
+then you can use:
+
+```shellsession
+$ deno test -A node/_tools/test.ts -- event-emitter
 ```
 
 The test should be passing with the latest deno, so if the test fails, try the

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -4,6 +4,11 @@ import { dirname, fromFileUrl, join, relative } from "../../path/mod.ts";
 import { fail } from "../../testing/asserts.ts";
 import { config, testList } from "./common.ts";
 
+// If the test case is invoked like
+// deno test -A node/_tools/test.ts -- <test-names>
+// Use the test-names as filters
+const filters = Deno.args;
+
 /**
  * This script will run the test files specified in the configuration file
  *
@@ -19,6 +24,14 @@ const testsFolder = dirname(fromFileUrl(import.meta.url));
 const decoder = new TextDecoder();
 
 for await (const file of dir) {
+  // If filter patterns are given and any pattern doesn't match
+  // to the file path, then skip the case
+  if (
+    filters.length > 0 &&
+    filters.every((pattern) => !file.path.includes(pattern))
+  ) {
+    continue;
+  }
   Deno.test({
     name: relative(testsFolder, file.path),
     fn: async () => {


### PR DESCRIPTION
This PR adds a function to filter the Node.js test cases. You can only execute tests which include the given specific patterns:

```sh
deno test -A node/_tools/test.ts -- <pattern-to-match>
```

This should improve the productivity of node.js compat testing