### PR TITLE
test(http): update MockListener and fix test

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -106,6 +106,12 @@ class MockListener implements Deno.Listener {
       yield this.conn;
     }
   }
+
+  ref() {
+  }
+
+  unref() {
+  }
 }
 
 Deno.test(


### PR DESCRIPTION
We added ref and unref methods to (unstable) Listener interface in https://github.com/denoland/deno/pull/13961

This PR updates MockListener in http testing to follow the above update in CLI canary. This fixes the CI in main branch.