### PR TITLE
chore(crypto): export interface for docs

### DIFF
--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -9,7 +9,7 @@ type WebCryptoAlgorithmIdentifier = string | { name: string };
 
 // TODO(jeremyBanks): Remove this once the built-in `Crypto` interface is
 // complete and stable. For now we use this incomplete-but-stable definition.
-interface WebCrypto {
+export interface WebCrypto {
   getRandomValues<T extends BufferSource>(buffer: T): T;
   randomUUID?(): string;
   subtle?: {


### PR DESCRIPTION
This interface was previously not exposed making it invisible in deno
doc.
