### PR TITLE
chore: update mock Deno.Conn

### DIFF
--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -24,8 +24,8 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       return Promise.resolve(-1);
     },
     close: (): void => {},
-    setNoDelay: (nodelay?: boolean): void => {},
-    setKeepAlive: (keepalive?: boolean): void => {},
+    setNoDelay: (_nodelay?: boolean): void => {},
+    setKeepAlive: (_keepalive?: boolean): void => {},
     ...base,
   };
 }

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -24,6 +24,8 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       return Promise.resolve(-1);
     },
     close: (): void => {},
+    setNoDelay: (nodelay?: boolean): void => {},
+    setKeepAlive: (keepalive?: boolean): void => {},
     ...base,
   };
 }


### PR DESCRIPTION
This PR updates the mock `Deno.Conn` object which is used in `http` testing. This follows the change of CLI canary https://github.com/denoland/deno/pull/13103