### PR TITLE
chore(ci): fix version bumping to allow running deno

### DIFF
--- a/_tools/release/01_bump_version.ts
+++ b/_tools/release/01_bump_version.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run=git --no-check
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run=git,deno --no-check
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { getReleasesMdFile, loadRepo, VersionFile } from "./repo.ts";
 


### PR DESCRIPTION
I obviously don't run the shebangs on Windows, but should have still tested this.