### PR TITLE
fix(node/net) TypeScript error TS2322

### DIFF
--- a/node/net.ts
+++ b/node/net.ts
@@ -277,7 +277,7 @@ export function _normalizeArgs(args: unknown[]): NormalizedArgs {
   const arg0 = args[0] as Partial<NetConnectOptions> | number | string;
   let options: Partial<SocketConnectOptions> = {};
 
-  if (typeof arg0 === "object" && arg0 !== null) {
+  if (arg0 !== null) if (typeof arg0 === "object") {
     // (options[...][, cb])
     options = arg0;
   } else if (_isPipeName(arg0)) {

--- a/node/net.ts
+++ b/node/net.ts
@@ -277,18 +277,20 @@ export function _normalizeArgs(args: unknown[]): NormalizedArgs {
   const arg0 = args[0] as Partial<NetConnectOptions> | number | string;
   let options: Partial<SocketConnectOptions> = {};
 
-  if (arg0 !== null) if (typeof arg0 === "object") {
-    // (options[...][, cb])
-    options = arg0;
-  } else if (_isPipeName(arg0)) {
-    // (path[...][, cb])
-    (options as IpcSocketConnectOptions).path = arg0;
-  } else {
-    // ([port][, host][...][, cb])
-    (options as TcpSocketConnectOptions).port = arg0;
+  if (arg0 !== null) {
+    if (typeof arg0 === "object") {
+      // (options[...][, cb])
+      options = arg0;
+    } else if (_isPipeName(arg0)) {
+      // (path[...][, cb])
+      (options as IpcSocketConnectOptions).path = arg0;
+    } else {
+      // ([port][, host][...][, cb])
+      (options as TcpSocketConnectOptions).port = arg0;
 
-    if (args.length > 1 && typeof args[1] === "string") {
-      (options as TcpSocketConnectOptions).host = args[1];
+      if (args.length > 1 && typeof args[1] === "string") {
+        (options as TcpSocketConnectOptions).host = args[1];
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/denoland/deno_std/issues/1909.

This is only a simple fix for the type error.
Not sure if it pans out with the logic.

First PR, not sure if I did everything right.

Tests (node/_tools/test.ts) pass.

Reasoning explained [here](https://github.com/denoland/deno_std/issues/1909#issuecomment-1038262002). Copy-paste:

> Reason for this is that type inference fails because the `arg === null` case is not handled.

> This can be solved by replacing line 280 with:

```js
  if (arg0 !== null) if (typeof arg0 === "object") {
```

> although whether that makes sense for the rest of the logic is another question (`options` will then remain empty).