### PR TITLE
feat(fmt): update `ANSI_PATTERN`

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -518,11 +518,11 @@ export function bgRgb24(str: string, color: number | Rgb): string {
   );
 }
 
-// https://github.com/chalk/ansi-regex/blob/2b56fb0c7a07108e5b54241e8faec160d393aedb/index.js
+// https://github.com/chalk/ansi-regex/blob/02fa893d619d3da85411acc8fd4e2eea0e95a9d9/index.js
 const ANSI_PATTERN = new RegExp(
   [
-    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
-    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))",
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
   ].join("|"),
   "g",
 );

--- a/fmt/colors_test.ts
+++ b/fmt/colors_test.ts
@@ -7,19 +7,19 @@ Deno.test("reset", function (): void {
   assertEquals(c.reset("foo bar"), "[0mfoo bar[0m");
 });
 
-Deno.test("singleColor", function (): void {
+Deno.test("single color", function (): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test("doubleColor", function (): void {
+Deno.test("double color", function (): void {
   assertEquals(c.bgBlue(c.red("foo bar")), "[44m[31mfoo bar[39m[49m");
 });
 
-Deno.test("replacesCloseCharacters", function (): void {
+Deno.test("replaces close characters", function (): void {
   assertEquals(c.red("Hel[39mlo"), "[31mHel[31mlo[39m");
 });
 
-Deno.test("enablingColors", function (): void {
+Deno.test("enabling colors", function (): void {
   assertEquals(c.getColorEnabled(), true);
   c.setColorEnabled(false);
   assertEquals(c.bgBlue(c.red("foo bar")), "foo bar");
@@ -27,183 +27,183 @@ Deno.test("enablingColors", function (): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test("testBold", function (): void {
+Deno.test("test bold", function (): void {
   assertEquals(c.bold("foo bar"), "[1mfoo bar[22m");
 });
 
-Deno.test("testDim", function (): void {
+Deno.test("test dim", function (): void {
   assertEquals(c.dim("foo bar"), "[2mfoo bar[22m");
 });
 
-Deno.test("testItalic", function (): void {
+Deno.test("test italic", function (): void {
   assertEquals(c.italic("foo bar"), "[3mfoo bar[23m");
 });
 
-Deno.test("testUnderline", function (): void {
+Deno.test("test underline", function (): void {
   assertEquals(c.underline("foo bar"), "[4mfoo bar[24m");
 });
 
-Deno.test("testInverse", function (): void {
+Deno.test("test inverse", function (): void {
   assertEquals(c.inverse("foo bar"), "[7mfoo bar[27m");
 });
 
-Deno.test("testHidden", function (): void {
+Deno.test("test hidden", function (): void {
   assertEquals(c.hidden("foo bar"), "[8mfoo bar[28m");
 });
 
-Deno.test("testStrikethrough", function (): void {
+Deno.test("test strikethrough", function (): void {
   assertEquals(c.strikethrough("foo bar"), "[9mfoo bar[29m");
 });
 
-Deno.test("testBlack", function (): void {
+Deno.test("test black", function (): void {
   assertEquals(c.black("foo bar"), "[30mfoo bar[39m");
 });
 
-Deno.test("testRed", function (): void {
+Deno.test("test red", function (): void {
   assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
 });
 
-Deno.test("testGreen", function (): void {
+Deno.test("test green", function (): void {
   assertEquals(c.green("foo bar"), "[32mfoo bar[39m");
 });
 
-Deno.test("testYellow", function (): void {
+Deno.test("test yellow", function (): void {
   assertEquals(c.yellow("foo bar"), "[33mfoo bar[39m");
 });
 
-Deno.test("testBlue", function (): void {
+Deno.test("test blue", function (): void {
   assertEquals(c.blue("foo bar"), "[34mfoo bar[39m");
 });
 
-Deno.test("testMagenta", function (): void {
+Deno.test("test magenta", function (): void {
   assertEquals(c.magenta("foo bar"), "[35mfoo bar[39m");
 });
 
-Deno.test("testCyan", function (): void {
+Deno.test("test cyan", function (): void {
   assertEquals(c.cyan("foo bar"), "[36mfoo bar[39m");
 });
 
-Deno.test("testWhite", function (): void {
+Deno.test("test white", function (): void {
   assertEquals(c.white("foo bar"), "[37mfoo bar[39m");
 });
 
-Deno.test("testGray", function (): void {
+Deno.test("test gray", function (): void {
   assertEquals(c.gray("foo bar"), "[90mfoo bar[39m");
 });
 
-Deno.test("testBrightBlack", function (): void {
+Deno.test("test brightBlack", function (): void {
   assertEquals(c.brightBlack("foo bar"), "[90mfoo bar[39m");
 });
 
-Deno.test("testBrightRed", function (): void {
+Deno.test("test brightRed", function (): void {
   assertEquals(c.brightRed("foo bar"), "[91mfoo bar[39m");
 });
 
-Deno.test("testBrightGreen", function (): void {
+Deno.test("test brightGreen", function (): void {
   assertEquals(c.brightGreen("foo bar"), "[92mfoo bar[39m");
 });
 
-Deno.test("testBrightYellow", function (): void {
+Deno.test("test brightYellow", function (): void {
   assertEquals(c.brightYellow("foo bar"), "[93mfoo bar[39m");
 });
 
-Deno.test("testBrightBlue", function (): void {
+Deno.test("test brightBlue", function (): void {
   assertEquals(c.brightBlue("foo bar"), "[94mfoo bar[39m");
 });
 
-Deno.test("testBrightMagenta", function (): void {
+Deno.test("test brightMagenta", function (): void {
   assertEquals(c.brightMagenta("foo bar"), "[95mfoo bar[39m");
 });
 
-Deno.test("testBrightCyan", function (): void {
+Deno.test("test brightCyan", function (): void {
   assertEquals(c.brightCyan("foo bar"), "[96mfoo bar[39m");
 });
 
-Deno.test("testBrightWhite", function (): void {
+Deno.test("test brightWhite", function (): void {
   assertEquals(c.brightWhite("foo bar"), "[97mfoo bar[39m");
 });
 
-Deno.test("testBgBlack", function (): void {
+Deno.test("test bgBlack", function (): void {
   assertEquals(c.bgBlack("foo bar"), "[40mfoo bar[49m");
 });
 
-Deno.test("testBgRed", function (): void {
+Deno.test("test bgRed", function (): void {
   assertEquals(c.bgRed("foo bar"), "[41mfoo bar[49m");
 });
 
-Deno.test("testBgGreen", function (): void {
+Deno.test("test bgGreen", function (): void {
   assertEquals(c.bgGreen("foo bar"), "[42mfoo bar[49m");
 });
 
-Deno.test("testBgYellow", function (): void {
+Deno.test("test bgYellow", function (): void {
   assertEquals(c.bgYellow("foo bar"), "[43mfoo bar[49m");
 });
 
-Deno.test("testBgBlue", function (): void {
+Deno.test("test bgBlue", function (): void {
   assertEquals(c.bgBlue("foo bar"), "[44mfoo bar[49m");
 });
 
-Deno.test("testBgMagenta", function (): void {
+Deno.test("test bgMagenta", function (): void {
   assertEquals(c.bgMagenta("foo bar"), "[45mfoo bar[49m");
 });
 
-Deno.test("testBgCyan", function (): void {
+Deno.test("test bgCyan", function (): void {
   assertEquals(c.bgCyan("foo bar"), "[46mfoo bar[49m");
 });
 
-Deno.test("testBgWhite", function (): void {
+Deno.test("test bgWhite", function (): void {
   assertEquals(c.bgWhite("foo bar"), "[47mfoo bar[49m");
 });
 
-Deno.test("testBgBrightBlack", function (): void {
+Deno.test("test bgBrightBlack", function (): void {
   assertEquals(c.bgBrightBlack("foo bar"), "[100mfoo bar[49m");
 });
 
-Deno.test("testBgBrightRed", function (): void {
+Deno.test("test bgBrightRed", function (): void {
   assertEquals(c.bgBrightRed("foo bar"), "[101mfoo bar[49m");
 });
 
-Deno.test("testBgBrightGreen", function (): void {
+Deno.test("test bgBrightGreen", function (): void {
   assertEquals(c.bgBrightGreen("foo bar"), "[102mfoo bar[49m");
 });
 
-Deno.test("testBgBrightYellow", function (): void {
+Deno.test("test bgBrightYellow", function (): void {
   assertEquals(c.bgBrightYellow("foo bar"), "[103mfoo bar[49m");
 });
 
-Deno.test("testBgBrightBlue", function (): void {
+Deno.test("test bgBrightBlue", function (): void {
   assertEquals(c.bgBrightBlue("foo bar"), "[104mfoo bar[49m");
 });
 
-Deno.test("testBgBrightMagenta", function (): void {
+Deno.test("test bgBrightMagenta", function (): void {
   assertEquals(c.bgBrightMagenta("foo bar"), "[105mfoo bar[49m");
 });
 
-Deno.test("testBgBrightCyan", function (): void {
+Deno.test("test bgBrightCyan", function (): void {
   assertEquals(c.bgBrightCyan("foo bar"), "[106mfoo bar[49m");
 });
 
-Deno.test("testBgBrightWhite", function (): void {
+Deno.test("test bgBrightWhite", function (): void {
   assertEquals(c.bgBrightWhite("foo bar"), "[107mfoo bar[49m");
 });
 
-Deno.test("testClampUsingRgb8", function (): void {
+Deno.test("test clamp using rgb8", function (): void {
   assertEquals(c.rgb8("foo bar", -10), "[38;5;0mfoo bar[39m");
 });
 
-Deno.test("testTruncateUsingRgb8", function (): void {
+Deno.test("test truncate using rgb8", function (): void {
   assertEquals(c.rgb8("foo bar", 42.5), "[38;5;42mfoo bar[39m");
 });
 
-Deno.test("testRgb8", function (): void {
+Deno.test("test rgb8", function (): void {
   assertEquals(c.rgb8("foo bar", 42), "[38;5;42mfoo bar[39m");
 });
 
-Deno.test("test_bgRgb8", function (): void {
+Deno.test("test bgRgb8", function (): void {
   assertEquals(c.bgRgb8("foo bar", 42), "[48;5;42mfoo bar[49m");
 });
 
-Deno.test("test_rgb24", function (): void {
+Deno.test("test rgb24", function (): void {
   assertEquals(
     c.rgb24("foo bar", {
       r: 41,
@@ -214,11 +214,11 @@ Deno.test("test_rgb24", function (): void {
   );
 });
 
-Deno.test("test_rgb24number", function (): void {
+Deno.test("test rgb24 number", function (): void {
   assertEquals(c.rgb24("foo bar", 0x070809), "[38;2;7;8;9mfoo bar[39m");
 });
 
-Deno.test("test_bgRgb24", function (): void {
+Deno.test("test bgRgb24", function (): void {
   assertEquals(
     c.bgRgb24("foo bar", {
       r: 41,
@@ -229,6 +229,17 @@ Deno.test("test_bgRgb24", function (): void {
   );
 });
 
-Deno.test("test_bgRgb24number", function (): void {
+Deno.test("test bgRgb24 number", function (): void {
   assertEquals(c.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
 });
+
+// https://github.com/chalk/strip-ansi/blob/2b8c961e75760059699373f9a69101065c3ded3a/test.js#L4-L6
+Deno.test("test stripColor", function (): void {
+  assertEquals(
+    c.stripColor(
+      "\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m",
+    ),
+    "foofoo",
+  );
+});
+

--- a/fmt/colors_test.ts
+++ b/fmt/colors_test.ts
@@ -242,4 +242,3 @@ Deno.test("test stripColor", function (): void {
     "foofoo",
   );
 });
-


### PR DESCRIPTION
Bringing two updates to `ANSI_PATTERN` used in fmt/colors:

- [Fix potential ReDoS](https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9)
- [Match cursorSave and cursorRestore escape codes](https://github.com/chalk/ansi-regex/commit/02fa893d619d3da85411acc8fd4e2eea0e95a9d9)

Also added preliminary test for `stripColor`.