### PR TITLE
test(node): enable hasCrypto flag

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -50,6 +50,7 @@
       "test-zlib-convenience-methods.js",
       "test-zlib-empty-buffer.js",
       "test-zlib-invalid-input.js",
+      "test-zlib-random-byte-pipes.js",
       "test-zlib-write-after-flush.js",
       "test-zlib-zero-byte.js",
       "test-zlib-zero-windowBits.js"

--- a/node/_tools/suites/common/index.js
+++ b/node/_tools/suites/common/index.js
@@ -378,6 +378,7 @@ module.exports = {
   expectsError,
   expectWarning,
   getBufferSources,
+  hasCrypto: true,
   invalidArgTypeHelper,
   mustCall,
   mustCallAtLeast,

--- a/node/_tools/suites/parallel/test-util-types.js
+++ b/node/_tools/suites/parallel/test-util-types.js
@@ -298,13 +298,12 @@ for (const [ value, _method ] of [
 //   assert.ok(types.isModuleNamespaceObject(m.namespace));
 // })().then(common.mustCall());
 
-// TODO(wafuwafu13): Implement `common.hasCrypto`
-// {
-//   // eslint-disable-next-line node-core/crypto-check
-//   if (common.hasCrypto) {
-//     const crypto = require('crypto');
-//     assert.ok(!types.isKeyObject(crypto.createHash('sha1')));
-//   }
-//   assert.ok(!types.isCryptoKey());
-//   assert.ok(!types.isKeyObject());
-// }
+{
+  // eslint-disable-next-line node-core/crypto-check
+  if (common.hasCrypto) {
+    const crypto = require('crypto');
+    assert.ok(!types.isKeyObject(crypto.createHash('sha1')));
+  }
+  assert.ok(!types.isCryptoKey());
+  assert.ok(!types.isKeyObject());
+}

--- a/node/_tools/suites/parallel/test-zlib-random-byte-pipes.js
+++ b/node/_tools/suites/parallel/test-zlib-random-byte-pipes.js
@@ -150,7 +150,8 @@ class HashStream extends Stream {
 
 for (const [ createCompress, createDecompress ] of [
   [ zlib.createGzip, zlib.createGunzip ],
-  [ zlib.createBrotliCompress, zlib.createBrotliDecompress ],
+  // TODO(kt3k): Enable this when we support brotli in zlib
+  // [ zlib.createBrotliCompress, zlib.createBrotliDecompress ],
 ]) {
   const inp = new RandomReadStream({ total: 1024, block: 256, jitter: 16 });
   const out = new HashStream();

--- a/node/internal/crypto/keys.ts
+++ b/node/internal/crypto/keys.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+import { kKeyObject } from "./util.js";
+const kKeyType = Symbol("kKeyType");
+
+// deno-lint-ignore no-explicit-any
+export function isKeyObject(obj: any) {
+  return obj != null && obj[kKeyType] !== undefined;
+}
+
+// deno-lint-ignore no-explicit-any
+export function isCryptoKey(obj: any) {
+  return obj != null && obj[kKeyObject] !== undefined;
+}

--- a/node/internal/crypto/util.js
+++ b/node/internal/crypto/util.js
@@ -1,6 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 let defaultEncoding = "buffer";
 
+const kKeyObject = Symbol("kKeyObject");
+
 function setDefaultEncoding(val) {
   defaultEncoding = val;
 }
@@ -10,4 +12,4 @@ function getDefaultEncoding() {
 }
 
 export default { getDefaultEncoding, setDefaultEncoding };
-export { getDefaultEncoding, setDefaultEncoding };
+export { getDefaultEncoding, kKeyObject, setDefaultEncoding };

--- a/node/internal/util/types.ts
+++ b/node/internal/util/types.ts
@@ -22,6 +22,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import * as bindingTypes from "../../internal_binding/types.ts";
+export { isCryptoKey, isKeyObject } from "../crypto/keys.ts";
 
 const _toString = Object.prototype.toString;
 
@@ -133,6 +134,4 @@ export const {
   isModuleNamespaceObject,
   isAnyArrayBuffer,
   isBoxedPrimitive,
-  // isKeyObject,
-  // isCryptoKey
 } = bindingTypes;


### PR DESCRIPTION
This PR enables `hasCrypto` flag in compat testing module. This flag should be true in compat testing as we provide cryptographic features in `std/node`