### PR TITLE
feat(testing): add TestContext argument to it

### DIFF
--- a/testing/_test_suite.ts
+++ b/testing/_test_suite.ts
@@ -28,7 +28,7 @@ export interface DescribeDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
 
 /** The options for creating an individual test case with the it function. */
 export interface ItDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
-  fn: (this: T) => void | Promise<void>;
+  fn: (this: T, t: Deno.TestContext) => void | Promise<void>;
   /**
    * The `describe` function returns a `TestSuite` representing the group of tests.
    * If `it` is called within a `describe` calls `fn`, the suite will default to that parent `describe` calls returned `TestSuite`.
@@ -309,7 +309,7 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
               }
             }
           } else {
-            await TestSuiteInternal.runTest(fn!, context);
+            await TestSuiteInternal.runTest(t, fn!, context);
           }
         },
       };
@@ -321,7 +321,8 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
   }
 
   static async runTest<T>(
-    fn: (this: T) => void | Promise<void>,
+    t: Deno.TestContext,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
     context: T,
     activeIndex = 0,
   ) {
@@ -338,7 +339,7 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
         }
       }
       try {
-        await TestSuiteInternal.runTest(fn, context, activeIndex + 1);
+        await TestSuiteInternal.runTest(t, fn, context, activeIndex + 1);
       } finally {
         const { afterEach } = testSuite.describe;
         if (typeof afterEach === "function") {
@@ -350,7 +351,7 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
         }
       }
     } else {
-      await fn.call(context);
+      await fn.call(context, t);
     }
   }
 }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -97,7 +97,9 @@ function buildMessage(
         ? createColor(detail.type, { background: true })(detail.value)
         : detail.value
     ).join("") ?? result.value;
-    diffMessages.push(c(`${createSign(result.type)}${line}`));
+    diffMessages.push(c(`${
+      createSign(result.type)
+    }${line}`));
   });
   messages.push(...(stringDiff ? [diffMessages.join("")] : diffMessages));
   messages.push("");

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -17,21 +17,21 @@ export type ItArgs<T> =
   ]
   | [
     name: string,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
-  | [fn: (this: T) => void | Promise<void>]
+  | [fn: (this: T, t: Deno.TestContext) => void | Promise<void>]
   | [
     name: string,
     options: Omit<ItDefinition<T>, "fn" | "name">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     options: Omit<ItDefinition<T>, "fn">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     options: Omit<ItDefinition<T>, "fn" | "name">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
@@ -41,27 +41,27 @@ export type ItArgs<T> =
   | [
     suite: TestSuite<T>,
     name: string,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     name: string,
     options: Omit<ItDefinition<T>, "fn" | "name" | "suite">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<ItDefinition<T>, "fn" | "suite">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<ItDefinition<T>, "fn" | "name" | "suite">,
-    fn: (this: T) => void | Promise<void>,
+    fn: (this: T, t: Deno.TestContext) => void | Promise<void>,
   ];
 
 /** Generates an ItDefinition from ItArgs. */
