### PR TITLE
feat(assertRejects): fails on synchronous throw #1302

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -750,6 +750,7 @@ export async function assertRejects<E extends Error = Error>(
   }
   let doesThrow = false;
   let isPromiseReturned = false;
+  const msgToAppendToError = msg ? `: ${msg}` : ".";
   try {
     const possiblePromise = fn();
     if (possiblePromise instanceof Promise) {
@@ -757,6 +758,9 @@ export async function assertRejects<E extends Error = Error>(
       await possiblePromise;
     }
   } catch (error) {
+    if (!isPromiseReturned) {
+      throw new AssertionError(`Function throws when expected to reject${msgToAppendToError}`);
+    }
     if (error instanceof Error === false) {
       throw new AssertionError("A non-Error object was rejected.");
     }
@@ -771,12 +775,8 @@ export async function assertRejects<E extends Error = Error>(
     }
     doesThrow = true;
   }
-  msg = msg ? `: ${msg}` : ".";
-  if (!isPromiseReturned) {
-    throw new AssertionError(`Function throws when expected to reject${msg}`);
-  } else if (!doesThrow) {
-    msg = `Expected function to reject${msg}`;
-    throw new AssertionError(msg);
+  if (!doesThrow) {
+    throw new AssertionError(`Expected function to reject${msgToAppendToError}`);
   }
 }
 

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -757,9 +757,6 @@ export async function assertRejects<E extends Error = Error>(
       await possiblePromise;
     }
   } catch (error) {
-    if (!isPromiseReturned) {
-      throw new AssertionError("Function throws when expected to reject.");
-    }
     if (error instanceof Error === false) {
       throw new AssertionError("A non-Error object was rejected.");
     }
@@ -774,8 +771,11 @@ export async function assertRejects<E extends Error = Error>(
     }
     doesThrow = true;
   }
-  if (!doesThrow) {
-    msg = `Expected function to reject${msg ? `: ${msg}` : "."}`;
+  msg = msg ? `: ${msg}` : ".";
+  if (!isPromiseReturned) {
+    throw new AssertionError(`Function throws when expected to reject${msg}`);
+  } else if (!doesThrow) {
+    msg = `Expected function to reject${msg}`;
     throw new AssertionError(msg);
   }
 }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -749,9 +749,17 @@ export async function assertRejects<E extends Error = Error>(
     msg = msgIncludesOrMsg;
   }
   let doesThrow = false;
+  let isPromiseReturned = false;
   try {
-    await fn();
+    const possiblePromise = fn();
+    if (possiblePromise instanceof Promise) {
+      isPromiseReturned = true;
+      await possiblePromise;
+    }
   } catch (error) {
+    if (!isPromiseReturned) {
+      throw new AssertionError("An error was thrown but a promise was not rejected.");
+    }
     if (error instanceof Error === false) {
       throw new AssertionError("A non-Error object was thrown or rejected.");
     }

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -759,7 +759,9 @@ export async function assertRejects<E extends Error = Error>(
     }
   } catch (error) {
     if (!isPromiseReturned) {
-      throw new AssertionError(`Function throws when expected to reject${msgToAppendToError}`);
+      throw new AssertionError(
+        `Function throws when expected to reject${msgToAppendToError}`,
+      );
     }
     if (error instanceof Error === false) {
       throw new AssertionError("A non-Error object was rejected.");
@@ -776,7 +778,9 @@ export async function assertRejects<E extends Error = Error>(
     doesThrow = true;
   }
   if (!doesThrow) {
-    throw new AssertionError(`Expected function to reject${msgToAppendToError}`);
+    throw new AssertionError(
+      `Expected function to reject${msgToAppendToError}`,
+    );
   }
 }
 

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -758,10 +758,10 @@ export async function assertRejects<E extends Error = Error>(
     }
   } catch (error) {
     if (!isPromiseReturned) {
-      throw new AssertionError("An error was thrown but a promise was not rejected.");
+      throw new AssertionError("Function throws when expected to reject.");
     }
     if (error instanceof Error === false) {
-      throw new AssertionError("A non-Error object was thrown or rejected.");
+      throw new AssertionError("A non-Error object was rejected.");
     }
     assertIsError(
       error,
@@ -775,7 +775,7 @@ export async function assertRejects<E extends Error = Error>(
     doesThrow = true;
   }
   if (!doesThrow) {
-    msg = `Expected function to throw${msg ? `: ${msg}` : "."}`;
+    msg = `Expected function to reject${msg ? `: ${msg}` : "."}`;
     throw new AssertionError(msg);
   }
 }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1277,8 +1277,8 @@ Deno.test("Assert Throws Non-Error Fail", () => {
   );
 });
 
