### PR TITLE
fix(docs): update outdated reference to `deno_website2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ change once the library is stabilized.
 
 To check compatibility of different version of standard library with Deno CLI
 see
-[this list](https://raw.githubusercontent.com/denoland/deno_website2/main/versions.json).
+[this list](https://raw.githubusercontent.com/denoland/dotland/main/versions.json).
 
 ## How to use
 


### PR DESCRIPTION
Follow up to https://github.com/denoland/dotland/pull/1900