### PR TITLE
BREAKING(testing): use Object.is() for strict equality

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -245,7 +245,7 @@ export function assertStrictEquals<T>(
   expected: T,
   msg?: string,
 ): asserts actual is T {
-  if (actual === expected) {
+  if (Object.is(actual, expected)) {
     return;
   }
 
@@ -309,7 +309,7 @@ export function assertNotStrictEquals(
   expected: unknown,
   msg?: string,
 ): void {
-  if (actual !== expected) {
+  if (!Object.is(actual, expected)) {
     return;
   }
 
@@ -340,7 +340,7 @@ export function assertAlmostEquals(
   tolerance = 1e-7,
   msg?: string,
 ) {
-  if (actual === expected) {
+  if (Object.is(actual, expected)) {
     return;
   }
   const delta = Math.abs(expected - actual);

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1022,6 +1022,7 @@ Deno.test({
     assertStrictEquals(true, true);
     assertStrictEquals(10, 10);
     assertStrictEquals("abc", "abc");
+    assertStrictEquals(NaN, NaN);
 
     const xs = [1, false, "foo"];
     const ys = xs;
@@ -1074,6 +1075,7 @@ Deno.test({
     assertNotStrictEquals(10, 11);
     assertNotStrictEquals("abc", "xyz");
     assertNotStrictEquals(1, "1");
+    assertNotStrictEquals(-0, +0);
 
     const xs = [1, false, "foo"];
     const ys = [1, true, "bar"];
@@ -1089,6 +1091,7 @@ Deno.test({
   name: "strictly unequal fail case",
   fn(): void {
     assertThrows(() => assertNotStrictEquals(1, 1), AssertionError);
+    assertThrows(() => assertNotStrictEquals(NaN, NaN), AssertionError);
   },
 });
 
@@ -1097,6 +1100,8 @@ Deno.test("assert almost equals number", () => {
   assertAlmostEquals(-0, +0);
   assertAlmostEquals(Math.PI, Math.PI);
   assertAlmostEquals(0.1 + 0.2, 0.3);
+  assertAlmostEquals(NaN, NaN);
+  assertAlmostEquals(Number.NaN, Number.NaN);
   assertThrows(() => assertAlmostEquals(1, 2));
   assertThrows(() => assertAlmostEquals(1, 1.1));
 
@@ -1128,11 +1133,6 @@ Deno.test("assert almost equals number", () => {
     () => assertAlmostEquals(Infinity, NaN),
     AssertionError,
     '"Infinity" expected to be close to "NaN"',
-  );
-  assertThrows(
-    () => assertAlmostEquals(NaN, NaN),
-    AssertionError,
-    '"NaN" expected to be close to "NaN"',
   );
 });
 


### PR DESCRIPTION
This commit updates `assertStrictEquals()`, `assertAlmostEquals()`, and `assertNotStrictEquals()` to use `Object.is()` instead of the `===` operator. The reason is that `Object.is()` better matches user expectations of an assertion library in a couple edge cases. It also better aligns with the behavior of at least one other runtime's assertion library (Node.js).

Fixes: https://github.com/denoland/deno_std/issues/2151