### PR TITLE
fix(io/buffer): super and initialized prop

### DIFF
--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -723,11 +723,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
   }
 
   constructor(writer: Writer, size: number = DEFAULT_BUF_SIZE) {
-    if (size <= 0) {
-      size = DEFAULT_BUF_SIZE;
-    }
-    const buf = new Uint8Array(size);
-    super(buf);
+    super(new Uint8Array(size <= 0 ? DEFAULT_BUF_SIZE : size));
     this.#writer = writer;
   }
 
@@ -824,11 +820,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
   }
 
   constructor(writer: WriterSync, size: number = DEFAULT_BUF_SIZE) {
-    if (size <= 0) {
-      size = DEFAULT_BUF_SIZE;
-    }
-    const buf = new Uint8Array(size);
-    super(buf);
+    super(new Uint8Array(size <= 0 ? DEFAULT_BUF_SIZE : size));
     this.#writer = writer;
   }
 


### PR DESCRIPTION
This gets rid of the error messages like the following when using `io/buffer.ts` under tsc directly via dnt: 

```
TS2376: A 'super' call must be the first statement in the constructor when a class contains initialized properties, parameter properties, or private identifiers.
```

While this is being fixed in future version of TypeScript, it is a limitation that is easy to work around and allows people to use the `std` lib via dnt without type errors.