### PR TITLE
feat(node): shim get-caller-file

### DIFF
--- a/node/module.ts
+++ b/node/module.ts
@@ -511,6 +511,11 @@ class Module {
       }
     }
 
+    // NOTE(@bartlomieju): this is a temporary solution. We provide some
+    // npm modules with fixes in inconsistencies between Deno and Node.js.
+    const upstreamMod = loadUpstreamModule(request, parent, request);
+    if (upstreamMod) return upstreamMod.exports;
+
     const filename = Module._resolveFilename(request, parent, isMain);
     if (filename.startsWith("node:")) {
       // Slice 'node:' prefix
@@ -533,11 +538,6 @@ class Module {
     // Native module polyfills
     const mod = loadNativeModule(filename, request);
     if (mod) return mod.exports;
-
-    // NOTE(@bartlomieju): this is a temporary solution. We provide some
-    // npm modules with fixes in inconsistencies between Deno and Node.js.
-    const upstreamMod = loadUpstreamModule(filename, parent, request);
-    if (upstreamMod) return upstreamMod.exports;
 
     // Don't call updateChildren(), Module constructor already does.
     const module = new Module(filename, parent);

--- a/node/upstream_modules.ts
+++ b/node/upstream_modules.ts
@@ -9,6 +9,30 @@ module.exports = () => {
 };
 `;
 
+const getCallerFile = `
+const re = /^file:/;
+
+function getCallerFile(position = 2) {
+  if (position >= Error.stackTraceLimit) {
+    throw new TypeError('getCallerFile(position) requires position be less then Error.stackTraceLimit but position was: \`' + position + '\` and Error.stackTraceLimit was: \`' + Error.stackTraceLimit + '\`');
+  }
+
+  const oldPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = (_, stack)  => stack;
+  const stack = new Error().stack;
+  Error.prepareStackTrace = oldPrepareStackTrace;
+
+
+  if (stack !== null && typeof stack === 'object') {
+    // stack[0] holds this file
+    // stack[1] holds where this function was called
+    // stack[2] holds the file we're interested in
+    return stack[position] ? (stack[position] as any).getFileName().replace(re, "") : undefined;
+  }
+};
+`;
+
 export default {
   "caller-path": callerPath,
+  "get-caller-file": getCallerFile,
 } as Record<string, string>;

--- a/node/upstream_modules.ts
+++ b/node/upstream_modules.ts
@@ -9,12 +9,13 @@ module.exports = () => {
 };
 `;
 
+// From: https://github.com/stefanpenner/get-caller-file/blob/2383bf9e98ed3c568ff69d7586cf59c0f1dcb9d3/index.ts
 const getCallerFile = `
-const re = /^file:/;
+const re = /^file:\\/\\//;
 
-function getCallerFile(position = 2) {
+module.exports = function getCallerFile(position = 2) {
   if (position >= Error.stackTraceLimit) {
-    throw new TypeError('getCallerFile(position) requires position be less then Error.stackTraceLimit but position was: \`' + position + '\` and Error.stackTraceLimit was: \`' + Error.stackTraceLimit + '\`');
+    throw new TypeError('getCallerFile(position) requires position be less then Error.stackTraceLimit but position was: "' + position + '" and Error.stackTraceLimit was: "' + Error.stackTraceLimit + '"');
   }
 
   const oldPrepareStackTrace = Error.prepareStackTrace;
@@ -27,7 +28,7 @@ function getCallerFile(position = 2) {
     // stack[0] holds this file
     // stack[1] holds where this function was called
     // stack[2] holds the file we're interested in
-    return stack[position] ? (stack[position] as any).getFileName().replace(re, "") : undefined;
+    return stack[position] ? stack[position].getFileName().replace(re, "") : undefined;
   }
 };
 `;

--- a/node/upstream_modules_test.ts
+++ b/node/upstream_modules_test.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { createRequire } from "./module.ts";
+import { assertEquals } from "../testing/asserts.ts";
+
+const require = createRequire(import.meta.url);
+
+Deno.test("get-caller-file works", () => {
+  const getCallerFile = require("get-caller-file");
+  // The caller is foo. foo belongs to this file.
+  // So the getCallerFile() returns the filename of this file
+  function foo() {
+    return getCallerFile();
+  }
+  assertEquals(foo(), import.meta.url.replace(/^file:\/\//, ""));
+});


### PR DESCRIPTION
This PR adds the shim of [get-caller-file](https://npm.im/get-caller-file).

CallSite.prototype.getFileName returns `file://` scheme url in deno, but it returns absolute file path in Node.js. This PR fixes that difference by providing shim.

`get-caller-file` is depended by yargs. So this should improve the compatibility of many cli tools which depends on yargs.

closes #2026