### PR TITLE
fix(node): type checking on AsyncResource

### DIFF
--- a/node/async_hooks.ts
+++ b/node/async_hooks.ts
@@ -93,8 +93,8 @@ export class AsyncResource {
   }
 
   emitDestroy() {
-    if (this[destroyedSymbol] !== undefined) {
-      this[destroyedSymbol].destroyed = true;
+    if (this[destroyedSymbol] != null) {
+      this[destroyedSymbol] = { destroyed: true };
     }
     // TODO(kt3k): Uncomment the below
     // emitDestroy(this[async_id_symbol]);

--- a/node/async_hooks.ts
+++ b/node/async_hooks.ts
@@ -28,7 +28,7 @@ type AsyncResourceOptions = number | {
 export class AsyncResource {
   [async_id_symbol]: number;
   [trigger_async_id_symbol]: number;
-  [destroyedSymbol]: { destroyed: boolean };
+  [destroyedSymbol]?: { destroyed: boolean };
 
   constructor(type: string, opts: AsyncResourceOptions = {}) {
     validateString(type, "type");

--- a/node/async_hooks.ts
+++ b/node/async_hooks.ts
@@ -28,7 +28,7 @@ type AsyncResourceOptions = number | {
 export class AsyncResource {
   [async_id_symbol]: number;
   [trigger_async_id_symbol]: number;
-  [destroyedSymbol]?: { destroyed: boolean };
+  [destroyedSymbol]!: { destroyed: boolean };
 
   constructor(type: string, opts: AsyncResourceOptions = {}) {
     validateString(type, "type");
@@ -93,8 +93,8 @@ export class AsyncResource {
   }
 
   emitDestroy() {
-    if (this[destroyedSymbol] != null) {
-      this[destroyedSymbol] = { destroyed: true };
+    if (this[destroyedSymbol] !== undefined) {
+      this[destroyedSymbol].destroyed = true;
     }
     // TODO(kt3k): Uncomment the below
     // emitDestroy(this[async_id_symbol]);


### PR DESCRIPTION
This fixes an issue where TypeScript correctly identifies symbol field initialization errors in TypeScript 4.7 but previously didn't.

Ref: denoland/deno#14242