### PR TITLE
BREAKING(encoding/csv): add return type to csv's parse and remove a parse func from args

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -57,18 +57,15 @@ function is as follows:
   `columns`, the first line will be skipped. If you provide `skipFirstRow: true`
   but not `columns`, the first line will be skipped and used as header
   definitions.
-- **`columns: string[] | HeaderOptions[];`**: If you provide `string[]` or
+- **`columns: string[] | ColumnOptions[];`**: If you provide `string[]` or
   `ColumnOptions[]`, those names will be used for header definition.
 - **`parse?: (input: unknown) => unknown;`**: Parse function for the row, which
   will be executed after parsing of all columns. Therefore if you don't provide
   `skipFirstRow`, `columns`, and `parse` function, input will be `string[]`.
 
-##### `HeaderOptions`
+##### `ColumnOptions`
 
 - **`name: string;`**: Name of the header to be used as property.
-- **`parse?: (input: string) => unknown;`**: Parse function for the column. This
-  is executed on each entry of the header. This can be combined with the Parse
-  function of the rows.
 
 ##### `ReadOptions`
 

--- a/encoding/README.md
+++ b/encoding/README.md
@@ -44,12 +44,10 @@ Parse the CSV from the `reader` with the options provided and return
 Parse the CSV string/buffer with the options provided. The result of this
 function is as follows:
 
-- If you don't provide `opt.skipFirstRow`, `opt.parse`, and `opt.columns`, it
-  returns `string[][]`.
-- If you provide `opt.skipFirstRow` or `opt.columns` but not `opt.parse`, it
-  returns `object[]`.
-- If you provide `opt.parse`, it returns an array where each element is the
-  value returned from `opt.parse`.
+- If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns
+  `string[][]`.
+- If you provide `opt.skipFirstRow` or `opt.columns` it returns
+  `Record<string, unknown>[]`.
 
 ##### `ParseOptions`
 
@@ -59,9 +57,6 @@ function is as follows:
   definitions.
 - **`columns: string[] | ColumnOptions[];`**: If you provide `string[]` or
   `ColumnOptions[]`, those names will be used for header definition.
