### PR TITLE
test: add --no-prompt to deno run

### DIFF
--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -204,7 +204,7 @@ for (const s of scenes) {
       );
 
       try {
-        const args = [Deno.execPath(), "run", "--quiet"];
+        const args = [Deno.execPath(), "run", "--quiet", "--no-prompt"];
 
         if (s.read) {
           args.push("--allow-read");

--- a/fs/exists_test.ts
+++ b/fs/exists_test.ts
@@ -113,7 +113,7 @@ for (const s of scenes) {
   let title = `test ${s.async ? "exists" : "existsSync"}("testdata/${s.file}")`;
   title += ` ${s.read ? "with" : "without"} --allow-read`;
   Deno.test(`[fs] existsPermission ${title}`, async function () {
-    const args = [Deno.execPath(), "run", "--quiet"];
+    const args = [Deno.execPath(), "run", "--quiet", "--no-prompt"];
 
     if (s.read) {
       args.push("--allow-read");


### PR DESCRIPTION
The tests failed locally. Adding --no-prompt fixed them.