### PR TITLE
fix(node): Use Web Crypto API via globalThis

### DIFF
--- a/node/_crypto/crypto_browserify/randombytes.ts
+++ b/node/_crypto/crypto_browserify/randombytes.ts
@@ -28,10 +28,12 @@ export function randomBytes(
       for (let generated = 0; generated < size; generated += MAX_BYTES) {
         // buffer.slice automatically checks if the end is past the end of
         // the buffer so we don't have to here
-        crypto.getRandomValues(bytes.slice(generated, generated + MAX_BYTES));
+        globalThis.crypto.getRandomValues(
+          bytes.slice(generated, generated + MAX_BYTES),
+        );
       }
     } else {
-      crypto.getRandomValues(bytes);
+      globalThis.crypto.getRandomValues(bytes);
     }
   }
 

--- a/node/_crypto/randomBytes.ts
+++ b/node/_crypto/randomBytes.ts
@@ -16,12 +16,12 @@ function generateRandomBytes(size: number) {
   //Work around for getRandomValues max generation
   if (size > MAX_RANDOM_VALUES) {
     for (let generated = 0; generated < size; generated += MAX_RANDOM_VALUES) {
-      crypto.getRandomValues(
+      globalThis.crypto.getRandomValues(
         bytes.slice(generated, generated + MAX_RANDOM_VALUES),
       );
     }
   } else {
-    crypto.getRandomValues(bytes);
+    globalThis.crypto.getRandomValues(bytes);
   }
 
   return bytes;

--- a/node/_crypto/randomInt.ts
+++ b/node/_crypto/randomInt.ts
@@ -42,7 +42,7 @@ export default function randomInt(
 
   const randomBuffer = new Uint32Array(1);
 
-  crypto.getRandomValues(randomBuffer);
+  globalThis.crypto.getRandomValues(randomBuffer);
 
   const randomNumber = randomBuffer[0] / (0xffffffff + 1);
 

--- a/node/crypto.ts
+++ b/node/crypto.ts
@@ -14,7 +14,7 @@ import {
   publicEncrypt,
 } from "./_crypto/crypto_browserify/public_encrypt/mod.js";
 
-const randomUUID = () => crypto.randomUUID();
+const randomUUID = () => globalThis.crypto.randomUUID();
 const webcrypto = crypto;
 
 export default {

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -97,7 +97,9 @@ function buildMessage(
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value
     ).join("") ?? result.value;
-    diffMessages.push(c(`${createSign(result.type)}${line}`));
+    diffMessages.push(c(`${
+      createSign(result.type)
+    }${line}`));
   });
   messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");


### PR DESCRIPTION
close #2114

I think the cause of #2114 is that the global variable `crypto` in the repl references the Node's Crypto API instead of the Web Crypto API.
This PR will replace `crypto.xxx` with `globalThis.crypto.xxx`.

I'm not really sure if this change fixes #2114 (I don't know how to test it). Therefore, there is still no certainty that this approach is suitable.