### PR TITLE
perf(http): optimize file server

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -265,7 +265,7 @@ export async function serveFile(
   filePath: string,
   { etagAlgorithm, fileInfo }: ServeFileOptions = {},
 ): Promise<Response> {
-  let file: Deno.File;
+  let file: Deno.FsFile;
   if (fileInfo === undefined) {
     [file, fileInfo] = await Promise.all([
       Deno.open(filePath),

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -610,17 +610,18 @@ const getTestFileLastModified = async () => {
   }
 };
 
-const createEtagHash = async (message: string) => {
-  // see: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
-  const hashType = "SHA-1"; // Faster, and this isn't a security sensitive cryptographic use case
-  const msgUint8 = new TextEncoder().encode(message);
-  const hashBuffer = await crypto.subtle.digest(hashType, msgUint8);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(
-    "",
-  );
-  return hashHex;
-};
+function createEtagHash(buf: string): string {
+  let hash = 2166136261; // 32-bit FNV offset basis
+  for (let i = 0; i < buf.length; i++) {
+    hash ^= buf.charCodeAt(i);
+    // Equivalent to `hash *= 16777619` without using BigInt
+    // 32-bit FNV prime
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) +
+      (hash << 24);
+  }
+  // 32-bit hex string
+  return (hash >>> 0).toString(16);
+}
 
 Deno.test(
   "file_server returns 206 for range request responses",

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -97,7 +97,9 @@ function buildMessage(
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value
     ).join("") ?? result.value;
-    diffMessages.push(c(`${createSign(result.type)}${line}`));
+    diffMessages.push(c(`${
+      createSign(result.type)
+    }${line}`));
   });
   messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");


### PR DESCRIPTION
Towards #2107 

Major changes:

- use native readable streams optimization. `Deno.File#readable` instead of a wrapper stream. See https://github.com/denoland/deno/pull/14284
- use fnv-1a default etag hash function. Adds an option to allow using others.
- ~~faster hex function for out of other algorithms (like `sha-1`), using hex lookup table.~~
- disables logging by default when invoked independently. Replaces the `--quiet` flag with `--verbose`. Public API remains unchanged.
- ~~use simpler extname extraction to avoid scanning manually. (downsides?)~~

Benchmarks:

`main`:
```
Running 10s test @ http://localhost:4507/README.md
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.44ms  522.77us  26.73ms   97.55%
    Req/Sec     1.40k   119.07     2.63k    97.39%
  112288 requests in 10.10s, 432.42MB read
Requests/sec:  11114.28
Transfer/sec:     42.80MB
```

This patch:
```
wrk -t8 -c20 -d10s http://localhost:4507/README.md
Running 10s test @ http://localhost:4507/README.md
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.01ms  163.42us   6.32ms   85.73%
    Req/Sec     1.99k    67.51     2.09k    86.51%
  160068 requests in 10.10s, 611.53MB read
Requests/sec:  15848.72
Transfer/sec:     60.55MB
```