-- **`parse?: (input: unknown) => unknown;`**: Parse function for the row, which
-  will be executed after parsing of all columns. Therefore if you don't provide
-  `skipFirstRow`, `columns`, and `parse` function, input will be `string[]`.
 
 ##### `ColumnOptions`
 

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -365,11 +365,11 @@ export interface ParseOptions extends ReadOptions {
 
 /**
  * Csv parse helper to manipulate data.
- * Provides an auto/custom mapper for columns for columns and rows.
+ * Provides an auto/custom mapper for columns.
  * @param input Input to parse. Can be a string or BufReader.
  * @param opt options of the parser.
- * @returns If you don't provide `opt.skipFirstRow`, `opt.parse`, and `opt.columns`, it returns `string[][]`.
- *   If you provide `opt.skipFirstRow` or `opt.columns` but not `opt.parse`, it returns `object[]`.
+ * @returns If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns `string[][]`.
+ *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unkown>[]`.
  */
 export async function parse(
   input: string | BufReader,

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -421,8 +421,7 @@ export async function parse(
       i++;
       const out: Record<string, unknown> = {};
       for (let j = 0; j < e.length; j++) {
-        const h = headers[j];
-        out[h.name] = e[j];
+        out[headers[j].name] = e[j];
       }
       return out;
     });

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -334,6 +334,8 @@ export async function readMatrix(
  * Parse the CSV string/buffer with the options provided.
  *
  * ColumnOptions provides the column definition
+ * and the parse function for each entry of the
+ * column.
  */
 export interface ColumnOptions {
   /**
@@ -363,6 +365,29 @@ export interface ParseOptions extends ReadOptions {
  * @returns If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns `string[][]`.
  *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unkown>[]`.
  */
+export async function parse(
+  input: string | BufReader,
+): Promise<string[][]>;
+export async function parse(
+  input: string | BufReader,
+  opt: Omit<ParseOptions, "columns" | "skipFirstRow">,
+): Promise<string[][]>;
+export async function parse(
+  input: string | BufReader,
+  opt: Omit<ParseOptions, "columns"> & {
+    columns: string[] | ColumnOptions[];
+  },
+): Promise<Record<string, unknown>[]>;
+export async function parse(
+  input: string | BufReader,
+  opt: Omit<ParseOptions, "skipFirstRow"> & {
+    skipFirstRow: true;
+  },
+): Promise<Record<string, unknown>[]>;
+export async function parse(
+  input: string | BufReader,
+  opt: ParseOptions,
+): Promise<string[][] | Record<string, unknown>[]>;
 export async function parse(
   input: string | BufReader,
   opt: ParseOptions = {

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -334,20 +334,12 @@ export async function readMatrix(
  * Parse the CSV string/buffer with the options provided.
  *
  * ColumnOptions provides the column definition
- * and the parse function for each entry of the
- * column.
  */
 export interface ColumnOptions {
   /**
    * Name of the column to be used as property
    */
   name: string;
-  /**
-   * Parse function for the column.
-   * This is executed on each entry of the header.
-   * This can be combined with the Parse function of the rows.
-   */
-  parse?: (input: string) => unknown;
 }
 
 export interface ParseOptions extends ReadOptions {
@@ -414,6 +406,7 @@ export async function parse(
         );
       }
     }
+
     return r.map((e) => {
       if (e.length !== headers.length) {
         throw `Error number of fields line:${i}`;

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -550,69 +550,17 @@ const parseTestCases = [
     ],
   },
   {
-    name: "header mapping parse entry",
-    in: "a,b,c\ne,f,g\n",
-    columns: [
-      {
-        name: "this",
-        parse: (e: string): string => {
-          return `b${e}$$`;
-        },
-      },
-      {
-        name: "is",
-        parse: (e: string): number => {
-          return e.length;
-        },
-      },
-      {
-        name: "sparta",
-        parse: (e: string): unknown => {
-          return { bim: `boom-${e}` };
-        },
-      },
-    ],
-    result: [
-      { this: "ba$$", is: 1, sparta: { bim: `boom-c` } },
-      { this: "be$$", is: 1, sparta: { bim: `boom-g` } },
-    ],
-  },
-  {
-    name: "multiline parse",
-    in: "a,b,c\ne,f,g\n",
-    parse: (e: string[]): unknown => {
-      return { super: e[0], street: e[1], fighter: e[2] };
-    },
-    skipFirstRow: false,
-    result: [
-      { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" },
-    ],
-  },
-  {
-    name: "header mapping object parseline",
-    in: "a,b,c\ne,f,g\n",
-    columns: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
-    parse: (e: Record<string, unknown>): unknown => {
-      return { super: e.this, street: e.is, fighter: e.sparta };
-    },
-    result: [
-      { super: "a", street: "b", fighter: "c" },
-      { super: "e", street: "f", fighter: "g" },
-    ],
-  },
-  {
     name: "provides both opts.skipFirstRow and opts.columns",
     in: "a,b,1\nc,d,2\ne,f,3",
     skipFirstRow: true,
     columns: [
       { name: "foo" },
       { name: "bar" },
-      { name: "baz", parse: (e: string) => Number(e) },
+      { name: "baz" },
     ],
     result: [
-      { foo: "c", bar: "d", baz: 2 },
-      { foo: "e", bar: "f", baz: 3 },
+      { foo: "c", bar: "d", baz: "2" },
+      { foo: "e", bar: "f", baz: "3" },
     ],
   },
 ];
@@ -624,7 +572,6 @@ for (const testCase of parseTestCases) {
       const r = await parse(testCase.in, {
         skipFirstRow: testCase.skipFirstRow,
         columns: testCase.columns,
-        parse: testCase.parse as (input: unknown) => unknown,
       });
       assertEquals(r, testCase.result);
     },


### PR DESCRIPTION
Resolves #881

Took from a comment in the issue by @dsherret and removed the ability to pass a `parse` arg to the function which gave it the responsibility of parsing and, optionally, data transformation. Let me know wha you think!