-Deno.test("Assert Throws Async Non-Error Fail", () => {
-  assertRejects(
+Deno.test("Assert Throws Async Non-Error Fail", async () => {
+  await assertRejects(
     () => {
       return assertRejects(
         () => {
@@ -1292,7 +1292,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
     "A non-Error object was thrown or rejected.",
   );
 
-  assertRejects(
+  await assertRejects(
     () => {
       return assertRejects(() => {
         return Promise.reject(null);
@@ -1302,7 +1302,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
     "A non-Error object was thrown or rejected.",
   );
 
-  assertRejects(
+  await assertRejects(
     () => {
       return assertRejects(() => {
         return Promise.reject(undefined);
@@ -1312,7 +1312,7 @@ Deno.test("Assert Throws Async Non-Error Fail", () => {
     "A non-Error object was thrown or rejected.",
   );
 
-  assertRejects(
+  await assertRejects(
     () => {
       return assertRejects(() => {
         throw undefined;
@@ -1374,8 +1374,8 @@ Deno.test("Assert Throws Parent Error", () => {
   );
 });
 
-Deno.test("Assert Throws Async Parent Error", () => {
-  assertRejects(
+Deno.test("Assert Throws Async Parent Error", async () => {
+  await assertRejects(
     () => {
       throw new AssertionError("Fail!");
     },

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -803,6 +803,12 @@ Deno.test("testingAssertThrowsWithReturnType", () => {
   });
 });
 
+Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronous", async () => {
+  await assertRejects(() => assertRejects(() => {
+    throw new Error();
+  }));
+});
+
 Deno.test("testingAssertRejectsWithReturnType", async () => {
   await assertRejects(() => {
     throw new Error();
@@ -826,7 +832,7 @@ Deno.test("testingAssertThrowsWithErrorCallback", () => {
 
 Deno.test("testingAssertRejectsWithErrorCallback", async () => {
   await assertRejects(
-    () => {
+    async () => {
       throw new AggregateError([new Error("foo"), new Error("bar")], "baz");
     },
     (error: Error) => {
@@ -1314,7 +1320,7 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
 
   await assertRejects(
     () => {
-      return assertRejects(() => {
+      return assertRejects(async () => {
         throw undefined;
       });
     },
@@ -1376,7 +1382,7 @@ Deno.test("Assert Throws Parent Error", () => {
 
 Deno.test("Assert Throws Async Parent Error", async () => {
   await assertRejects(
-    () => {
+    async () => {
       throw new AssertionError("Fail!");
     },
     Error,

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1295,7 +1295,7 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
       );
     },
     AssertionError,
-    "A non-Error object was thrown or rejected.",
+    "A non-Error object was rejected.",
   );
 
   await assertRejects(
@@ -1305,7 +1305,7 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
       });
     },
     AssertionError,
-    "A non-Error object was thrown or rejected.",
+    "A non-Error object was rejected.",
   );
 
   await assertRejects(
@@ -1315,7 +1315,7 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
       });
     },
     AssertionError,
-    "A non-Error object was thrown or rejected.",
+    "A non-Error object was rejected.",
   );
 
   await assertRejects(
@@ -1325,7 +1325,7 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
       });
     },
     AssertionError,
-    "A non-Error object was thrown or rejected.",
+    "A non-Error object was rejected.",
   );
 });
 

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -803,7 +803,7 @@ Deno.test("testingAssertThrowsWithReturnType", () => {
   });
 });
 
-Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronous", async () => {
+Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronousAndThrow", async () => {
   await assertRejects(() => assertRejects(() => {
     throw new Error();
   }));
@@ -811,7 +811,7 @@ Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronous", async () => {
 
 Deno.test("testingAssertRejectsWithReturnType", async () => {
   await assertRejects(() => {
-    throw new Error();
+    return Promise.reject(new Error());
   });
 });
 
@@ -832,8 +832,8 @@ Deno.test("testingAssertThrowsWithErrorCallback", () => {
 
 Deno.test("testingAssertRejectsWithErrorCallback", async () => {
   await assertRejects(
-    async () => {
-      throw new AggregateError([new Error("foo"), new Error("bar")], "baz");
+    () => {
+      return Promise.reject(new AggregateError([new Error("foo"), new Error("bar")], "baz"));
     },
     (error: Error) => {
       assert(error instanceof AggregateError);
@@ -1320,8 +1320,8 @@ Deno.test("Assert Throws Async Non-Error Fail", async () => {
 
   await assertRejects(
     () => {
-      return assertRejects(async () => {
-        throw undefined;
+      return assertRejects(() => {
+        return Promise.reject(undefined);
       });
     },
     AssertionError,
@@ -1381,9 +1381,8 @@ Deno.test("Assert Throws Parent Error", () => {
 });
 
 Deno.test("Assert Throws Async Parent Error", async () => {
-  await assertRejects(
-    async () => {
-      throw new AssertionError("Fail!");
+  await assertRejects(() => {
+      return Promise.reject(new AssertionError("Fail!"));
     },
     Error,
     "Fail!",

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -809,6 +809,12 @@ Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronousAndThrow", async 
   }));
 });
 
+Deno.test("testingAssertRejectsFailWithRightMessageWhenFunctionIsSynchronousAndThrow", async () => {
+  await assertRejects(() => assertRejects(() => {
+    throw { wrong: 'true'} ;
+  }), AssertionError, 'Function throws when expected to reject.');
+});
+
 Deno.test("testingAssertRejectsWithReturnType", async () => {
   await assertRejects(() => {
     return Promise.reject(new Error());

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -804,15 +804,22 @@ Deno.test("AssertThrowsWithReturnType", () => {
 });
 
 Deno.test("AssertRejectsFailIfGivenFunctionIsSynchronousAndThrow", async () => {
-  await assertRejects(() => assertRejects(() => {
-    throw new Error();
-  }));
+  await assertRejects(() =>
+    assertRejects(() => {
+      throw new Error();
+    })
+  );
 });
 
 Deno.test("AssertRejectsFailWithRightMessageWhenFunctionIsSynchronousAndThrow", async () => {
-  await assertRejects(() => assertRejects(() => {
-    throw { wrong: 'true'} ;
-  }), AssertionError, 'Function throws when expected to reject.');
+  await assertRejects(
+    () =>
+      assertRejects(() => {
+        throw { wrong: "true" };
+      }),
+    AssertionError,
+    "Function throws when expected to reject.",
+  );
 });
 
 Deno.test("AssertRejectsWithReturnType", async () => {
@@ -839,7 +846,9 @@ Deno.test("AssertThrowsWithErrorCallback", () => {
 Deno.test("AssertRejectsWithErrorCallback", async () => {
   await assertRejects(
     () => {
-      return Promise.reject(new AggregateError([new Error("foo"), new Error("bar")], "baz"));
+      return Promise.reject(
+        new AggregateError([new Error("foo"), new Error("bar")], "baz"),
+      );
     },
     (error: Error) => {
       assert(error instanceof AggregateError);
@@ -1387,7 +1396,8 @@ Deno.test("Assert Throws Parent Error", () => {
 });
 
 Deno.test("Assert Throws Async Parent Error", async () => {
-  await assertRejects(() => {
+  await assertRejects(
+    () => {
       return Promise.reject(new AssertionError("Fail!"));
     },
     Error,

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -25,7 +25,7 @@ import {
 } from "./asserts.ts";
 import { bold, gray, green, red, stripColor, yellow } from "../fmt/colors.ts";
 
-Deno.test("testingEqualDifferentZero", () => {
+Deno.test("EqualDifferentZero", () => {
   assert(equal(0, -0));
   assert(equal(0, +0));
   assert(equal(+0, -0));
@@ -37,7 +37,7 @@ Deno.test("testingEqualDifferentZero", () => {
   assert(equal({ msg: "hello", array: [0] }, { msg: "hello", array: [-0] }));
 });
 
-Deno.test("testingEqual", function (): void {
+Deno.test("Equal", function (): void {
   assert(equal("world", "world"));
   assert(!equal("hello", "world"));
   assertFalse(equal("hello", "world"));
@@ -279,7 +279,7 @@ Deno.test("testingEqual", function (): void {
   );
 });
 
-Deno.test("testingEqualCircular", () => {
+Deno.test("EqualCircular", () => {
   const objA: { prop?: unknown } = {};
   objA.prop = objA;
   const objB: { prop?: unknown } = {};
@@ -293,7 +293,7 @@ Deno.test("testingEqualCircular", () => {
   assert(equal(mapA, mapB));
 });
 
-Deno.test("testingNotEquals", function (): void {
+Deno.test("NotEquals", function (): void {
   const a = { foo: "bar" };
   const b = { bar: "foo" };
   assertNotEquals(a, b);
@@ -314,7 +314,7 @@ Deno.test("testingNotEquals", function (): void {
   assertEquals(didThrow, true);
 });
 
-Deno.test("testingAssertExists", function (): void {
+Deno.test("AssertExists", function (): void {
   assertExists("Denosaurus");
   assertExists(false);
   assertExists(0);
@@ -347,7 +347,7 @@ Deno.test("testingAssertExists", function (): void {
   assertEquals(didThrow, true);
 });
 
-Deno.test("testingAssertStringContains", function (): void {
+Deno.test("AssertStringContains", function (): void {
   assertStringIncludes("Denosaurus", "saur");
   assertStringIncludes("Denosaurus", "Deno");
   assertStringIncludes("Denosaurus", "rus");
@@ -362,7 +362,7 @@ Deno.test("testingAssertStringContains", function (): void {
   assertEquals(didThrow, true);
 });
 
-Deno.test("testingArrayContains", function (): void {
+Deno.test("ArrayContains", function (): void {
   const fixture = ["deno", "iz", "luv"];
   const fixtureObject = [{ deno: "luv" }, { deno: "Js" }];
   assertArrayIncludes(fixture, ["deno"]);
@@ -394,7 +394,7 @@ missing: [
   );
 });
 
-Deno.test("testingAssertStringContainsThrow", function (): void {
+Deno.test("AssertStringContainsThrow", function (): void {
   let didThrow = false;
   try {
     assertStringIncludes("Denosaurus from Jurassic", "Raptor");
@@ -409,11 +409,11 @@ Deno.test("testingAssertStringContainsThrow", function (): void {
   assert(didThrow);
 });
 
-Deno.test("testingAssertStringMatching", function (): void {
+Deno.test("AssertStringMatching", function (): void {
   assertMatch("foobar@deno.com", RegExp(/[a-zA-Z]+@[a-zA-Z]+.com/));
 });
 
-Deno.test("testingAssertStringMatchingThrows", function (): void {
+Deno.test("AssertStringMatchingThrows", function (): void {
   let didThrow = false;
   try {
     assertMatch("Denosaurus from Jurassic", RegExp(/Raptor/));
@@ -428,11 +428,11 @@ Deno.test("testingAssertStringMatchingThrows", function (): void {
   assert(didThrow);
 });
 
-Deno.test("testingAssertStringNotMatching", function (): void {
+Deno.test("AssertStringNotMatching", function (): void {
   assertNotMatch("foobar.deno.com", RegExp(/[a-zA-Z]+@[a-zA-Z]+.com/));
 });
 
-Deno.test("testingAssertStringNotMatchingThrows", function (): void {
+Deno.test("AssertStringNotMatchingThrows", function (): void {
   let didThrow = false;
   try {
     assertNotMatch("Denosaurus from Jurassic", RegExp(/from/));
@@ -447,7 +447,7 @@ Deno.test("testingAssertStringNotMatchingThrows", function (): void {
   assert(didThrow);
 });
 
-Deno.test("testingAssertObjectMatching", function (): void {
+Deno.test("AssertObjectMatching", function (): void {
   const sym = Symbol("foo");
   const a = { foo: true, bar: false };
   const b = { ...a, baz: a };
@@ -744,7 +744,7 @@ Deno.test("testingAssertObjectMatching", function (): void {
   );
 });
 
-Deno.test("testingAssertsUnimplemented", function (): void {
+Deno.test("AssertsUnimplemented", function (): void {
   let didThrow = false;
   try {
     unimplemented();
@@ -756,7 +756,7 @@ Deno.test("testingAssertsUnimplemented", function (): void {
   assert(didThrow);
 });
 
-Deno.test("testingAssertsUnreachable", function (): void {
+Deno.test("AssertsUnreachable", function (): void {
   let didThrow = false;
   try {
     unreachable();
@@ -768,7 +768,7 @@ Deno.test("testingAssertsUnreachable", function (): void {
   assert(didThrow);
 });
 
-Deno.test("testingAssertFail", function (): void {
+Deno.test("AssertFail", function (): void {
   assertThrows(fail, AssertionError, "Failed assertion.");
   assertThrows(
     (): void => {
@@ -779,7 +779,7 @@ Deno.test("testingAssertFail", function (): void {
   );
 });
 
-Deno.test("testingAssertFailWithWrongErrorClass", function (): void {
+Deno.test("AssertFailWithWrongErrorClass", function (): void {
   assertThrows(
     (): void => {
       //This next assertThrows will throw an AssertionError due to the wrong
@@ -797,31 +797,31 @@ Deno.test("testingAssertFailWithWrongErrorClass", function (): void {
   );
 });
 
-Deno.test("testingAssertThrowsWithReturnType", () => {
+Deno.test("AssertThrowsWithReturnType", () => {
   assertThrows(() => {
     throw new Error();
   });
 });
 
-Deno.test("testingAssertRejectsFailIfGivenFunctionIsSynchronousAndThrow", async () => {
+Deno.test("AssertRejectsFailIfGivenFunctionIsSynchronousAndThrow", async () => {
   await assertRejects(() => assertRejects(() => {
     throw new Error();
   }));
 });
 
-Deno.test("testingAssertRejectsFailWithRightMessageWhenFunctionIsSynchronousAndThrow", async () => {
+Deno.test("AssertRejectsFailWithRightMessageWhenFunctionIsSynchronousAndThrow", async () => {
   await assertRejects(() => assertRejects(() => {
     throw { wrong: 'true'} ;
   }), AssertionError, 'Function throws when expected to reject.');
 });
 
-Deno.test("testingAssertRejectsWithReturnType", async () => {
+Deno.test("AssertRejectsWithReturnType", async () => {
   await assertRejects(() => {
     return Promise.reject(new Error());
   });
 });
 
-Deno.test("testingAssertThrowsWithErrorCallback", () => {
+Deno.test("AssertThrowsWithErrorCallback", () => {
   assertThrows(
     () => {
       throw new AggregateError([new Error("foo"), new Error("bar")], "baz");
@@ -836,7 +836,7 @@ Deno.test("testingAssertThrowsWithErrorCallback", () => {
   );
 });
 
-Deno.test("testingAssertRejectsWithErrorCallback", async () => {
+Deno.test("AssertRejectsWithErrorCallback", async () => {
   await assertRejects(
     () => {
       return Promise.reject(new AggregateError([new Error("foo"), new Error("bar")], "baz"));

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -1211,7 +1211,7 @@ Deno.test("assertSpyCallAync on sync error", async () => {
     throw new ExampleError("failed");
   });
 
-  await assertRejects(() => spyFunc(), ExampleError, "fail");
+  assertThrows(() => spyFunc(), ExampleError, "fail");
   await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,


### PR DESCRIPTION
Based on issue #1302 

`assertRejects` now throw when the given function does not return a promise.