### PR TITLE
fix(node/fs): Fix writing redundant data

### DIFF
--- a/node/_fs/_fs_write.mjs
+++ b/node/_fs/_fs_write.mjs
@@ -21,8 +21,9 @@ export function writeSync(fd, buffer, offset, length, position) {
       Deno.seekSync(fd, position, Deno.SeekMode.Start);
     }
     let currentOffset = offset;
+    const end = offset + length;
     while (currentOffset - offset < length) {
-      currentOffset += Deno.writeSync(fd, buffer.subarray(currentOffset));
+      currentOffset += Deno.writeSync(fd, buffer.subarray(currentOffset, end));
     }
     return currentOffset - offset;
   };
@@ -66,8 +67,12 @@ export function write(fd, buffer, offset, length, position, callback) {
       await Deno.seek(fd, position, Deno.SeekMode.Start);
     }
     let currentOffset = offset;
+    const end = offset + length;
     while (currentOffset - offset < length) {
-      currentOffset += await Deno.write(fd, buffer.subarray(currentOffset));
+      currentOffset += await Deno.write(
+        fd,
+        buffer.subarray(currentOffset, end)
+      );
     }
     return currentOffset - offset;
   };
@@ -86,10 +91,12 @@ export function write(fd, buffer, offset, length, position, callback) {
       position = null;
     }
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
-    innerWrite(fd, buffer, offset, length, position)
-      .then((nwritten) => {
+    innerWrite(fd, buffer, offset, length, position).then(
+      (nwritten) => {
         callback(null, nwritten, buffer);
-      }, (err) => callback(err));
+      },
+      (err) => callback(err)
+    );
     return;
   }
 
@@ -116,6 +123,6 @@ export function write(fd, buffer, offset, length, position, callback) {
     (nwritten) => {
       callback(null, nwritten, buffer);
     },
-    (err) => callback(err),
+    (err) => callback(err)
   );
 }

--- a/node/_fs/_fs_write.mjs
+++ b/node/_fs/_fs_write.mjs
@@ -71,7 +71,7 @@ export function write(fd, buffer, offset, length, position, callback) {
     while (currentOffset - offset < length) {
       currentOffset += await Deno.write(
         fd,
-        buffer.subarray(currentOffset, end)
+        buffer.subarray(currentOffset, end),
       );
     }
     return currentOffset - offset;
@@ -95,7 +95,7 @@ export function write(fd, buffer, offset, length, position, callback) {
       (nwritten) => {
         callback(null, nwritten, buffer);
       },
-      (err) => callback(err)
+      (err) => callback(err),
     );
     return;
   }
@@ -123,6 +123,6 @@ export function write(fd, buffer, offset, length, position, callback) {
     (nwritten) => {
       callback(null, nwritten, buffer);
     },
-    (err) => callback(err)
+    (err) => callback(err),
   );
 }

--- a/node/_fs/_fs_write_test.ts
+++ b/node/_fs/_fs_write_test.ts
@@ -1,0 +1,52 @@
+import { write, writeSync } from "./_fs_write.mjs";
+import { assertEquals } from "../../testing/asserts.ts";
+import { Buffer } from "../buffer.ts";
+
+const decoder = new TextDecoder("utf-8");
+
+Deno.test({
+  name: "Data is written to the file with the correct length",
+  async fn() {
+    const tempFile: string = await Deno.makeTempFile();
+    const file: Deno.FsFile = await Deno.open(tempFile, {
+      create: true,
+      write: true,
+      read: true,
+    });
+    const buffer = Buffer.from("hello world");
+    const bytesWrite = await new Promise((resolve, reject) => {
+      write(file.rid, buffer, 0, 5, (err: unknown, nwritten: number) => {
+        if (err) return reject(err);
+        resolve(nwritten);
+      });
+    });
+    Deno.close(file.rid);
+
+    const data = await Deno.readFile(tempFile);
+    await Deno.remove(tempFile);
+
+    assertEquals(bytesWrite, 5);
+    assertEquals(decoder.decode(data), "hello");
+  },
+});
+
+Deno.test({
+  name: "Data is written synchronously to the file with the correct length",
+  fn() {
+    const tempFile: string = Deno.makeTempFileSync();
+    const file: Deno.FsFile = Deno.openSync(tempFile, {
+      create: true,
+      write: true,
+      read: true,
+    });
+    const buffer = Buffer.from("hello world");
+    const bytesWrite = writeSync(file.rid, buffer, 0, 5);
+    Deno.close(file.rid);
+
+    const data = Deno.readFileSync(tempFile);
+    Deno.removeSync(tempFile);
+
+    assertEquals(bytesWrite, 5);
+    assertEquals(decoder.decode(data), "hello");
+  },
+});


### PR DESCRIPTION
If `buffer.length` is larger than `length`, more date will be writed into file.