### PR TITLE
fix(node/child_process): Allow number and boolean env vars.

### DIFF
--- a/node/internal/child_process.ts
+++ b/node/internal/child_process.ts
@@ -12,6 +12,7 @@ import { isWindows } from "../../_util/os.ts";
 import { Buffer } from "../buffer.ts";
 import { nextTick } from "../_next_tick.ts";
 import { ERR_INVALID_ARG_VALUE } from "../_errors.ts";
+import { mapValues } from "../../collections/map_values.ts";
 
 type NodeStdio = "pipe" | "overlapped" | "ignore" | "inherit" | "ipc";
 type DenoStdio = "inherit" | "piped" | "null";
@@ -119,10 +120,12 @@ export class ChildProcess extends EventEmitter {
     this.spawnfile = cmd[0];
     this.spawnargs = cmd;
 
+    const stringEnv = mapValues(env, (value) => value.toString());
+
     try {
       this.#process = Deno.run({
         cmd,
-        env,
+        env: stringEnv,
         stdin: toDenoStdio(stdin as NodeStdio | number),
         stdout: toDenoStdio(stdout as NodeStdio | number),
         stderr: toDenoStdio(stderr as NodeStdio | number),
@@ -260,7 +263,7 @@ export interface ChildProcessOptions {
   /**
    * Environment variables passed to the child process.
    */
-  env?: Record<string, string>;
+  env?: Record<string, string | number | boolean>;
 
   /**
    * This option defines child process's stdio configuration.


### PR DESCRIPTION
This is useful for additional compatibility with Node.JS, which allows
numbers and booleans to be values to environment variables. In Deno, we
convert those values to strings to match the signature of Deno#run.

This should resolve #1725.