### PR TITLE
feat(node): add process.execPath

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -391,6 +391,11 @@ class Process extends EventEmitter {
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode
   _eval: string | undefined = undefined;
+
+  /** https://nodejs.org/api/process.html#processexecpath */
+  get execPath() {
+    return argv[0];
+  }
 }
 
 /** https://nodejs.org/api/process.html#process_process */

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -408,3 +408,7 @@ Deno.test("process.config", () => {
 Deno.test("process._exiting", () => {
   assert(process._exiting === false);
 });
+
+Deno.test("process.execPath", () => {
+  assertEquals(process.execPath, process.argv[0]);
+});


### PR DESCRIPTION
This PR adds `process.execPath` in std/node.

This resolves one of the issues in running npm in compat mode. ref: https://github.com/denoland/deno/issues/13187