### PR TITLE
fix(crypto): Browser compatibility

### DIFF
--- a/_wasm_crypto/_build.ts
+++ b/_wasm_crypto/_build.ts
@@ -116,8 +116,8 @@ import wasmBytes from "./crypto.wasm.mjs";
 ${
   generatedScript.replace(
     /^const wasm_url =.*?;\nlet wasmCode =.*?;\n.*?const wasmInstance =.*?;\n/sm,
-    `const wasmModule = new WebAssembly.Module(wasmBytes);\n` +
-      `const wasmInstance = new WebAssembly.Instance(wasmModule, imports);`,
+    `const wasmModule = await WebAssembly.compile(wasmBytes);\n` +
+      `const wasmInstance = await WebAssembly.instantiate(wasmModule, imports);`,
   )
 }
 

--- a/_wasm_crypto/crypto.mjs
+++ b/_wasm_crypto/crypto.mjs
@@ -389,8 +389,8 @@ const imports = {
   },
 };
 
-const wasmModule = new WebAssembly.Module(wasmBytes);
-const wasmInstance = new WebAssembly.Instance(wasmModule, imports);
+const wasmModule = await WebAssembly.compile(wasmBytes);
+const wasmInstance = await WebAssembly.instantiate(wasmModule, imports);
 const wasm = wasmInstance.exports;
 
 // for testing/debugging


### PR DESCRIPTION
Chrome disables `WebAssembly.Module` and `WebAssembly.Instance` for buffers larger than 4 KB.