### PR TITLE
http: serve() should export the interface ServeTlsInit

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -567,7 +567,7 @@ export async function serve(
   return await s;
 }
 
-interface ServeTlsInit extends ServeInit {
+export interface ServeTlsInit extends ServeInit {
   /** The path to the file containing the TLS private key. */
   keyFile: string;
 


### PR DESCRIPTION
I would like to see `ServeTlsInit` being exported the way `ServeInit` already is.