### PR TITLE
fix(fs/walk): filter special files

### DIFF
--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -126,22 +126,18 @@ export async function* walk(
       assert(entry.name != null);
       let path = join(root, entry.name);
 
-      let isFile = entry.isFile;
+      let { isSymlink, isDirectory } = entry;
 
-      if (entry.isSymlink) {
-        if (followSymlinks) {
-          path = await Deno.realPath(path);
-          isFile = await Deno.lstat(path).then((s) => s.isFile);
-        } else {
-          continue;
-        }
+      if (isSymlink) {
+        if (!followSymlinks) continue;
+        path = await Deno.realPath(path);
+        // Caveat emptor: don't assume |path| is not a symlink. realpath()
+        // resolves symlinks but another process can replace the file system
+        // entity with a different type of entity before we call lstat().
+        ({ isSymlink, isDirectory } = await Deno.lstat(path));
       }
 
-      if (isFile) {
-        if (includeFiles && include(path, exts, match, skip)) {
-          yield { path, ...entry };
-        }
-      } else {
+      if (isSymlink || isDirectory) {
         yield* walk(path, {
           maxDepth: maxDepth - 1,
           includeFiles,
@@ -151,6 +147,8 @@ export async function* walk(
           match,
           skip,
         });
+      } else if (includeFiles && include(path, exts, match, skip)) {
+        yield { path, ...entry };
       }
     }
   } catch (err) {
@@ -190,21 +188,18 @@ export function* walkSync(
     assert(entry.name != null);
     let path = join(root, entry.name);
 
-    let isFile = entry.isFile;
-    if (entry.isSymlink) {
-      if (followSymlinks) {
-        path = Deno.realPathSync(path);
-        isFile = Deno.lstatSync(path).isFile;
-      } else {
-        continue;
-      }
+    let { isSymlink, isDirectory } = entry;
+
+    if (isSymlink) {
+      if (!followSymlinks) continue;
+      path = Deno.realPathSync(path);
+      // Caveat emptor: don't assume |path| is not a symlink. realpath()
+      // resolves symlinks but another process can replace the file system
+      // entity with a different type of entity before we call lstat().
+      ({ isSymlink, isDirectory } = Deno.lstatSync(path));
     }
 
-    if (isFile) {
-      if (includeFiles && include(path, exts, match, skip)) {
-        yield { path, ...entry };
-      }
-    } else {
+    if (isSymlink || isDirectory) {
       yield* walkSync(path, {
         maxDepth: maxDepth - 1,
         includeFiles,
@@ -214,6 +209,8 @@ export function* walkSync(
         match,
         skip,
       });
+    } else if (includeFiles && include(path, exts, match, skip)) {
+      yield { path, ...entry };
     }
   }
 }

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-explicit-any
 import { walk, WalkEntry, WalkOptions, walkSync } from "./walk.ts";
 import {
   assert,
@@ -8,8 +9,8 @@ import {
 } from "../testing/asserts.ts";
 
 export function testWalk(
-  setup: (arg0: string) => void | Promise<void>,
-  t: () => void | Promise<void>,
+  setup: (arg0: string) => any | Promise<any>,
+  t: (context: any) => void | Promise<void>,
   ignore = false,
 ): void {
   const name = t.name;
@@ -18,8 +19,8 @@ export function testWalk(
     const d = await Deno.makeTempDir();
     Deno.chdir(d);
     try {
-      await setup(d);
-      await t();
+      const context = await setup(d);
+      await t(context);
     } finally {
       Deno.chdir(origCwd);
       await Deno.remove(d, { recursive: true });
@@ -281,6 +282,20 @@ testWalk(
     assertEquals(files.length, 4);
     assert(files.some((f): boolean => f.endsWith("/b")));
   },
+);
+
+// https://github.com/denoland/deno_std/issues/1789
+testWalk(
+  (d: string) => {
+    return Deno.listen({ path: d + "/a", transport: "unix" });
+  },
+  async function unixSocket(listener: Deno.Listener) {
+    assertReady(2);
+    const files = await walkArray(".", { followSymlinks: true });
+    assertEquals(files, [".", "a"]);
+    listener.close();
+  },
+  Deno.build.os === "windows",
 );
 
 testWalk(


### PR DESCRIPTION
Don't error on special files like UNIX domain sockets. Filter them out
instead.

Fixes #1789.

<hr>

I opted to filter them out because you can't really do anything except unlink them but maybe they should be included instead? Produces entries that look like this though:
```
{
  path: "/foo",
  name: "bar.sock",
  isFile: false,
  isDirectory: false,
  isSymlink: false,
}
```
Feedback appreciated.