### PR TITLE
chore: update node:unit task to fix CI

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,7 +37,7 @@
     "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=node/",
     "test:faketime": "faketime '2021-12-31' deno test --unstable --allow-all datetime/test_2021_12_31.ts",
     "test:browser": "git grep --name-only \"// This module is browser compatible.\" | grep -v \".github/workflows\" | xargs deno cache --config browser-compat.tsconfig.json",
-    "node:unit": "deno test --unstable --allow-all node/ --ignore=node/_tools/test.ts,node/_tools/versions/",
+    "node:unit": "DENO_FUTURE_CHECK=1 deno test --unstable --allow-all node/ --ignore=node/_tools/test.ts,node/_tools/versions/",
     "node:test": "deno test --unstable --allow-all node/_tools/test.ts",
     "node:setup": "deno run --allow-read --allow-net --allow-write node/_tools/setup.ts"
   }

--- a/node/_fs/_fs_close.ts
+++ b/node/_fs/_fs_close.ts
@@ -1,7 +1,9 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import type { CallbackWithError } from "./_fs_common.ts";
+import { getValidatedFd } from "../internal/fs/utils.mjs";
 
 export function close(fd: number, callback: CallbackWithError): void {
+  fd = getValidatedFd(fd);
   setTimeout(() => {
     let error = null;
     try {
@@ -14,5 +16,6 @@ export function close(fd: number, callback: CallbackWithError): void {
 }
 
 export function closeSync(fd: number): void {
+  fd = getValidatedFd(fd);
   Deno.close(fd);
 }

--- a/node/_fs/_fs_close_test.ts
+++ b/node/_fs/_fs_close_test.ts
@@ -29,13 +29,10 @@ Deno.test({
 
 Deno.test({
   name: "ASYNC: Invalid fd",
-  async fn() {
-    await new Promise<void>((resolve, reject) => {
-      close(-1, (err) => {
-        if (err !== null) return resolve();
-        reject();
-      });
-    });
+  fn() {
+    assertThrows(() => {
+      close(-1, (_err) => {});
+    }, RangeError);
   },
 });
 

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -97,7 +97,9 @@ function buildMessage(
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value
     ).join("") ?? result.value;
-    diffMessages.push(c(`${createSign(result.type)}${line}`));
+    diffMessages.push(c(`${
+      createSign(result.type)
+    }${line}`));
   });
   messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -97,9 +97,7 @@ function buildMessage(
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value
     ).join("") ?? result.value;
-    diffMessages.push(c(`${
-      createSign(result.type)
-    }${line}`));
+    diffMessages.push(c(`${createSign(result.type)}${line}`));
   });
   messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");


### PR DESCRIPTION
From denoland/deno#14072 `deno run` prints warning and that causes some CI errors in `node/child_process` testing. This PR fixes it.