### PR TITLE
docs(path/README): Fix missed syntax highlighting language in code block

### DIFF
--- a/path/README.md
+++ b/path/README.md
@@ -12,7 +12,7 @@ Codes in the following example uses POSIX path but it automatically use Windows
 path on Windows. Use methods under `posix` or `win32` object instead to handle
 non platform specific path like:
 
-```
+```ts
 import { posix, win32 } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
 const p1 = posix.fromFileUrl("file:///home/foo");
 const p2 = win32.fromFileUrl("file:///home/foo");


### PR DESCRIPTION
Isn't it supposed to be a TypeScript code block?

- Added TypeScipt syntax highlighting for the missed code block.