@@ -166,9 +166,9 @@ export function it<T>(...args: ItArgs<T>): void {
       sanitizeExit,
       sanitizeOps,
       sanitizeResources,
-      async fn() {
+      async fn(t) {
         if (!TestSuiteInternal.running) TestSuiteInternal.running = true;
-        await fn.call({} as T);
+        await fn.call({} as T, t);
       },
     });
   }

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -109,6 +109,7 @@ Deno.test("global", async (t) => {
       fns = [spy(), spy()],
       { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } = hookFns();
 
+    const context = new TestContext("global");
     try {
       beforeAll(beforeAllFn);
       afterAll(afterAllFn);
@@ -128,7 +129,6 @@ Deno.test("global", async (t) => {
       assertEquals(Object.keys(options).sort(), ["fn", "name"]);
       assertEquals(options.name, "global");
 
-      const context = new TestContext("global");
       const result = options.fn(context);
       assertStrictEquals(Promise.resolve(result), result);
       assertEquals(await result, undefined);
@@ -141,7 +141,7 @@ Deno.test("global", async (t) => {
     let fn = fns[0];
     assertSpyCall(fn, 0, {
       self: { allTimer: 1, eachTimer: 2 },
-      args: [],
+      args: [context.steps[0]],
       returned: undefined,
     });
     assertSpyCalls(fn, 1);
@@ -149,7 +149,7 @@ Deno.test("global", async (t) => {
     fn = fns[1];
     assertSpyCall(fn, 0, {
       self: { allTimer: 1, eachTimer: 3 },
-      args: [],
+      args: [context.steps[1]],
       returned: undefined,
     });
     assertSpyCalls(fn, 1);
@@ -194,7 +194,7 @@ Deno.test("global", async (t) => {
         assertSpyCalls(context.spies.step, 0);
         assertSpyCall(fn, 0, {
           self: {},
-          args: [],
+          args: [context],
           returned: undefined,
         });
       } finally {
@@ -697,14 +697,14 @@ Deno.test("global", async (t) => {
         let fn = fns[0];
         assertSpyCall(fn, 0, {
           self: {},
-          args: [],
+          args: [context.steps[0]],
           returned: undefined,
         });
 
         fn = fns[1];
         assertSpyCall(fn, 0, {
           self: {},
-          args: [],
+          args: [context.steps[1]],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
@@ -1340,7 +1340,6 @@ Deno.test("global", async (t) => {
           fn = fns[1];
           assertSpyCall(fn, 0, {
             self: {},
-            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1438,7 +1437,6 @@ Deno.test("global", async (t) => {
           fn = fns[1];
           assertSpyCall(fn, 0, {
             self: {},
-            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1520,6 +1518,7 @@ Deno.test("global", async (t) => {
           fns = [spy(), spy()],
           { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } = hookFns();
 
+        const context = new TestContext("example");
         try {
           cb({ beforeAllFn, afterAllFn, beforeEachFn, afterEachFn, fns });
 
@@ -1532,7 +1531,6 @@ Deno.test("global", async (t) => {
           assertEquals(Object.keys(options).sort(), ["fn", "name"]);
           assertEquals(options.name, "example");
 
-          const context = new TestContext("example");
           const result = options.fn(context);
           assertStrictEquals(Promise.resolve(result), result);
           assertEquals(await result, undefined);
@@ -1545,7 +1543,7 @@ Deno.test("global", async (t) => {
         let fn = fns[0];
         assertSpyCall(fn, 0, {
           self: { allTimer: 1, eachTimer: 2 },
-          args: [],
+          args: [context.steps[0]],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
@@ -1553,7 +1551,7 @@ Deno.test("global", async (t) => {
         fn = fns[1];
         assertSpyCall(fn, 0, {
           self: { allTimer: 1, eachTimer: 3 },
-          args: [],
+          args: [context.steps[1]],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
@@ -1616,6 +1614,7 @@ Deno.test("global", async (t) => {
             fns = [spy(), spy()],
             { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } = hookFns();
 
+          const context = new TestContext("example");
           try {
             describe("example", () => {
               beforeAll(beforeAllFn);
@@ -1639,16 +1638,14 @@ Deno.test("global", async (t) => {
             assertEquals(Object.keys(options).sort(), ["fn", "name"]);
             assertEquals(options.name, "example");
 
-            let context = new TestContext("example");
             const result = options.fn(context);
             assertStrictEquals(Promise.resolve(result), result);
             assertEquals(await result, undefined);
             assertSpyCalls(context.spies.step, 1);
 
-            context = context.steps[0];
             assertStrictEquals(Promise.resolve(result), result);
             assertEquals(await result, undefined);
-            assertSpyCalls(context.spies.step, 2);
+            assertSpyCalls(context.steps[0].spies.step, 2);
           } finally {
             TestSuiteInternal.reset();
             test.restore();
@@ -1657,7 +1654,7 @@ Deno.test("global", async (t) => {
           let fn = fns[0];
           assertSpyCall(fn, 0, {
             self: { allTimer: 1, eachTimer: 2 },
-            args: [],
+            args: [context.steps[0].steps[0]],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1665,7 +1662,7 @@ Deno.test("global", async (t) => {
           fn = fns[1];
           assertSpyCall(fn, 0, {
             self: { allTimer: 1, eachTimer: 3 },
-            args: [],
+            args: [context.steps[0].steps[1]],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1717,6 +1714,7 @@ Deno.test("global", async (t) => {
               },
             );
 
+          const context = new TestContext("example");
           try {
             describe("example", () => {
               beforeAll(beforeAllFn);
@@ -1746,16 +1744,14 @@ Deno.test("global", async (t) => {
             assertEquals(Object.keys(options).sort(), ["fn", "name"]);
             assertEquals(options.name, "example");
 
-            let context = new TestContext("example");
             const result = options.fn(context);
             assertStrictEquals(Promise.resolve(result), result);
             assertEquals(await result, undefined);
             assertSpyCalls(context.spies.step, 1);
 
-            context = context.steps[0];
             assertStrictEquals(Promise.resolve(result), result);
             assertEquals(await result, undefined);
-            assertSpyCalls(context.spies.step, 2);
+            assertSpyCalls(context.steps[0].spies.step, 2);
           } finally {
             TestSuiteInternal.reset();
             test.restore();
@@ -1769,7 +1765,7 @@ Deno.test("global", async (t) => {
               eachTimer: 3,
               eachTimerNested: 4,
             },
-            args: [],
+            args: [context.steps[0].steps[0]],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1782,7 +1778,7 @@ Deno.test("global", async (t) => {
               eachTimer: 5,
               eachTimerNested: 6,
             },
-            args: [],
+            args: [context.steps[0].steps[1]],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);


### PR DESCRIPTION
The assertSnapshot function from https://github.com/denoland/deno_std/pull/2039 that is being worked on will need access to the `Deno.TestContext` for the test case it is used in. This updates `it` to take a function that will have the `Deno.TestContext` passed to it as its first and only argument. This will also enable making use of the test step api within an `it` function.

The `deno fmt` command also made me update the `assert.ts` file.