### PR TITLE
refactor(http): file_server uses std/media_types

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -7,6 +7,7 @@
 
 import { extname, posix } from "../path/mod.ts";
 import { encode } from "../encoding/hex.ts";
+import { contentType } from "../media_types/mod.ts";
 import { serve, serveTls } from "./server.ts";
 import { Status, STATUS_TEXT } from "./http_status.ts";
 import { parse } from "../flags/mod.ts";
@@ -23,162 +24,8 @@ interface EntryInfo {
   name: string;
 }
 
-interface FileServerArgs {
-  _: string[];
-  // -p --port
-  port: string;
-  // --cors
-  cors: boolean;
-  // --no-dir-listing
-  "dir-listing": boolean;
-  dotfiles: boolean;
-  // --host
-  host: string;
-  // -c --cert
-  cert: string;
-  // -k --key
-  key: string;
-  // -h --help
-  help: boolean;
-  // --quiet
-  quiet: boolean;
-}
-
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
-
-const MEDIA_TYPES: Record<string, string> = {
-  ".md": "text/markdown",
-  ".html": "text/html",
-  ".htm": "text/html",
-  ".json": "application/json",
-  ".map": "application/json",
-  ".txt": "text/plain",
-  ".ts": "text/typescript",
-  ".tsx": "text/tsx",
-  ".js": "application/javascript",
-  ".jsx": "text/jsx",
-  ".gz": "application/gzip",
-  ".css": "text/css",
-  ".wasm": "application/wasm",
-  ".mjs": "application/javascript",
-  ".otf": "font/otf",
-  ".ttf": "font/ttf",
-  ".woff": "font/woff",
-  ".woff2": "font/woff2",
-  ".conf": "text/plain",
-  ".list": "text/plain",
-  ".log": "text/plain",
-  ".ini": "text/plain",
-  ".vtt": "text/vtt",
-  ".yaml": "text/yaml",
-  ".yml": "text/yaml",
-  ".mid": "audio/midi",
-  ".midi": "audio/midi",
-  ".mp3": "audio/mp3",
-  ".mp4a": "audio/mp4",
-  ".m4a": "audio/mp4",
-  ".ogg": "audio/ogg",
-  ".spx": "audio/ogg",
-  ".opus": "audio/ogg",
-  ".wav": "audio/wav",
-  ".webm": "audio/webm",
-  ".aac": "audio/x-aac",
-  ".flac": "audio/x-flac",
-  ".mp4": "video/mp4",
-  ".mp4v": "video/mp4",
-  ".mkv": "video/x-matroska",
-  ".mov": "video/quicktime",
-  ".svg": "image/svg+xml",
-  ".avif": "image/avif",
-  ".bmp": "image/bmp",
-  ".gif": "image/gif",
-  ".heic": "image/heic",
-  ".heif": "image/heif",
-  ".jpeg": "image/jpeg",
-  ".jpg": "image/jpeg",
-  ".png": "image/png",
-  ".tiff": "image/tiff",
-  ".psd": "image/vnd.adobe.photoshop",
-  ".ico": "image/vnd.microsoft.icon",
-  ".webp": "image/webp",
-  ".es": "application/ecmascript",
-  ".epub": "application/epub+zip",
-  ".jar": "application/java-archive",
-  ".war": "application/java-archive",
-  ".webmanifest": "application/manifest+json",
-  ".doc": "application/msword",
-  ".dot": "application/msword",
-  ".docx":
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  ".dotx":
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-  ".cjs": "application/node",
-  ".bin": "application/octet-stream",
-  ".pkg": "application/octet-stream",
-  ".dump": "application/octet-stream",
-  ".exe": "application/octet-stream",
-  ".deploy": "application/octet-stream",
-  ".img": "application/octet-stream",
-  ".msi": "application/octet-stream",
-  ".pdf": "application/pdf",
-  ".pgp": "application/pgp-encrypted",
-  ".asc": "application/pgp-signature",
-  ".sig": "application/pgp-signature",
-  ".ai": "application/postscript",
-  ".eps": "application/postscript",
-  ".ps": "application/postscript",
-  ".rdf": "application/rdf+xml",
-  ".rss": "application/rss+xml",
-  ".rtf": "application/rtf",
-  ".apk": "application/vnd.android.package-archive",
-  ".key": "application/vnd.apple.keynote",
-  ".numbers": "application/vnd.apple.keynote",
-  ".pages": "application/vnd.apple.pages",
-  ".geo": "application/vnd.dynageo",
-  ".gdoc": "application/vnd.google-apps.document",
-  ".gslides": "application/vnd.google-apps.presentation",
-  ".gsheet": "application/vnd.google-apps.spreadsheet",
-  ".kml": "application/vnd.google-earth.kml+xml",
-  ".mkz": "application/vnd.google-earth.kmz",
-  ".icc": "application/vnd.iccprofile",
-  ".icm": "application/vnd.iccprofile",
-  ".xls": "application/vnd.ms-excel",
-  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  ".xlm": "application/vnd.ms-excel",
-  ".ppt": "application/vnd.ms-powerpoint",
-  ".pot": "application/vnd.ms-powerpoint",
-  ".pptx":
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  ".potx":
-    "application/vnd.openxmlformats-officedocument.presentationml.template",
-  ".xps": "application/vnd.ms-xpsdocument",
-  ".odc": "application/vnd.oasis.opendocument.chart",
-  ".odb": "application/vnd.oasis.opendocument.database",
-  ".odf": "application/vnd.oasis.opendocument.formula",
-  ".odg": "application/vnd.oasis.opendocument.graphics",
-  ".odp": "application/vnd.oasis.opendocument.presentation",
-  ".ods": "application/vnd.oasis.opendocument.spreadsheet",
-  ".odt": "application/vnd.oasis.opendocument.text",
-  ".rar": "application/vnd.rar",
-  ".unityweb": "application/vnd.unity",
-  ".dmg": "application/x-apple-diskimage",
-  ".bz": "application/x-bzip",
-  ".crx": "application/x-chrome-extension",
-  ".deb": "application/x-debian-package",
-  ".php": "application/x-httpd-php",
-  ".iso": "application/x-iso9660-image",
-  ".sh": "application/x-sh",
-  ".sql": "application/x-sql",
-  ".srt": "application/x-subrip",
-  ".xml": "application/xml",
-  ".zip": "application/zip",
-};
-
-/** Returns the content-type based on the extension of a path. */
-function contentType(path: string): string | undefined {
-  return MEDIA_TYPES[extname(path)];
-}
 
 // The fnv-1a hash function.
 function fnv1a(buf: string): string {
@@ -288,7 +135,7 @@ export async function serveFile(
   const headers = setBaseHeaders();
 
   // Set mime-type using the file extension in filePath
-  const contentTypeValue = contentType(filePath);
+  const contentTypeValue = contentType(extname(filePath));
   if (contentTypeValue) {
     headers.set("content-type", contentTypeValue);
   }

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -161,7 +161,10 @@ Deno.test(
     await startFileServer();
     try {
       const res = await fetch("http://localhost:4507/README.md");
-      assertEquals(res.headers.get("content-type"), "text/markdown");
+      assertEquals(
+        res.headers.get("content-type"),
+        "text/markdown; charset=UTF-8",
+      );
       const downloadedFile = await res.text();
       const localFile = new TextDecoder().decode(
         await Deno.readFile(join(moduleDir, "README.md")),
@@ -179,7 +182,7 @@ Deno.test(
     await startFileServer({ target: "./testdata" });
     try {
       const res = await fetch("http://localhost:4507/hello.html");
-      assertEquals(res.headers.get("content-type"), "text/html");
+      assertEquals(res.headers.get("content-type"), "text/html; charset=UTF-8");
       const downloadedFile = await res.text();
       const localFile = new TextDecoder().decode(
         await Deno.readFile(join(testdataDir, "hello.html")),
@@ -345,7 +348,7 @@ Deno.test("contentType", async () => {
   try {
     const res = await fetch("http://localhost:4507/testdata/hello.html");
     const contentType = res.headers.get("content-type");
-    assertEquals(contentType, "text/html");
+    assertEquals(contentType, "text/html; charset=UTF-8");
     await res.text(); // Consuming the body so that the test doesn't leak resources
   } finally {
     await killFileServer();
@@ -754,11 +757,17 @@ Deno.test(
       const txtRes = await fetch(
         "http://localhost:4507/testdata/test%20file.txt",
       );
-      assertEquals(txtRes.headers.get("content-type"), "text/plain");
+      assertEquals(
+        txtRes.headers.get("content-type"),
+        "text/plain; charset=UTF-8",
+      );
       await txtRes.text(); // Consuming the body so that the test doesn't leak resources
 
       const htmlRes = await fetch("http://localhost:4507/testdata/hello.html");
-      assertEquals(htmlRes.headers.get("content-type"), "text/html");
+      assertEquals(
+        htmlRes.headers.get("content-type"),
+        "text/html; charset=UTF-8",
+      );
       await htmlRes.text(); // Consuming the body so that the test doesn't leak resources
     } finally {
       await killFileServer();


### PR DESCRIPTION
This PR refactors http/file_server to use the media_types module from std.

It also removes some dead code that was not being referenced in the file.