### PR TITLE
fix(node/dns): export more types

### DIFF
--- a/node/dns.ts
+++ b/node/dns.ts
@@ -270,6 +270,13 @@ export const CANCELLED = "ECANCELLED";
 
 export { ADDRCONFIG, lookup, promises };
 
+export type {
+  LookupAddress,
+  LookupAllOptions,
+  LookupOneOptions,
+  LookupOptions,
+};
+
 export default {
   ADDRCONFIG,
   lookup,


### PR DESCRIPTION
After #2164, I get this error when I try to use the node/net module.

```shell
> deno run ./node/module_all.ts
Check file:///C:/Users/azusa/work/deno/deno_std/node/module_all.ts
error: TS2614 [ERROR]: Module '"file:///C:/Users/azusa/work/deno/deno_std/node/dns.ts"' has no exported member 'LookupOneOptions'. Did you mean to use 'import LookupOneOptions from "file:///C:/Users/azusa/work/deno/deno_std/node/dns.ts"' instead?
import type { LookupOneOptions } from "./dns.ts";
              ~~~~~~~~~~~~~~~~
    at file:///C:/Users/azusa/work/deno/deno_std/node/net.ts:70:15
```

Fix this problem by exporting the interface that is no longer exported from node/dns after #2164 again.