### PR TITLE
chore(archive): fix lint error in tar.ts

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -65,7 +65,7 @@ async function readBlock(
  * Simple file reader
  */
 class FileReader implements Reader {
-  private file?: Deno.File;
+  private file?: Deno.FsFile;
 
   constructor(private filePath: string) {}
 


### PR DESCRIPTION
This fixes the lint error:

```
(no-deprecated-deno-api) `Deno.File` is deprecated and scheduled for removal in Deno 2.0
```

---
Note:
- `Deno.File` became `Deno.FsFile` in https://github.com/denoland/deno/pull/13660
- `no-deprecated-deno-api` was updated in https://github.com/denoland/deno_lint/pull/1015
- `deno_lint` was upgraded to `0.26.0` in https://github.com/denoland/deno/pull/13758