### PR TITLE
chore: Add `getUid` to `_deno_unstable.ts`

### DIFF
--- a/_deno_unstable.ts
+++ b/_deno_unstable.ts
@@ -53,6 +53,16 @@ export function futimeSync(
   }
 }
 
+export function getUid(
+  ...args: Parameters<typeof Deno.getUid>
+): ReturnType<typeof Deno.getUid> {
+  if (typeof Deno.getUid == "function") {
+    return Deno.getUid(...args);
+  } else {
+    throw new TypeError("Requires --unstable");
+  }
+}
+
 export function hostname(
   ...args: Parameters<typeof Deno.hostname>
 ): ReturnType<typeof Deno.hostname> {

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import * as DenoUnstable from "../../_deno_unstable.ts";
 import { type CallbackWithError, makeCallback } from "./_fs_common.ts";
 import { fs, os } from "../internal_binding/constants.ts";
 import { getValidatedPath, getValidMode } from "../internal/fs/utils.js";
@@ -21,7 +22,7 @@ export function access(
   Deno.lstat(path).then((info) => {
     const m = +mode || 0;
     let fileMode = +info.mode! || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.getUid()) {
+    if (Deno.build.os !== "windows" && info.uid === DenoUnstable.getUid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;


### PR DESCRIPTION
`Deno.getUid()` is still an unstable API, so this PR adds it to `_deno_unstable.ts`

Related to #1819