### PR TITLE
fix(node/process): ignore SIGBREAK binding on non windows

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -302,7 +302,11 @@ class Process extends EventEmitter {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.on("${event}")`);
     } else if (event.startsWith("SIG")) {
-      DenoUnstable.addSignalListener(event as Deno.Signal, listener);
+      if (event === "SIGBREAK" && Deno.build.os !== "windows") {
+        // Ignores SIGBREAK if the platform is not windows.
+      } else {
+        DenoUnstable.addSignalListener(event as Deno.Signal, listener);
+      }
     } else {
       super.on(event, listener);
     }
@@ -323,7 +327,11 @@ class Process extends EventEmitter {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.off("${event}")`);
     } else if (event.startsWith("SIG")) {
-      DenoUnstable.removeSignalListener(event as Deno.Signal, listener);
+      if (event === "SIGBREAK" && Deno.build.os !== "windows") {
+        // Ignores SIGBREAK if the platform is not windows.
+      } else {
+        DenoUnstable.removeSignalListener(event as Deno.Signal, listener);
+      }
     } else {
       super.off(event, listener);
     }

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -202,6 +202,16 @@ Deno.test({
 });
 
 Deno.test({
+  name: "process.on SIGBREAK doesn't throw",
+  ignore: Deno.build.os == "windows",
+  fn() {
+    const listener = () => {};
+    process.on("SIGBREAK", listener);
+    process.off("SIGBREAK", listener);
+  },
+});
+
+Deno.test({
   name: "process.argv",
   fn() {
     assert(Array.isArray(process.argv));


### PR DESCRIPTION
`process.on("SIGBREAK", handlers)` throws with invalid signal error (SIGBREAK is not a valid signal name for non-windows platforms, ref: https://github.com/denoland/deno/blob/245f69256b9e22f7759b887e82138ad3844a8cf4/runtime/ops/signal.rs).

This PR makes `process.on` ignore `SIGBREAK` binding on non-windows platforms.

Note: `SIGBREAK` is a signal for handling CTRL + BREAK on windows, and it's only meaningful for windows. ref: https://nodejs.org/api/process.html#event-message

part of #2010 

