### PR TITLE
test(node): update global var leak detection

### DIFF
--- a/node/_tools/test/common/index.js
+++ b/node/_tools/test/common/index.js
@@ -51,6 +51,7 @@ let knownGlobals = [
   getParent,
   window,
   self,
+  reportError,
 ];
 
 if (global.AbortController)


### PR DESCRIPTION
This PR updates the setup of global var leak detection in node compat testing.

We added `reportError` global in https://github.com/denoland/deno/pull/13799. We need to mark this as known global now.