### PR TITLE
feat(testing)!: Infer stub and spy return types from properties

### DIFF
--- a/testing/_test_utils.ts
+++ b/testing/_test_utils.ts
@@ -8,6 +8,9 @@ export class Point {
   toString(): string {
     return [this.x, this.y].join(", ");
   }
+  explicitTypes(_x: number, _y: string) {
+    return true;
+  }
   *[Symbol.iterator](): IterableIterator<number> {
     yield this.x;
     yield this.y;

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -371,8 +371,10 @@ export function stub<
   property: Prop,
   func: (
     this: Self,
-    ...args: Partial<GetParametersFromProp<Self, Prop>>
-  ) => GetReturnFromProp<Self, Prop>,
+    // deno-lint-ignore no-explicit-any
+    ...args: any[]
+    // deno-lint-ignore no-explicit-any
+  ) => any,
 ): Stub<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
 export function stub<
   Self,

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -371,8 +371,7 @@ export function stub<
   property: Prop,
   func: (
     this: Self,
-    // deno-lint-ignore no-explicit-any
-    ...args: any[]
+    ...args: GetParametersFromProp<Self, Prop>
   ) => GetReturnFromProp<Self, Prop>,
 ): Stub<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
 export function stub<

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -289,6 +289,21 @@ function methodSpy<
   return spy;
 }
 
+/** Utility for extracting the arguments type from a property */
+type GetParametersFromProp<
+  Self,
+  Prop extends keyof Self,
+> = Self[Prop] extends (...args: infer Args) => unknown ? Args
+  : unknown[];
+
+/** Utility for extracting the return type from a property */
+type GetReturnFromProp<
+  Self,
+  Prop extends keyof Self,
+> // deno-lint-ignore no-explicit-any
+ = Self[Prop] extends (...args: any[]) => infer Return ? Return
+  : unknown;
+
 /** Wraps a function or instance method with a Spy. */
 export function spy<
   // deno-lint-ignore no-explicit-any
@@ -304,9 +319,11 @@ export function spy<
 >(func: (this: Self, ...args: Args) => Return): Spy<Self, Args, Return>;
 export function spy<
   Self,
-  Args extends unknown[],
-  Return,
->(self: Self, property: keyof Self): Spy<Self, Args, Return>;
+  Prop extends keyof Self,
+>(
+  self: Self,
+  property: Prop,
+): Spy<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
 export function spy<
   Self,
   Args extends unknown[],
@@ -341,19 +358,22 @@ export interface Stub<
 /** Replaces an instance method with a Stub. */
 export function stub<
   Self,
-  // deno-lint-ignore no-explicit-any
-  Args extends unknown[] = any[],
-  Return = undefined,
->(self: Self, property: keyof Self): Stub<Self, Args, Return>;
-export function stub<
-  Self,
-  Args extends unknown[],
-  Return,
+  Prop extends keyof Self,
 >(
   self: Self,
-  property: keyof Self,
-  func: (this: Self, ...args: Args) => Return,
-): Stub<Self, Args, Return>;
+  property: Prop,
+): Stub<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
+export function stub<
+  Self,
+  Prop extends keyof Self,
+>(
+  self: Self,
+  property: Prop,
+  func: (
+    this: Self,
+    ...args: Partial<GetParametersFromProp<Self, Prop>>
+  ) => GetReturnFromProp<Self, Prop>,
+): Stub<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
 export function stub<
   Self,
   Args extends unknown[],

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -373,8 +373,7 @@ export function stub<
     this: Self,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-    // deno-lint-ignore no-explicit-any
