### PR TITLE
feat(testing/asserts): use assertion signature for "assertStrictEquals"

### DIFF
--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -45,12 +45,15 @@ Deno.test("[async] debounce: flushed", function () {
 
 Deno.test("[async] debounce: with params & context", async function () {
   const params: Array<string | number> = [];
-  const d = debounce(function (param1: string, param2: number) {
-    assertEquals(d.pending, false);
-    params.push(param1);
-    params.push(param2);
-    assertStrictEquals(d, this);
-  }, 100);
+  const d: DebouncedFunction<[string, number]> = debounce(
+    function (param1: string, param2: number) {
+      assertEquals(d.pending, false);
+      params.push(param1);
+      params.push(param2);
+      assertStrictEquals(d, this);
+    },
+    100,
+  );
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'string'.
   d(1, 1);
   d("foo", 1);

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -323,21 +323,11 @@ export function assertNotEquals(
  * assertStrictEquals(1, 2)
  * ```
  */
-export function assertStrictEquals(
+export function assertStrictEquals <T>(
   actual: unknown,
-  expected: unknown,
-  msg?: string,
-): void;
-export function assertStrictEquals<T>(
-  actual: T,
   expected: T,
   msg?: string,
-): void;
-export function assertStrictEquals(
-  actual: unknown,
-  expected: unknown,
-  msg?: string,
-): void {
+): asserts actual is T {
   if (actual === expected) {
     return;
   }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -323,7 +323,7 @@ export function assertNotEquals(
  * assertStrictEquals(1, 2)
  * ```
  */
-export function assertStrictEquals <T>(
+export function assertStrictEquals<T>(
   actual: unknown,
   expected: T,
   msg?: string,

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -840,6 +840,30 @@ Deno.test({
 });
 
 Deno.test({
+  name: "strict types test",
+  fn(): void {
+    const x = { number: 2 };
+
+    const y = x as Record<never, never>;
+    const z = x as unknown;
+
+    // y.number;
+    //   ~~~~~~
+    // Property 'number' does not exist on type 'Record<never, never>'.deno-ts(2339)
+
+    assertStrictEquals(y, x);
+    y.number; // ok
+
+    // z.number;
+    // ~
+    // Object is of type 'unknown'.deno-ts(2571)
+
+    assertStrictEquals(z, x);
+    z.number; // ok
+  },
+});
+
+Deno.test({
   name: "strict pass case",
   fn(): void {
     assertStrictEquals(true, true);


### PR DESCRIPTION
In the same spirit as https://github.com/denoland/deno_std/pull/969, this PR retypes the signature for `assertStrictEquals` such that it can be used as a [type assertion function](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions). The nature of the runtime assertion is now reflected in the type system.

I also added a test with comments to demonstrate this change.

Please note that — because this has an effect on the type system — it is possible that new compiler errors will appear in code where they did not before (this is intended and desirable for type safety).