### PR TITLE
fix(testing): assertObjectMatch for RegExp/Map/Set

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -605,7 +605,7 @@ export function assertObjectMatch(
             continue;
           }
         } // On nested objects references, build a filtered object recursively
-        else if (typeof value === "object") {
+        else if ((typeof value === "object") && (!(value instanceof RegExp))) {
           const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
             filtered[key] = fn(value as loose, subset as loose);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -604,10 +604,28 @@ export function assertObjectMatch(
             filtered[key] = fn({ ...value }, { ...subset });
             continue;
           }
+        } // On regexp references, keep value as it to avoid loosing pattern and flags
+        else if (value instanceof RegExp) {
+          filtered[key] = value;
+          continue;
         } // On nested objects references, build a filtered object recursively
-        else if ((typeof value === "object") && (!(value instanceof RegExp))) {
+        else if (typeof value === "object") {
           const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
+            // When both operands are maps, build a filtered map with common keys and filter nested objects inside
+            if ((value instanceof Map) && (subset instanceof Map)) {
+              filtered[key] = new Map(
+                [...value].filter(([k]) => subset.has(k)).map((
+                  [k, v],
+                ) => [k, typeof v === "object" ? fn(v, subset.get(k)) : v]),
+              );
+              continue;
+            }
+            // When both operands are set, build a filtered set with common values
+            if ((value instanceof Set) && (subset instanceof Set)) {
+              filtered[key] = new Set([...value].filter((v) => subset.has(v)));
+              continue;
+            }
             filtered[key] = fn(value as loose, subset as loose);
             continue;
           }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -382,6 +382,11 @@ Deno.test("testingAssertObjectMatching", function (): void {
   const k = { foo: [[1, [2, [3]]]], bar: true };
   const l = { foo: [[1, [2, [a, e, j, k]]]], bar: true };
   const m = { foo: /abc+/i, bar: [/abc/g, /abc/m] };
+  const n = {
+    foo: new Set(["foo", "bar"]),
+    bar: new Map([["foo", 1], ["bar", 2]]),
+    baz: new Map([["a", a], ["b", b]]),
+  };
 
   // Simple subset
   assertObjectMatch(a, {
@@ -446,6 +451,11 @@ Deno.test("testingAssertObjectMatching", function (): void {
   // Regexp
   assertObjectMatch(m, { foo: /abc+/i });
   assertObjectMatch(m, { bar: [/abc/g, /abc/m] });
+  //Built-in data structures
+  assertObjectMatch(n, { foo: new Set(["foo"]) });
+  assertObjectMatch(n, { bar: new Map([["bar", 2]]) });
+  assertObjectMatch(n, { baz: new Map([["b", b]]) });
+  assertObjectMatch(n, { baz: new Map([["b", { foo: true }]]) });
 
   // Missing key
   {
@@ -619,19 +629,25 @@ Deno.test("testingAssertObjectMatching", function (): void {
     });
   }
   //Regexp
-  {
-    let didThrow;
-    try {
-      assertObjectMatch(m, { foo: /abc+/ });
-      assertObjectMatch(m, { foo: /abc*/i });
-      assertObjectMatch(m, { bar: [/abc/m, /abc/g] });
-      didThrow = false;
-    } catch (e) {
-      assert(e instanceof AssertionError);
-      didThrow = true;
-    }
-    assertEquals(didThrow, true);
-  }
+  assertThrows(() => assertObjectMatch(m, { foo: /abc+/ }), AssertionError);
+  assertThrows(() => assertObjectMatch(m, { foo: /abc*/i }), AssertionError);
+  assertThrows(
+    () => assertObjectMatch(m, { bar: [/abc/m, /abc/g] }),
+    AssertionError,
+  );
+  //Built-in data structures
+  assertThrows(
+    () => assertObjectMatch(n, { foo: new Set(["baz"]) }),
+    AssertionError,
+  );
+  assertThrows(
+    () => assertObjectMatch(n, { bar: new Map([["bar", 3]]) }),
+    AssertionError,
+  );
+  assertThrows(
+    () => assertObjectMatch(n, { baz: new Map([["a", { baz: true }]]) }),
+    AssertionError,
+  );
 });
 
 Deno.test("testingAssertsUnimplemented", function (): void {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -381,7 +381,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
   const j = { foo: [[1, 2, 3]], bar: true };
   const k = { foo: [[1, [2, [3]]]], bar: true };
   const l = { foo: [[1, [2, [a, e, j, k]]]], bar: true };
-  const m = { foo: /abc+/i, bar: true };
+  const m = { foo: /abc+/i, bar: [/abc/g, /abc/m] };
 
   // Simple subset
   assertObjectMatch(a, {
@@ -445,6 +445,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
   assertObjectMatch(l, { foo: [[1, [2, [a, e, j, k]]]] });
   // Regexp
   assertObjectMatch(m, { foo: /abc+/i });
+  assertObjectMatch(m, { bar: [/abc/g, /abc/m] });
 
   // Missing key
   {
@@ -623,6 +624,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
     try {
       assertObjectMatch(m, { foo: /abc+/ });
       assertObjectMatch(m, { foo: /abc*/i });
+      assertObjectMatch(m, { bar: [/abc/m, /abc/g] });
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -622,7 +622,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
     let didThrow;
     try {
       assertObjectMatch(m, { foo: /abc+/ });
-      assertObjectMatch(m, { foo: /abc*/ });
+      assertObjectMatch(m, { foo: /abc*/i });
       didThrow = false;
     } catch (e) {
       assert(e instanceof AssertionError);

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -381,6 +381,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
   const j = { foo: [[1, 2, 3]], bar: true };
   const k = { foo: [[1, [2, [3]]]], bar: true };
   const l = { foo: [[1, [2, [a, e, j, k]]]], bar: true };
+  const m = { foo: /abc+/i, bar: true };
 
   // Simple subset
   assertObjectMatch(a, {
@@ -442,6 +443,9 @@ Deno.test("testingAssertObjectMatching", function (): void {
   assertObjectMatch(j, { foo: [[1, 2, 3]] });
   assertObjectMatch(k, { foo: [[1, [2, [3]]]] });
   assertObjectMatch(l, { foo: [[1, [2, [a, e, j, k]]]] });
+  // Regexp
+  assertObjectMatch(m, { foo: /abc+/i });
+
   // Missing key
   {
     let didThrow;
@@ -612,6 +616,19 @@ Deno.test("testingAssertObjectMatching", function (): void {
     assertObjectMatch({ positions: [[1, 2, 3, 4]] }, {
       positions: [[1, 2, 3]],
     });
+  }
+  //Regexp
+  {
+    let didThrow;
+    try {
+      assertObjectMatch(m, { foo: /abc+/ });
+      assertObjectMatch(m, { foo: /abc*/ });
+      didThrow = false;
+    } catch (e) {
+      assert(e instanceof AssertionError);
+      didThrow = true;
+    }
+    assertEquals(didThrow, true);
   }
 });
 


### PR DESCRIPTION
The following currently passes, though it shouldn't:
```ts
assertObjectMatch({ foo: /abc*/ }, { foo: /abc+/ });   // different pattern
assertObjectMatch({ foo: /abc+/ }, { foo: /abc+/i });  // different flags
```

It's because `RegExp` are of type `"object"` so they enter in the `filter()` function.

For some reason, the regex source pattern isn't listed by both `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols` methods, which only returns `"lastIndex"` (which isn't' enough to differentiate between 2 regexs):
```ts
const r = /abc/i
console.log(typeof r, [...Object.getOwnPropertyNames(r), ...Object.getOwnPropertySymbols(r)])
// "object", Array [ "lastIndex" ]
```

This is a small patch which avoids regexs entering this condition and instead being treated like a primitive

