### PR TITLE
chore(node): make the message for notImplemented required

### DIFF
--- a/node/_fs/_fs_readlink.ts
+++ b/node/_fs/_fs_readlink.ts
@@ -40,7 +40,7 @@ function getEncoding(
       } else if (optOrCallback.encoding === "buffer") {
         return "buffer";
       } else {
-        notImplemented();
+        notImplemented(`fs.readlink encoding=${optOrCallback.encoding}`);
       }
     }
     return null;

--- a/node/_fs/_fs_streams.ts
+++ b/node/_fs/_fs_streams.ts
@@ -15,7 +15,11 @@ class ReadStream extends NodeReadable {
       opts.fd || opts.start || opts.end || opts.fs
     );
     if (hasBadOptions) {
-      notImplemented();
+      notImplemented(
+        `fs.ReadStream.prototype.constructor with unsupported options (${
+          JSON.stringify(opts)
+        })`,
+      );
     }
     const file = Deno.openSync(path, { read: true });
     const buffer = new Uint8Array(16 * 1024);

--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -18,7 +18,7 @@ export type TextEncodings =
 
 export type Encodings = BinaryEncodings | TextEncodings;
 
-export function notImplemented(msg?: string): never {
+export function notImplemented(msg: string): never {
   const message = msg ? `Not implemented: ${msg}` : "Not implemented";
   throw new Error(message);
 }

--- a/node/cluster.ts
+++ b/node/cluster.ts
@@ -9,16 +9,16 @@ import { notImplemented } from "./_utils.ts";
  */
 export class Worker {
   constructor() {
-    notImplemented();
+    notImplemented("cluster.Worker.prototype.constructor");
   }
 }
 /** Calls .disconnect() on each worker in cluster.workers. */
 export function disconnected() {
-  notImplemented();
+  notImplemented("cluster.disconnected");
 }
 /** Spawn a new worker process. */
 export function fork() {
-  notImplemented();
+  notImplemented("cluster.fork");
 }
 /** True if the process is a primary. This is determined by
  * the process.env.NODE_UNIQUE_ID. If process.env.NODE_UNIQUE_ID is undefined,
@@ -38,12 +38,12 @@ export const schedulingPolicy = undefined;
 export const settings = undefined;
 /** Deprecated alias for .setupPrimary(). */
 export function setupMaster() {
-  notImplemented();
+  notImplemented("cluster.setupMaster");
 }
 /** setupPrimary is used to change the default 'fork' behavior. Once called,
  * the settings will be present in cluster.settings. */
 export function setupPrimary() {
-  notImplemented();
+  notImplemented("cluster.setupPrimary");
 }
 /** A reference to the current worker object. Not available in the primary
  * process. */

--- a/node/dgram.ts
+++ b/node/dgram.ts
@@ -45,55 +45,55 @@ export class Socket extends EventEmitter {
     super();
   }
   addMembership(_multicastAddress: string, _interfaceAddress?: string): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.addMembership");
   }
   addSourceSpecificMembership(
     _sourceAddress: string,
     _groupAddress: string,
     _interfaceAddress?: string,
   ): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.addSourceSpecifiMembership");
   }
   address(): AddressInfo {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.address");
   }
   bind(port?: number, address?: string, callback?: () => void): this;
   bind(port: number, callback?: () => void): this;
   bind(callback: () => void): this;
   bind(options: BindOptions, callback?: () => void): this;
   bind(..._args: unknown[]): this {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.bind");
   }
   close(_callback?: () => void): this {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.close");
   }
 
   connect(port: number, address?: string, callback?: () => void): void;
   connect(port: number, callback: () => void): void;
   connect(_port: number, _arg1?: unknown, _arg2?: unknown): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.connect");
   }
   disconnect(): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.");
   }
   dropMembership(_multicastAddress: string, _interfaceAddress?: string): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.dropMembership");
   }
   dropSourceSpecificMembership(
     _sourceAddress: string,
     _groupAddress: string,
     _interfaceAddress?: string,
   ): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.dropSourceSpecificMembership");
   }
   getRecvBufferSize(): number {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.getRecvBufferSize");
   }
   getSendBufferSize(): number {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.getSendBufferSize");
   }
   ref(): this {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.ref");
   }
   send(
     msg: MessageType | ReadonlyArray<MessageType>,
@@ -133,35 +133,35 @@ export class Socket extends EventEmitter {
   ): void;
   // deno-lint-ignore no-explicit-any
   send(_msg: MessageType | ReadonlyArray<any>, ..._args: unknown[]): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.send");
   }
 
   remoteAddress(): AddressInfo {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.remoteAddress");
   }
   setBroadcast(_arg: boolean): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setBroadcast");
   }
   setMulticastInterface(_interfaceAddress: string): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setMulticastInterface");
   }
   setMulticastLoopback(_arg: boolean): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setMulticastLoopback");
   }
   setMulticastTTL(_ttl: number): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setMulticastTTL");
   }
   setRecvBufferSize(_size: number): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setRecvBufferSize");
   }
   setSendBufferSize(_size: number): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setSendBufferSize");
   }
   setTTL(_ttl: number): void {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.setTTL");
   }
   unref(): this {
-    notImplemented();
+    notImplemented("dgram.Socket.prototype.unref");
   }
   override addListener(event: "close", listener: () => void): this;
   override addListener(event: "connect", listener: () => void): this;

