### PR TITLE
fix(node/process): Fix `EventEmitter` methods

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -98,36 +98,3 @@ export const versions = {
   unicode: "13.0",
   ...Deno.version,
 };
-
-function hrtime(time?: [number, number]): [number, number] {
-  const milli = performance.now();
-  const sec = Math.floor(milli / 1000);
-  const nano = Math.floor(milli * 1_000_000 - sec * 1_000_000_000);
-  if (!time) {
-    return [sec, nano];
-  }
-  const [prevSec, prevNano] = time;
-  return [sec - prevSec, nano - prevNano];
-}
-
-hrtime.bigint = function (): BigInt {
-  const [sec, nano] = hrtime();
-  return BigInt(sec) * 1_000_000_000n + BigInt(nano);
-};
-
-function memoryUsage(): {
-  rss: number;
-  heapTotal: number;
-  heapUsed: number;
-  external: number;
-  arrayBuffers: number;
-} {
-  return {
-    ...Deno.memoryUsage(),
-    arrayBuffers: 0,
-  };
-}
-
-memoryUsage.rss = function (): number {
-  return memoryUsage().rss;
-};

--- a/node/process.ts
+++ b/node/process.ts
@@ -4,7 +4,7 @@ import * as DenoUnstable from "../_deno_unstable.ts";
 import { warnNotImplemented } from "./_utils.ts";
 import { EventEmitter } from "./events.ts";
 import { validateString } from "./internal/validators.mjs";
-import { ERR_INVALID_ARG_TYPE } from "./internal/errors.ts";
+import { ERR_INVALID_ARG_TYPE, ERR_UNKNOWN_SIGNAL } from "./internal/errors.ts";
 import { getOptionValue } from "./_options.ts";
 import { assert } from "../_util/assert.ts";
 import { fromFileUrl } from "../path/mod.ts";
@@ -56,6 +56,7 @@ const notImplementedEvents = [
   "uncaughtException",
   "uncaughtExceptionMonitor",
   "unhandledRejection",
+  "worker",
 ];
 
 // The first 2 items are placeholders.
@@ -231,6 +232,27 @@ memoryUsage.rss = function (): number {
   return memoryUsage().rss;
 };
 
+export function kill(pid: number, sig: Deno.Signal | number = "SIGTERM") {
+  if (pid != (pid | 0)) {
+    throw new ERR_INVALID_ARG_TYPE("pid", "number", pid);
+  }
+
+  if (typeof sig === "string") {
+    try {
+      Deno.kill(pid, sig);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        throw new ERR_UNKNOWN_SIGNAL(sig);
+      }
+      throw e;
+    }
+  } else {
+    throw new ERR_UNKNOWN_SIGNAL(sig.toString());
+  }
+
+  return true;
+}
+
 class Process extends EventEmitter {
   constructor() {
     super();
@@ -290,8 +312,6 @@ class Process extends EventEmitter {
 
   /** https://nodejs.org/api/process.html#process_process_events */
   override on(event: "exit", listener: (code: number) => void): this;
-  // deno-lint-ignore no-explicit-any
-  override on(event: string, listener: (...args: any[]) => void): this;
   override on(
     event: typeof notImplementedEvents[number],
     // deno-lint-ignore ban-types
@@ -315,8 +335,6 @@ class Process extends EventEmitter {
   }
 
   override off(event: "exit", listener: (code: number) => void): this;
-  // deno-lint-ignore no-explicit-any
-  override off(event: string, listener: (...args: any[]) => void): this;
   override off(
     event: typeof notImplementedEvents[number],
     // deno-lint-ignore ban-types
@@ -339,37 +357,95 @@ class Process extends EventEmitter {
     return this;
   }
 
+  // deno-lint-ignore no-explicit-any
+  override emit(event: string, ...args: any[]): boolean {
+    if (event.startsWith("SIG")) {
+      if (event === "SIGBREAK" && Deno.build.os !== "windows") {
+        // Ignores SIGBREAK if the platform is not windows.
+      } else {
+        Deno.kill(Deno.pid, event as Deno.Signal);
+      }
+    } else {
+      return super.emit(event, ...args);
+    }
+
+    return true;
+  }
+
+  override prependListener(
+    event: "exit",
+    listener: (code: number) => void,
+  ): this;
+  override prependListener(
+    event: typeof notImplementedEvents[number],
+    // deno-lint-ignore ban-types
+    listener: Function,
+  ): this;
+  override prependListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
+    if (notImplementedEvents.includes(event)) {
+      warnNotImplemented(`process.prependListener("${event}")`);
+    } else if (event.startsWith("SIG")) {
+      if (event === "SIGBREAK" && Deno.build.os !== "windows") {
+        // Ignores SIGBREAK if the platform is not windows.
+      } else {
+        DenoUnstable.addSignalListener(event as Deno.Signal, listener);
+      }
+    } else {
+      super.prependListener(event, listener);
+    }
+
+    return this;
+  }
+
   /** https://nodejs.org/api/process.html#process_process_pid */
   pid = pid;
 
   /** https://nodejs.org/api/process.html#process_process_platform */
   platform = platform;
 
-  // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
-  removeAllListeners(eventName?: string | symbol): this {
-    // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
-    return super.removeAllListeners(eventName);
-  }
-
-  // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
-  removeListener(
+  override addListener(event: "exit", listener: (code: number) => void): this;
+  override addListener(
     event: typeof notImplementedEvents[number],
-    //deno-lint-ignore ban-types
+    // deno-lint-ignore ban-types
     listener: Function,
   ): this;
-  // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
-  removeListener(event: "exit", listener: (code: number) => void): this;
-  // @ts-ignore `deno_std`'s types are scricter than types from DefinitelyTyped for Node.js thus causing problems
-  //deno-lint-ignore no-explicit-any
-  removeListener(event: string, listener: (...args: any[]) => void): this {
+  override addListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
+    if (notImplementedEvents.includes(event)) {
+      warnNotImplemented(`process.addListener("${event}")`);
+      return this;
+    }
+
+    return this.on(event, listener);
+  }
+
+  override removeListener(
+    event: "exit",
+    listener: (code: number) => void,
+  ): this;
+  override removeListener(
+    event: typeof notImplementedEvents[number],
+    // deno-lint-ignore ban-types
+    listener: Function,
+  ): this;
+  override removeListener(
+    event: string,
+    // deno-lint-ignore no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.removeListener("${event}")`);
       return this;
     }
 
-    super.removeListener("exit", listener);
-
-    return this;
+    return this.on(event, listener);
   }
 
   /**
@@ -386,6 +462,9 @@ class Process extends EventEmitter {
    * https://nodejs.org/api/process.html#process_process_hrtime_time
    */
   hrtime = hrtime;
+
+  /** https://nodejs.org/api/process.html#processkillpid-signal */
+  kill = kill;
 
   memoryUsage = memoryUsage;
 


### PR DESCRIPTION
1. Add `process.kill`.
2. Fix `addListener` and `removeListener`, they should be alias for `on` and `off`.
3. Override `emit` and `prependListener` to handle signal events.

The `once` and `prependOnceListener` also need to override. But I think we should export `_onceWrap` first.

https://github.com/denoland/deno_std/blob/8e01ec6cb7e00eb82c0a34fbff3a748ca48dd6aa/node/_events.mjs#L506-L512