### PR TITLE
fix(node): make global.<timerFunc> Node.js timers

### DIFF
--- a/node/_tools/test/common/index.js
+++ b/node/_tools/test/common/index.js
@@ -49,6 +49,8 @@ let knownGlobals = [
   onload,
   onunload,
   getParent,
+  window,
+  self,
 ];
 
 if (global.AbortController)

--- a/node/global.ts
+++ b/node/global.ts
@@ -2,6 +2,12 @@
 // deno-lint-ignore-file no-var
 import processModule from "./process.ts";
 import { Buffer as bufferModule } from "./buffer.ts";
+import {
+  clearInterval,
+  clearTimeout,
+  setInterval,
+  setTimeout,
+} from "./timers.ts";
 import timers from "./timers.ts";
 
 type GlobalType = {
@@ -9,6 +15,10 @@ type GlobalType = {
   Buffer: typeof bufferModule;
   setImmediate: typeof timers.setImmediate;
   clearImmediate: typeof timers.clearImmediate;
+  setTimeout: typeof timers.setTimeout;
+  clearTimeout: typeof timers.clearTimeout;
+  setInterval: typeof timers.setInterval;
+  clearInterval: typeof timers.clearInterval;
 };
 
 declare global {
@@ -29,7 +39,22 @@ declare global {
 }
 
 Object.defineProperty(globalThis, "global", {
-  value: globalThis,
+  value: new Proxy(globalThis, {
+    get(target, prop, receiver) {
+      switch (prop) {
+        case "setInterval":
+          return setInterval;
+        case "setTimeout":
+          return setTimeout;
+        case "clearInterval":
+          return clearInterval;
+        case "clearTimeout":
+          return clearTimeout;
+        default:
+          return Reflect.get(target, prop, receiver);
+      }
+    },
+  }),
   writable: false,
   enumerable: false,
   configurable: true,

--- a/node/global_test.ts
+++ b/node/global_test.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import "./global.ts";
-import { assert, assertStrictEquals } from "../testing/asserts.ts";
+import {
+  assert,
+  assertNotEquals,
+  assertStrictEquals,
+} from "../testing/asserts.ts";
 import { Buffer as BufferModule } from "./buffer.ts";
 import processModule from "./process.ts";
 import timers from "./timers.ts";
@@ -13,8 +17,6 @@ import timers from "./timers.ts";
 // probably gonna change in the future
 
 Deno.test("global is correctly defined", () => {
-  // deno-lint-ignore no-undef
-  assertStrictEquals(global, globalThis);
   // deno-lint-ignore no-undef
   assertStrictEquals(global.Buffer, BufferModule);
   // deno-lint-ignore no-undef
@@ -51,6 +53,20 @@ Deno.test("process is correctly defined", () => {
   assert(globalThis.process.arch);
   assertStrictEquals(window.process, processModule);
   assert(window.process.arch);
+});
+
+Deno.test("global timers are not Node.js timers", () => {
+  assertNotEquals(setTimeout, timers.setTimeout);
+  assertNotEquals(clearTimeout, timers.clearTimeout);
+  assertNotEquals(setInterval, timers.setInterval);
+  assertNotEquals(clearInterval, timers.clearInterval);
+});
+
+Deno.test("timers in `global` object are Node.js timers", () => {
+  assertStrictEquals(global.setTimeout, timers.setTimeout);
+  assertStrictEquals(global.clearTimeout, timers.clearTimeout);
+  assertStrictEquals(global.setInterval, timers.setInterval);
+  assertStrictEquals(global.clearInterval, timers.clearInterval);
 });
 
 Deno.test("setImmediate is correctly defined", () => {


### PR DESCRIPTION
This PR replaces `global` object in std/node with Proxy object which intercepts the access to timer functions and returns the Node.js versions of them.

This change enables running the code like the below:

```js
const { setInterval } = global;

...
setInterval(...).unref();
```

The actual example of the above structure is found in [here](https://github.com/mochajs/mocha/blob/b46db73fa0e58c92bde925eaa4054210b771b5a9/lib/nodejs/parallel-buffered-runner.js) in mocha code base.

Note: This change doesn't affects globalThis object. So actual global timers are still web compliant timers provided by Deno CLI.

---
part of https://github.com/denoland/deno/issues/12886