### PR TITLE
fix(collections/group_by): improve type safety

### DIFF
--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -28,22 +28,16 @@
  * })
  * ```
  */
-export function groupBy<T>(
+export function groupBy<T, K extends string>(
   array: readonly T[],
-  selector: (el: T) => string,
-): Record<string, T[]> {
-  const ret: Record<string, T[]> = {};
+  selector: (el: T) => K,
+): Partial<Record<K, T[]>> {
+  const ret: Partial<Record<K, T[]>> = {};
 
   for (const element of array) {
     const key = selector(element);
-
-    if (ret[key] === undefined) {
-      ret[key] = [element];
-
-      continue;
-    }
-
-    ret[key].push(element);
+    const arr = ret[key] ??= [] as T[];
+    arr.push(element);
   }
 
   return ret;


### PR DESCRIPTION
This PR introduces the following type changes:

- **Fix**: the properties of the return type are now marked as **optional** because they may or may not exist. This aligns with both the runtime behavior of this function and the behavior of the corresponding [stage-3 proposal](https://github.com/tc39/proposal-array-grouping).
- Enhancement: the properties of the return type are now inferred from the return type of the selector.

```ts
const nums = [1, 2, 3, 4];
const result = groupBy(nums, n => n % 2 === 0 ? 'even' : 'odd');
console.log(result); // { odd: [1, 3] }

// before
result.even // number[]
result.odd // number[]
result.unknown // number[]

// after
result.even // number[] | undefined
result.odd // number[] | undefined
result.unknown /*
       ^^^^^^^
Property 'unknown' does not exist on type 'Partial<Record<"even" | "odd", number[]>>'.(2339) */
```