### PR TITLE
feat(crypto): add KeyStack for rotatable key data signing

### DIFF
--- a/crypto/README.md
+++ b/crypto/README.md
@@ -5,9 +5,16 @@ algorithms that are not part of the web standard, as well as a
 `subtle.digest()`, `subtle.digestSync()`, and `subtle.timingSafeEqual()` methods
 which provide additional functionality not covered by web crypto.
 
-## Usage
+It also includes some utilities for key management.
 
-```typescript
+## `crypto` usage
+
+The `crypto` export provides an enhanced version of the built-in
+[Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
+providing additional cryptographic algorithms using the same interface as the
+Web Crypto API, but also delegating to the built in APIs when possible.
+
+```ts
 import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
 
 // This will delegate to the runtime's WebCrypto implementation.
@@ -31,7 +38,7 @@ console.log(
 );
 ```
 
-## Supported algorithms
+### Supported algorithms
 
 Here is a list of supported algorithms. If the algorithm name in WebCrypto and
 Wasm/Rust is the same, this library prefers to use algorithms that are supported
@@ -133,4 +140,19 @@ const b = await crypto.subtle.digest(
 );
 
 assert(timingSafeEqual(a, b));
+```
+
+## `KeyStack` usage
+
+The `KeyStack` export implements the `KeyRing` interface for managing rotatable
+keys for signing data to prevent tampering, like with HTTP cookies.
+
+```ts
+import { KeyStack } from "https://deno.land/std@$STD_VERSION/crypto/keystack.ts";
+
+const keyStack = new KeyStack(["hello", "world"]);
+const digest = await keyStack.sign("some data");
+
+const rotatedStack = new KeyStack(["deno", "says", "hello", "world"]);
+await rotatedStack.verify("some data", digest); // true
 ```

