### PR TITLE
chore(node/crypto): add EVP_BytesToKey

### DIFF
--- a/node/_crypto/crypto_browserify/evp_bytes_to_key.ts
+++ b/node/_crypto/crypto_browserify/evp_bytes_to_key.ts
@@ -1,0 +1,54 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2017 crypto-browserify. All rights reserved. MIT license.
+
+import { Buffer } from "../../buffer.ts";
+import { createHash } from "../../crypto.ts";
+
+export function EVP_BytesToKey(
+  password: string | Buffer,
+  salt: string | Buffer,
+  keyBits: number,
+  ivLen: number,
+) {
+  if (!Buffer.isBuffer(password)) password = Buffer.from(password, "binary");
+  if (salt) {
+    if (!Buffer.isBuffer(salt)) salt = Buffer.from(salt, "binary");
+    if (salt.length !== 8) {
+      throw new RangeError("salt should be Buffer with 8 byte length");
+    }
+  }
+
+  let keyLen = keyBits / 8;
+  const key = Buffer.alloc(keyLen);
+  const iv = Buffer.alloc(ivLen || 0);
+  let tmp = Buffer.alloc(0);
+
+  while (keyLen > 0 || ivLen > 0) {
+    const hash = createHash("md5");
+    hash.update(tmp);
+    hash.update(password);
+    if (salt) hash.update(salt);
+    tmp = hash.digest() as Buffer;
+
+    let used = 0;
+
+    if (keyLen > 0) {
+      const keyStart = key.length - keyLen;
+      used = Math.min(keyLen, tmp.length);
+      tmp.copy(key, keyStart, 0, used);
+      keyLen -= used;
+    }
+
+    if (used < tmp.length && ivLen > 0) {
+      const ivStart = iv.length - ivLen;
+      const length = Math.min(ivLen, tmp.length - used);
+      tmp.copy(iv, ivStart, used, used + length);
+      ivLen -= length;
+    }
+  }
+
+  tmp.fill(0);
+  return { key, iv };
+}
+
+export default EVP_BytesToKey;

--- a/node/_crypto/crypto_browserify/evp_bytes_to_key_test.ts
+++ b/node/_crypto/crypto_browserify/evp_bytes_to_key_test.ts
@@ -1,0 +1,16 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2017 crypto-browserify. All rights reserved. MIT license.
+
+import { assertThrows } from "../../../testing/asserts.ts";
+import { EVP_BytesToKey } from "./evp_bytes_to_key.ts";
+import { Buffer } from "../../buffer.ts";
+
+Deno.test("salt buffer length is 7", function () {
+  assertThrows(
+    function () {
+      EVP_BytesToKey(Buffer.alloc(5), Buffer.alloc(7), 1, 1);
+    },
+    undefined,
+    "salt should be Buffer with 8 byte length",
+  );
+});


### PR DESCRIPTION
This PR adds [evp_bytestokey](https://www.npmjs.com/package/evp_bytestokey) module to `std/node/_crypto`. This is one of the dependencies of [`public-encrypt`](https://www.npmjs.com/package/public-encrypt)

I only ported the last test cases from the project because other test cases depends on [C extension with openssl library](https://github.com/crypto-browserify/EVP_BytesToKey/blob/master/test/main.cc), and don't seem easily portable

part of #1962 