### PR TITLE
Change crypto/randomInt (and associated test) to generate maximum exclusive instead of inclusive

### DIFF
--- a/node/_crypto/randomInt.ts
+++ b/node/_crypto/randomInt.ts
@@ -49,7 +49,7 @@ export default function randomInt(
   min = Math.ceil(min);
   max = Math.floor(max);
 
-  const result = Math.floor(randomNumber * (max - min + 1)) + min;
+  const result = Math.floor(randomNumber * (max - min)) + min;
 
   if (cb) {
     cb(null, result);

--- a/node/_crypto/randomInt_test.ts
+++ b/node/_crypto/randomInt_test.ts
@@ -2,7 +2,7 @@
 import randomInt from "./randomInt.ts";
 import { assert, assertThrows } from "../../testing/asserts.ts";
 
-const between = (x: number, min: number, max: number) => x >= min && x <= max;
+const between = (x: number, min: number, max: number) => x >= min && x < max;
 
 Deno.test("[node/crypto.randomInt] One Param: Max", () => {
   assert(between(randomInt(55), 0, 55));


### PR DESCRIPTION
Referencing #2099 - committed the `randomInt` fix and modified the `between` assertion within `randomInt_test.ts` to disallow maximum inclusion when checking generated value.