### PR TITLE
style(uuid): add return type to `validate`

### DIFF
--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -33,7 +33,7 @@ export function isNil(id: string): boolean {
  * validate("6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b") // true
  * ```
  */
-export function validate(uuid: string) {
+export function validate(uuid: string): boolean {
   return /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i
     .test(
       uuid,


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno_std/pull/1720

Side note: it seems like almost all code in this repo uses explicit return types, however, it's not mentioned in the [style guide](https://deno.land/manual@v1.17.0/contributing/style_guide). Should it be?