### PR TITLE
fix(node/module): fix commonjs wrapper

### DIFF
--- a/node/_module/cjs/cjs_declare_timers.js
+++ b/node/_module/cjs/cjs_declare_timers.js
@@ -1,0 +1,8 @@
+const setTimeout = () => {};
+const clearTimeout = () => {};
+const setInterval = () => {};
+const clearInterval = () => {};
+setTimeout();
+clearTimeout();
+setInterval();
+clearInterval();

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -42,7 +42,7 @@ for await (const path of testPaths) {
     fn: async () => {
       const targetTestPath = join(toolsPath, config.suitesFolder, path);
 
-      const v8Flags = ["--stack-size=2000"];
+      const v8Flags = ["--stack-size=4000"];
       const testSourceCode = await Deno.readTextFile(targetTestPath);
       // TODO(kt3k): Parse `Flags` directive correctly
       if (testSourceCode.includes("Flags: --expose_externalize_string")) {

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -48,6 +48,7 @@ for await (const path of testPaths) {
         "--quiet",
         "--unstable",
         "--no-check",
+        "--v8-flags=--stack-size=1968",
       ];
       const testSourceCode = await Deno.readTextFile(targetTestPath);
       // TODO(kt3k): Parse `Flags` directive correctly

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -41,6 +41,14 @@ for await (const path of testPaths) {
     ignore,
     fn: async () => {
       const targetTestPath = join(toolsPath, config.suitesFolder, path);
+
+      const v8Flags = ["--stack-size=2000"];
+      const testSourceCode = await Deno.readTextFile(targetTestPath);
+      // TODO(kt3k): Parse `Flags` directive correctly
+      if (testSourceCode.includes("Flags: --expose_externalize_string")) {
+        v8Flags.push("--expose-externalize-string");
+      }
+
       const cmd = [
         Deno.execPath(),
         "run",
@@ -48,15 +56,11 @@ for await (const path of testPaths) {
         "--quiet",
         "--unstable",
         "--no-check",
-        "--v8-flags=--stack-size=1968",
+        "--v8-flags=" + v8Flags.join(),
+        requireTs,
+        targetTestPath,
       ];
-      const testSourceCode = await Deno.readTextFile(targetTestPath);
-      // TODO(kt3k): Parse `Flags` directive correctly
-      if (testSourceCode.includes("Flags: --expose_externalize_string")) {
-        cmd.push("--v8-flags=--expose-externalize-string");
-      }
-      cmd.push(requireTs);
-      cmd.push(targetTestPath);
+
       // Pipe stdout in order to output each test result as Deno.test output
       // That way the tests will respect the `--quiet` option when provided
       const test = Deno.run({

--- a/node/module.ts
+++ b/node/module.ts
@@ -212,7 +212,7 @@ class Module {
     // to avoid exposing them in global namespace.
     `
     (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
-      const inner = function(exports, require, module, __filename, __dirname) {
+      const inner = function (exports, require, module, __filename, __dirname) {
     `,
     `
       };
@@ -220,7 +220,6 @@ class Module {
     })
     `,
   ];
-
   // Loads a module at the given file path. Returns that module's
   // `exports` property.
   // deno-lint-ignore no-explicit-any

--- a/node/module.ts
+++ b/node/module.ts
@@ -210,14 +210,8 @@ class Module {
   static wrapper = [
     // We provide non standard timer APIs in the CommonJS wrapper
     // to avoid exposing them in global namespace.
-    `
-    (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
-      (function (exports, require, module, __filename, __dirname) {
-    `,
-    `
-      }).call(this, exports, require, module, __filename, __dirname);
-    })
-    `,
+    "(function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) { (function (exports, require, module, __filename, __dirname) {",
+    "\n}).call(this, exports, require, module, __filename, __dirname); })",
   ];
   // Loads a module at the given file path. Returns that module's
   // `exports` property.

--- a/node/module.ts
+++ b/node/module.ts
@@ -210,8 +210,13 @@ class Module {
   static wrapper = [
     // We provide non standard timer APIs in the CommonJS wrapper
     // to avoid exposing them in global namespace.
-    "(function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) { ",
-    "\n});",
+    `
+    (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
+      (function (exports, require, module, __filename, __dirname) {
+    `,
+    `
+      })(exports, require, module, __filename, __dirname);
+    });`,
   ];
 
   // Loads a module at the given file path. Returns that module's

--- a/node/module.ts
+++ b/node/module.ts
@@ -212,11 +212,10 @@ class Module {
     // to avoid exposing them in global namespace.
     `
     (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
-      const inner = function (exports, require, module, __filename, __dirname) {
+      (function (exports, require, module, __filename, __dirname) {
     `,
     `
-      };
-      inner.call(this, exports, require, module, __filename, __dirname);
+      }).call(this, exports, require, module, __filename, __dirname);
     })
     `,
   ];

--- a/node/module.ts
+++ b/node/module.ts
@@ -212,7 +212,6 @@ class Module {
     // to avoid exposing them in global namespace.
     `
     (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
-      "use strict";
       const inner = function(exports, require, module, __filename, __dirname) {
     `,
     `

--- a/node/module.ts
+++ b/node/module.ts
@@ -211,7 +211,9 @@ class Module {
     // We provide non standard timer APIs in the CommonJS wrapper
     // to avoid exposing them in global namespace.
     "(function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) { {",
-    "} });",
+    // The new line char is necessary for the case when the last line
+    // of the module is a line comment.
+    "\n} });",
   ];
 
   // Loads a module at the given file path. Returns that module's

--- a/node/module.ts
+++ b/node/module.ts
@@ -210,10 +210,16 @@ class Module {
   static wrapper = [
     // We provide non standard timer APIs in the CommonJS wrapper
     // to avoid exposing them in global namespace.
-    "(function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) { {",
-    // The new line char is necessary for the case when the last line
-    // of the module is a line comment.
-    "\n} });",
+    `
+    (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
+      "use strict";
+      const inner = function(exports, require, module, __filename, __dirname) {
+    `,
+    `
+      };
+      inner.call(this, exports, require, module, __filename, __dirname);
+    })
+    `,
   ];
 
   // Loads a module at the given file path. Returns that module's

--- a/node/module.ts
+++ b/node/module.ts
@@ -210,13 +210,8 @@ class Module {
   static wrapper = [
     // We provide non standard timer APIs in the CommonJS wrapper
     // to avoid exposing them in global namespace.
-    `
-    (function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) {
-      (function (exports, require, module, __filename, __dirname) {
-    `,
-    `
-      })(exports, require, module, __filename, __dirname);
-    });`,
+    "(function (exports, require, module, __filename, __dirname, setTimeout, clearTimeout, setInterval, clearInterval) { {",
+    "} });",
   ];
 
   // Loads a module at the given file path. Returns that module's

--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -197,3 +197,7 @@ Deno.test("module has proper members", function () {
   assert(module.Module === Module);
   assert(typeof module.wrap == "function");
 });
+
+Deno.test("a module can have its own timers declarations", function () {
+  require("./_module/cjs/cjs_declare_timers");
+});


### PR DESCRIPTION
Some npm modules have their own timer declarations (ref: https://github.com/discordjs/discord.js/blob/988a51b7641f8b33cc9387664605ddc02134859d/src/rest/RESTManager.js#L3 ), but those declarations conflicts with parameters of commonjs wrapper, and cause SyntaxError.

~~This PR adds the internal block inside the cjs wrapper and avoids the above error.~~ this doesn't work because now module can't control the strictness of the module. ("use strict" doesn't have effect anymore)

This PR adds another inner wrapper inside of the current one. The inner wrapper only provides the canonical commonjs items `exports`, `require`, `module`, `__filename`, `__dirname`, which prevents the conflicts of the declarations of timer functions.

closes #1901