### PR TITLE
Improved error message for csv's parse function

### DIFF
--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -242,7 +242,7 @@ export async function parse(
 
     return r.map((e) => {
       if (e.length !== headers.length) {
-        throw `Error number of fields line:${i}`;
+        throw `Error number of fields line: ${i}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${e.length}`;
       }
       i++;
       const out: Record<string, unknown> = {};

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -242,7 +242,9 @@ export async function parse(
 
     return r.map((e) => {
       if (e.length !== headers.length) {
-        throw new Error(`Error number of fields line: ${i}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${e.length}`);
+        throw new Error(
+          `Error number of fields line: ${i}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${e.length}`,
+        );
       }
       i++;
       const out: Record<string, unknown> = {};

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -242,7 +242,7 @@ export async function parse(
 
     return r.map((e) => {
       if (e.length !== headers.length) {
-        throw `Error number of fields line: ${i}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${e.length}`;
+        throw new Error(`Error number of fields line: ${i}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${e.length}`);
       }
       i++;
       const out: Record<string, unknown> = {};

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -563,17 +563,35 @@ const parseTestCases = [
       { foo: "e", bar: "f", baz: "3" },
     ],
   },
+  {
+    name: "mismatching number of headers and fields",
+    in: "a,b,c\nd,e",
+    columns: [{ name: "a" }, { name: "b" }, { name: "c" }],
+    error: new Error(`Error number of fields line: 1\nNumber of fields found: 3\nExpected number of fields: 2`)
+  }
 ];
 
 for (const testCase of parseTestCases) {
   Deno.test({
     name: `[CSV] Parse ${testCase.name}`,
     async fn() {
-      const r = await parse(testCase.in, {
-        skipFirstRow: testCase.skipFirstRow,
-        columns: testCase.columns,
-      });
-      assertEquals(r, testCase.result);
+      if (testCase.error) {
+        await assertRejects(async () => {
+          await parse(testCase.in, {
+            skipFirstRow: testCase.skipFirstRow,
+            columns: testCase.columns,
+          })
+        }, (error: Error) => {
+          assertEquals(error.message, testCase.error.message);
+        });
+      }
+      else {
+        const r = await parse(testCase.in, {
+          skipFirstRow: testCase.skipFirstRow,
+          columns: testCase.columns,
+        });
+        assertEquals(r, testCase.result);
+      }
     },
   });
 }

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -567,8 +567,10 @@ const parseTestCases = [
     name: "mismatching number of headers and fields",
     in: "a,b,c\nd,e",
     columns: [{ name: "a" }, { name: "b" }, { name: "c" }],
-    error: new Error(`Error number of fields line: 1\nNumber of fields found: 3\nExpected number of fields: 2`)
-  }
+    error: new Error(
+      `Error number of fields line: 1\nNumber of fields found: 3\nExpected number of fields: 2`,
+    ),
+  },
 ];
 
 for (const testCase of parseTestCases) {
@@ -580,12 +582,11 @@ for (const testCase of parseTestCases) {
           await parse(testCase.in, {
             skipFirstRow: testCase.skipFirstRow,
             columns: testCase.columns,
-          })
+          });
         }, (error: Error) => {
           assertEquals(error.message, testCase.error.message);
         });
-      }
-      else {
+      } else {
         const r = await parse(testCase.in, {
           skipFirstRow: testCase.skipFirstRow,
           columns: testCase.columns,


### PR DESCRIPTION
Hey, I was using the csv parse function with a poorly coded csv file and the error message wasn't too helpful with tracking what exactly was wrong. 

I added a couple more hints:
- The number of fields found for the headers row
- The number of fields of values row (expected to match the headers)

When this is useful:
- When the number of headers doesn't match one of the subsequent rows
