### PR TITLE
test: re-enable npm testing

### DIFF
--- a/node/integrationtest/test.ts
+++ b/node/integrationtest/test.ts
@@ -15,7 +15,7 @@ Deno.test("integration test of compat mode", {
   const tempDir = await Deno.makeTempDir();
   const opts = { env, cwd: tempDir };
   const npmPath = join(tempDir, "node_modules", "npm");
-  const _gulpPath = join(tempDir, "node_modules", "gulp");
+  const yargsPath = join(tempDir, "node_modules", "yargs");
   const mysql2Path = join(tempDir, "node_modules", "mysql2");
   const expressPath = join(tempDir, "node_modules", "express");
   let hasDocker;
@@ -35,18 +35,12 @@ Deno.test("integration test of compat mode", {
     assert((await Deno.lstat(join(mysql2Path, "package.json"))).isFile);
   });
 
-  // FIXME(kt3k): `npm install gulp` fails at postinstall step of `es5-ext` module.
-  // Skips this test case for now.
-  // See https://github.com/denoland/deno_std/runs/5466969636?check_suite_focus=true
-  // for details
-  /*
-  await t.step("npm install gulp", async () => {
+  await t.step("Runs `npm install <mod>`", async () => {
     const npmCli = join(npmPath, "index.js");
-    await exec(`deno run --compat --unstable -A ${npmCli} install gulp`, opts);
-    const stat = await Deno.lstat(join(gulpPath, "package.json"));
+    await exec(`deno run --compat --unstable -A ${npmCli} install yargs`, opts);
+    const stat = await Deno.lstat(join(yargsPath, "package.json"));
     assert(stat.isFile);
   });
-  */
 
   await t.step("run express example app", async () => {
     await Deno.writeTextFile(


### PR DESCRIPTION
This PR enables `npm install` testing again.

The problem was cause by the specific module in the dependencies of `gulp` (the issue is tracked in https://github.com/denoland/deno_std/issues/2013)

This PR changes the target module to `yargs`, and avoids the above problem.