### PR TITLE
fix(wasi): ContextOptions is an optional argument

### DIFF
--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -346,7 +346,7 @@ export default class Context {
 
   exports: Record<string, WebAssembly.ImportValue>;
 
-  constructor(options: ContextOptions) {
+  constructor(options?: ContextOptions = {}) {
     this.#args = options.args ?? [];
     this.#env = options.env ?? {};
     this.#exitOnReturn = options.exitOnReturn ?? true;

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -346,7 +346,7 @@ export default class Context {
 
   exports: Record<string, WebAssembly.ImportValue>;
 
-  constructor(options?: ContextOptions = {}) {
+  constructor(options: ContextOptions = {}) {
     this.#args = options.args ?? [];
     this.#env = options.env ?? {};
     this.#exitOnReturn = options.exitOnReturn ?? true;


### PR DESCRIPTION
According to the node.js docs,
we can use WASI class without arguments. I mean that the `ContextOptions` should be optional.
This is a problematic to load https://github.com/ruby/ruby.wasm .

See also: https://nodejs.org/api/wasi.html