### PR TITLE
fix(testing): Compare circular objects

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -71,6 +71,7 @@ export function equal(c: unknown, d: unknown): boolean {
       if (Object.keys(a || {}).length !== Object.keys(b || {}).length) {
         return false;
       }
+      seen.set(a, b);
       if (isKeyedCollection(a) && isKeyedCollection(b)) {
         if (a.size !== b.size) {
           return false;
@@ -108,7 +109,6 @@ export function equal(c: unknown, d: unknown): boolean {
           return false;
         }
       }
-      seen.set(a, b);
       if (a instanceof WeakRef || b instanceof WeakRef) {
         if (!(a instanceof WeakRef && b instanceof WeakRef)) return false;
         return compare(a.deref(), b.deref());

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -279,6 +279,20 @@ Deno.test("testingEqual", function (): void {
   );
 });
 
+Deno.test("testingEqualCircular", () => {
+  const objA: { prop?: unknown } = {};
+  objA.prop = objA;
+  const objB: { prop?: unknown } = {};
+  objB.prop = objB;
+  assert(equal(objA, objB));
+
+  const mapA = new Map();
+  mapA.set("prop", mapA);
+  const mapB = new Map();
+  mapB.set("prop", mapB);
+  assert(equal(mapA, mapB));
+});
+
 Deno.test("testingNotEquals", function (): void {
   const a = { foo: "bar" };
   const b = { bar: "foo" };


### PR DESCRIPTION
fixes #2171 

The `equal` function keeps track of encountered objects by adding them to `seen`. Encountered objects must be added to `seen` before the first recursive call to `compare` because otherwise the `compare` function will infinitely recurse when comparing circular objects.