### PR TITLE
fix(log): Fix log formatter issue

### DIFF
--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -37,7 +37,7 @@ export class BaseHandler {
       return this.formatter(logRecord);
     }
 
-    return this.formatter.replace(/{([^\s|}]+)}/g, (match, p1): string => {
+    return this.formatter.replace(/{([^\s}]+)}/g, (match, p1): string => {
       const value = logRecord[p1 as keyof LogRecord];
 
       // do not interpolate missing values

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -37,7 +37,7 @@ export class BaseHandler {
       return this.formatter(logRecord);
     }
 
-    return this.formatter.replace(/{(\S+)}/g, (match, p1): string => {
+    return this.formatter.replace(/{([^\s|}]+)}/g, (match, p1): string => {
       const value = logRecord[p1 as keyof LogRecord];
 
       // do not interpolate missing values

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -94,6 +94,23 @@ Deno.test("testFormatterAsString", function (): void {
   assertEquals(handler.messages, ["test DEBUG Hello, world!"]);
 });
 
+Deno.test("testFormatterAsStringWithoutSpace", function (): void {
+  const handler = new TestHandler("DEBUG", {
+    formatter: "test:{levelName}:{msg}",
+  });
+
+  handler.handle(
+    new LogRecord({
+      msg: "Hello, world!",
+      args: [],
+      level: LogLevels.DEBUG,
+      loggerName: "default",
+    }),
+  );
+
+  assertEquals(handler.messages, ["test:DEBUG:Hello, world!"]);
+});
+
 Deno.test("testFormatterWithEmptyMsg", function () {
   const handler = new TestHandler("DEBUG", {
     formatter: "test {levelName} {msg}",


### PR DESCRIPTION
When I create a log formatter which like `[{loggerName}][{levelName}] {msg}` and I expect to get a log looks like `[database][INFO] client connecting...` , but I get `[{loggerName}][{levelName}] client connecting...`. To solve this problem, I try to add a SPACE between `[{}]` and it worked, but in my opinion, we should allow removing the space between the log record fields.