### PR TITLE
build: add `.devcontainer`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+
+ENV DENO_INSTALL=/deno
+RUN mkdir -p /deno \
+    && curl -fsSL https://deno.land/x/install/install.sh | sh \
+    && chown -R vscode /deno
+
+ENV PATH=${DENO_INSTALL}/bin:${PATH} \
+    DENO_DIR=${DENO_INSTALL}/.cache/deno

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,15 @@
 {
-	"name": "Deno",
- 	"build": {
-		"dockerfile": "Dockerfile",
-	},
-	"settings": {
-		"deno.enable": true,
-		"deno.lint": true,
-		"editor.defaultFormatter": "denoland.vscode-deno"
-	},
-	"extensions": [
-		"denoland.vscode-deno"
-	],
-	"remoteUser": "vscode"
+  "name": "Deno",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "settings": {
+    "deno.enable": true,
+    "deno.lint": true,
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "extensions": [
+    "denoland.vscode-deno"
+  ],
+  "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Deno",
+ 	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"settings": {
+		"deno.enable": true,
+		"deno.lint": true,
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"extensions": [
+		"denoland.vscode-deno"
+	],
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
*(This is based on [microsoft/vscode-dev-containers/containers/deno](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/deno))*

Adds a `.devcontainer` definition to support VS Code remote development environments (such as GitHub Codespace for example).
It comes with latest deno version installed, along with the vscode extension pre-configured