### PR TITLE
feat(node): add https.request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Unit test node/
         run: deno test --unstable --allow-all --import-map=test_import_map.json --config strict-ts44.tsconfig.json node/ --ignore=node/_tools/test.ts,node/_tools/versions/
+        env:
+          NODE_EXTRA_CA_CERTS: ${{ github.workspace }}/http/testdata/tls/RootCA.pem
 
       - name: Run Node tests canary
         run: deno test --unstable --allow-all --import-map=test_import_map.json --config strict-ts44.tsconfig.json node/_tools/test.ts

--- a/node/https.ts
+++ b/node/https.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-explicit-any ban-types
 
 import { notImplemented } from "./_utils.ts";
+import { Readable, Writable } from "./stream.ts";
+import { urlToHttpOptions } from "./internal/url.ts";
 
 export class Agent {
   constructor() {
@@ -16,12 +19,188 @@ export class Server {
 export function createServer() {
   notImplemented();
 }
-export function get() {
-  notImplemented();
+
+interface RequestOptions {
+  agent?: Agent | boolean;
+  auth?: string;
+  createConnection?: Function;
+  defaultPort?: number;
+  family?: number;
+  headers?: Object;
+  hints?: number;
+  host?: string;
+  hostname?: string;
+  insecureHTTPParser?: boolean;
+  localAddress?: string;
+  localPort?: number;
+  lookup?: Function;
+  maxHeaderSize?: number;
+  method?: string;
+  path?: string;
+  port?: number;
+  protocol?: string;
+  setHost?: boolean;
+  socketPath?: string;
+  timeout?: number;
+  signal?: AbortSignal;
+  href?: string;
 }
+
+// Store additional root CAs.
+// undefined means NODE_EXTRA_CA_CERTS is not checked yet.
+// null means there's no additional root CAs.
+let caCerts: string[] | undefined | null;
+
+/** Makes a request to an https server. */
+export function get(
+  url: string | URL,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function get(
+  opts: RequestOptions,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function get(
+  url: string | URL,
+  opts: RequestOptions,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function get(...args: any[]) {
+  const req = request(args[0], args[1], args[2]);
+  req.end();
+  return req;
+}
+
 export const globalAgent = undefined;
-export function request() {
-  notImplemented();
+/** HttpsClientRequest class loosely follows http.ClientRequest class API. */
+class HttpsClientRequest extends Writable {
+  body: null | ReadableStream = null;
+  controller: ReadableStreamDefaultController | null = null;
+  constructor(
+    public opts: RequestOptions,
+    public cb: (res: HttpsIncomingMessage) => void,
+  ) {
+    super();
+  }
+
+  _write(chunk: any, _enc: string, cb: () => void) {
+    if (this.controller) {
+      this.controller.enqueue(chunk);
+      cb();
+      return;
+    }
+
+    this.body = new ReadableStream({
+      start: (controller) => {
+        this.controller = controller;
+        controller.enqueue(chunk);
+        cb();
+      },
+    });
+  }
+
+  async _final() {
+    const client = await this.#createCustomClient();
+    const opts = { body: this.body, method: this.opts.method, client };
+    const res = new HttpsIncomingMessage(await fetch(this.opts.href!, opts));
+    if (client) {
+      res.on("end", () => {
+        client.close();
+      });
+    }
+    this.cb(res);
+  }
+
+  async #createCustomClient(): Promise<Deno.HttpClient | undefined> {
+    if (caCerts === null) {
+      return undefined;
+    }
+    if (caCerts !== undefined) {
+      return Deno.createHttpClient({ caCerts });
+    }
+    const status = await Deno.permissions.query({
+      name: "env",
+      variable: "NODE_EXTRA_CA_CERTS",
+    });
+    if (status.state !== "granted") {
+      caCerts = null;
+      return undefined;
+    }
+    const certFilename = Deno.env.get("NODE_EXTRA_CA_CERTS");
+    if (!certFilename) {
+      caCerts = null;
+      return undefined;
+    }
+    const caCert = await Deno.readTextFile(certFilename);
+    caCerts = [caCert];
+    return Deno.createHttpClient({ caCerts });
+  }
+}
+
+/** HttpsIncomingMessage class loosely follows http.IncomingMessage class API. */
+class HttpsIncomingMessage extends Readable {
+  reader: ReadableStreamDefaultReader | undefined;
+  constructor(public resp: Response) {
+    super();
+    this.reader = resp.body?.getReader();
+  }
+
+  async _read(_size: number) {
+    if (this.reader === undefined) {
+      this.push(null);
+      return;
+    }
+    try {
+      const res = await this.reader.read();
+      if (res.done) {
+        this.push(null);
+        return;
+      }
+      this.push(res.value);
+    } catch (e) {
+      this.destroy(e);
+    }
+  }
+
+  get headers() {
+    return this.resp.headers;
+  }
+
+  get statusCode() {
+    return this.resp.status;
+  }
+
+  get statusMessage() {
+    return this.resp.statusText;
+  }
+}
+
+/** Makes a request to an https server. */
+export function request(
+  url: string | URL,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function request(
+  opts: RequestOptions,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function request(
+  url: string | URL,
+  opts: RequestOptions,
+  cb?: (res: HttpsIncomingMessage) => void,
+): HttpsClientRequest;
+export function request(...args: any[]) {
+  let options = {};
+  if (typeof args[0] === "string") {
+    options = urlToHttpOptions(new URL(args.shift()));
+  } else if (args[0] instanceof URL) {
+    options = urlToHttpOptions(args.shift());
+  }
+  if (args[0] && typeof args[0] !== "function") {
+    Object.assign(options, args.shift());
+  }
+  args.unshift(options);
+  return new HttpsClientRequest(args[0], args[1]);
 }
 export default {
   Agent,

--- a/node/https.ts
+++ b/node/https.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
-// deno-lint-ignore-file no-explicit-any ban-types
 
 import { notImplemented } from "./_utils.ts";
 import { Readable, Writable } from "./stream.ts";
@@ -23,9 +22,11 @@ export function createServer() {
 interface RequestOptions {
   agent?: Agent | boolean;
   auth?: string;
+  // deno-lint-ignore ban-types
   createConnection?: Function;
   defaultPort?: number;
   family?: number;
+  // deno-lint-ignore ban-types
   headers?: Object;
   hints?: number;
   host?: string;
@@ -33,6 +34,7 @@ interface RequestOptions {
   insecureHTTPParser?: boolean;
   localAddress?: string;
   localPort?: number;
+  // deno-lint-ignore ban-types
   lookup?: Function;
   maxHeaderSize?: number;
   method?: string;
@@ -65,6 +67,7 @@ export function get(
   opts: RequestOptions,
   cb?: (res: HttpsIncomingMessage) => void,
 ): HttpsClientRequest;
+// deno-lint-ignore no-explicit-any
 export function get(...args: any[]) {
   const req = request(args[0], args[1], args[2]);
   req.end();
@@ -83,6 +86,7 @@ class HttpsClientRequest extends Writable {
     super();
   }
 
+  // deno-lint-ignore no-explicit-any
   _write(chunk: any, _enc: string, cb: () => void) {
     if (this.controller) {
       this.controller.enqueue(chunk);
@@ -158,7 +162,8 @@ class HttpsIncomingMessage extends Readable {
       }
       this.push(res.value);
     } catch (e) {
-      this.destroy(e);
+      // deno-lint-ignore no-explicit-any
+      this.destroy(e as any);
     }
   }
 

--- a/node/https.ts
+++ b/node/https.ts
@@ -194,6 +194,7 @@ export function request(
   opts: RequestOptions,
   cb?: (res: HttpsIncomingMessage) => void,
 ): HttpsClientRequest;
+// deno-lint-ignore no-explicit-any
 export function request(...args: any[]) {
   let options = {};
   if (typeof args[0] === "string") {

--- a/node/https_test.ts
+++ b/node/https_test.ts
@@ -1,0 +1,56 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-explicit-any
+
+import * as https from "./https.ts";
+import { serveTls } from "../http/server.ts";
+import { dirname, fromFileUrl, join } from "../path/mod.ts";
+import { assertEquals } from "../testing/asserts.ts";
+
+const stdRoot = dirname(dirname(fromFileUrl(import.meta.url)));
+const tlsDataDir = join(stdRoot, "http", "testdata", "tls");
+const keyFile = join(tlsDataDir, "localhost.key");
+const certFile = join(tlsDataDir, "localhost.crt");
+
+Deno.test("[node/https] request makes https request", async () => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  const serveFinish = serveTls((_req) => {
+    return new Response("abcd\n".repeat(1_000));
+  }, { keyFile, certFile, port: 4505, hostname: "localhost", signal });
+
+  https.request("https://localhost:4505", (res: any) => {
+    let data = "";
+    res.on("data", (chunk: any) => {
+      data += chunk;
+    });
+    res.on("end", () => {
+      assertEquals(data.length, 5_000);
+      controller.abort();
+    });
+  }).end();
+
+  await serveFinish;
+});
+
+Deno.test("[node/https] get makes https GET request", async () => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  const serveFinish = serveTls((_req) => {
+    return new Response("abcd\n".repeat(1_000));
+  }, { keyFile, certFile, port: 4505, hostname: "localhost", signal });
+
+  https.get("https://localhost:4505", (res: any) => {
+    let data = "";
+    res.on("data", (chunk: any) => {
+      data += chunk;
+    });
+    res.on("end", () => {
+      assertEquals(data.length, 5_000);
+      controller.abort();
+    });
+  }).end();
+
+  await serveFinish;
+});


### PR DESCRIPTION
closes #1703 

This PR implements `https.request` using `fetch` API.

I first tried to follow the node.js implementation more closely, but it seems too complicated to follow (wasted almost 2 days on it...). I also heard feedbacks in the design meetings and more people seem preferring implementation by `fetch`. So I switched to this version.

If this PR looks good, I'll align `http.request` to this implementation as it seems flaky ref: #1738 