### PR TITLE
chore: warn on non supported event, but still register listener

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -321,6 +321,7 @@ class Process extends EventEmitter {
   override on(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.on("${event}")`);
+      super.on(event, listener);
     } else if (event.startsWith("SIG")) {
       if (event === "SIGBREAK" && Deno.build.os !== "windows") {
         // Ignores SIGBREAK if the platform is not windows.
@@ -344,6 +345,7 @@ class Process extends EventEmitter {
   override off(event: string, listener: (...args: any[]) => void): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.off("${event}")`);
+      super.off(event, listener);
     } else if (event.startsWith("SIG")) {
       if (event === "SIGBREAK" && Deno.build.os !== "windows") {
         // Ignores SIGBREAK if the platform is not windows.
@@ -388,6 +390,7 @@ class Process extends EventEmitter {
   ): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.prependListener("${event}")`);
+      super.prependListener(event, listener);
     } else if (event.startsWith("SIG")) {
       if (event === "SIGBREAK" && Deno.build.os !== "windows") {
         // Ignores SIGBREAK if the platform is not windows.
@@ -420,7 +423,6 @@ class Process extends EventEmitter {
   ): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.addListener("${event}")`);
-      return this;
     }
 
     return this.on(event, listener);
@@ -442,7 +444,6 @@ class Process extends EventEmitter {
   ): this {
     if (notImplementedEvents.includes(event)) {
       warnNotImplemented(`process.removeListener("${event}")`);
-      return this;
     }
 
     return this.off(event, listener);

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -375,9 +375,13 @@ Deno.test("process.on, process.off, process.removeListener doesn't throw on unim
   const handler = () => {};
   events.forEach((ev) => {
     process.on(ev, handler);
+    assertEquals(process.listenerCount(ev), 1);
     process.off(ev, handler);
+    assertEquals(process.listenerCount(ev), 0);
     process.on(ev, handler);
+    assertEquals(process.listenerCount(ev), 1);
     process.removeListener(ev, handler);
+    assertEquals(process.listenerCount(ev), 0);
   });
 });
 


### PR DESCRIPTION
This PR changes the behavior of binding to 'unimplemented' events on `process` object.

With this change, the events are still not handled, but the listeners are actually registered on `process` object and it increased/decreased the `listenerCount` of the each event.

This makes mocha's unit testing happy, and now we can pass `npx nps test.node.jsapi` test category in compat mode with this change.

part of #12886