### PR TITLE
fix(io/readers): use an array as a MultiReader constructor parameter to avoid Maximum call stack size exceeded

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -447,7 +447,7 @@ export class Tar {
 
     // append 2 empty records
     readers.push(new Buffer(clean(recordSize * 2)));
-    return new MultiReader(...readers);
+    return new MultiReader(readers);
   }
 }
 

--- a/io/readers.ts
+++ b/io/readers.ts
@@ -18,8 +18,8 @@ export class MultiReader implements Deno.Reader {
   private readonly readers: Deno.Reader[];
   private currentIndex = 0;
 
-  constructor(...readers: Deno.Reader[]) {
-    this.readers = readers;
+  constructor(readers: Deno.Reader[]) {
+    this.readers = [...readers];
   }
 
   async read(p: Uint8Array): Promise<number | null> {

--- a/io/readers_test.ts
+++ b/io/readers_test.ts
@@ -29,7 +29,7 @@ Deno.test("ioStringReader", async function () {
 });
 
 Deno.test("ioMultiReader", async function () {
-  const r = new MultiReader(new StringReader("abc"), new StringReader("def"));
+  const r = new MultiReader([new StringReader("abc"), new StringReader("def")]);
   const w = new StringWriter();
   const n = await copyN(r, w, 4);
   assertEquals(n, 4);

--- a/mime/multipart.ts
+++ b/mime/multipart.ts
@@ -363,7 +363,7 @@ export class MultipartReader {
         const file = await Deno.open(filepath, { write: true });
 
         try {
-          const size = await copy(new MultiReader(buf, p), file);
+          const size = await copy(new MultiReader([buf, p]), file);
 
           file.close();
           formFile = {


### PR DESCRIPTION
Closes #1954 