### PR TITLE
chore: add sigbreak to os constant

### DIFF
--- a/node/internal_binding/constants.ts
+++ b/node/internal_binding/constants.ts
@@ -116,6 +116,7 @@ export const os = {
     SIGSTOP: 17,
     SIGTSTP: 18,
     SIGTTIN: 21,
+    SIGBREAK: 21,
     SIGTTOU: 22,
     SIGURG: 16,
     SIGXCPU: 24,

--- a/node/os.ts
+++ b/node/os.ts
@@ -315,6 +315,7 @@ export const constants = {
   signals: {
     "SIGABRT": "SIGABRT",
     "SIGALRM": "SIGALRM",
+    "SIGBREAK": "SIGBREAK",
     "SIGBUS": "SIGBUS",
     "SIGCHLD": "SIGCHLD",
     "SIGCONT": "SIGCONT",

--- a/node/os_test.ts
+++ b/node/os_test.ts
@@ -180,6 +180,7 @@ Deno.test({
     assertEquals(os.constants.signals.SIGKILL, "SIGKILL");
     assertEquals(os.constants.signals.SIGCONT, "SIGCONT");
     assertEquals(os.constants.signals.SIGXFSZ, "SIGXFSZ");
+    assertEquals(os.constants.signals.SIGBREAK, "SIGBREAK");
   },
 });
 


### PR DESCRIPTION
This PR adds SIGBREAK to the OS signals, a prerequisite for https://github.com/denoland/deno/pull/14694.