### PR TITLE
fix(node/http): ignore error from `respondWith`

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -106,6 +106,12 @@ class MockListener implements Deno.Listener {
       yield this.conn;
     }
   }
+
+  ref() {
+  }
+
+  unref() {
+  }
 }
 
 Deno.test(

--- a/node/http.ts
+++ b/node/http.ts
@@ -326,7 +326,9 @@ export class ServerResponse extends NodeWritable {
         status: this.statusCode,
         statusText: this.statusMessage,
       }),
-    );
+    ).catch(() => {
+      // ignore this error
+    });
   }
 
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
In addition to #2057, this PR tries to fix the CI, by ignoring error thrown by `respondWith` in `node/http`.