### PR TITLE
fix(node): fix http.request for minipass-fetch 2.x

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -123,14 +123,15 @@ class ClientRequest extends NodeWritable {
 
     const client = await this._createCustomClient();
     const opts = { body: this.body, method: this.opts.method, client };
-    const mayResponse = fetch(this._createUrlStrFromOptions(this.opts), opts).catch((e) => {
-      if (e.message.includes("connection closed before message completed")) {
-        // Node.js seems ignoring this error
-      } else {
-        this.emit("error", e);
-      }
-      return undefined;
-    });
+    const mayResponse = fetch(this._createUrlStrFromOptions(this.opts), opts)
+      .catch((e) => {
+        if (e.message.includes("connection closed before message completed")) {
+          // Node.js seems ignoring this error
+        } else {
+          this.emit("error", e);
+        }
+        return undefined;
+      });
     const res = new IncomingMessageForClient(
       await mayResponse,
       this._createSocket(),
@@ -165,14 +166,16 @@ class ClientRequest extends NodeWritable {
       return opts.href;
     } else {
       const {
-	auth,
-	protocol,
-	host,
-	hostname,
-	path,
-	port,
+        auth,
+        protocol,
+        host,
+        hostname,
+        path,
+        port,
       } = opts;
-      return `${protocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${port ? `:${port}` : ""}${path}`
+      return `${protocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${
+        port ? `:${port}` : ""
+      }${path}`;
     }
   }
 }

--- a/node/http.ts
+++ b/node/http.ts
@@ -123,7 +123,7 @@ class ClientRequest extends NodeWritable {
 
     const client = await this._createCustomClient();
     const opts = { body: this.body, method: this.opts.method, client };
-    const mayResponse = fetch(this.opts.href!, opts).catch((e) => {
+    const mayResponse = fetch(this._createUrlStrFromOptions(this.opts), opts).catch((e) => {
       if (e.message.includes("connection closed before message completed")) {
         // Node.js seems ignoring this error
       } else {
@@ -157,6 +157,23 @@ class ClientRequest extends NodeWritable {
     // Sometimes the libraries check some properties of socket
     // e.g. if (!response.socket.authorized) { ... }
     return new Socket({});
+  }
+
+  // deno-lint-ignore no-explicit-any
+  _createUrlStrFromOptions(opts: any) {
+    if (opts.href) {
+      return opts.href;
+    } else {
+      const {
+	auth,
+	protocol,
+	host,
+	hostname,
+	path,
+	port,
+      } = opts;
+      return `${protocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${port ? `:${port}` : ""}${path}`
+    }
   }
 }
 

--- a/node/integrationtest/test.ts
+++ b/node/integrationtest/test.ts
@@ -27,11 +27,7 @@ Deno.test("integration test of compat mode", {
   }
 
   await t.step("Runs `yarn add <mod>`", async () => {
-    // FIXME(kt3k): npm@8.5.3 doesn't work with compat mode
-    await exec(
-      `deno run --compat --unstable -A ${yarnUrl} add npm@8.5.2`,
-      opts,
-    );
+    await exec(`deno run --compat --unstable -A ${yarnUrl} add npm`, opts);
     assert((await Deno.lstat(join(npmPath, "package.json"))).isFile);
     await exec(`deno run --compat --unstable -A ${yarnUrl} add express`, opts);
     assert((await Deno.lstat(join(expressPath, "package.json"))).isFile);


### PR DESCRIPTION
This PR fixes the call of `http.request` without `href` option.

`minipass-fetch@>2` calls `http.request` without `href` option ([this commit](https://github.com/npm/minipass-fetch/commit/f96f3b13e68f3851fd9fadb762c58f441a4c3f48) started it).

`npm` started depending on `minipass-fetch@2` indirectly at [this commit](https://github.com/npm/cli/commit/3c17b6965f0c5fffd5ac908388568a307466a73f), and that [broke](https://github.com/denoland/deno_std/runs/5417966994?check_suite_focus=true) the integration test of `npm install` in compat mode in CI

closes #2001