### PR TITLE
:bug: Export equalsSimd and equalsNaive

### DIFF
--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -6,7 +6,7 @@
  * @param a first array to check equality
  * @param b second array to check equality
  */
-function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
+export function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < b.length; i++) {
     if (a[i] !== b[i]) return false;
@@ -19,7 +19,7 @@ function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
  * @param a first array to check equality
  * @param b second array to check equality
  */
-function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
+export function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   const len = a.length;
   const compressable = Math.floor(len / 4);


### PR DESCRIPTION
These two methods are used on `bytes/equals_bench.ts` but are not exported, so it throws TypeScript and Runtime Errors, most notably 

```
error: Uncaught SyntaxError: The requested module './equals.ts' does not provide an export named 'equalsNaive'
import { equalsNaive, equalsSimd } from "./equals.ts";
```

I discover these errors while trying to port the remaining benchmarks to the new `Deno.bench` API, similar to #2173 