### PR TITLE
Don't use globalThis.setTimeout types in node/timers

### DIFF
--- a/node/timers.ts
+++ b/node/timers.ts
@@ -6,10 +6,9 @@ const setTimeout_ = globalThis.setTimeout;
 const clearTimeout_ = globalThis.clearTimeout;
 const setInterval_ = globalThis.setInterval;
 const clearInterval_ = globalThis.clearInterval;
-type TimerParams = Parameters<typeof globalThis.setTimeout>;
 export function setTimeout(
-  cb: TimerParams[0],
-  timeout?: TimerParams[1],
+  cb: (...args: unknown[]) => void,
+  timeout?: number,
   ...args: unknown[]
 ) {
   validateCallback(cb);
@@ -26,8 +25,8 @@ export function setTimeout(
   return timer;
 }
 export function setUnrefTimeout(
-  cb: TimerParams[0],
-  timeout?: TimerParams[1],
+  cb: (...args: unknown[]) => void,
+  timeout?: number,
   ...args: unknown[]
 ) {
   setTimeout(cb, timeout, ...args).unref();
@@ -39,8 +38,8 @@ export function clearTimeout(timeout?: Timeout | number) {
   clearTimeout_(+timeout);
 }
 export function setInterval(
-  cb: TimerParams[0],
-  timeout?: TimerParams[1],
+  cb: (...args: unknown[]) => void,
+  timeout?: number,
   ...args: unknown[]
 ) {
   validateCallback(cb);


### PR DESCRIPTION
Unlike globalThis.setTimeout in browsers, the setTimeout in node only
accepts functions, not strings.

The existing code works fine when typechecking with
lib.deno.shared_globals.d.ts, which declares setTimeout callback
argument as "(...args: any[]) => void". It is only a problem when
using lib.dom.d.ts, which declares the callback as having type
"string | Function". With the lib.dom.d.ts declaration, typechecking
fails because there is no .bind in string.