### PR TITLE
fix(node/timers): set custom promisify function

### DIFF
--- a/node/timers.ts
+++ b/node/timers.ts
@@ -2,6 +2,7 @@
 
 import { Timeout, TIMEOUT_MAX } from "./internal/timers.mjs";
 import { validateCallback } from "./internal/validators.mjs";
+import { promisify } from "./internal/util.mjs";
 const setTimeout_ = globalThis.setTimeout;
 const clearTimeout_ = globalThis.clearTimeout;
 const setInterval_ = globalThis.setInterval;
@@ -24,6 +25,12 @@ export function setTimeout(
   ));
   return timer;
 }
+Object.defineProperty(setTimeout, promisify.custom, {
+  value: (timeout: number, ...args: unknown[]) => {
+    return new Promise((cb) => setTimeout(cb, timeout, ...args));
+  },
+  enumerable: true,
+});
 export function setUnrefTimeout(
   cb: (...args: unknown[]) => void,
   timeout?: number,

--- a/node/timers_test.ts
+++ b/node/timers_test.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+import { assert } from "../testing/asserts.ts";
 import timers from "./timers.ts";
+import timersPromises from "./timers/promises.ts";
 
 Deno.test("[node/timers setTimeout]", () => {
   {
@@ -39,4 +41,12 @@ Deno.test("[node/timers setImmediate]", () => {
     const id = timers.setImmediate(() => {});
     timers.clearImmediate(id);
   }
+});
+
+Deno.test("[node/timers/promises setTimeout]", () => {
+  const { setTimeout } = timersPromises;
+  const p = setTimeout(0);
+
+  assert(p instanceof Promise);
+  return p;
 });


### PR DESCRIPTION
Fixes promisified timers. Without this fix. this code:
```
import { setTimeout } from 'https://deno.land/std@0.138.0/node/timers/promises.ts';
await setTimeout(2000);
```
Would result in:
```
error: Uncaught TypeError: Callback must be a function. Received 2000
    throw new codes.ERR_INVALID_CALLBACK(callback);
```

I looked around for code on how to easily test this, but could not really find any good way. 
