### PR TITLE
fix(node/module): interpret length parameter as optional in blitBuffer

### DIFF
--- a/node/_buffer.mjs
+++ b/node/_buffer.mjs
@@ -1888,8 +1888,9 @@ function utf8ToBytes(string, units) {
   return bytes;
 }
 
-function blitBuffer(src, dst, offset, length) {
+function blitBuffer(src, dst, offset, byteLength) {
   let i;
+  const length = byteLength === undefined ? src.length : byteLength;
   for (i = 0; i < length; ++i) {
     if (i + offset >= dst.length || i >= src.length) {
       break;

--- a/node/_tools/test/parallel/test-buffer-write.js
+++ b/node/_tools/test/parallel/test-buffer-write.js
@@ -113,3 +113,9 @@ assert.strictEqual(Buffer.alloc(4)
   assert.strictEqual(buf.write('ыы', 1, 'utf16le'), 4);
   assert.deepStrictEqual([...buf], [0, 0x4b, 0x04, 0x4b, 0x04, 0, 0, 0]);
 }
+
+{
+  const buf = Buffer.alloc(8);
+  assert.strictEqual(buf.utf8Write('abc', 0), 3);
+  assert.deepStrictEqual([...buf], [0x61, 0x62, 0x63, 0, 0, 0, 0, 0]);
+}


### PR DESCRIPTION
As indicated by the [node source code](https://github.com/nodejs/node/blob/ce29d28/src/node_buffer.cc#L726), the `length`parameter is optional and defaults to the length of the `src`.

Closes https://github.com/denoland/deno_std/issues/2046