### PR TITLE
feat(http): Add add http methods enum

### DIFF
--- a/http/http_method.ts
+++ b/http/http_method.ts
@@ -1,0 +1,34 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+/**
+ * Enum of HTTP RFC 7231 & RFC 5789 methods.
+ *
+ * ```ts
+ * import {
+ *   Method
+ * } from "https://deno.land/std@$STD_VERSION/http/http_method.ts";
+ *
+ * console.log(Method.GET); //=> "GET"
+ * ```
+ */
+export enum Method {
+  /* RFC 7231, 4.3.1 */
+  GET = "GET",
+  /* RFC 7231, 4.3.2 */
+  HEAD = "HEAD",
+  /* RFC 7231, 4.3.3  */
+  POST = "POST",
+  /* RFC 7231, 4.3.4 */
+  PUT = "PUT",
+  /* RFC 7231, 4.3.5 */
+  DELETE = "DELETE",
+  /* RFC 7231, 4.3.6 */
+  CONNECT = "CONNECT",
+  /* RFC 7231, 4.3.7 */
+  OPTIONS = "OPTIONS",
+  /* RFC 7231, 4.3.8 */
+  TRACE = "TRACE",
+  /* RFC 5789, 2 */
+  PATCH = "PATCH",
+}

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 export * from "./cookie.ts";
+export * from "./http_method.ts";
 export * from "./http_status.ts";
 export * from "./server.ts";


### PR DESCRIPTION
This is an old issue that first was discussed in [5790](https://github.com/denoland/deno/issues/5790) and even had a PR opened (5854)(https://github.com/denoland/deno/pull/5854) however the work on this issue was stopped, I think this is still relevant and it would be convenient to have this in std library.

