### PR TITLE
chore: move streams/buffer.ts to io/buffer_stream.ts

### DIFF
--- a/io/buffer_stream.ts
+++ b/io/buffer_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import { assert } from "../_util/assert.ts";
 import { copy } from "../bytes/mod.ts";
 

--- a/io/buffer_stream_test.ts
+++ b/io/buffer_stream_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "../testing/asserts.ts";
-import { Buffer } from "./buffer.ts";
+import { Buffer } from "./buffer_stream.ts";
 
 Deno.test("Buffer Write & Read", async function () {
   const buf = new Buffer();


### PR DESCRIPTION
Since we are doing https://github.com/denoland/deno_std/issues/1986, it would be weird to have all the stream versions of things in the `streams` folder instead of the corresponding folder