--- a/node/domain.ts
+++ b/node/domain.ts
@@ -4,11 +4,11 @@
 import { notImplemented } from "./_utils.ts";
 
 export function create() {
-  notImplemented();
+  notImplemented("domain.create");
 }
 export class Domain {
   constructor() {
-    notImplemented();
+    notImplemented("domain.Domain.prototype.constructor");
   }
 }
 export default {

--- a/node/http2.ts
+++ b/node/http2.ts
@@ -5,42 +5,42 @@ import { notImplemented } from "./_utils.ts";
 
 export class Http2Session {
   constructor() {
-    notImplemented();
+    notImplemented("Http2Session.prototype.constructor");
   }
 }
 export class ServerHttp2Session {
   constructor() {
-    notImplemented();
+    notImplemented("ServerHttp2Session");
   }
 }
 export class ClientHttp2Session {
   constructor() {
-    notImplemented();
+    notImplemented("ClientHttp2Session");
   }
 }
 export class Http2Stream {
   constructor() {
-    notImplemented();
+    notImplemented("Http2Stream");
   }
 }
 export class ClientHttp2Stream {
   constructor() {
-    notImplemented();
+    notImplemented("ClientHttp2Stream");
   }
 }
 export class ServerHttp2Stream {
   constructor() {
-    notImplemented();
+    notImplemented("ServerHttp2Stream");
   }
 }
 export class Http2Server {
   constructor() {
-    notImplemented();
+    notImplemented("Http2Server");
   }
 }
 export class Http2SecureServer {
   constructor() {
-    notImplemented();
+    notImplemented("Http2SecureServer");
   }
 }
 export function createServer() {}
@@ -53,12 +53,12 @@ export function getUnpackedSettings() {}
 export const sensitiveHeaders = Symbol("nodejs.http2.sensitiveHeaders");
 export class Http2ServerRequest {
   constructor() {
-    notImplemented();
+    notImplemented("Http2ServerRequest");
   }
 }
 export class Http2ServerResponse {
   constructor() {
-    notImplemented();
+    notImplemented("Http2ServerResponse");
   }
 }
 export default {

--- a/node/https.ts
+++ b/node/https.ts
@@ -17,11 +17,11 @@ export class Agent extends HttpAgent {
 
 export class Server {
   constructor() {
-    notImplemented();
+    notImplemented("https.Server.prototype.constructor");
   }
 }
 export function createServer() {
-  notImplemented();
+  notImplemented("https.createServer");
 }
 
 interface HttpsRequestOptions extends RequestOptions {

--- a/node/inspector.ts
+++ b/node/inspector.ts
@@ -16,22 +16,22 @@ class Session extends EventEmitter {
 
   constructor() {
     super();
-    notImplemented();
+    notImplemented("inspector.Session.prototype.constructor");
   }
 
   /** Connects the session to the inspector back-end. */
   connect() {
-    notImplemented();
+    notImplemented("inspector.Session.prototype.connect");
   }
 
   /** Connects the session to the main thread
    * inspector back-end. */
   connectToMainThread() {
-    notImplemented();
+    notImplemented("inspector.Session.prototype.connectToMainThread");
   }
 
   [onMessageSymbol](_message: string) {
-    notImplemented();
+    notImplemented("inspector.Session.prototype[Symbol('onMessage')]");
   }
 
   /** Posts a message to the inspector back-end. */
@@ -40,7 +40,7 @@ class Session extends EventEmitter {
     _params?: Record<string, unknown>,
     _callback?: (...args: unknown[]) => void,
   ): void {
-    notImplemented();
+    notImplemented("inspector.Session.prototype.post");
   }
 
   /** Immediately closes the session, all pending
@@ -48,20 +48,20 @@ class Session extends EventEmitter {
    * error.
    */
   disconnect() {
-    notImplemented();
+    notImplemented("inspector.Session.prototype.disconnect");
   }
 }
 
 /** Activates inspector on host and port.
  * See https://nodejs.org/api/inspector.html#inspectoropenport-host-wait */
 function open(_port?: number, _host?: string, _wait?: boolean): void {
-  notImplemented();
+  notImplemented("inspector.Session.prototype.open");
 }
 
 /** Deactivate the inspector. Blocks until there are no active connections.
  * See https://nodejs.org/api/inspector.html#inspectorclose */
 function close() {
-  notImplemented();
+  notImplemented("inspector.Session.prototype.close");
 }
 
 /** Return the URL of the active inspector, or undefined if there is none.
@@ -74,7 +74,7 @@ function url() {
 /** Blocks until a client (existing or connected later) has sent Runtime.runIfWaitingForDebugger command.
  * See https://nodejs.org/api/inspector.html#inspectorwaitfordebugger */
 function waitForDebugger() {
-  notImplemented();
+  notImplemented("inspector.wairForDebugger");
 }
 
 const console = globalThis.console;

--- a/node/internal/child_process.ts
+++ b/node/internal/child_process.ts
@@ -287,7 +287,7 @@ function toDenoStdio(
     !supportedNodeStdioTypes.includes(pipe as NodeStdio) ||
     typeof pipe === "number" || pipe instanceof Stream
   ) {
-    notImplemented();
+    notImplemented(`toDenoStdio pipe=${typeof pipe} (${pipe})`);
   }
   switch (pipe) {
     case "pipe":
@@ -299,7 +299,7 @@ function toDenoStdio(
     case "inherit":
       return "inherit";
     default:
-      notImplemented();
+      notImplemented(`toDenoStdio pipe=${typeof pipe} (${pipe})`);
   }
 }
 
@@ -471,7 +471,7 @@ function normalizeStdioOption(
     switch (stdio) {
       case "overlapped":
         if (isWindows) {
-          notImplemented();
+          notImplemented("normalizeStdioOption overlapped (on windows)");
         }
         // 'overlapped' is same as 'piped' on non Windows system.
         return ["pipe", "pipe", "pipe"];
@@ -482,7 +482,7 @@ function normalizeStdioOption(
       case "ignore":
         return ["ignore", "ignore", "ignore"];
       default:
-        notImplemented();
+        notImplemented(`normalizeStdioOption stdio=${typeof stdio} (${stdio})`);
     }
   }
 }

--- a/node/internal/http.ts
+++ b/node/internal/http.ts
@@ -24,7 +24,7 @@ function resetCache() {
 export function emitStatistics(
   _statistics: { startTime: [number, number] } | null,
 ) {
-  notImplemented();
+  notImplemented("internal/http.emitStatistics");
 }
 
 export const kOutHeaders = Symbol("kOutHeaders");

--- a/node/internal_binding/handle_wrap.ts
+++ b/node/internal_binding/handle_wrap.ts
@@ -39,11 +39,11 @@ export class HandleWrap extends AsyncWrap {
   }
 
   ref() {
-    notImplemented();
+    notImplemented("HandleWrap.prototype.ref");
   }
 
   unref() {
-    notImplemented();
+    notImplemented("HandleWrap.prototype.unref");
   }
 
   // deno-lint-ignore no-explicit-any

--- a/node/internal_binding/pipe_wrap.ts
+++ b/node/internal_binding/pipe_wrap.ts
@@ -72,11 +72,11 @@ export class Pipe extends ConnectionWrap {
   }
 
   bind() {
-    notImplemented();
+    notImplemented("Pipe.prototype.bind");
   }
 
   listen() {
-    notImplemented();
+    notImplemented("Pipe.prototype.listen");
   }
 
   connect(
@@ -90,21 +90,21 @@ export class Pipe extends ConnectionWrap {
       writable: boolean,
     ) => void,
   ) {
-    notImplemented();
+    notImplemented("Pipe.prototype.connect");
   }
 
   open(_fd: number): number {
     // REF: https://github.com/denoland/deno/issues/6529
-    notImplemented();
+    notImplemented("Pipe.prototype.open");
   }
 
   // Windows only
   setPendingInstances(_instances: number) {
-    notImplemented();
+    notImplemented("Pipe.prototype.setPendingInstances");
   }
 
   fchmod() {
-    notImplemented();
+    notImplemented("Pipe.prototype.fchmod");
   }
 }
 

--- a/node/internal_binding/stream_wrap.ts
+++ b/node/internal_binding/stream_wrap.ts
@@ -157,7 +157,7 @@ export class LibuvStreamWrap extends HandleWrap {
    */
   useUserBuffer(_userBuf: unknown): number {
     // TODO(cmorten)
-    notImplemented();
+    notImplemented("LibuvStreamWrap.prototype.useUserBuffer");
   }
 
   /**
@@ -191,7 +191,7 @@ export class LibuvStreamWrap extends HandleWrap {
     _allBuffers: boolean,
   ): number {
     // TODO(cmorten)
-    notImplemented();
+    notImplemented("LibuvStreamWrap.prototype.writev");
   }
 
   /**
@@ -219,7 +219,7 @@ export class LibuvStreamWrap extends HandleWrap {
    * @return An error status code.
    */
   writeUcs2String(_req: WriteWrap<LibuvStreamWrap>, _data: string): number {
-    notImplemented();
+    notImplemented("LibuvStreamWrap.prototype.writeUcs2String");
   }
 
   /**

--- a/node/internal_binding/tcp_wrap.ts
+++ b/node/internal_binding/tcp_wrap.ts
@@ -152,7 +152,7 @@ export class TCP extends ConnectionWrap {
    */
   open(_fd: number): number {
     // REF: https://github.com/denoland/deno/issues/6529
-    notImplemented();
+    notImplemented("TCP.prototype.open");
   }
 
   /**
@@ -306,7 +306,7 @@ export class TCP extends ConnectionWrap {
    */
   setSimultaneousAccepts(_enable: boolean) {
     // Low priority to implement owing to it being deprecated in Node.
-    notImplemented();
+    notImplemented("TCP.prototype.setSimultaneousAccepts");
   }
 
   /**

--- a/node/internal_binding/util.ts
+++ b/node/internal_binding/util.ts
@@ -28,7 +28,7 @@
 import { notImplemented } from "../_utils.ts";
 
 export function guessHandleType(_fd: number): string {
-  notImplemented();
+  notImplemented("gessHandleType");
 }
 
 export const ALL_PROPERTIES = 0;

--- a/node/net.ts
+++ b/node/net.ts
@@ -795,7 +795,7 @@ export class Socket extends Duplex {
       this[asyncIdSymbol] = _getNewAsyncId(this._handle);
     } else if (options.fd !== undefined) {
       // REF: https://github.com/denoland/deno/issues/6529
-      notImplemented();
+      notImplemented("net.Socket.prototype.constructor with fd option");
     }
 
     const onread = options.onread;

--- a/node/repl.ts
+++ b/node/repl.ts
@@ -5,7 +5,7 @@ import { notImplemented } from "./_utils.ts";
 
 class REPLServer {
   constructor() {
-    notImplemented();
+    notImplemented("REPLServer.prototype.constructor");
   }
 }
 export const builtinModules = [
@@ -53,7 +53,7 @@ export const builtinModules = [
   "zlib",
 ];
 export function start() {
-  notImplemented();
+  notImplemented("repl.start");
 }
 export default {
   REPLServer,

--- a/node/tls.ts
+++ b/node/tls.ts
@@ -36,7 +36,7 @@ export class CryptoStream {}
 export class SecurePair {}
 export class Server {}
 export function createSecurePair() {
-  notImplemented();
+  notImplemented("tls.createSecurePair");
 }
 
 export default {

--- a/node/v8.ts
+++ b/node/v8.ts
@@ -4,70 +4,70 @@
 import { notImplemented } from "./_utils.ts";
 
 export function cachedDataVersionTag() {
-  notImplemented();
+  notImplemented("v8.cachedDataVersionTag");
 }
 export function getHeapCodeStatistics() {
-  notImplemented();
+  notImplemented("v8.getHeapCodeStatistics");
 }
 export function getHeapSnapshot() {
-  notImplemented();
+  notImplemented("v8.getHeapSnapshot");
 }
 export function getHeapSpaceStatistics() {
-  notImplemented();
+  notImplemented("v8.getHeapSpaceStatistics");
 }
 export function getHeapStatistics() {
-  notImplemented();
+  notImplemented("v8.getHeapStatistics");
 }
 export function setFlagsFromString() {
-  notImplemented();
+  notImplemented("v8.setFlagsFromString");
 }
 export function stopCoverage() {
-  notImplemented();
+  notImplemented("v8.stopCoverage");
 }
 export function takeCoverage() {
-  notImplemented();
+  notImplemented("v8.takeCoverage");
 }
 export function writeHeapSnapshot() {
-  notImplemented();
+  notImplemented("v8.writeHeapSnapshot");
 }
 export function serialize() {
-  notImplemented();
+  notImplemented("v8.serialize");
 }
 export function deserialize() {
-  notImplemented();
+  notImplemented("v8.deserialize");
 }
 export class Serializer {
   constructor() {
-    notImplemented();
+    notImplemented("v8.Serializer.prototype.constructor");
   }
 }
 export class Deserializer {
   constructor() {
-    notImplemented();
+    notImplemented("v8.Deserializer.prototype.constructor");
   }
 }
 export class DefaultSerializer {
   constructor() {
-    notImplemented();
+    notImplemented("v8.DefaultSerializer.prototype.constructor");
   }
 }
 export class DefaultDeserializer {
   constructor() {
-    notImplemented();
+    notImplemented("v8.DefaultDeserializer.prototype.constructor");
   }
 }
 export const promiseHooks = {
   onInit() {
-    notImplemented();
+    notImplemented("v8.promiseHooks.onInit");
   },
   onSettled() {
-    notImplemented();
+    notImplemented("v8.promiseHooks.onSetttled");
   },
   onBefore() {
-    notImplemented();
+    notImplemented("v8.promiseHooks.onBefore");
   },
   createHook() {
-    notImplemented();
+    notImplemented("v8.promiseHooks.createHook");
   },
 };
 export default {

--- a/node/vm.ts
+++ b/node/vm.ts
@@ -15,20 +15,20 @@ export class Script {
   }
 
   runInContext(_contextifiedObject: any, _options: any) {
-    notImplemented();
+    notImplemented("Script.prototype.runInContext");
   }
 
   runInNewContext(_contextObject: any, _options: any) {
-    notImplemented();
+    notImplemented("Script.prototype.runInNewContext");
   }
 
   createCachedData() {
-    notImplemented();
+    notImplemented("Script.prototyp.createCachedData");
   }
 }
 
 export function createContext(_contextObject: any, _options: any) {
-  notImplemented();
+  notImplemented("createContext");
 }
 
 export function createScript(code: string, options: any) {
@@ -40,7 +40,7 @@ export function runInContext(
   _contextifiedObject: any,
   _options: any,
 ) {
-  notImplemented();
+  notImplemented("unInContext");
 }
 
 export function runInNewContext(
@@ -48,7 +48,7 @@ export function runInNewContext(
   _contextObject: any,
   _options: any,
 ) {
-  notImplemented();
+  notImplemented("runInNewContext");
 }
 
 export function runInThisContext(
@@ -59,15 +59,15 @@ export function runInThisContext(
 }
 
 export function isContext(_maybeContext: any) {
-  notImplemented();
+  notImplemented("isContext");
 }
 
 export function compileFunction(_code: string, _params: any, _options: any) {
-  notImplemented();
+  notImplemented("compileFunction");
 }
 
 export function measureMemory(_options: any) {
-  notImplemented();
+  notImplemented("measureMemory");
 }
 
 export default {

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -86,7 +86,8 @@ class _Worker extends EventEmitter {
     this.emit("exit", 0);
   }
 
-  readonly getHeapSnapshot = notImplemented;
+  readonly getHeapSnapshot = () =>
+    notImplemented("Worker.prototype.getHeapSnapshot");
   // fake performance
   readonly performance = globalThis.performance;
 }
@@ -170,8 +171,9 @@ if (!isMainThread) {
   parentPort.eventNames = () => [""];
   parentPort.listenerCount = () => 0;
 
-  parentPort.emit = () => notImplemented();
-  parentPort.removeAllListeners = () => notImplemented();
+  parentPort.emit = () => notImplemented("parentPort.emit");
+  parentPort.removeAllListeners = () =>
+    notImplemented("parentPort.removeAllListeners");
 
   // Receive startup message
   [{ threadId, workerData, environmentData }] = await once(
@@ -204,22 +206,28 @@ const _MessageChannel: typeof MessageChannel =
   (globalThis as any).MessageChannel;
 export const BroadcastChannel = globalThis.BroadcastChannel;
 export const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
+export function markAsUntransferable() {
+  notImplemented("markAsUntransferable");
+}
+export function moveMessagePortToContext() {
+  notImplemented("moveMessagePortToContext");
+}
+export function receiveMessageOnPort() {
+  notImplemented("receiveMessageOnPort");
+}
 export {
   _MessageChannel as MessageChannel,
   _MessagePort as MessagePort,
   _Worker as Worker,
-  notImplemented as markAsUntransferable,
-  notImplemented as moveMessagePortToContext,
-  notImplemented as receiveMessageOnPort,
   parentPort,
   threadId,
   workerData,
 };
 
 export default {
-  markAsUntransferable: notImplemented,
-  moveMessagePortToContext: notImplemented,
-  receiveMessageOnPort: notImplemented,
+  markAsUntransferable,
+  moveMessagePortToContext,
+  receiveMessageOnPort,
   MessagePort: _MessagePort,
   MessageChannel: _MessageChannel,
   BroadcastChannel,

--- a/node/zlib.ts
+++ b/node/zlib.ts
@@ -34,47 +34,47 @@ import {
 } from "./_zlib.mjs";
 export class Options {
   constructor() {
-    notImplemented();
+    notImplemented("Options.prototype.constructor");
   }
 }
 export class BrotliOptions {
   constructor() {
-    notImplemented();
+    notImplemented("BrotliOptions.prototype.constructor");
   }
 }
 export class BrotliCompress {
   constructor() {
-    notImplemented();
+    notImplemented("BrotliCompress.prototype.constructor");
   }
 }
 export class BrotliDecompress {
   constructor() {
-    notImplemented();
+    notImplemented("BrotliDecompress.prototype.constructor");
   }
 }
 export class ZlibBase {
   constructor() {
-    notImplemented();
+    notImplemented("ZlibBase.prototype.constructor");
   }
 }
 export { constants };
 export function createBrotliCompress() {
-  notImplemented();
+  notImplemented("createBrotliCompress");
 }
 export function createBrotliDecompress() {
-  notImplemented();
+  notImplemented("createBrotliDecompress");
 }
 export function brotliCompress() {
-  notImplemented();
+  notImplemented("brotliCompress");
 }
 export function brotliCompressSync() {
-  notImplemented();
+  notImplemented("brotliCompressSync");
 }
 export function brotliDecompress() {
-  notImplemented();
+  notImplemented("brotliDecompress");
 }
 export function brotliDecompressSync() {
-  notImplemented();
+  notImplemented("brotliDecompressSync");
 }
 
 export default {


### PR DESCRIPTION
This PR makes the 1st arg (message) for `notImplemented` utility required.

If the message is omitted, the program only shows `notImplemented` and it doesn't give any information, and therefore that's inconvenient. This PR make the message required and improve the situation.