### PR TITLE
feat(node/assert): add deepEqual and notDeepEqual 

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -8,7 +8,7 @@ Deno standard library as it's a compatibility module.
 
 ## Supported modules
 
-- [x] assert _partly_
+- [x] assert
 - [x] assert/strict _partly_
 - [x] async_hooks _partly_
 - [x] buffer

--- a/node/assert.ts
+++ b/node/assert.ts
@@ -15,6 +15,24 @@ import {
 } from "./internal/errors.ts";
 import { isDeepEqual } from "./internal/util/comparisons.ts";
 
+function innerFail(obj: {
+  actual?: unknown;
+  expected?: unknown;
+  message?: string | Error;
+  operator?: string;
+}) {
+  if (obj.message instanceof Error) {
+    throw obj.message;
+  }
+
+  throw new AssertionError({
+    actual: obj.actual,
+    expected: obj.expected,
+    message: obj.message,
+    operator: obj.operator,
+  });
+}
+
 interface ExtendedAssertionErrorConstructorOptions
   extends AssertionErrorConstructorOptions {
   generatedMessage?: boolean;
@@ -327,25 +345,9 @@ function deepEqual(
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  if (isDeepEqual(actual, expected)) {
-    return;
+  if (!isDeepEqual(actual, expected)) {
+    innerFail({ actual, expected, message, operator: "deepEqual" });
   }
-
-  if (typeof message === "string") {
-    throw new AssertionError({
-      message,
-    });
-  } else if (message instanceof Error) {
-    throw message;
-  }
-
-  throw createAssertionError({
-    actual,
-    expected,
-    message,
-    operator: "deepEqual",
-    generatedMessage: true,
-  });
 }
 function notDeepEqual(
   actual: unknown,
@@ -356,25 +358,9 @@ function notDeepEqual(
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  if (!isDeepEqual(actual, expected)) {
-    return;
+  if (isDeepEqual(actual, expected)) {
+    innerFail({ actual, expected, message, operator: "notDeepEqual" });
   }
-
-  if (typeof message === "string") {
-    throw new AssertionError({
-      message,
-    });
-  } else if (message instanceof Error) {
-    throw message;
-  }
-
-  throw createAssertionError({
-    actual,
-    expected,
-    message,
-    operator: "notDeepEqual",
-    generatedMessage: true,
-  });
 }
 function deepStrictEqual(
   actual: unknown,

--- a/node/assert.ts
+++ b/node/assert.ts
@@ -13,6 +13,7 @@ import {
   ERR_INVALID_RETURN_VALUE,
   ERR_MISSING_ARGS,
 } from "./internal/errors.ts";
+import { isDeepEqual } from "./internal/util/comparisons.ts";
 
 interface ExtendedAssertionErrorConstructorOptions
   extends AssertionErrorConstructorOptions {
@@ -317,21 +318,63 @@ function notStrictEqual(
   );
 }
 
-function deepEqual() {
+function deepEqual(
+  actual: unknown,
+  expected: unknown,
+  message?: string | Error,
+) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  // TODO(kt3k): Implement deepEqual
-  throw new Error("Not implemented");
+  if (isDeepEqual(actual, expected)) {
+    return;
+  }
+
+  if (typeof message === "string") {
+    throw new AssertionError({
+      message,
+    });
+  } else if (message instanceof Error) {
+    throw message;
+  }
+
+  throw createAssertionError({
+    actual,
+    expected,
+    message,
+    operator: "deepEqual",
+    generatedMessage: true,
+  });
 }
-function notDeepEqual() {
+function notDeepEqual(
+  actual: unknown,
+  expected: unknown,
+  message?: string | Error,
+) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  // TODO(kt3k): Implement notDeepEqual
-  throw new Error("Not implemented");
+  if (!isDeepEqual(actual, expected)) {
+    return;
+  }
+
+  if (typeof message === "string") {
+    throw new AssertionError({
+      message,
+    });
+  } else if (message instanceof Error) {
+    throw message;
+  }
+
+  throw createAssertionError({
+    actual,
+    expected,
+    message,
+    operator: "notDeepEqual",
+    generatedMessage: true,
+  });
 }
 function deepStrictEqual(
   actual: unknown,

--- a/node/internal/util/comparisons.ts
+++ b/node/internal/util/comparisons.ts
@@ -45,7 +45,7 @@ let memo: Memo;
 export function isDeepStrictEqual(val1: unknown, val2: unknown): boolean {
   return innerDeepEqual(val1, val2, true);
 }
-function isDeepEqual(val1: unknown, val2: unknown): boolean {
+export function isDeepEqual(val1: unknown, val2: unknown): boolean {
   return innerDeepEqual(val1, val2, false);
 }
 


### PR DESCRIPTION
Those were skipped because they don't have test cases in `test-assert.js`.

I used the implementation of `isDeepEqual()` from [`./node/internal/utils/comparisons.ts`](https://github.com/denoland/deno_std/blob/main/node/internal/util/comparisons.ts), which I believe to be a direct copy of the code in Node.

These functions missing is what prevents [Recast](https://github.com/benjamn/recast) from working on Deno using esm.sh.

It's my first time contributing to the Node compat modules, so let me know if I missed anything 😊

