### PR TITLE
docs(async): use top-level await in tee docs

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -203,17 +203,13 @@ const gen = async function* gen() {
 
 const [branch1, branch2] = tee(gen());
 
-(async () => {
-  for await (const n of branch1) {
-    console.log(n); // => 1, 2, 3
-  }
-})();
+for await (const n of branch1) {
+  console.log(n); // => 1, 2, 3
+}
 
-(async () => {
-  for await (const n of branch2) {
-    console.log(n); // => 1, 2, 3
-  }
-})();
+for await (const n of branch2) {
+  console.log(n); // => 1, 2, 3
+}
 ```
 
 ## deadline

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -62,17 +62,13 @@ class Queue<T> {
  *
  *     const [branch1, branch2] = tee(gen());
  *
- *     (async () => {
- *       for await (const n of branch1) {
- *         console.log(n); // => 1, 2, 3
- *       }
- *     })();
+ *     for await (const n of branch1) {
+ *       console.log(n); // => 1, 2, 3
+ *     }
  *
- *     (async () => {
- *       for await (const n of branch2) {
- *         console.log(n); // => 1, 2, 3
- *       }
- *     })();
+ *     for await (const n of branch2) {
+ *       console.log(n); // => 1, 2, 3
+ *     }
  * ```
  */
 export function tee<T, N extends number = 2>(


### PR DESCRIPTION
Eliminate redundant function wrapping in documentation of async's tee method. Resolves https://github.com/denoland/deno_std/issues/2279