### PR TITLE
Change bind6 comment to IPv6

### DIFF
--- a/node/internal_binding/tcp_wrap.ts
+++ b/node/internal_binding/tcp_wrap.ts
@@ -165,7 +165,7 @@ export class TCP extends ConnectionWrap {
   }
 
   /**
-   * Bind to an IPv4 address.
+   * Bind to an IPv6 address.
    * @param address The hostname to bind to.
    * @param port The port to bind to
    * @return An error status code.


### PR DESCRIPTION
Correctly describe bind6 as connecting to an IPv6 address instead of IPv4.