### PR TITLE
fix(media_types): work around type issues under Node.js

### DIFF
--- a/media_types/mod.ts
+++ b/media_types/mod.ts
@@ -45,6 +45,7 @@ export const types = new Map<string, KeyOfDb>();
       continue;
     }
 
+    // @ts-ignore work around denoland/dnt#148
     extensions.set(type, exts);
 
     for (const ext of exts) {


### PR DESCRIPTION
This works around an issue when you try to use `media_types` under Node.js via dnt.  Node.js doesn't have as good type inference as Deno does when using JSON imports, and causes some assignment issues.