-  ) => any,
+  ) => GetReturnFromProp<Self, Prop>,
 ): Stub<Self, GetParametersFromProp<Self, Prop>, GetReturnFromProp<Self, Prop>>;
 export function stub<
   Self,

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -412,8 +412,23 @@ Deno.test("stub function", () => {
   );
   assertEquals(func.restored, true);
 
+  // @ts-expect-error Stubbing with incorrect argument types should cause a type error
+  stub(new Point(2, 3), "explicitTypes", (_x: string, _y: number) => true);
+
+  // @ts-expect-error Stubbing with an incorrect return type should cause a type error
+  stub(new Point(2, 3), "explicitTypes", () => "string");
+
+  // Stubbing without argument types infers them from the real function
+  stub(new Point(2, 3), "explicitTypes", (_x, _y) => {
+    // `toExponential()` only exists on `number`, so this will error if _x is not a number
+    _x.toExponential();
+    // `toLowerCase()` only exists on `string`, so this will error if _y is not a string
+    _y.toLowerCase();
+    return true;
+  });
+
   // Stubbing without argument types should not cause any type errors:
-  const explicitTypesFunc = stub(point, "explicitTypes", () => true);
+  const explicitTypesFunc = stub(new Point(2, 3), "explicitTypes", () => true);
 
   // Check if the returned type is correct:
   assertThrows(() => {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -127,6 +127,7 @@ Deno.test("spy function", () => {
   );
   assertEquals(func.restored, false);
 
+  // Check if the returned type is correct:
   const explicitTypesSpy = spy(point, "explicitTypes");
   assertThrows(() => {
     assertSpyCall(explicitTypesSpy, 0, {
@@ -411,7 +412,10 @@ Deno.test("stub function", () => {
   );
   assertEquals(func.restored, true);
 
-  const explicitTypesFunc = stub(point, "explicitTypes");
+  // Stubbing without arguments and return type should not cause any type errors:
+  const explicitTypesFunc = stub(point, "explicitTypes", () => {});
+
+  // Check if the returned type is correct:
   assertThrows(() => {
     assertSpyCall(explicitTypesFunc, 0, {
       // @ts-expect-error Test if passing incorrect argument types causes an error

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -427,6 +427,9 @@ Deno.test("stub function", () => {
     return true;
   });
 
+  // Stubbing with returnsNext() should not give any type errors
+  stub(new Point(2, 3), "explicitTypes", returnsNext([true, false, true]));
+
   // Stubbing without argument types should not cause any type errors:
   const explicitTypesFunc = stub(new Point(2, 3), "explicitTypes", () => true);
 

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -412,8 +412,8 @@ Deno.test("stub function", () => {
   );
   assertEquals(func.restored, true);
 
-  // Stubbing without arguments and return type should not cause any type errors:
-  const explicitTypesFunc = stub(point, "explicitTypes", () => {});
+  // Stubbing without argument types should not cause any type errors:
+  const explicitTypesFunc = stub(point, "explicitTypes", () => true);
 
   // Check if the returned type is correct:
   assertThrows(() => {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -126,6 +126,16 @@ Deno.test("spy function", () => {
     "function cannot be restored",
   );
   assertEquals(func.restored, false);
+
+  const explicitTypesSpy = spy(point, "explicitTypes");
+  assertThrows(() => {
+    assertSpyCall(explicitTypesSpy, 0, {
+      // @ts-expect-error Test if passing incorrect argument types causes an error
+      args: ["not a number", "string"],
+      // @ts-expect-error Test if passing incorrect return type causes an error
+      returned: "not a boolean",
+    });
+  });
 });
 
 Deno.test("spy instance method", () => {
@@ -400,6 +410,16 @@ Deno.test("stub function", () => {
     "instance method already restored",
   );
   assertEquals(func.restored, true);
+
+  const explicitTypesFunc = stub(point, "explicitTypes");
+  assertThrows(() => {
+    assertSpyCall(explicitTypesFunc, 0, {
+      // @ts-expect-error Test if passing incorrect argument types causes an error
+      args: ["not a number", "string"],
+      // @ts-expect-error Test if passing incorrect return type causes an error
+      returned: "not a boolean",
+    });
+  });
 });
 
 Deno.test("mockSession and mockSessionAsync", async () => {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -137,6 +137,13 @@ Deno.test("spy function", () => {
       returned: "not a boolean",
     });
   });
+
+  // Calling assertSpyCall with the correct types should not cause any type errors:
+  point.explicitTypes(1, "hello");
+  assertSpyCall(explicitTypesSpy, 0, {
+    args: [1, "hello"],
+    returned: true,
+  });
 });
 
 Deno.test("spy instance method", () => {
@@ -431,7 +438,8 @@ Deno.test("stub function", () => {
   stub(new Point(2, 3), "explicitTypes", returnsNext([true, false, true]));
 
   // Stubbing without argument types should not cause any type errors:
-  const explicitTypesFunc = stub(new Point(2, 3), "explicitTypes", () => true);
+  const point2 = new Point(2, 3);
+  const explicitTypesFunc = stub(point2, "explicitTypes", () => true);
 
   // Check if the returned type is correct:
   assertThrows(() => {
@@ -441,6 +449,13 @@ Deno.test("stub function", () => {
       // @ts-expect-error Test if passing incorrect return type causes an error
       returned: "not a boolean",
     });
+  });
+
+  // Calling assertSpyCall with the correct types should not cause any type errors
+  point2.explicitTypes(1, "hello");
+  assertSpyCall(explicitTypesFunc, 0, {
+    args: [1, "hello"],
+    returned: true,
   });
 });
 

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -93,8 +93,9 @@ Deno.test("Fake Date instance methods passthrough to real Date instance methods"
       `${now}`;
       assertSpyCall(func2, 0, {
         args: ["string"],
+        returned:
+          "Mon May 25 2020 07:00:00 GMT+0200 (Central European Summer Time)",
       });
-      assert(typeof func2.calls[0].returned === "string");
     } finally {
       func2.restore();
     }

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -70,19 +70,33 @@ Deno.test("Fake Date instance methods passthrough to real Date instance methods"
     const now = new Date("2020-05-25T05:00:00.12345Z");
     assertEquals(now.toISOString(), "2020-05-25T05:00:00.123Z");
 
-    const func = spy(
+    const func1 = spy(
       _internals.Date.prototype,
       "toISOString",
     );
     try {
       now.toISOString();
-      assertSpyCall(func, 0, {
+      assertSpyCall(func1, 0, {
         args: [],
         returned: "2020-05-25T05:00:00.123Z",
       });
-      assertInstanceOf(func.calls[0].self, _internals.Date);
+      assertInstanceOf(func1.calls[0].self, _internals.Date);
     } finally {
-      func.restore();
+      func1.restore();
+    }
+
+    const func2 = spy(
+      _internals.Date.prototype,
+      Symbol.toPrimitive,
+    );
+    try {
+      `${now}`;
+      assertSpyCall(func2, 0, {
+        args: ["string"],
+      });
+      assert(typeof func2.calls[0].returned === "string");
+    } finally {
+      func2.restore();
     }
   } finally {
     time.restore();

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -90,11 +90,10 @@ Deno.test("Fake Date instance methods passthrough to real Date instance methods"
       Symbol.toPrimitive,
     );
     try {
-      `${now}`;
+      Number(now);
       assertSpyCall(func2, 0, {
-        args: ["string"],
-        returned:
-          "Mon May 25 2020 07:00:00 GMT+0200 (Central European Summer Time)",
+        args: ["number"],
+        returned: 1590382800123,
       });
     } finally {
       func2.restore();

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -79,8 +79,9 @@ Deno.test("Fake Date instance methods passthrough to real Date instance methods"
           }
           const returned = Symbol();
           const func = stub(
-            _internals.Date.prototype,
-            method as keyof Date,
+            // deno-lint-ignore no-explicit-any
+            _internals.Date.prototype as any,
+            method,
             () => returned,
           );
           try {
@@ -107,8 +108,9 @@ Deno.test("Fake Date instance methods passthrough to real Date instance methods"
           }
           const returned = Symbol();
           const func = stub(
-            _internals.Date.prototype,
-            method as keyof Date,
+            // deno-lint-ignore no-explicit-any
+            _internals.Date.prototype as any,
+            method,
             () => returned,
           );
           try {


### PR DESCRIPTION
This has a breaking change because the generic parameters have changed from `spy<Self, Args, Return>()` to `spy<Self, Prop>()`.
Only the types have been changed so there should be no runtime difference.

There's still a type error that I'm not sure how to resolve, which is why this is still a draft. Initially I thought it was [a bug in TypeScript](https://github.com/microsoft/TypeScript/issues/48805). But it seems like that's not the case.
Adding `// @ts-ignore` seems to work without breaking any other types, but I'd prefer to find a better way around this.

Fixes #2121 