### PR TITLE
feat(async): Add `abortable` to async module.

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -21,7 +21,7 @@ const p = delay(1000);
 const c = new AbortController();
 setTimeout(() => c.abort(), 100);
 
-// Below throws `AbortedError` after 100 ms
+// Below throws `DOMException` after 100 ms
 await abortable(p, c.signal);
 ```
 
@@ -39,7 +39,7 @@ const p = async function* () {
 const c = new AbortController();
 setTimeout(() => c.abort(), 100);
 
-// Below throws `AbortedError` after 100 ms
+// Below throws `DOMException` after 100 ms
 // and items become `["Hello"]`
 const items: string[] = [];
 for await (const item of abortable(p(), c.signal)) {

--- a/async/README.md
+++ b/async/README.md
@@ -6,6 +6,47 @@ async is a module to provide help with asynchronous tasks.
 
 The following functions and class are exposed in `mod.ts`:
 
+## abortable
+
+The `abortable` is a wrapper function that makes `Promise` and `AsyncIterable`
+cancelable.
+
+For example, in the case of `Promise`, it looks like this
+
+```typescript
+import { abortable } from "https://deno.land/std/async/mod.ts";
+import { delay } from "https://deno.land/std/async/mod.ts";
+
+const p = delay(1000);
+const c = new AbortController();
+setTimeout(() => c.abort(), 100);
+
+// Below throws `AbortedError` after 100 ms
+await abortable(p, c.signal);
+```
+
+and for `AsyncIterable` as follows
+
+```typescript
+import { abortable } from "https://deno.land/std/async/mod.ts";
+import { delay } from "https://deno.land/std/async/mod.ts";
+
+const p = async function* () {
+  yield "Hello";
+  await delay(1000);
+  yield "World";
+};
+const c = new AbortController();
+setTimeout(() => c.abort(), 100);
+
+// Below throws `AbortedError` after 100 ms
+// and items become `["Hello"]`
+const items: string[] = [];
+for await (const item of abortable(p(), c.signal)) {
+  items.push(item);
+}
+```
+
 ## debounce
 
 Debounces a given function by a given time.

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -1,0 +1,68 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { deferred } from "./deferred.ts";
+
+export class AbortedError extends Error {
+  reason?: any;
+
+  constructor(reason?: any) {
+    super(reason ? `Aborted: ${reason}` : "Aborted");
+    this.name = "AbortedError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Make Promise or AsyncIterable abortable with a given signal.
+ */
+export function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T>;
+export function abortable<T>(
+  p: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncGenerator<T>;
+export function abortable<T>(
+  p: Promise<T> | AsyncIterable<T>,
+  signal: AbortSignal,
+): Promise<T> | AsyncIterable<T> {
+  if (p instanceof Promise) {
+    return abortablePromise(p, signal);
+  } else {
+    return abortableAsyncIterable(p, signal);
+  }
+}
+
+function abortablePromise<T>(p: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new AbortedError(signal.reason));
+  }
+  const waiter = deferred<never>();
+  const abort = () => waiter.reject(new AbortedError(signal.reason));
+  signal.addEventListener("abort", abort, { once: true });
+  return Promise.race([
+    waiter,
+    p.finally(() => {
+      signal.removeEventListener("abort", abort);
+    }),
+  ]);
+}
+
+async function* abortableAsyncIterable<T>(
+  p: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncGenerator<T> {
+  if (signal.aborted) {
+    throw new AbortedError(signal.reason);
+  }
+  const waiter = deferred<never>();
+  const abort = () => waiter.reject(new AbortedError(signal.reason));
+  signal.addEventListener("abort", abort, { once: true });
+
+  const it = p[Symbol.asyncIterator]();
+  while (true) {
+    const { done, value } = await Promise.race([waiter, it.next()]);
+    if (done) {
+      signal.removeEventListener("abort", abort);
+      return;
+    }
+    yield value;
+  }
+}

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -2,8 +2,12 @@
 import { deferred } from "./deferred.ts";
 
 export class AbortedError extends Error {
+  // This `reason` comes from `AbortSignal` thus must be `any`.
+  // deno-lint-ignore no-explicit-any
   reason?: any;
 
+  // This `reason` comes from `AbortSignal` thus must be `any`.
+  // deno-lint-ignore no-explicit-any
   constructor(reason?: any) {
     super(reason ? `Aborted: ${reason}` : "Aborted");
     this.name = "AbortedError";

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -1,0 +1,92 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { assertEquals, assertRejects } from "../testing/asserts.ts";
+import { deferred } from "./deferred.ts";
+import { abortable, AbortedError } from "./abortable.ts";
+
+Deno.test("[async] abortable (Promise)", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const result = await abortable(p, c.signal);
+  assertEquals(result, "Hello");
+  clearTimeout(t);
+});
+
+Deno.test("[async] abortable (Promise) with signal aborted after delay", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  setTimeout(() => c.abort(), 50);
+  await assertRejects(async () => {
+    await abortable(p, c.signal);
+  }, AbortedError);
+  clearTimeout(t);
+});
+
+Deno.test("[async] abortable (Promise) with already aborted signal", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  c.abort();
+  await assertRejects(async () => {
+    await abortable(p, c.signal);
+  }, AbortedError);
+  clearTimeout(t);
+});
+
+Deno.test("[async] abortable (AsyncIterable)", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const a = async function* () {
+    yield "Hello";
+    await p;
+    yield "World";
+  };
+  const items: string[] = [];
+  for await (const item of abortable(a(), c.signal)) {
+    items.push(item);
+  }
+  assertEquals(items, ["Hello", "World"]);
+  clearTimeout(t);
+});
+
+Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const a = async function* () {
+    yield "Hello";
+    await p;
+    yield "World";
+  };
+  setTimeout(() => c.abort(), 50);
+  const items: string[] = [];
+  await assertRejects(async () => {
+    for await (const item of abortable(a(), c.signal)) {
+      items.push(item);
+    }
+  }, AbortedError);
+  assertEquals(items, ["Hello"]);
+  clearTimeout(t);
+});
+
+Deno.test("[async] abortable (AsyncIterable) with already aborted signal", async () => {
+  const c = new AbortController();
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const a = async function* () {
+    yield "Hello";
+    await p;
+    yield "World";
+  };
+  c.abort();
+  const items: string[] = [];
+  await assertRejects(async () => {
+    for await (const item of abortable(a(), c.signal)) {
+      items.push(item);
+    }
+  }, AbortedError);
+  assertEquals(items, []);
+  clearTimeout(t);
+});

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertRejects } from "../testing/asserts.ts";
 import { deferred } from "./deferred.ts";
-import { abortable, AbortedError } from "./abortable.ts";
+import { abortable } from "./abortable.ts";
 
 Deno.test("[async] abortable (Promise)", async () => {
   const c = new AbortController();
@@ -17,9 +17,13 @@ Deno.test("[async] abortable (Promise) with signal aborted after delay", async (
   const p = deferred();
   const t = setTimeout(() => p.resolve("Hello"), 100);
   setTimeout(() => c.abort(), 50);
-  await assertRejects(async () => {
-    await abortable(p, c.signal);
-  }, AbortedError);
+  await assertRejects(
+    async () => {
+      await abortable(p, c.signal);
+    },
+    DOMException,
+    "AbortError",
+  );
   clearTimeout(t);
 });
 
@@ -28,9 +32,13 @@ Deno.test("[async] abortable (Promise) with already aborted signal", async () =>
   const p = deferred();
   const t = setTimeout(() => p.resolve("Hello"), 100);
   c.abort();
-  await assertRejects(async () => {
-    await abortable(p, c.signal);
-  }, AbortedError);
+  await assertRejects(
+    async () => {
+      await abortable(p, c.signal);
+    },
+    DOMException,
+    "AbortError",
+  );
   clearTimeout(t);
 });
 
@@ -62,11 +70,15 @@ Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", a
   };
   setTimeout(() => c.abort(), 50);
   const items: string[] = [];
-  await assertRejects(async () => {
-    for await (const item of abortable(a(), c.signal)) {
-      items.push(item);
-    }
-  }, AbortedError);
+  await assertRejects(
+    async () => {
+      for await (const item of abortable(a(), c.signal)) {
+        items.push(item);
+      }
+    },
+    DOMException,
+    "AbortError",
+  );
   assertEquals(items, ["Hello"]);
   clearTimeout(t);
 });
@@ -82,11 +94,15 @@ Deno.test("[async] abortable (AsyncIterable) with already aborted signal", async
   };
   c.abort();
   const items: string[] = [];
-  await assertRejects(async () => {
-    for await (const item of abortable(a(), c.signal)) {
-      items.push(item);
-    }
-  }, AbortedError);
+  await assertRejects(
+    async () => {
+      for await (const item of abortable(a(), c.signal)) {
+        items.push(item);
+      }
+    },
+    DOMException,
+    "AbortError",
+  );
   assertEquals(items, []);
   clearTimeout(t);
 });


### PR DESCRIPTION
Hi. 

The `abortable` is a wrapper function that makes `Promise` and `AsyncIterable` cancelable.

For example, in the case of `Promise`, it looks like this

```typescript
import { abortable } from "https://deno.land/std/async/mod.ts";
import { delay } from "https://deno.land/std/async/mod.ts";
const p = delay(1000);
const c = new AbortController();
setTimeout(() => c.abort(), 100);
// Below throws `AbortedError` after 100 ms
await abortable(p, c.signal);
```

and for `AsyncIterable` as follows

```typescript
import { abortable } from "https://deno.land/std/async/mod.ts";
import { delay } from "https://deno.land/std/async/mod.ts";
const p = async function* () {
  yield "Hello";
  await delay(1000);
  yield "World";
};
const c = new AbortController();
setTimeout(() => c.abort(), 100);
// Below throws `AbortedError` after 100 ms
// and items become `["Hello"]`
const items: string[] = [];
for await (const item of abortable(p(), c.signal)) {
  items.push(item);
}
```

I hope you all like it.