### PR TITLE
test(testing/snapshot): Add regression test for Deno.inspect compacting empty iterables

### DIFF
--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -183,3 +183,15 @@ snapshot[`Snapshot Test - Regression #2140 1`] = `
   title: "Testing a page",
 }
 `;
+
+snapshot[`Snapshot Test - Regression #2144 1`] = `
+{
+  fmt: {
+    files: {
+      exclude: [],
+      include: [],
+    },
+    options: {},
+  },
+}
+`;

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -188,8 +188,10 @@ snapshot[`Snapshot Test - Regression #2144 1`] = `
 {
   fmt: {
     files: {
-      exclude: [],
-      include: [],
+      exclude: [
+      ],
+      include: [
+      ],
     },
     options: {},
   },

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -191,3 +191,18 @@ Deno.test("Snapshot Test - Regression #2140", async (t) => {
       `,
   });
 });
+
+// Regression test for https://github.com/denoland/deno_std/issues/2144
+// Empty arrays should be compacted
+Deno.test("Snapshot Test - Regression #2144", async (t) => {
+  const config = {
+    fmt: {
+      files: {
+        exclude: [],
+        include: [],
+      },
+      options: {},
+    },
+  };
+  await assertSnapshot(t, config);
+});


### PR DESCRIPTION
Adds regression test for #2144 

Depends on [this PR in denoland/deno](https://github.com/denoland/deno/pull/14387).