### PR TITLE
fix(node): work around |this| check in deno core

### DIFF
--- a/node/timers.ts
+++ b/node/timers.ts
@@ -1,17 +1,46 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 // TODO(bartlomieju): implement the 'NodeJS.Timeout' and 'NodeJS.Immediate' versions of the timers.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1163ead296d84e7a3c80d71e7c81ecbd1a130e9a/types/node/v12/globals.d.ts#L1120-L1131
-export const setTimeout = globalThis.setTimeout;
-export const clearTimeout = globalThis.clearTimeout;
-export const setInterval = globalThis.setInterval;
-export const clearInterval = globalThis.clearInterval;
-export const setImmediate = (
-  // deno-lint-ignore no-explicit-any
-  cb: (...args: any[]) => void,
-  // deno-lint-ignore no-explicit-any
+
+// deno-lint-ignore-file no-explicit-any
+
+// Deno's built-in timer functions throw "Illegal invocation" exceptions
+// unless they are called with this == globalThis or this == null.
+
+export function setTimeout(
+  handler: (...args: any[]) => void,
+  timeout?: number,
   ...args: any[]
-): number => globalThis.setTimeout(cb, 0, ...args);
-export const clearImmediate = globalThis.clearTimeout;
+): number {
+  return globalThis.setTimeout(handler, timeout, ...args);
+}
+
+export function clearTimeout(id: number): void {
+  globalThis.clearTimeout(id);
+}
+
+export function setInterval(
+  handler: (...args: any[]) => void,
+  timeout?: number,
+  ...args: any[]
+): number {
+  return globalThis.setInterval(handler, timeout, ...args);
+}
+
+export function clearInterval(id: number): void {
+  globalThis.clearInterval(id);
+}
+
+export function setImmediate(
+  handler: (...args: any[]) => void,
+  ...args: any[]
+): number {
+  return globalThis.setTimeout(handler, 0, ...args);
+}
+
+export function clearImmediate(id: number): void {
+  globalThis.clearTimeout(id);
+}
 
 export default {
   setTimeout,

--- a/node/timers_test.ts
+++ b/node/timers_test.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import timers from "./timers.ts";
+
+Deno.test("[node/timers setTimeout]", () => {
+  {
+    const { clearTimeout, setTimeout } = timers;
+    const id = setTimeout(() => {});
+    clearTimeout(id);
+  }
+
+  {
+    const id = timers.setTimeout(() => {});
+    timers.clearTimeout(id);
+  }
+});
+
+Deno.test("[node/timers setInterval]", () => {
+  {
+    const { clearInterval, setInterval } = timers;
+    const id = setInterval(() => {});
+    clearInterval(id);
+  }
+
+  {
+    const id = timers.setInterval(() => {});
+    timers.clearInterval(id);
+  }
+});
+
+Deno.test("[node/timers setImmediate]", () => {
+  {
+    const { clearImmediate, setImmediate } = timers;
+    const id = setImmediate(() => {});
+    clearImmediate(id);
+  }
+
+  {
+    const id = timers.setImmediate(() => {});
+    timers.clearImmediate(id);
+  }
+});


### PR DESCRIPTION
Deno's built-in timer functions throw "Illegal invocation" exceptions
unless they are called with this == globalThis or this == null.