### PR TITLE
chore: set compat env var automatically on testing

### DIFF
--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -16,6 +16,7 @@ const filters = Deno.args;
  */
 
 const toolsPath = dirname(fromFileUrl(import.meta.url));
+const stdRootUrl = new URL("../../", import.meta.url).href;
 const testPaths = getPathsFromTestSuites(config.tests);
 const windowsIgnorePaths = new Set(
   getPathsFromTestSuites(config.windowsIgnore),
@@ -51,6 +52,9 @@ for await (const path of testPaths) {
       // That way the tests will respect the `--quiet` option when provided
       const test = Deno.run({
         cmd,
+        env: {
+          DENO_NODE_COMPAT_URL: stdRootUrl,
+        },
         stderr: "piped",
         stdout: "piped",
       });
@@ -70,7 +74,7 @@ for await (const path of testPaths) {
         console.log(`Error: "${path}" failed`);
         console.log(
           "You can repeat only this test with the command:",
-          magenta(cmd.join(" ")),
+          magenta(`deno test -A node/_tools/test.ts -- ${path}`),
         );
         fail(stderr);
       }


### PR DESCRIPTION
This PR sets `DENO_NODE_COMPAT_URL` env var to the local std root while node.js compat testing. So the contributors can simply run `deno test` without setting env vars.