### PR TITLE
feat(http): expose serveDir function from file_server.ts

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -602,18 +602,19 @@ interface ServeDirOptions {
  * Serves the files under the given directory root (opts.fsRoot).
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
+ * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
  *
  * serve((req) => {
- *   const pathname = new URL(req).pathname;
+ *   const pathname = new URL(req.url).pathname;
  *   if (pathname.startsWith("/static")) {
  *     return serveDir(req, {
  *       fsRoot: "path/to/static/files/dir",
  *     });
  *   }
  *   // Do dynamic responses
- * })
+ *   return new Response();
+ * });
  * ```
  *
  * Optionally you can pass `urlRoot` option. If it's specified that part is stripped from the beginning of the requested pathname.
@@ -622,7 +623,7 @@ interface ServeDirOptions {
  * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
  *
  * // ...
- * serveDir(req, {
+ * serveDir(new Request("http://localhost/static/path/to/file"), {
  *   fsRoot: "public",
  *   urlRoot: "static",
  * });


### PR DESCRIPTION
This PR exposes `serveDir` function from `http/file_server.ts` module.

`serveDir` can be used like the below. This example serves the files under `path/to/static/files/dir` when the requested path starts with `/static`

```ts
import { serve } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
serve((req) => {
  const pathname = new URL(req.url).pathname;
  if (pathname.startsWith("/static")) {
    return serveDir(req, {
      fsRoot: "path/to/static/files/dir",
    });
  }
  // Do dynamic responses
});
```

closes #1905 
closes #898