### PR TITLE
chore: replace TS `private` with private identifiers

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -128,18 +128,18 @@ async function readBlock(
  * Simple file reader
  */
 class FileReader implements Reader {
-  private file?: Deno.FsFile;
+  #file?: Deno.FsFile;
 
   constructor(private filePath: string) {}
 
   public async read(p: Uint8Array): Promise<number | null> {
-    if (!this.file) {
-      this.file = await Deno.open(this.filePath, { read: true });
+    if (!this.#file) {
+      this.#file = await Deno.open(this.filePath, { read: true });
     }
-    const res = await Deno.read(this.file.rid, p);
+    const res = await Deno.read(this.#file.rid, p);
     if (res === null) {
-      Deno.close(this.file.rid);
-      this.file = undefined;
+      Deno.close(this.#file.rid);
+      this.#file = undefined;
     }
     return res;
   }

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -14,54 +14,54 @@ interface TaggedYieldedValue<T> {
  *   does not matter; if there is any, it is discarded.
  */
 export class MuxAsyncIterator<T> implements AsyncIterable<T> {
-  private iteratorCount = 0;
-  private yields: Array<TaggedYieldedValue<T>> = [];
+  #iteratorCount = 0;
+  #yields: Array<TaggedYieldedValue<T>> = [];
   // deno-lint-ignore no-explicit-any
-  private throws: any[] = [];
-  private signal: Deferred<void> = deferred();
+  #throws: any[] = [];
+  #signal: Deferred<void> = deferred();
 
   add(iterable: AsyncIterable<T>): void {
-    ++this.iteratorCount;
-    this.callIteratorNext(iterable[Symbol.asyncIterator]());
+    ++this.#iteratorCount;
+    this.#callIteratorNext(iterable[Symbol.asyncIterator]());
   }
 
-  private async callIteratorNext(
+  async #callIteratorNext(
     iterator: AsyncIterator<T>,
   ) {
     try {
       const { value, done } = await iterator.next();
       if (done) {
-        --this.iteratorCount;
+        --this.#iteratorCount;
       } else {
-        this.yields.push({ iterator, value });
+        this.#yields.push({ iterator, value });
       }
     } catch (e) {
-      this.throws.push(e);
+      this.#throws.push(e);
     }
-    this.signal.resolve();
+    this.#signal.resolve();
   }
 
   async *iterate(): AsyncIterableIterator<T> {
-    while (this.iteratorCount > 0) {
+    while (this.#iteratorCount > 0) {
       // Sleep until any of the wrapped iterators yields.
-      await this.signal;
+      await this.#signal;
 
       // Note that while we're looping over `yields`, new items may be added.
-      for (let i = 0; i < this.yields.length; i++) {
-        const { iterator, value } = this.yields[i];
+      for (let i = 0; i < this.#yields.length; i++) {
+        const { iterator, value } = this.#yields[i];
         yield value;
-        this.callIteratorNext(iterator);
+        this.#callIteratorNext(iterator);
       }
 
-      if (this.throws.length) {
-        for (const e of this.throws) {
+      if (this.#throws.length) {
+        for (const e of this.#throws) {
           throw e;
         }
-        this.throws.length = 0;
+        this.#throws.length = 0;
       }
       // Clear the `yields` list and reset the `signal` promise.
-      this.yields.length = 0;
-      this.signal = deferred();
+      this.#yields.length = 0;
+      this.#signal = deferred();
     }
   }
 

--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -15,7 +15,7 @@ function swap<T>(array: T[], a: number, b: number) {
  * using JavaScript's built in comparison operators to sort the values.
  */
 export class BinaryHeap<T> implements Iterable<T> {
-  private data: T[] = [];
+  #data: T[] = [];
   constructor(private compare: (a: T, b: T) => number = descend) {}
 
   /** Creates a new binary heap from an array like or iterable object. */
@@ -51,9 +51,9 @@ export class BinaryHeap<T> implements Iterable<T> {
         options?.compare ?? (collection as unknown as BinaryHeap<U>).compare,
       );
       if (options?.compare || options?.map) {
-        unmappedValues = collection.data;
+        unmappedValues = collection.#data;
       } else {
-        result.data = Array.from(collection.data as unknown as U[]);
+        result.#data = Array.from(collection.#data as unknown as U[]);
       }
     } else {
       result = options?.compare
@@ -70,32 +70,33 @@ export class BinaryHeap<T> implements Iterable<T> {
 
   /** The amount of values stored in the binary heap. */
   get length(): number {
-    return this.data.length;
+    return this.#data.length;
   }
 
   /** Returns the greatest value in the binary heap, or undefined if it is empty. */
   peek(): T | undefined {
-    return this.data[0];
+    return this.#data[0];
   }
 
   /** Removes the greatest value from the binary heap and returns it, or null if it is empty. */
   pop(): T | undefined {
-    const size: number = this.data.length - 1;
-    swap(this.data, 0, size);
+    const size: number = this.#data.length - 1;
+    swap(this.#data, 0, size);
     let parent = 0;
     let right: number = 2 * (parent + 1);
     let left: number = right - 1;
     while (left < size) {
       if (
-        this.compare(this.data[left], this.data[parent]) < 0 &&
-        (right === size || this.compare(this.data[left], this.data[right]) < 0)
+        this.compare(this.#data[left], this.#data[parent]) < 0 &&
+        (right === size ||
+          this.compare(this.#data[left], this.#data[right]) < 0)
       ) {
-        swap(this.data, parent, left);
+        swap(this.#data, parent, left);
         parent = left;
       } else if (
-        right < size && this.compare(this.data[right], this.data[parent]) < 0
+        right < size && this.compare(this.#data[right], this.#data[parent]) < 0
       ) {
-        swap(this.data, parent, right);
+        swap(this.#data, parent, right);
         parent = right;
       } else {
         break;
@@ -103,34 +104,34 @@ export class BinaryHeap<T> implements Iterable<T> {
       right = 2 * (parent + 1);
       left = right - 1;
     }
-    return this.data.pop();
+    return this.#data.pop();
   }
 
   /** Adds values to the binary heap. */
   push(...values: T[]): number {
     for (const value of values) {
-      let index: number = this.data.length;
+      let index: number = this.#data.length;
       let parent: number = Math.floor(index / 2);
-      this.data.push(value);
+      this.#data.push(value);
       while (
-        index !== 0 && this.compare(this.data[index], this.data[parent]) < 0
+        index !== 0 && this.compare(this.#data[index], this.#data[parent]) < 0
       ) {
-        swap(this.data, parent, index);
+        swap(this.#data, parent, index);
         index = parent;
         parent = Math.floor(index / 2);
       }
     }
-    return this.data.length;
+    return this.#data.length;
   }
 
   /** Removes all values from the binary heap. */
   clear(): void {
-    this.data = [];
+    this.#data = [];
   }
 
   /** Checks if the binary heap is empty. */
   isEmpty(): boolean {
-    return this.data.length === 0;
+    return this.#data.length === 0;
   }
 
   /** Returns an iterator for retrieving and removing values from the binary heap. */

--- a/hash/_sha3/sponge.ts
+++ b/hash/_sha3/sponge.ts
@@ -33,7 +33,7 @@ export class Sponge {
   }
 
   /** Applies padding to internal state */
-  private pad(): void {
+  #pad(): void {
     this.#state[this.#rp] ^= this.#option.dsbyte;
     this.#state[this.#option.rate - 1] ^= 0x80;
   }
@@ -44,7 +44,7 @@ export class Sponge {
       throw new Error("sha3: length cannot be negative");
     }
 
-    this.pad();
+    this.#pad();
 
     const hash = new Uint8Array(length);
     let pos = 0;

--- a/hash/md5.ts
+++ b/hash/md5.ts
@@ -30,14 +30,14 @@ export class Md5 {
     this.#n1 = 0;
   }
 
-  private addLength(len: number): void {
+  #addLength(len: number): void {
     let n0 = this.#n0;
     n0 += len;
     if (n0 > 0xffffffff) this.#n1 += 1;
     this.#n0 = n0 >>> 0;
   }
 
-  private hash(block: Uint8Array): void {
+  #hash(block: Uint8Array): void {
     let a = this.#a;
     let b = this.#b;
     let c = this.#c;
@@ -174,12 +174,12 @@ export class Md5 {
     } else {
       // hash first block
       this.#block.set(msg.slice(0, free), pos);
-      this.hash(this.#block);
+      this.#hash(this.#block);
 
       // hash as many blocks as possible
       let i = free;
       while (i + BLOCK_SIZE <= msg.length) {
-        this.hash(msg.slice(i, i + BLOCK_SIZE));
+        this.#hash(msg.slice(i, i + BLOCK_SIZE));
         i += BLOCK_SIZE;
       }
 
@@ -189,7 +189,7 @@ export class Md5 {
     }
 
     this.#pos = pos;
-    this.addLength(msg.length);
+    this.#addLength(msg.length);
 
     return this;
   }

--- a/hash/sha1.ts
+++ b/hash/sha1.ts
@@ -114,7 +114,7 @@ export class Sha1 {
       if (i >= 64) {
         this.#block = blocks[16];
         this.#start = i - 64;
-        this.hash();
+        this.#hash();
         this.#hashed = true;
       } else {
         this.#start = i;
@@ -139,7 +139,7 @@ export class Sha1 {
     this.#block = blocks[16];
     if (i >= 56) {
       if (!this.#hashed) {
-        this.hash();
+        this.#hash();
       }
       blocks[0] = this.#block;
       blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] =
@@ -148,10 +148,10 @@ export class Sha1 {
     }
     blocks[14] = (this.#hBytes << 3) | (this.#bytes >>> 29);
     blocks[15] = this.#bytes << 3;
-    this.hash();
+    this.#hash();
   }
 
-  private hash(): void {
+  #hash(): void {
     let a = this.#h0;
     let b = this.#h1;
     let c = this.#h2;

--- a/io/readers.ts
+++ b/io/readers.ts
@@ -15,19 +15,19 @@ export class StringReader extends Buffer {
 
 /** Reader utility for combining multiple readers */
 export class MultiReader implements Deno.Reader {
-  private readonly readers: Deno.Reader[];
-  private currentIndex = 0;
+  readonly #readers: Deno.Reader[];
+  #currentIndex = 0;
 
   constructor(readers: Deno.Reader[]) {
-    this.readers = [...readers];
+    this.#readers = [...readers];
   }
 
   async read(p: Uint8Array): Promise<number | null> {
-    const r = this.readers[this.currentIndex];
+    const r = this.#readers[this.#currentIndex];
     if (!r) return null;
     const result = await r.read(p);
     if (result === null) {
-      this.currentIndex++;
+      this.#currentIndex++;
       return 0;
     }
     return result;

--- a/io/writers.ts
+++ b/io/writers.ts
@@ -7,14 +7,14 @@ const decoder = new TextDecoder();
 
 /** Writer utility for buffering string chunks */
 export class StringWriter implements Writer, WriterSync {
-  private chunks: Uint8Array[] = [];
-  private byteLength = 0;
-  private cache: string | undefined;
+  #chunks: Uint8Array[] = [];
+  #byteLength = 0;
+  #cache: string | undefined;
 
   constructor(private base: string = "") {
     const c = new TextEncoder().encode(base);
-    this.chunks.push(c);
-    this.byteLength += c.byteLength;
+    this.#chunks.push(c);
+    this.#byteLength += c.byteLength;
   }
 
   write(p: Uint8Array): Promise<number> {
@@ -22,23 +22,23 @@ export class StringWriter implements Writer, WriterSync {
   }
 
   writeSync(p: Uint8Array): number {
-    this.chunks.push(p);
-    this.byteLength += p.byteLength;
-    this.cache = undefined;
+    this.#chunks.push(p);
+    this.#byteLength += p.byteLength;
+    this.#cache = undefined;
     return p.byteLength;
   }
 
   toString(): string {
-    if (this.cache) {
-      return this.cache;
+    if (this.#cache) {
+      return this.#cache;
     }
-    const buf = new Uint8Array(this.byteLength);
+    const buf = new Uint8Array(this.#byteLength);
     let offs = 0;
-    for (const chunk of this.chunks) {
+    for (const chunk of this.#chunks) {
       buf.set(chunk, offs);
       offs += chunk.byteLength;
     }
-    this.cache = decoder.decode(buf);
-    return this.cache;
+    this.#cache = decoder.decode(buf);
+    return this.#cache;
   }
 }

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -88,7 +88,7 @@ export class Logger {
    * function, not the function itself, unless the function isn't called, in which
    * case undefined is returned.  All types are coerced to strings for logging.
    */
-  private _log<T>(
+  #_log<T>(
     level: number,
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
@@ -145,7 +145,7 @@ export class Logger {
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this._log(LogLevels.DEBUG, msg, ...args);
+    return this.#_log(LogLevels.DEBUG, msg, ...args);
   }
 
   info<T>(msg: () => T, ...args: unknown[]): T | undefined;
@@ -154,7 +154,7 @@ export class Logger {
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this._log(LogLevels.INFO, msg, ...args);
+    return this.#_log(LogLevels.INFO, msg, ...args);
   }
 
   warning<T>(msg: () => T, ...args: unknown[]): T | undefined;
@@ -163,7 +163,7 @@ export class Logger {
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this._log(LogLevels.WARNING, msg, ...args);
+    return this.#_log(LogLevels.WARNING, msg, ...args);
   }
 
   error<T>(msg: () => T, ...args: unknown[]): T | undefined;
@@ -172,7 +172,7 @@ export class Logger {
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this._log(LogLevels.ERROR, msg, ...args);
+    return this.#_log(LogLevels.ERROR, msg, ...args);
   }
 
   critical<T>(msg: () => T, ...args: unknown[]): T | undefined;
@@ -184,6 +184,6 @@ export class Logger {
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this._log(LogLevels.CRITICAL, msg, ...args);
+    return this.#_log(LogLevels.CRITICAL, msg, ...args);
   }
 }

--- a/mime/multipart.ts
+++ b/mime/multipart.ts
@@ -212,16 +212,16 @@ class PartReader implements Deno.Reader, Deno.Closer {
 
   close(): void {}
 
-  private contentDisposition!: string;
-  private contentDispositionParams!: { [key: string]: string };
+  #contentDisposition!: string;
+  #contentDispositionParams!: { [key: string]: string };
 
-  private getContentDispositionParams(): { [key: string]: string } {
-    if (this.contentDispositionParams) return this.contentDispositionParams;
+  #getContentDispositionParams(): { [key: string]: string } {
+    if (this.#contentDispositionParams) return this.#contentDispositionParams;
     const cd = this.headers.get("content-disposition");
     const params: { [key: string]: string } = {};
     assert(cd != null, "content-disposition must be set");
     const comps = decodeURI(cd).split(";");
-    this.contentDisposition = comps[0];
+    this.#contentDisposition = comps[0];
     comps
       .slice(1)
       .map((v: string): string => v.trim())
@@ -237,16 +237,16 @@ class PartReader implements Deno.Reader, Deno.Closer {
           }
         }
       });
-    return (this.contentDispositionParams = params);
+    return (this.#contentDispositionParams = params);
   }
 
   get fileName(): string {
-    return this.getContentDispositionParams()["filename"];
+    return this.#getContentDispositionParams()["filename"];
   }
 
   get formName(): string {
-    const p = this.getContentDispositionParams();
-    if (this.contentDisposition === "form-data") {
+    const p = this.#getContentDispositionParams();
+    if (this.#contentDisposition === "form-data") {
       return p["name"];
     }
     return "";
@@ -345,7 +345,7 @@ export class MultipartReader {
     let maxValueBytes = maxMemory + (10 << 20);
     const buf = new Buffer(new Uint8Array(maxValueBytes));
     for (;;) {
-      const p = await this.nextPart();
+      const p = await this.#nextPart();
       if (p === null) {
         break;
       }
@@ -421,12 +421,12 @@ export class MultipartReader {
     return multipartFormData(fileMap, valueMap);
   }
 
-  private currentPart: PartReader | undefined;
-  private partsRead = 0;
+  #currentPart: PartReader | undefined;
+  #partsRead = 0;
 
-  private async nextPart(): Promise<PartReader | null> {
-    if (this.currentPart) {
-      this.currentPart.close();
+  async #nextPart(): Promise<PartReader | null> {
+    if (this.#currentPart) {
+      this.#currentPart.close();
     }
     if (equals(this.dashBoundary, encoder.encode("--"))) {
       throw new Error("boundary is empty");
@@ -437,24 +437,24 @@ export class MultipartReader {
       if (line === null) {
         throw new Deno.errors.UnexpectedEof();
       }
-      if (this.isBoundaryDelimiterLine(line)) {
-        this.partsRead++;
+      if (this.#isBoundaryDelimiterLine(line)) {
+        this.#partsRead++;
         const r = new TextProtoReader(this.bufReader);
         const headers = await r.readMIMEHeader();
         if (headers === null) {
           throw new Deno.errors.UnexpectedEof();
         }
         const np = new PartReader(this, headers);
-        this.currentPart = np;
+        this.#currentPart = np;
         return np;
       }
-      if (this.isFinalBoundary(line)) {
+      if (this.#isFinalBoundary(line)) {
         return null;
       }
       if (expectNewPart) {
         throw new Error(`expecting a new Part; got line ${line}`);
       }
-      if (this.partsRead === 0) {
+      if (this.#partsRead === 0) {
         continue;
       }
       if (equals(line, this.newLine)) {
@@ -465,7 +465,7 @@ export class MultipartReader {
     }
   }
 
-  private isFinalBoundary(line: Uint8Array): boolean {
+  #isFinalBoundary(line: Uint8Array): boolean {
     if (!startsWith(line, this.dashBoundaryDash)) {
       return false;
     }
@@ -473,7 +473,7 @@ export class MultipartReader {
     return rest.length === 0 || equals(skipLWSPChar(rest), this.newLine);
   }
 
-  private isBoundaryDelimiterLine(line: Uint8Array): boolean {
+  #isBoundaryDelimiterLine(line: Uint8Array): boolean {
     if (!startsWith(line, this.dashBoundary)) {
       return false;
     }
@@ -523,8 +523,8 @@ function multipartFormData(
 
 class PartWriter implements Deno.Writer {
   closed = false;
-  private readonly partHeader: string;
-  private headersWritten = false;
+  readonly #partHeader: string;
+  #headersWritten = false;
 
   constructor(
     private writer: Deno.Writer,
@@ -542,7 +542,7 @@ class PartWriter implements Deno.Writer {
       buf += `${key}: ${value}\r\n`;
     }
     buf += `\r\n`;
-    this.partHeader = buf;
+    this.#partHeader = buf;
   }
 
   close(): void {
@@ -553,9 +553,9 @@ class PartWriter implements Deno.Writer {
     if (this.closed) {
       throw new Error("part is closed");
     }
-    if (!this.headersWritten) {
-      await this.writer.write(encoder.encode(this.partHeader));
-      this.headersWritten = true;
+    if (!this.#headersWritten) {
+      await this.writer.write(encoder.encode(this.#partHeader));
+      this.#headersWritten = true;
     }
     return this.writer.write(p);
   }
@@ -581,23 +581,23 @@ function checkBoundary(b: string): string {
  *
  * Writer for creating multipart/form-data */
 export class MultipartWriter {
-  private readonly _boundary: string;
+  readonly #_boundary: string;
 
   get boundary(): string {
-    return this._boundary;
+    return this.#_boundary;
   }
 
-  private lastPart: PartWriter | undefined;
-  private bufWriter: BufWriter;
-  private isClosed = false;
+  #lastPart: PartWriter | undefined;
+  #bufWriter: BufWriter;
+  #isClosed = false;
 
   constructor(private readonly writer: Deno.Writer, boundary?: string) {
     if (boundary !== void 0) {
-      this._boundary = checkBoundary(boundary);
+      this.#_boundary = checkBoundary(boundary);
     } else {
-      this._boundary = randomBoundary();
+      this.#_boundary = randomBoundary();
     }
-    this.bufWriter = new BufWriter(writer);
+    this.#bufWriter = new BufWriter(writer);
   }
 
   formDataContentType(): string {
@@ -605,19 +605,19 @@ export class MultipartWriter {
   }
 
   createPart(headers: Headers): Deno.Writer {
-    if (this.isClosed) {
+    if (this.#isClosed) {
       throw new Error("multipart: writer is closed");
     }
-    if (this.lastPart) {
-      this.lastPart.close();
+    if (this.#lastPart) {
+      this.#lastPart.close();
     }
     const part = new PartWriter(
       this.writer,
       this.boundary,
       headers,
-      !this.lastPart,
+      !this.#lastPart,
     );
-    this.lastPart = part;
+    this.#lastPart = part;
     return part;
   }
 
@@ -655,21 +655,21 @@ export class MultipartWriter {
     await copy(file, f);
   }
 
-  private flush() {
-    return this.bufWriter.flush();
+  #flush() {
+    return this.#bufWriter.flush();
   }
 
   /** Close writer. No additional data can be written to stream */
   async close() {
-    if (this.isClosed) {
+    if (this.#isClosed) {
       throw new Error("multipart: writer is closed");
     }
-    if (this.lastPart) {
-      this.lastPart.close();
-      this.lastPart = void 0;
+    if (this.#lastPart) {
+      this.#lastPart.close();
+      this.#lastPart = void 0;
     }
     await this.writer.write(encoder.encode(`\r\n--${this.boundary}--\r\n`));
-    await this.flush();
-    this.isClosed = true;
+    await this.#flush();
+    this.#isClosed = true;
   }
 }

--- a/node/_fs/_fs_dir.ts
+++ b/node/_fs/_fs_dir.ts
@@ -3,29 +3,29 @@ import Dirent from "./_fs_dirent.ts";
 import { assert } from "../../_util/assert.ts";
 
 export default class Dir {
-  private dirPath: string | Uint8Array;
-  private syncIterator!: Iterator<Deno.DirEntry> | null;
-  private asyncIterator!: AsyncIterator<Deno.DirEntry> | null;
+  #dirPath: string | Uint8Array;
+  #syncIterator!: Iterator<Deno.DirEntry> | null;
+  #asyncIterator!: AsyncIterator<Deno.DirEntry> | null;
 
   constructor(path: string | Uint8Array) {
-    this.dirPath = path;
+    this.#dirPath = path;
   }
 
   get path(): string {
-    if (this.dirPath instanceof Uint8Array) {
-      return new TextDecoder().decode(this.dirPath);
+    if (this.#dirPath instanceof Uint8Array) {
+      return new TextDecoder().decode(this.#dirPath);
     }
-    return this.dirPath;
+    return this.#dirPath;
   }
 
   // deno-lint-ignore no-explicit-any
   read(callback?: (...args: any[]) => void): Promise<Dirent | null> {
     return new Promise((resolve, reject) => {
-      if (!this.asyncIterator) {
-        this.asyncIterator = Deno.readDir(this.path)[Symbol.asyncIterator]();
+      if (!this.#asyncIterator) {
+        this.#asyncIterator = Deno.readDir(this.path)[Symbol.asyncIterator]();
       }
-      assert(this.asyncIterator);
-      this.asyncIterator
+      assert(this.#asyncIterator);
+      this.#asyncIterator
         .next()
         .then(({ value }) => {
           resolve(value ? value : null);
@@ -42,11 +42,11 @@ export default class Dir {
   }
 
   readSync(): Dirent | null {
-    if (!this.syncIterator) {
-      this.syncIterator = Deno.readDirSync(this.path)![Symbol.iterator]();
+    if (!this.#syncIterator) {
+      this.#syncIterator = Deno.readDirSync(this.path)![Symbol.iterator]();
     }
 
-    const file: Deno.DirEntry = this.syncIterator.next().value;
+    const file: Deno.DirEntry = this.#syncIterator.next().value;
 
     return file ? new Dirent(file) : null;
   }

--- a/node/http.ts
+++ b/node/http.ts
@@ -230,7 +230,7 @@ export class ServerResponse extends NodeWritable {
   statusCode?: number = undefined;
   statusMessage?: string = undefined;
   #headers = new Headers({});
-  private readable: ReadableStream;
+  #readable: ReadableStream;
   headersSent = false;
   #reqEvent: Deno.RequestEvent;
   #firstChunk: Chunk | null = null;
@@ -276,7 +276,7 @@ export class ServerResponse extends NodeWritable {
         return cb(null);
       },
     });
-    this.readable = readable;
+    this.#readable = readable;
     this.#reqEvent = reqEvent;
   }
 
@@ -319,7 +319,7 @@ export class ServerResponse extends NodeWritable {
   respond(final: boolean, singleChunk?: Chunk) {
     this.headersSent = true;
     this.#ensureHeaders(singleChunk);
-    const body = singleChunk ?? (final ? null : this.readable);
+    const body = singleChunk ?? (final ? null : this.#readable);
     this.#reqEvent.respondWith(
       new Response(body, {
         headers: this.#headers,
@@ -347,7 +347,7 @@ export class ServerResponse extends NodeWritable {
 
 // TODO(@AaronO): optimize
 export class IncomingMessageForServer extends NodeReadable {
-  private req: Request;
+  #req: Request;
   url: string;
 
   constructor(req: Request) {
@@ -373,10 +373,10 @@ export class IncomingMessageForServer extends NodeReadable {
         reader?.cancel().finally(() => cb(err));
       },
     });
-    this.req = req;
+    this.#req = req;
     // TODO: consider more robust path extraction, e.g:
     // url: (new URL(request.url).pathname),
-    this.url = req.url.slice(this.req.url.indexOf("/", 8));
+    this.url = req.url.slice(this.#req.url.indexOf("/", 8));
   }
 
   get aborted() {
@@ -387,10 +387,10 @@ export class IncomingMessageForServer extends NodeReadable {
   }
 
   get headers() {
-    return Object.fromEntries(this.req.headers.entries());
+    return Object.fromEntries(this.#req.headers.entries());
   }
   get method() {
-    return this.req.method;
+    return this.#req.method;
   }
 }
 

--- a/node/internal/child_process.ts
+++ b/node/internal/child_process.ts
@@ -196,13 +196,13 @@ export class ChildProcess extends EventEmitter {
           const signalCode = this.signalCode == null ? null : this.signalCode;
           // The 'exit' and 'close' events must be emitted after the 'spawn' event.
           this.emit("exit", exitCode, signalCode);
-          await this._waitForChildStreamsToClose();
+          await this.#_waitForChildStreamsToClose();
           this.#close();
           this.emit("close", exitCode, signalCode);
         });
       })();
     } catch (err) {
-      this._handleError(err);
+      this.#_handleError(err);
     }
   }
 
@@ -238,7 +238,7 @@ export class ChildProcess extends EventEmitter {
     notImplemented("ChildProcess.unref()");
   }
 
-  private async _waitForChildStreamsToClose(): Promise<void> {
+  async #_waitForChildStreamsToClose(): Promise<void> {
     const promises = [] as Array<Promise<void>>;
     if (this.stdin && !this.stdin.destroyed) {
       assert(this.stdin);
@@ -254,7 +254,7 @@ export class ChildProcess extends EventEmitter {
     await Promise.all(promises);
   }
 
-  private _handleError(err: unknown): void {
+  #_handleError(err: unknown): void {
     nextTick(() => {
       this.emit("error", err); // TODO(uki00a) Convert `err` into nodejs's `SystemError` class.
     });

--- a/node/url.ts
+++ b/node/url.ts
@@ -162,7 +162,7 @@ export class Url {
     this.href = null;
   }
 
-  private parseHost() {
+  #parseHost() {
     let host = this.host || "";
     let port: RegExpExecArray | null | string = portPattern.exec(host);
     if (port) {
@@ -752,7 +752,7 @@ export class Url {
       }
 
       // pull out port.
-      this.parseHost();
+      this.#parseHost();
 
       // We've indicated that there is a hostname,
       // so even if it's empty, it has to be present.

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -259,10 +259,10 @@ Deno.test("Equal", function (): void {
   assert(
     !equal(
       new (class A {
-        private hello = "world";
+        #hello = "world";
       })(),
       new (class B {
-        private hello = "world";
+        #hello = "world";
       })(),
     ),
   );
@@ -270,10 +270,10 @@ Deno.test("Equal", function (): void {
   assertFalse(
     equal(
       new (class A {
-        private hello = "world";
+        #hello = "world";
       })(),
       new (class B {
-        private hello = "world";
+        #hello = "world";
       })(),
     ),
   );


### PR DESCRIPTION
Replace TypeScript `private` variables and methods to JavaScript private identifiers. This PR doesn't include refactoring to private identifies where it's not possible to do so (e.g. properties in constructors).

Tackles https://github.com/denoland/deno_std/issues/1649.