### PR TITLE
fix(collections): prevent cycles in deepMerge()

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -58,6 +58,23 @@ export function deepMerge<
   other: Readonly<U>,
   options?: Readonly<Options>,
 ): DeepMerge<T, U, Options> {
+  return deepMergeInternal(record, other, new Set(), options);
+}
+
+function deepMergeInternal<
+  T extends Record<PropertyKey, unknown>,
+  U extends Record<PropertyKey, unknown>,
+  Options extends DeepMergeOptions = {
+    arrays: "merge";
+    sets: "merge";
+    maps: "merge";
+  },
+>(
+  record: Readonly<T>,
+  other: Readonly<U>,
+  seen: Set<NonNullable<object>>,
+  options?: Readonly<Options>,
+) {
   // Extract options
   // Clone left operand to avoid performing mutations in-place
   type Result = DeepMerge<T, U, Options>;
@@ -87,8 +104,12 @@ export function deepMerge<
 
     const b = other[key] as ResultMember;
 
-    if (isNonNullObject(a) && isNonNullObject(b)) {
-      result[key] = mergeObjects(a, b, options) as ResultMember;
+    if (
+      isNonNullObject(a) && isNonNullObject(b) && !seen.has(a) && !seen.has(b)
+    ) {
+      seen.add(a);
+      seen.add(b);
+      result[key] = mergeObjects(a, b, seen, options) as ResultMember;
 
       continue;
     }
@@ -103,6 +124,7 @@ export function deepMerge<
 function mergeObjects(
   left: Readonly<NonNullable<object>>,
   right: Readonly<NonNullable<object>>,
+  seen: Set<NonNullable<object>>,
   options: Readonly<DeepMergeOptions> = {
     arrays: "merge",
     sets: "merge",
@@ -111,7 +133,7 @@ function mergeObjects(
 ): Readonly<NonNullable<object>> {
   // Recursively merge mergeable objects
   if (isMergeable(left) && isMergeable(right)) {
-    return deepMerge(left, right);
+    return deepMergeInternal(left, right, seen);
   }
 
   if (isIterable(left) && isIterable(right)) {


### PR DESCRIPTION
This commit adds logic to `deepMerge()` to prevent infinite looping over cyclic data structures. The algorithm will now bail out before calling `mergeObjects()` if either object has already been processed.

Fixes: https://github.com/denoland/deno_std/issues/2134