### PR TITLE
fix(node/module): catch errors from core.evalContext

### DIFF
--- a/node/module.ts
+++ b/node/module.ts
@@ -1312,7 +1312,14 @@ function wrapSafe(
 ): RequireWrapper {
   // TODO(bartlomieju): fix this
   const wrapper = Module.wrap(content);
-  const [f, err] = core.evalContext(wrapper, filename);
+  const [f, err] = (() => {
+    try {
+      return core.evalContext(wrapper, filename);
+    }
+    catch (thrown: any) {
+      return [null, { thrown }];
+    }
+  })();
   if (err) {
     if (process.mainModule === cjsModuleInstance) {
       enrichCJSError(err.thrown);

--- a/node/module.ts
+++ b/node/module.ts
@@ -1315,8 +1315,7 @@ function wrapSafe(
   const [f, err] = (() => {
     try {
       return core.evalContext(wrapper, filename);
-    }
-    catch (thrown: any) {
+    } catch (thrown: any) {
       return [null, { thrown }];
     }
   })();


### PR DESCRIPTION
quick stab at https://github.com/denoland/deno/issues/12939

not tested

expected result: better error reporting on SyntaxError (parse error)

`return [null, { thrown }]` should imitate the API of [Deno.core.evalContext](https://github.com/denoland/deno/blob/061090de7e95e8e7a97f3277bd1a72899ebd1570/core/bindings.rs#L686)
