### PR TITLE
fix(node/net): setNoDelay and setKeepAlive no-ops

### DIFF
--- a/node/internal_binding/tcp_wrap.ts
+++ b/node/internal_binding/tcp_wrap.ts
@@ -279,7 +279,8 @@ export class TCP extends ConnectionWrap {
    * @return An error status code.
    */
   setNoDelay(_noDelay: boolean): number {
-    notImplemented();
+    // TODO(bnoordhuis) https://github.com/denoland/deno/pull/13103
+    return 0;
   }
 
   /**
@@ -288,7 +289,8 @@ export class TCP extends ConnectionWrap {
    * @return An error status code.
    */
   setKeepAlive(_enable: boolean, _initialDelay: number): number {
-    notImplemented();
+    // TODO(bnoordhuis) https://github.com/denoland/deno/pull/13103
+    return 0;
   }
 
   /**


### PR DESCRIPTION
These methods have no directly observable side effects and should
therefore be safe to turn into no-ops. Doing so unblocks a number
of third-party modules.

Can be implemented once https://github.com/denoland/deno/pull/13103
lands.