### PR TITLE
chore: mock process.umask

### DIFF
--- a/_deno_unstable.ts
+++ b/_deno_unstable.ts
@@ -123,16 +123,6 @@ export function systemMemoryInfo(
   }
 }
 
-export function umask(
-  ...args: Parameters<typeof Deno.umask>
-): ReturnType<typeof Deno.umask> {
-  if (typeof Deno.umask == "function") {
-    return Deno.umask(...args);
-  } else {
-    throw new TypeError("Requires --unstable");
-  }
-}
-
 export function utime(
   ...args: Parameters<typeof Deno.utime>
 ): ReturnType<typeof Deno.utime> {

--- a/node/process.ts
+++ b/node/process.ts
@@ -398,7 +398,13 @@ class Process extends EventEmitter {
   }
 
   /** https://nodejs.org/api/process.html#processumaskmask */
-  umask = DenoUnstable.umask;
+  umask() {
+    // Always return the system default umask value.
+    // We don't use Deno.umask here because it has a race
+    // condition bug.
+    // See https://github.com/denoland/deno_std/issues/1893#issuecomment-1032897779
+    return 0o22;
+  }
 
   /** https://nodejs.org/api/process.html#processgetuid */
   getuid(): number {


### PR DESCRIPTION
This PR mocks `process.umask` with the hard coded default value. This avoids the bug of `Deno.umask` described in [this comment](https://github.com/denoland/deno_std/issues/1893#issuecomment-1032897779)

With this change, `yarn install` / `yarn add <mod>` commands finally work without errors!

closes #1893
closes https://github.com/denoland/deno/issues/13420