### PR TITLE
chore(ci): fix version bump git push

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          persist-credentials: false
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1.0.0


### PR DESCRIPTION
So close. Maybe this will fix this.

```
Creating branch release_0_134.0...
Switched to a new branch 'release_0_134.0'
[release_0_134.0 9bfa4a14] 0.134.0
 2 files changed, [10](https://github.com/denoland/deno_std/runs/5869850645?check_suite_focus=true#step:5:10) insertions(+), 1 deletion(-)
Pushing branch...
fatal: could not read Username for 'https://github.com': No such device or address
error: Uncaught (in promise) Error: Error executing git. Code: 128
    throw new Error(
          ^
    at runCommandWithOutput (https://raw.githubusercontent.com/denoland/automation/0.10.0/helpers.ts:47:[11](https://github.com/denoland/deno_std/runs/5869850645?check_suite_focus=true#step:5:11))
    at async file:///home/runner/work/deno_std/deno_std/_tools/release/02_create_pr.ts:[19](https://github.com/denoland/deno_std/runs/5869850645?check_suite_focus=true#step:5:19):1
Error: Process completed with exit code 1.
```