### PR TITLE
fix(node/worker_threads): Don't wait for parent message in web worker

### DIFF
--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -201,3 +201,24 @@ Deno.test("module has proper members", function () {
 Deno.test("a module can have its own timers declarations", function () {
   require("./_module/cjs/cjs_declare_timers");
 });
+
+Deno.test("require in a web worker", async () => {
+  const code = `\
+    import { createRequire } from "${new URL("module.ts", import.meta.url)}";
+    const require = createRequire("${import.meta.url}");
+    const result = require("./_module/cjs/cjs_a.js");
+    if (result.helloA() != "A") {
+      throw new Error("assertion failed in worker");
+    }
+    postMessage(null);
+  `;
+  const worker = new Worker(
+    `data:application/javascript;base64,${btoa(code)}`,
+    { type: "module", deno: { namespace: true } },
+  );
+  await new Promise((resolve, reject) => {
+    worker.addEventListener("message", resolve);
+    worker.addEventListener("error", reject);
+  });
+  worker.terminate();
+});

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -30,6 +30,7 @@ export interface WorkerOptions {
 }
 
 const kHandle = Symbol("kHandle");
+const PRIVATE_WORKER_THREAD_NAME = "$DENO_STD_NODE_WORKER_THREAD";
 class _Worker extends EventEmitter {
   readonly threadId: number;
   readonly resourceLimits: Required<
@@ -54,7 +55,7 @@ class _Worker extends EventEmitter {
     const handle = this[kHandle] = new Worker(
       specifier,
       {
-        ...(options || {}),
+        name: PRIVATE_WORKER_THREAD_NAME,
         type: "module",
         // unstable
         deno: { namespace: true },
@@ -92,11 +93,9 @@ class _Worker extends EventEmitter {
   readonly performance = globalThis.performance;
 }
 
+// deno-lint-ignore no-explicit-any
 export const isMainThread =
-  // deno-lint-ignore no-explicit-any
-  typeof (globalThis as any).DedicatedWorkerGlobalScope === "undefined" ||
-  // deno-lint-ignore no-explicit-any
-  self instanceof (globalThis as any).DedicatedWorkerGlobalScope === false;
+  (globalThis as any).name !== PRIVATE_WORKER_THREAD_NAME;
 
 // fake resourceLimits
 export const resourceLimits = isMainThread ? {} : {
@@ -133,6 +132,8 @@ type ParentPort = typeof self & NodeEventTarget;
 let parentPort: ParentPort = null as any;
 
 if (!isMainThread) {
+  // deno-lint-ignore no-explicit-any
+  delete (globalThis as any).name;
   // deno-lint-ignore no-explicit-any
   const listeners = new WeakMap<(...args: any[]) => void, (ev: any) => any>();
 
@@ -176,10 +177,12 @@ if (!isMainThread) {
     notImplemented("parentPort.removeAllListeners");
 
   // Receive startup message
+  console.trace();
   [{ threadId, workerData, environmentData }] = await once(
     parentPort,
     "message",
   );
+  console.trace(threadId, workerData, environmentData);
 
   // alias
   parentPort.addEventListener("offline", () => {

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -177,12 +177,10 @@ if (!isMainThread) {
     notImplemented("parentPort.removeAllListeners");
 
   // Receive startup message
-  console.trace();
   [{ threadId, workerData, environmentData }] = await once(
     parentPort,
     "message",
   );
-  console.trace(threadId, workerData, environmentData);
 
   // alias
   parentPort.addEventListener("offline", () => {

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -93,8 +93,8 @@ class _Worker extends EventEmitter {
   readonly performance = globalThis.performance;
 }
 
-// deno-lint-ignore no-explicit-any
 export const isMainThread =
+  // deno-lint-ignore no-explicit-any
   (globalThis as any).name !== PRIVATE_WORKER_THREAD_NAME;
 
 // fake resourceLimits


### PR DESCRIPTION
Fixes #2181. Uses a different method for detecting if the environment is in a node worker thread so that web workers don't count. That way it doesn't wait for a parent startup message that is never coming.