### PR TITLE
0.125.0

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,4 +1,4 @@
-### 0.124.0 / 2022.02.03
+### 0.125.0 / 2022.02.03
 
 - feat(node): add punycode module (#1857)
 - feat(node): add url.resolve (#1851)
@@ -9,6 +9,9 @@
 - fix(node/http): fix http.request (#1856)
 - fix(node/net): mock response.socket object (#1858)
 - fix: bypass TS errors for missing --unstable (#1819)
+
+Note 0.124.0 is the same as 0.125.0 but ignoring a typescript error related to a
+new feature added setNoDelay.
 
 ### 0.123.0 / 2022.01.27
 

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -24,7 +24,11 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       return Promise.resolve(-1);
     },
     close: (): void => {},
+    // TODO(ry) Remove the following ts-ignore. This was added to workaround
+    // incompatibilities between Deno versions.
+    // @ts-ignore
     setNoDelay: (_nodelay?: boolean): void => {},
+    // @ts-ignore
     setKeepAlive: (_keepalive?: boolean): void => {},
     ...base,
   };

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -24,11 +24,10 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       return Promise.resolve(-1);
     },
     close: (): void => {},
-    // TODO(ry) Remove the following ts-ignore. This was added to workaround
-    // incompatibilities between Deno versions.
-    // @ts-ignore
+    // TODO(ry) Remove the following ts-ignore.
+    // @ts-ignore This was added to workaround incompatibilities between Deno versions.
     setNoDelay: (_nodelay?: boolean): void => {},
-    // @ts-ignore
+    // @ts-ignore This was added to workaround incompatibilities between Deno versions.
     setKeepAlive: (_keepalive?: boolean): void => {},
     ...base,
   };

--- a/version.ts
+++ b/version.ts
@@ -5,4 +5,4 @@
  * the cli's API is stable. In the future when std becomes stable, likely we
  * will match versions with cli as we have in the past.
  */
-export const VERSION = "0.124.0";
+export const VERSION = "0.125.0";


### PR DESCRIPTION
0.124.0 won't work because it included c331dad1df56f41e1fd085b71b3793026677e26a, which depends on a feature not in  Deno 1.18. This reverts that change.