### PR TITLE
chore: add `networkInterfaces` to `_deno_unstable.ts`

### DIFF
--- a/_deno_unstable.ts
+++ b/_deno_unstable.ts
@@ -142,3 +142,13 @@ export function utimeSync(
     throw new TypeError("Requires --unstable");
   }
 }
+
+export function networkInterfaces(
+  ...args: Parameters<typeof Deno.networkInterfaces>
+): ReturnType<typeof Deno.networkInterfaces> {
+  if (typeof Deno.networkInterfaces == "function") {
+    return Deno.networkInterfaces(...args);
+  } else {
+    throw new TypeError("Requires --unstable");
+  }
+}

--- a/node/os.ts
+++ b/node/os.ts
@@ -191,7 +191,7 @@ export function loadavg(): number[] {
 export function networkInterfaces(): NetworkInterfaces {
   const interfaces: NetworkInterfaces = {};
   for (
-    const { name, address, netmask, family, mac, scopeid, cidr } of Deno
+    const { name, address, netmask, family, mac, scopeid, cidr } of DenoUnstable
       .networkInterfaces()
   ) {
     const addresses = interfaces[name] ||= [];


### PR DESCRIPTION
`Deno.networkInterfaces` is still an unstable api.

Related: #1900 