### PR TITLE
chore(node): ignore test-net-socket-close-after-end.js on darwin

### DIFF
--- a/node/_tools/common.ts
+++ b/node/_tools/common.ts
@@ -22,6 +22,7 @@ interface Config {
    */
   tests: TestSuites;
   windowsIgnore: TestSuites;
+  darwinIgnore: TestSuites;
   suitesFolder: string;
   versionsFolder: string;
 }

--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -655,6 +655,11 @@
       "test-util-inspect.js"
     ]
   },
+  "darwinIgnore": {
+    "parallel": [
+      "test-net-socket-close-after-end.js"
+    ]
+  },
   "suitesFolder": "test",
   "versionsFolder": "versions"
 }

--- a/node/_tools/test.ts
+++ b/node/_tools/test.ts
@@ -24,6 +24,9 @@ const requireTs = "require.ts";
 const windowsIgnorePaths = new Set(
   getPathsFromTestSuites(config.windowsIgnore),
 );
+const darwinIgnorePaths = new Set(
+  getPathsFromTestSuites(config.darwinIgnore),
+);
 
 const decoder = new TextDecoder();
 
@@ -36,7 +39,9 @@ for await (const path of testPaths) {
   ) {
     continue;
   }
-  const ignore = Deno.build.os === "windows" && windowsIgnorePaths.has(path);
+  const ignore =
+    (Deno.build.os === "windows" && windowsIgnorePaths.has(path)) ||
+    (Deno.build.os === "darwin" && darwinIgnorePaths.has(path));
   Deno.test({
     name: `Node.js compatibility "${path}"`,
     ignore,


### PR DESCRIPTION
The test case `node/_tools/test/parallel/test-net-socket-close-after-end.js` looks very flaky in macOS recently.

This PR (temporarily) disables that test case only on darwin.

closes #2241 