--- a/crypto/keystack.ts
+++ b/crypto/keystack.ts
@@ -32,22 +32,6 @@ export interface KeyRing {
 
 const encoder = new TextEncoder();
 
-function assert(value: unknown, message = "Assertion error"): asserts value {
-  if (!value) {
-    throw new Error(message);
-  }
-}
-
-const REPLACEMENTS: Record<string, string> = {
-  "/": "_",
-  "+": "-",
-  "=": "",
-};
-
-function encodeBase64Safe(data: string | ArrayBuffer): string {
-  return base64.encode(data).replace(/\/|\+|=/g, (c) => REPLACEMENTS[c]);
-}
-
 function importKey(key: Key): Promise<CryptoKey> {
   if (typeof key === "string") {
     key = encoder.encode(key);

--- a/crypto/keystack.ts
+++ b/crypto/keystack.ts
@@ -1,0 +1,212 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+/**
+ * Provides the {@linkcode KeyStack} class which implements the
+ * {@linkcode KeyRing} interface for managing rotatable keys.
+ *
+ * @module
+ */
+
+import * as base64 from "../encoding/base64.ts";
+
+/** Types of data that can be signed cryptographically. */
+export type Data = string | number[] | ArrayBuffer | Uint8Array;
+
+/** Types of keys that can be used to sign data. */
+export type Key = string | number[] | ArrayBuffer | Uint8Array;
+
+/** An abstract interface for a keyring which handles signing of data based on
+ * a string based digest. */
+export interface KeyRing {
+  /** Given a set of data and a digest, return the key index of the key used
+   * to sign the data. The index is 0 based. A non-negative number indices the
+   * digest is valid and a key was found. */
+  indexOf(data: Data, digest: string): Promise<number> | number;
+  /** Sign the data, returning a string based digest of the data. */
+  sign(data: Data): Promise<string> | string;
+  /** Verifies the digest matches the provided data, indicating the data was
+   * signed by the keyring and has not been tampered with. */
+  verify(data: Data, digest: string): Promise<boolean> | boolean;
+}
+
+const encoder = new TextEncoder();
+
+function assert(value: unknown, message = "Assertion error"): asserts value {
+  if (!value) {
+    throw new Error(message);
+  }
+}
+
+const REPLACEMENTS: Record<string, string> = {
+  "/": "_",
+  "+": "-",
+  "=": "",
+};
+
+function encodeBase64Safe(data: string | ArrayBuffer): string {
+  return base64.encode(data).replace(/\/|\+|=/g, (c) => REPLACEMENTS[c]);
+}
+
+function importKey(key: Key): Promise<CryptoKey> {
+  if (typeof key === "string") {
+    key = encoder.encode(key);
+  } else if (Array.isArray(key)) {
+    key = new Uint8Array(key);
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    key,
+    {
+      name: "HMAC",
+      hash: { name: "SHA-256" },
+    },
+    true,
+    ["sign", "verify"],
+  );
+}
+
+function sign(data: Data, key: CryptoKey): Promise<ArrayBuffer> {
+  if (typeof data === "string") {
+    data = encoder.encode(data);
+  } else if (Array.isArray(data)) {
+    data = Uint8Array.from(data);
+  }
+  return crypto.subtle.sign("HMAC", key, data);
+}
+
+function compareArrayBuffer(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  assert(a.byteLength === b.byteLength, "ArrayBuffer lengths must match.");
+  const va = new DataView(a);
+  const vb = new DataView(b);
+  const length = va.byteLength;
+  let out = 0;
+  let i = -1;
+  while (++i < length) {
+    out |= va.getUint8(i) ^ vb.getUint8(i);
+  }
+  return out === 0;
+}
+
+/** Compare two strings, Uint8Arrays, ArrayBuffers, or arrays of numbers in a
+ * way that avoids timing based attacks on the comparisons on the values.
+ *
+ * The function will return `true` if the values match, or `false`, if they
+ * do not match.
+ *
+ * This was inspired by https://github.com/suryagh/tsscmp which provides a
+ * timing safe string comparison to avoid timing attacks as described in
+ * https://codahale.com/a-lesson-in-timing-attacks/.
+ */
+async function compare(a: Data, b: Data): Promise<boolean> {
+  const key = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(key);
+  const cryptoKey = await importKey(key);
+  const ah = await sign(a, cryptoKey);
+  const bh = await sign(b, cryptoKey);
+  return compareArrayBuffer(ah, bh);
+}
+
+/** A cryptographic key chain which allows signing of data to prevent tampering,
+ * but also allows for easy key rotation without needing to re-sign the data.
+ *
+ * Data is signed as SHA256 HMAC.
+ *
+ * This was inspired by [keygrip](https://github.com/crypto-utils/keygrip/).
+ *
+ * ### Example
+ *
+ * ```ts
+ * import { KeyStack } from "https://deno.land/std@$STD_VERSION/crypto/keystack.ts";
+ *
+ * const keyStack = new KeyStack(["hello", "world"]);
+ * const digest = await keyStack.sign("some data");
+ *
+ * const rotatedStack = new KeyStack(["deno", "says", "hello", "world"]);
+ * await rotatedStack.verify("some data", digest); // true
+ * ```
+ */
+export class KeyStack implements KeyRing {
+  #cryptoKeys = new Map<Key, CryptoKey>();
+  #keys: Key[];
+
+  async #toCryptoKey(key: Key): Promise<CryptoKey> {
+    if (!this.#cryptoKeys.has(key)) {
+      this.#cryptoKeys.set(key, await importKey(key));
+    }
+    return this.#cryptoKeys.get(key)!;
+  }
+
+  get length(): number {
+    return this.#keys.length;
+  }
+
+  /** A class which accepts an array of keys that are used to sign and verify
+   * data and allows easy key rotation without invalidation of previously signed
+   * data.
+   *
+   * @param keys An iterable of keys, of which the index 0 will be used to sign
+   *             data, but verification can happen against any key.
+   */
+  constructor(keys: Iterable<Key>) {
+    const values = Array.isArray(keys) ? keys : [...keys];
+    if (!(values.length)) {
+      throw new TypeError("keys must contain at least one value");
+    }
+    this.#keys = values;
+  }
+
+  /** Take `data` and return a SHA256 HMAC digest that uses the current 0 index
+   * of the `keys` passed to the constructor.  This digest is in the form of a
+   * URL safe base64 encoded string. */
+  async sign(data: Data): Promise<string> {
+    const key = await this.#toCryptoKey(this.#keys[0]);
+    return encodeBase64Safe(await sign(data, key));
+  }
+
+  /** Given `data` and a `digest`, verify that one of the `keys` provided the
+   * constructor was used to generate the `digest`.  Returns `true` if one of
+   * the keys was used, otherwise `false`. */
+  async verify(data: Data, digest: string): Promise<boolean> {
+    return (await this.indexOf(data, digest)) > -1;
+  }
+
+  /** Given `data` and a `digest`, return the current index of the key in the
+   * `keys` passed the constructor that was used to generate the digest.  If no
+   * key can be found, the method returns `-1`. */
+  async indexOf(data: Data, digest: string): Promise<number> {
+    for (let i = 0; i < this.#keys.length; i++) {
+      const cryptoKey = await this.#toCryptoKey(this.#keys[i]);
+      if (
+        await compare(digest, encodeBase64Safe(await sign(data, cryptoKey)))
+      ) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  [Symbol.for("Deno.customInspect")](inspect: (value: unknown) => string) {
+    const { length } = this;
+    return `${this.constructor.name} ${inspect({ length })}`;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](
+    depth: number,
+    // deno-lint-ignore no-explicit-any
+    options: any,
+    inspect: (value: unknown, options?: unknown) => string,
+  ) {
+    if (depth < 0) {
+      return options.stylize(`[${this.constructor.name}]`, "special");
+    }
+
+    const newOptions = Object.assign({}, options, {
+      depth: options.depth === null ? null : options.depth - 1,
+    });
+    const { length } = this;
+    return `${options.stylize(this.constructor.name, "special")} ${
+      inspect({ length }, newOptions)
+    }`;
+  }
+}

--- a/crypto/keystack_test.ts
+++ b/crypto/keystack_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the oak authors. All rights reserved. MIT license.
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "../testing/asserts.ts";
 

--- a/crypto/keystack_test.ts
+++ b/crypto/keystack_test.ts
@@ -1,0 +1,233 @@
+// Copyright 2018-2022 the oak authors. All rights reserved. MIT license.
+
+import { assert, assertEquals } from "../testing/asserts.ts";
+
+import { KeyStack } from "./keystack.ts";
+
+Deno.test({
+  name: "keyStack.sign() - single key",
+  async fn() {
+    const keys = ["hello"];
+    const keyStack = new KeyStack(keys);
+    const actual = await keyStack.sign("world");
+    const expected = "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ";
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "keyStack.sign() - two keys, first key used",
+  async fn() {
+    const keys = ["hello", "world"];
+    const keyStack = new KeyStack(keys);
+    const actual = await keyStack.sign("world");
+    const expected = "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ";
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "keyStack.verify() - single key",
+  async fn() {
+    const keys = ["hello"];
+    const keyStack = new KeyStack(keys);
+    const digest = await keyStack.sign("world");
+    assert(await keyStack.verify("world", digest));
+  },
+});
+
+Deno.test({
+  name: "keyStack.verify() - single key verify invalid",
+  async fn() {
+    const keys = ["hello"];
+    const keyStack = new KeyStack(keys);
+    const digest = await keyStack.sign("world");
+    assert(!await keyStack.verify("worlds", digest));
+  },
+});
+
+Deno.test({
+  name: "keyStack.verify() - two keys",
+  async fn() {
+    const keys = ["hello", "world"];
+    const keyStack = new KeyStack(keys);
+    const digest = await keyStack.sign("world");
+    assert(await keyStack.verify("world", digest));
+  },
+});
+
+Deno.test({
+  name: "keyStack.verify() - unshift key",
+  async fn() {
+    const keys = ["hello"];
+    const keyStack = new KeyStack(keys);
+    const digest = await keyStack.sign("world");
+    keys.unshift("world");
+    assertEquals(keys, ["world", "hello"]);
+    assert(await keyStack.verify("world", digest));
+  },
+});
+
+Deno.test({
+  name: "keyStack.verify() - shift key",
+  async fn() {
+    const keys = ["hello", "world"];
+    const keyStack = new KeyStack(keys);
+    const digest = await keyStack.sign("world");
+    assertEquals(keys.shift(), "hello");
+    assertEquals(keys, ["world"]);
+    assert(!await keyStack.verify("world", digest));
+  },
+});
+
+Deno.test({
+  name: "keyStack.indexOf() - single key",
+  async fn() {
+    const keys = ["hello"];
+    const keyStack = new KeyStack(keys);
+    assertEquals(
+      await keyStack.indexOf(
+        "world",
+        "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ",
+      ),
+      0,
+    );
+  },
+});
+
+Deno.test({
+  name: "keyStack.indexOf() - two keys index 0",
+  async fn() {
+    const keys = ["hello", "world"];
+    const keyStack = new KeyStack(keys);
+    assertEquals(
+      await keyStack.indexOf(
+        "world",
+        "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ",
+      ),
+      0,
+    );
+  },
+});
+
+Deno.test({
+  name: "keyStack.indexOf() - two keys index 1",
+  async fn() {
+    const keys = ["world", "hello"];
+    const keyStack = new KeyStack(keys);
+    assertEquals(
+      await keyStack.indexOf(
+        "world",
+        "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ",
+      ),
+      1,
+    );
+  },
+});
+
+Deno.test({
+  name: "keyStack.indexOf() - two keys not found",
+  async fn() {
+    const keys = ["world", "hello"];
+    const keyStack = new KeyStack(keys);
+    assertEquals(
+      await keyStack.indexOf(
+        "hello",
+        "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ",
+      ),
+      -1,
+    );
+  },
+});
+
+Deno.test({
+  name: "keyStack - number array key",
+  async fn() {
+    const keys = [[212, 213]];
+    const keyStack = new KeyStack(keys);
+    assert(await keyStack.verify("hello", await keyStack.sign("hello")));
+  },
+});
+
+Deno.test({
+  name: "keyStack - Uint8Array key",
+  async fn() {
+    const keys = [new Uint8Array([212, 213])];
+    const keyStack = new KeyStack(keys);
+    assert(await keyStack.verify("hello", await keyStack.sign("hello")));
+  },
+});
+
+Deno.test({
+  name: "keyStack - ArrayBuffer key",
+  async fn() {
+    const key = new ArrayBuffer(2);
+    const dataView = new DataView(key);
+    dataView.setInt8(0, 212);
+    dataView.setInt8(1, 213);
+    const keys = [key];
+    const keyStack = new KeyStack(keys);
+    assert(await keyStack.verify("hello", await keyStack.sign("hello")));
+  },
+});
+
+Deno.test({
+  name: "keyStack - number array data",
+  async fn() {
+    const keys = [[212, 213]];
+    const keyStack = new KeyStack(keys);
+    assert(await keyStack.verify([212, 213], await keyStack.sign([212, 213])));
+  },
+});
+
+Deno.test({
+  name: "keyStack - Uint8Array data",
+  async fn() {
+    const keys = [[212, 213]];
+    const keyStack = new KeyStack(keys);
+    assert(
+      await keyStack.verify(
+        new Uint8Array([212, 213]),
+        await keyStack.sign(new Uint8Array([212, 213])),
+      ),
+    );
+  },
+});
+
+Deno.test({
+  name: "keyStack - ArrayBuffer data",
+  async fn() {
+    const keys = [[212, 213]];
+    const keyStack = new KeyStack(keys);
+    const data1 = new ArrayBuffer(2);
+    const dataView1 = new DataView(data1);
+    dataView1.setInt8(0, 212);
+    dataView1.setInt8(1, 213);
+    const data2 = new ArrayBuffer(2);
+    const dataView2 = new DataView(data2);
+    dataView2.setInt8(0, 212);
+    dataView2.setInt8(1, 213);
+    assert(await keyStack.verify(data2, await keyStack.sign(data1)));
+  },
+});
+
+Deno.test({
+  name: "keyStack - user iterable keys",
+  async fn() {
+    const keys = new Set(["hello", "world"]);
+    const keyStack = new KeyStack(keys);
+    const actual = await keyStack.sign("world");
+    const expected = "8ayXAutfryPKKRpNxG3t3u4qeMza8KQSvtdxTP_7HMQ";
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "KeyStack - inspecting",
+  fn() {
+    assertEquals(
+      Deno.inspect(new KeyStack(["abcdef"])),
+      `KeyStack { length: 1 }`,
+    );
+  },
+});

--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -25,10 +25,9 @@ import {
   instantiateWasm,
 } from "../_wasm_crypto/mod.ts";
 import { timingSafeEqual } from "./timing_safe_equal.ts";
-
 import { fnv } from "./_fnv/index.ts";
 
-export { type Data, type Key, type KeyRing, KeyStack } from "./keystack.ts";
+export { type Data, type Key, KeyStack } from "./keystack.ts";
 
 /**
  * A copy of the global WebCrypto interface, with methods bound so they're

--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -12,6 +12,10 @@
  *
  * The "polyfill" delegates to `WebCrypto` where possible.
  *
+ * The {@linkcode KeyStack} export implements the {@linkcode KeyRing} interface
+ * for managing rotatable keys for signing data to prevent tampering, like with
+ * HTTP cookies.
+ *
  * @module
  */
 
@@ -23,6 +27,8 @@ import {
 import { timingSafeEqual } from "./timing_safe_equal.ts";
 
 import { fnv } from "./_fnv/index.ts";
+
+export { type Data, type Key, type KeyRing, KeyStack } from "./keystack.ts";
 
 /**
  * A copy of the global WebCrypto interface, with methods bound so they're


### PR DESCRIPTION
This adds a utility class which is a pre-cursor to being able to provide a cookie interface that can transparently sign and validate client cookies to prevent cookie tampering, which is a best practice we should be promoting.  It is currently part of `oak_commons` that I am contributing back to `std`.