### PR TITLE
tests(async): use generic assertRejects in pool_test.ts

### DIFF
--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -34,17 +34,16 @@ Deno.test("[async] pooledMap errors", async () => {
     return n;
   }
   const mappedNumbers: number[] = [];
-  await assertRejects(async () => {
+  const error = await assertRejects(async () => {
     for await (const m of pooledMap(3, [1, 2, 3, 4], mapNumber)) {
       mappedNumbers.push(m);
     }
-  }, (error: Error) => {
-    assert(error instanceof AggregateError);
-    assert(error.message === ERROR_WHILE_MAPPING_MESSAGE);
-    assertEquals(error.errors.length, 2);
-    assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
-    assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
-  });
+  }, AggregateError);
+  assert(error instanceof AggregateError);
+  assert(error.message === ERROR_WHILE_MAPPING_MESSAGE);
+  assertEquals(error.errors.length, 2);
+  assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");
+  assertStringIncludes(error.errors[1].stack, "Error: Bad number: 2");
   assertEquals(mappedNumbers, [3]);
 });
 


### PR DESCRIPTION
Fixes a deprecation warning. Resolves https://github.com/denoland/deno_std/issues/2283

This is a follow-up of https://github.com/denoland/deno_std/pull/2284

@kt3k I've basically followed your suggestion there, with the slight modification that instead of sending `ERROR_WHILE_MAPPING_MESSAGE` as a parameter to `assertRejects`, I maintain the strict equality check. It looks like `assertRejects` checks for inclusion of the passed-in message, rather than strict equality.