### PR TITLE
fix(encoding): fix jump link target

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -8,7 +8,7 @@ Helper module for dealing with external data structures.
 - [`base64url`](#base64url)
 - [`binary`](#binary)
 - [`csv`](#csv)
-- [`jsonc`](#JSONC)
+- [`jsonc`](#jsonc)
 - [`toml`](#toml)
 - [`yaml`](#yaml)
 


### PR DESCRIPTION
This fixes the `jsonc` jump link on the following page: https://deno.land/std@0.139.0/encoding#encoding