### PR TITLE
chore: Enable "noImplicitOverride" compiler option and fix errors

### DIFF
--- a/encoding/_yaml/error.ts
+++ b/encoding/_yaml/error.ts
@@ -14,7 +14,7 @@ export class YAMLError extends Error {
     this.name = this.constructor.name;
   }
 
-  public toString(_compact: boolean): string {
+  public override toString(_compact: boolean): string {
     return `${this.name}: ${this.message} ${this.mark}`;
   }
 }

--- a/encoding/csv_stringify.ts
+++ b/encoding/csv_stringify.ts
@@ -7,7 +7,7 @@ const QUOTE = '"';
 export const NEWLINE = "\r\n";
 
 export class StringifyError extends Error {
-  readonly name = "StringifyError";
+  override readonly name = "StringifyError";
 }
 
 function getEscapedString(value: unknown, sep: string): string {

--- a/hash/sha1.ts
+++ b/hash/sha1.ts
@@ -443,7 +443,7 @@ export class HmacSha1 extends Sha1 {
     this.#inner = true;
     this.#sharedMemory = sharedMemory;
   }
-  protected finalize(): void {
+  protected override finalize(): void {
     super.finalize();
     if (this.#inner) {
       this.#inner = false;

--- a/hash/sha256.ts
+++ b/hash/sha256.ts
@@ -584,7 +584,7 @@ export class HmacSha256 extends Sha256 {
     this.#sharedMemory = sharedMemory;
   }
 
-  protected finalize(): void {
+  protected override finalize(): void {
     super.finalize();
     if (this.#inner) {
       this.#inner = false;

--- a/hash/sha512.ts
+++ b/hash/sha512.ts
@@ -1136,7 +1136,7 @@ export class HmacSha512 extends Sha512 {
     this.#sharedMemory = sharedMemory;
   }
 
-  protected finalize(): void {
+  protected override finalize(): void {
     super.finalize();
     if (this.#inner) {
       this.#inner = false;

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -254,14 +254,14 @@ const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 
 export class BufferFullError extends Error {
-  name = "BufferFullError";
+  override name = "BufferFullError";
   constructor(public partial: Uint8Array) {
     super("Buffer full");
   }
 }
 
 export class PartialReadError extends Error {
-  name = "PartialReadError";
+  override name = "PartialReadError";
   partial?: Uint8Array;
   constructor() {
     super("Encountered UnexpectedEof, data only partially read");

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -55,7 +55,7 @@ export class BaseHandler {
 }
 
 export class ConsoleHandler extends BaseHandler {
-  format(logRecord: LogRecord): string {
+  override format(logRecord: LogRecord): string {
     let msg = super.format(logRecord);
 
     switch (logRecord.level) {
@@ -78,7 +78,7 @@ export class ConsoleHandler extends BaseHandler {
     return msg;
   }
 
-  log(msg: string): void {
+  override log(msg: string): void {
     console.log(msg);
   }
 }
@@ -87,7 +87,7 @@ export abstract class WriterHandler extends BaseHandler {
   protected _writer!: Deno.Writer;
   #encoder = new TextEncoder();
 
-  abstract log(msg: string): void;
+  abstract override log(msg: string): void;
 }
 
 interface FileHandlerOptions extends HandlerOptions {
@@ -120,7 +120,7 @@ export class FileHandler extends WriterHandler {
     };
   }
 
-  async setup() {
+  override async setup() {
     this._file = await Deno.open(this._filename, this._openOptions);
     this._writer = this._file;
     this._buf = new BufWriterSync(this._file);
@@ -128,7 +128,7 @@ export class FileHandler extends WriterHandler {
     addEventListener("unload", this.#unloadCallback);
   }
 
-  handle(logRecord: LogRecord): void {
+  override handle(logRecord: LogRecord): void {
     super.handle(logRecord);
 
     // Immediately flush if log level is higher than ERROR
@@ -150,7 +150,7 @@ export class FileHandler extends WriterHandler {
     }
   }
 
-  destroy() {
+  override destroy() {
     this.flush();
     this._file?.close();
     this._file = undefined;
@@ -175,7 +175,7 @@ export class RotatingFileHandler extends FileHandler {
     this.#maxBackupCount = options.maxBackupCount;
   }
 
-  async setup() {
+  override async setup() {
     if (this.#maxBytes < 1) {
       this.destroy();
       throw new Error("maxBytes cannot be less than 1");
@@ -209,7 +209,7 @@ export class RotatingFileHandler extends FileHandler {
     }
   }
 
-  log(msg: string): void {
+  override log(msg: string): void {
     const msgByteLength = this._encoder.encode(msg).byteLength + 1;
 
     if (this.#currentFileSize + msgByteLength > this.#maxBytes) {

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -21,7 +21,7 @@ const LOG_FILE = "./test_log.file";
 class TestHandler extends BaseHandler {
   public messages: string[] = [];
 
-  public log(str: string): void {
+  public override log(str: string): void {
     this.messages.push(str);
   }
 }
@@ -133,7 +133,7 @@ Deno.test({
   name: "FileHandler Shouldn't Have Broken line",
   async fn() {
     class TestFileHandler extends FileHandler {
-      flush() {
+      override flush() {
         super.flush();
         const decoder = new TextDecoder("utf-8");
         const data = Deno.readFileSync(LOG_FILE);
@@ -141,7 +141,7 @@ Deno.test({
         assertEquals(text.slice(-1), "\n");
       }
 
-      async destroy() {
+      override async destroy() {
         await super.destroy();
         await Deno.remove(LOG_FILE);
       }

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -8,12 +8,12 @@ class TestHandler extends BaseHandler {
   public messages: string[] = [];
   public records: LogRecord[] = [];
 
-  handle(record: LogRecord): void {
+  override handle(record: LogRecord): void {
     this.records.push(record);
     super.handle(record);
   }
 
-  public log(str: string): void {
+  public override log(str: string): void {
     this.messages.push(str);
   }
 }

--- a/log/mod_test.ts
+++ b/log/mod_test.ts
@@ -17,7 +17,7 @@ import { BaseHandler } from "./handlers.ts";
 class TestHandler extends BaseHandler {
   public messages: string[] = [];
 
-  public log(str: string): void {
+  public override log(str: string): void {
     this.messages.push(str);
   }
 }

--- a/log/test.ts
+++ b/log/test.ts
@@ -11,7 +11,7 @@ import {
 class TestHandler extends log.handlers.BaseHandler {
   public messages: string[] = [];
 
-  log(msg: string): void {
+  override log(msg: string): void {
     this.messages.push(msg);
   }
 }

--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -535,7 +535,7 @@ export class AssertionError extends Error {
     this.name = "AssertionError";
   }
 
-  toString() {
+  override toString() {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 

--- a/node/dgram.ts
+++ b/node/dgram.ts
@@ -163,74 +163,89 @@ export class Socket extends EventEmitter {
   unref(): this {
     notImplemented();
   }
-  addListener(event: "close", listener: () => void): this;
-  addListener(event: "connect", listener: () => void): this;
-  addListener(event: "error", listener: (err: Error) => void): this;
-  addListener(event: "listening", listener: () => void): this;
-  addListener(
+  override addListener(event: "close", listener: () => void): this;
+  override addListener(event: "connect", listener: () => void): this;
+  override addListener(event: "error", listener: (err: Error) => void): this;
+  override addListener(event: "listening", listener: () => void): this;
+  override addListener(
     event: "message",
     listener: (msg: Buffer, rinfo: RemoteInfo) => void,
   ): this;
-  // deno-lint-ignore no-explicit-any
-  addListener(event: string, listener: (...args: any[]) => void): this {
+  override addListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
     return super.addListener(event, listener);
   }
 
-  emit(event: "close"): boolean;
-  emit(event: "connect"): boolean;
-  emit(event: "error", err: Error): boolean;
-  emit(event: "listening"): boolean;
-  emit(event: "message", msg: Buffer, rinfo: RemoteInfo): boolean;
+  override emit(event: "close"): boolean;
+  override emit(event: "connect"): boolean;
+  override emit(event: "error", err: Error): boolean;
+  override emit(event: "listening"): boolean;
+  override emit(event: "message", msg: Buffer, rinfo: RemoteInfo): boolean;
   // deno-lint-ignore no-explicit-any
-  emit(event: string | symbol, ...args: any[]): boolean {
+  override emit(event: string | symbol, ...args: any[]): boolean {
     return super.emit(event, ...args);
   }
-  on(event: "close", listener: () => void): this;
-  on(event: "connect", listener: () => void): this;
-  on(event: "error", listener: (err: Error) => void): this;
-  on(event: "listening", listener: () => void): this;
-  on(
+  override on(event: "close", listener: () => void): this;
+  override on(event: "connect", listener: () => void): this;
+  override on(event: "error", listener: (err: Error) => void): this;
+  override on(event: "listening", listener: () => void): this;
+  override on(
     event: "message",
     listener: (msg: Buffer, rinfo: RemoteInfo) => void,
   ): this;
   // deno-lint-ignore no-explicit-any
-  on(event: string, listener: (...args: any[]) => void): this {
+  override on(event: string, listener: (...args: any[]) => void): this {
     return super.on(event, listener);
   }
-  once(event: "close", listener: () => void): this;
-  once(event: "connect", listener: () => void): this;
-  once(event: "error", listener: (err: Error) => void): this;
-  once(event: "listening", listener: () => void): this;
-  once(
+  override once(event: "close", listener: () => void): this;
+  override once(event: "connect", listener: () => void): this;
+  override once(event: "error", listener: (err: Error) => void): this;
+  override once(event: "listening", listener: () => void): this;
+  override once(
     event: "message",
     listener: (msg: Buffer, rinfo: RemoteInfo) => void,
   ): this;
   // deno-lint-ignore no-explicit-any
-  once(event: string, listener: (...args: any[]) => void): this {
+  override once(event: string, listener: (...args: any[]) => void): this {
     return super.on(event, listener);
   }
-  prependListener(event: "close", listener: () => void): this;
-  prependListener(event: "connect", listener: () => void): this;
-  prependListener(event: "error", listener: (err: Error) => void): this;
-  prependListener(event: "listening", listener: () => void): this;
-  prependListener(
+  override prependListener(event: "close", listener: () => void): this;
+  override prependListener(event: "connect", listener: () => void): this;
+  override prependListener(
+    event: "error",
+    listener: (err: Error) => void,
+  ): this;
+  override prependListener(event: "listening", listener: () => void): this;
+  override prependListener(
     event: "message",
     listener: (msg: Buffer, rinfo: RemoteInfo) => void,
   ): this;
-  // deno-lint-ignore no-explicit-any
-  prependListener(event: string, listener: (...args: any[]) => void): this {
+  override prependListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
     return super.prependListener(event, listener);
   }
-  prependOnceListener(event: "close", listener: () => void): this;
-  prependOnceListener(event: "connect", listener: () => void): this;
-  prependOnceListener(event: "error", listener: (err: Error) => void): this;
-  prependOnceListener(event: "listening", listener: () => void): this;
-  prependOnceListener(
+  override prependOnceListener(event: "close", listener: () => void): this;
+  override prependOnceListener(event: "connect", listener: () => void): this;
+  override prependOnceListener(
+    event: "error",
+    listener: (err: Error) => void,
+  ): this;
+  override prependOnceListener(event: "listening", listener: () => void): this;
+  override prependOnceListener(
     event: "message",
     listener: (msg: Buffer, rinfo: RemoteInfo) => void,
   ): this;
-  // deno-lint-ignore no-explicit-any
-  prependOnceListener(event: string, listener: (...args: any[]) => void): this {
+  override prependOnceListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
     return super.prependOnceListener(event, listener);
   }
 }

--- a/node/http.ts
+++ b/node/http.ts
@@ -100,7 +100,7 @@ class ClientRequest extends NodeWritable {
   }
 
   // deno-lint-ignore no-explicit-any
-  _write(chunk: any, _enc: string, cb: () => void) {
+  override _write(chunk: any, _enc: string, cb: () => void) {
     if (this.controller) {
       this.controller.enqueue(chunk);
       cb();
@@ -116,7 +116,7 @@ class ClientRequest extends NodeWritable {
     });
   }
 
-  async _final() {
+  override async _final() {
     const client = await this._createCustomClient();
     const opts = { body: this.body, method: this.opts.method, client };
     const mayResponse = fetch(this.opts.href!, opts).catch((e) => {
@@ -164,7 +164,7 @@ export class IncomingMessageForClient extends NodeReadable {
     this.reader = response?.body?.getReader();
   }
 
-  async _read(_size: number) {
+  override async _read(_size: number) {
     if (this.reader === undefined) {
       this.push(null);
       return;
@@ -306,7 +306,7 @@ export class ServerResponse extends NodeWritable {
   }
 
   // deno-lint-ignore no-explicit-any
-  end(chunk?: any, encoding?: any, cb?: any): this {
+  override end(chunk?: any, encoding?: any, cb?: any): this {
     if (!chunk && this.#headers.has("transfer-encoding")) {
       // FIXME(bnoordhuis) Node sends a zero length chunked body instead, i.e.,
       // the trailing "0\r\n", but respondWith() just hangs when I try that.

--- a/node/https.ts
+++ b/node/https.ts
@@ -57,7 +57,9 @@ export function get(...args: any[]) {
 export const globalAgent = undefined;
 /** HttpsClientRequest class loosely follows http.ClientRequest class API. */
 class HttpsClientRequest extends ClientRequest {
-  async _createCustomClient(): Promise<DenoUnstable.HttpClient | undefined> {
+  override async _createCustomClient(): Promise<
+    DenoUnstable.HttpClient | undefined
+  > {
     if (caCerts === null) {
       return undefined;
     }
@@ -82,7 +84,7 @@ class HttpsClientRequest extends ClientRequest {
     return DenoUnstable.createHttpClient({ caCerts });
   }
 
-  _createSocket(): Socket {
+  override _createSocket(): Socket {
     // deno-lint-ignore no-explicit-any
     return { authorized: true } as any;
   }

--- a/node/internal/errors.ts
+++ b/node/internal/errors.ts
@@ -325,7 +325,7 @@ export class NodeErrorAbstraction extends Error {
     this.stack = this.stack && `${name} [${this.code}]${this.stack.slice(20)}`;
   }
 
-  toString() {
+  override toString() {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 }
@@ -471,7 +471,7 @@ class NodeSystemError extends NodeErrorAbstraction {
     }
   }
 
-  toString() {
+  override toString() {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 }
@@ -2225,7 +2225,7 @@ export class ERR_HTTP2_INVALID_SETTING_VALUE extends NodeRangeError {
   }
 }
 export class ERR_HTTP2_STREAM_CANCEL extends NodeError {
-  cause?: Error;
+  override cause?: Error;
   constructor(error: Error) {
     super(
       "ERR_HTTP2_STREAM_CANCEL",

--- a/node/internal/fs/streams.ts
+++ b/node/internal/fs/streams.ts
@@ -47,7 +47,7 @@ export class WriteStreamClass extends Writable {
     }
   }
 
-  _construct(callback: (err?: Error) => void) {
+  override _construct(callback: (err?: Error) => void) {
     this[kFs].open(
       this.path.toString(),
       this.flags!,
@@ -66,7 +66,11 @@ export class WriteStreamClass extends Writable {
     );
   }
 
-  _write(data: Buffer, _encoding: string, cb: (err?: Error | null) => void) {
+  override _write(
+    data: Buffer,
+    _encoding: string,
+    cb: (err?: Error | null) => void,
+  ) {
     this[kIsPerformingIO] = true;
     this[kFs].write(
       this.fd!,
@@ -96,7 +100,7 @@ export class WriteStreamClass extends Writable {
     }
   }
 
-  _destroy(err: Error, cb: (err?: Error | null) => void) {
+  override _destroy(err: Error, cb: (err?: Error | null) => void) {
     if (this[kIsPerformingIO]) {
       this.once(kIoDone, (er) => closeStream(this, err || er, cb));
     } else {

--- a/node/internal_binding/pipe_wrap.ts
+++ b/node/internal_binding/pipe_wrap.ts
@@ -36,7 +36,7 @@ export enum socketType {
 }
 
 export class Pipe extends ConnectionWrap {
-  reading = false;
+  override reading = false;
   ipc: boolean;
 
   constructor(type: number) {

--- a/node/internal_binding/stream_wrap.ts
+++ b/node/internal_binding/stream_wrap.ts
@@ -231,7 +231,7 @@ export class LibuvStreamWrap extends HandleWrap {
     return this.writeBuffer(req, buffer);
   }
 
-  async _onClose(): Promise<number> {
+  override async _onClose(): Promise<number> {
     let status = 0;
     this.#reading = false;
 

--- a/node/internal_binding/tcp_wrap.ts
+++ b/node/internal_binding/tcp_wrap.ts
@@ -89,7 +89,7 @@ export enum constants {
 
 export class TCP extends ConnectionWrap {
   [ownerSymbol]: unknown = null;
-  reading = false;
+  override reading = false;
 
   #address?: string;
   #port?: number;
@@ -443,7 +443,7 @@ export class TCP extends ConnectionWrap {
   }
 
   /** Handle server closure. */
-  async _onClose(): Promise<number> {
+  override async _onClose(): Promise<number> {
     // TODO(cmorten): this isn't great
     this.#closed = true;
     this.reading = false;

--- a/node/net.ts
+++ b/node/net.ts
@@ -942,7 +942,7 @@ export class Socket extends Duplex {
    *
    * @return The socket itself.
    */
-  pause(): this {
+  override pause(): this {
     if (
       this[kBuffer] && !this.connecting && this._handle &&
       this._handle.reading
@@ -966,7 +966,7 @@ export class Socket extends Duplex {
    *
    * @return The socket itself.
    */
-  resume(): this {
+  override resume(): this {
     if (
       this[kBuffer] && !this.connecting && this._handle &&
       !this._handle.reading
@@ -1273,10 +1273,14 @@ export class Socket extends Duplex {
    * @param cb Optional callback for when the socket is finished.
    * @return The socket itself.
    */
-  end(cb?: () => void): this;
-  end(buffer: Uint8Array | string, cb?: () => void): this;
-  end(data: Uint8Array | string, encoding?: Encodings, cb?: () => void): this;
-  end(
+  override end(cb?: () => void): this;
+  override end(buffer: Uint8Array | string, cb?: () => void): this;
+  override end(
+    data: Uint8Array | string,
+    encoding?: Encodings,
+    cb?: () => void,
+  ): this;
+  override end(
     data?: Uint8Array | string | (() => void),
     encoding?: Encodings | (() => void),
     cb?: () => void,
@@ -1290,7 +1294,9 @@ export class Socket extends Duplex {
   /**
    * @param size Optional argument to specify how much data to read.
    */
-  read(size?: number): string | Uint8Array | Buffer | null | undefined {
+  override read(
+    size?: number,
+  ): string | Uint8Array | Buffer | null | undefined {
     if (
       this[kBuffer] && !this.connecting && this._handle &&
       !this._handle.reading
@@ -1325,7 +1331,7 @@ export class Socket extends Duplex {
   // The user has called .end(), and all the bytes have been
   // sent out to the other side.
   // deno-lint-ignore no-explicit-any
-  _final = (cb: any): any => {
+  override _final = (cb: any): any => {
     // If still connecting - defer handling `_final` until 'connect' will happen
     if (this.pending) {
       debug("_final: not yet connected");
@@ -1373,7 +1379,7 @@ export class Socket extends Duplex {
     this.emit("timeout");
   }
 
-  _read(size?: number): void {
+  override _read(size?: number): void {
     debug("_read");
     if (this.connecting || !this._handle) {
       debug("_read wait for connection");
@@ -1383,7 +1389,7 @@ export class Socket extends Duplex {
     }
   }
 
-  _destroy(
+  override _destroy(
     exception: Error | null,
     cb: (err: Error | null) => void,
   ) {
@@ -1507,7 +1513,7 @@ export class Socket extends Duplex {
     this._writeGeneric(true, chunks, "", cb);
   }
 
-  _write(
+  override _write(
     // deno-lint-ignore no-explicit-any
     data: any,
     encoding: string,

--- a/node/process.ts
+++ b/node/process.ts
@@ -289,13 +289,16 @@ class Process extends EventEmitter {
   nextTick = _nextTick;
 
   /** https://nodejs.org/api/process.html#process_process_events */
-  on(event: "exit", listener: (code: number) => void): this;
+  override on(event: "exit", listener: (code: number) => void): this;
   // deno-lint-ignore no-explicit-any
-  on(event: string, listener: (...args: any[]) => void): this;
-  // deno-lint-ignore ban-types
-  on(event: typeof notImplementedEvents[number], listener: Function): this;
+  override on(event: string, listener: (...args: any[]) => void): this;
+  override on(
+    event: typeof notImplementedEvents[number],
+    // deno-lint-ignore ban-types
+    listener: Function,
+  ): this;
   // deno-lint-ignore no-explicit-any
-  on(event: string, listener: (...args: any[]) => void): this {
+  override on(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.on("${event}")`);
     } else if (event.startsWith("SIG")) {
@@ -307,13 +310,16 @@ class Process extends EventEmitter {
     return this;
   }
 
-  off(event: "exit", listener: (code: number) => void): this;
+  override off(event: "exit", listener: (code: number) => void): this;
   // deno-lint-ignore no-explicit-any
-  off(event: string, listener: (...args: any[]) => void): this;
-  // deno-lint-ignore ban-types
-  off(event: typeof notImplementedEvents[number], listener: Function): this;
+  override off(event: string, listener: (...args: any[]) => void): this;
+  override off(
+    event: typeof notImplementedEvents[number],
+    // deno-lint-ignore ban-types
+    listener: Function,
+  ): this;
   // deno-lint-ignore no-explicit-any
-  off(event: string, listener: (...args: any[]) => void): this {
+  override off(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.off("${event}")`);
     } else if (event.startsWith("SIG")) {

--- a/strict-ts44.tsconfig.json
+++ b/strict-ts44.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "useUnknownInCatchVariables": true
+    "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true
   }
 }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -17,7 +17,7 @@ import { diff, DiffResult, diffstr, DiffType } from "./_diff.ts";
 const CAN_NOT_DISPLAY = "[Cannot display]";
 
 export class AssertionError extends Error {
-  name = "AssertionError";
+  override name = "AssertionError";
   constructor(message: string) {
     super(message);
   }


### PR DESCRIPTION
This commit makes deno_std `noImplicitOverride`-compliant and enables the compiler option in `deno.json` so that further changes don't regress it. Closes https://github.com/denoland/deno_std/issues/1933