### PR TITLE
chore(node): add randombytes from crypto-browserify

### DIFF
--- a/node/_crypto/crypto_browserify/README.md
+++ b/node/_crypto/crypto_browserify/README.md
@@ -1,0 +1,2 @@
+This directory contains the libraries ported from
+[crypto-browserify](https://github.com/crypto-browserify) organization.

--- a/node/_crypto/crypto_browserify/randombytes.ts
+++ b/node/_crypto/crypto_browserify/randombytes.ts
@@ -1,0 +1,45 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2017 crypto-browserify. All rights reserved. MIT license.
+import { Buffer } from "../../buffer.ts";
+import { nextTick } from "../../_next_tick.ts";
+
+// limit of Crypto.getRandomValues()
+// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+const MAX_BYTES = 65536;
+
+// Node supports requesting up to this number of bytes
+// https://github.com/nodejs/node/blob/master/lib/internal/crypto/random.js#L48
+const MAX_UINT32 = 4294967295;
+
+export function randomBytes(
+  size: number,
+  cb?: (err: Error | null, b: Buffer) => void,
+) {
+  // phantomjs needs to throw
+  if (size > MAX_UINT32) {
+    throw new RangeError("requested too many random bytes");
+  }
+
+  const bytes = Buffer.allocUnsafe(size);
+
+  if (size > 0) { // getRandomValues fails on IE if size == 0
+    if (size > MAX_BYTES) { // this is the max bytes crypto.getRandomValues
+      // can do at once see https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
+      for (let generated = 0; generated < size; generated += MAX_BYTES) {
+        // buffer.slice automatically checks if the end is past the end of
+        // the buffer so we don't have to here
+        crypto.getRandomValues(bytes.slice(generated, generated + MAX_BYTES));
+      }
+    } else {
+      crypto.getRandomValues(bytes);
+    }
+  }
+
+  if (typeof cb === "function") {
+    return nextTick(function () {
+      cb(null, bytes);
+    });
+  }
+
+  return bytes;
+}

--- a/node/_crypto/crypto_browserify/randombytes_test.ts
+++ b/node/_crypto/crypto_browserify/randombytes_test.ts
@@ -1,0 +1,48 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2017 crypto-browserify. All rights reserved. MIT license.
+import { randomBytes } from "./randombytes.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "../../../testing/asserts.ts";
+
+const MAX_BYTES = 65536;
+const MAX_UINT32 = 4294967295;
+
+Deno.test("sync", () => {
+  assertEquals(randomBytes(0)!.length, 0, "len: " + 0);
+  assertEquals(randomBytes(3)!.length, 3, "len: " + 3);
+  assertEquals(randomBytes(30)!.length, 30, "len: " + 30);
+  assertEquals(randomBytes(300)!.length, 300, "len: " + 300);
+  assertEquals(
+    randomBytes(17 + MAX_BYTES)!.length,
+    17 + MAX_BYTES,
+    "len: " + 17 + MAX_BYTES,
+  );
+  assertEquals(
+    randomBytes(MAX_BYTES * 100)!.length,
+    MAX_BYTES * 100,
+    "len: " + MAX_BYTES * 100,
+  );
+  assertThrows(function () {
+    randomBytes(MAX_UINT32 + 1);
+  });
+  assertThrows(function () {
+    assert(randomBytes(-1));
+  });
+  assertThrows(function () {
+    assert(randomBytes("hello" as unknown as number));
+  });
+});
+
+Deno.test("async", async () => {
+  await new Promise<void>((resolve) => {
+    randomBytes(3, function (err, resp) {
+      if (err) throw err;
+
+      assertEquals(resp.length, 3, "len: " + 3);
+      resolve();
+    });
+  });
+});


### PR DESCRIPTION
part of #1962 

This ports [randombytes](https://www.npmjs.com/package/randombytes), a small utility on top of `crypto.getRandomValues`, to `std/node`.