### PR TITLE
ci: use xl runners for lint and wasm jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           DENO_NODE_COMPAT_URL: file:///${{ github.workspace }}/
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'denoland' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -131,7 +131,7 @@ jobs:
 
   hash-wasm:
     name: "_wasm_crypto/"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'denoland' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR makes CI checks faster by using xl runners for lint and wasm jobs.