### PR TITLE
feat(http): add HTTP errors

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -38,6 +38,73 @@ console.log(Status.NotFound); //=> 404
 console.log(STATUS_TEXT[Status.NotFound]); //=> "Not Found"
 ```
 
+## HTTP errors
+
+Provides error classes for each HTTP error status code as well as utility
+functions for handling HTTP errors in a structured way.
+
+For example throwing an error and detecting thrown errors as HTTP errors, and
+setting values in a response.
+
+```ts
+import {
+  errors,
+  isHttpError,
+} from "https://deno.land/std@$STD_VERSION/http/http_errors.ts";
+
+try {
+  throw new errors.NotFound();
+} catch (e) {
+  if (isHttpError(e)) {
+    const response = new Response(e.message, { status: e.status });
+  } else {
+    throw e;
+  }
+}
+```
+
+Also the `createHttpError()` function can be used to create errors:
+
+```ts
+import { createHttpError } from "https://deno.land/std@$STD_VERSION/http/http_errors.ts";
+import { Status } from "https://deno.land/std@$STD_VERSION/http/http_status.ts";
+
+try {
+  throw createHttpError(
+    Status.BadRequest,
+    "The request was bad.",
+    { expose: false },
+  );
+} catch (e) {
+  // handle errors
+}
+```
+
+### `errors`
+
+A namespace that contains each error constructor. Each error extends `HTTPError`
+and provides `.status` and `.expose` properties, where the `.status` will be an
+error `Status` value and `.expose` indicates if information, like a stack trace,
+should be shared in the response.
+
+By default, `.expose` is set to false in server errors, and true for client
+errors.
+
+### `HttpError`
+
+The base case for all other HTTP errors, which extends `Error`.
+
+### `createHttpError()`
+
+A factory function which provides a way to create errors. It takes up to 3
+arguments, the error `Status`, an message, which defaults to the status text and
+error options, which incudes the `expose` property to set the `.expose` value on
+the error.
+
+### `isHttpError()`
+
+A type guard that checks if a value is an HTTP error.
+
 ## Cookie
 
 Helpers to manipulate the `Cookie` header.

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -1,0 +1,186 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+/** A collection of HTTP errors and utilities.
+ *
+ * The export {@linkcode errors} contains an individual class that extends
+ * {@linkcode HttpError} which makes handling HTTP errors in a structured way.
+ *
+ * The function {@linkcode createHttpError} provides a way to create instances
+ * of errors in a factory pattern.
+ *
+ * The function {@linkcode isHttpError} is a type guard that will narrow a value
+ * to an `HttpError` instance.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * import { errors, isHttpError } from "https://deno.land/std@$STD_VERSION/http/http_errors.ts";
+ *
+ * try {
+ *   throw new errors.NotFound();
+ * } catch (e) {
+ *   if (isHttpError(e)) {
+ *     const response = new Response(e.message, { status: e.status });
+ *   } else {
+ *     throw e;
+ *   }
+ * }
+ * ```
+ *
+ * ```ts
+ * import { createHttpError } from "https://deno.land/std@$STD_VERSION/http/http_errors.ts";
+ * import { Status } from "https://deno.land/std@$STD_VERSION/http/http_status.ts";
+ *
+ * try {
+ *   throw createHttpError(
+ *     Status.BadRequest,
+ *     "The request was bad.",
+ *     { expose: false }
+ *   );
+ * } catch (e) {
+ *   // handle errors
+ * }
+ * ```
+ *
+ * @module
+ */
+
+import {
+  type ErrorStatus,
+  isClientErrorStatus,
+  Status,
+  STATUS_TEXT,
+} from "./http_status.ts";
+
+const ERROR_STATUS_MAP = {
+  "BadRequest": 400,
+  "Unauthorized": 401,
+  "PaymentRequired": 402,
+  "Forbidden": 403,
+  "NotFound": 404,
+  "MethodNotAllowed": 405,
+  "NotAcceptable": 406,
+  "ProxyAuthRequired": 407,
+  "RequestTimeout": 408,
+  "Conflict": 409,
+  "Gone": 410,
+  "LengthRequired": 411,
+  "PreconditionFailed": 412,
+  "RequestEntityTooLarge": 413,
+  "RequestURITooLong": 414,
+  "UnsupportedMediaType": 415,
+  "RequestedRangeNotSatisfiable": 416,
+  "ExpectationFailed": 417,
+  "Teapot": 418,
+  "MisdirectedRequest": 421,
+  "UnprocessableEntity": 422,
+  "Locked": 423,
+  "FailedDependency": 424,
+  "UpgradeRequired": 426,
+  "PreconditionRequired": 428,
+  "TooManyRequests": 429,
+  "RequestHeaderFieldsTooLarge": 431,
+  "UnavailableForLegalReasons": 451,
+  "InternalServerError": 500,
+  "NotImplemented": 501,
+  "BadGateway": 502,
+  "ServiceUnavailable": 503,
+  "GatewayTimeout": 504,
+  "HTTPVersionNotSupported": 505,
+  "VariantAlsoNegotiates": 506,
+  "InsufficientStorage": 507,
+  "LoopDetected": 508,
+  "NotExtended": 510,
+  "NetworkAuthenticationRequired": 511,
+} as const;
+
+export type ErrorStatusKeys = keyof typeof ERROR_STATUS_MAP;
+
+export interface HttpErrorOptions extends ErrorOptions {
+  expose?: boolean;
+}
+
+/** The base class that all derivative HTTP extend, providing a `status` and an
+ * `expose` property. */
+export class HttpError extends Error {
+  constructor(message = "Http Error", options?: HttpErrorOptions) {
+    super(message, options);
+  }
+  /** A flag to indicate if the internals of the error, like the stack, should
+   * be exposed to a client, or if they are "private" and should not be leaked.
+   * By default, all client errors are `true` and all server errors are
+   * `false`. */
+  get expose(): boolean {
+    return false;
+  }
+  /** The error status that is set on the error. */
+  get status(): ErrorStatus {
+    return Status.InternalServerError;
+  }
+}
+
+function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
+  const name = `${Status[status]}Error`;
+  const ErrorCtor = class extends HttpError {
+    #expose = isClientErrorStatus(status);
+
+    constructor(message = STATUS_TEXT[status], options?: HttpErrorOptions) {
+      super(message, options);
+      if (options?.expose) {
+        this.#expose = true;
+      }
+      if (options?.expose === false) {
+        this.#expose = false;
+      }
+      Object.defineProperty(this, "name", {
+        configurable: true,
+        enumerable: false,
+        value: name,
+        writable: true,
+      });
+    }
+
+    override get expose() {
+      return this.#expose;
+    }
+
+    override get status() {
+      return status;
+    }
+  };
+  return ErrorCtor;
+}
+
+/** A map of HttpErrors that are unique instances for each HTTP error status
+ * code.
+ *
+ * ### Example
+ *
+ * ```ts
+ * import { errors } from "https://deno.land/std@$STD_VERSION/http/http_errors.ts";
+ *
+ * throw new errors.InternalServerError("Ooops!");
+ * ```
+ */
+export const errors: Record<ErrorStatusKeys, typeof HttpError> = {} as Record<
+  ErrorStatusKeys,
+  typeof HttpError
+>;
+
+for (const [key, value] of Object.entries(ERROR_STATUS_MAP)) {
+  errors[key as ErrorStatusKeys] = createHttpErrorConstructor(value);
+}
+
+/** Create an instance of an HttpError based on the status code provided. */
+export function createHttpError(
+  status: ErrorStatus = Status.InternalServerError,
+  message?: string,
+  options?: HttpErrorOptions,
+): HttpError {
+  return new errors[Status[status] as ErrorStatusKeys](message, options);
+}
+
+/** A type guard that determines if the value is an HttpError or not. */
+export function isHttpError(value: unknown): value is HttpError {
+  return value instanceof HttpError;
+}

--- a/http/http_errors_test.ts
+++ b/http/http_errors_test.ts
@@ -1,0 +1,103 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import { assert, assertEquals, assertInstanceOf } from "../testing/asserts.ts";
+
+import { type ErrorStatus, Status, STATUS_TEXT } from "./http_status.ts";
+
+import {
+  createHttpError,
+  errors,
+  type ErrorStatusKeys,
+  HttpError,
+} from "./http_errors.ts";
+
+const clientErrorStatus: ErrorStatus[] = [
+  Status.BadRequest,
+  Status.Unauthorized,
+  Status.PaymentRequired,
+  Status.Forbidden,
+  Status.NotFound,
+  Status.MethodNotAllowed,
+  Status.NotAcceptable,
+  Status.ProxyAuthRequired,
+  Status.RequestTimeout,
+  Status.Conflict,
+  Status.Gone,
+  Status.LengthRequired,
+  Status.PreconditionFailed,
+  Status.RequestEntityTooLarge,
+  Status.RequestURITooLong,
+  Status.UnsupportedMediaType,
+  Status.RequestedRangeNotSatisfiable,
+  Status.ExpectationFailed,
+  Status.Teapot,
+  Status.MisdirectedRequest,
+  Status.UnprocessableEntity,
+  Status.Locked,
+  Status.FailedDependency,
+  Status.UpgradeRequired,
+  Status.PreconditionRequired,
+  Status.TooManyRequests,
+  Status.RequestHeaderFieldsTooLarge,
+  Status.UnavailableForLegalReasons,
+];
+
+const serverErrorStatus: ErrorStatus[] = [
+  Status.InternalServerError,
+  Status.NotImplemented,
+  Status.BadGateway,
+  Status.ServiceUnavailable,
+  Status.GatewayTimeout,
+  Status.HTTPVersionNotSupported,
+  Status.VariantAlsoNegotiates,
+  Status.InsufficientStorage,
+  Status.LoopDetected,
+  Status.NotExtended,
+  Status.NetworkAuthenticationRequired,
+];
+
+Deno.test({
+  name: "http_error - validate client errors",
+  fn() {
+    for (const errorStatus of clientErrorStatus) {
+      const error = createHttpError(errorStatus);
+      const errorExpose = createHttpError(
+        errorStatus,
+        STATUS_TEXT[errorStatus],
+        {
+          expose: false,
+        },
+      );
+      assertInstanceOf(error, HttpError);
+      assertInstanceOf(error, errors[Status[errorStatus] as ErrorStatusKeys]);
+      assertEquals(error.name, `${Status[errorStatus]}Error`);
+      assertEquals(error.message, STATUS_TEXT[errorStatus]);
+      assertEquals(error.status, errorStatus);
+      assert(error.expose);
+      assert(!errorExpose.expose);
+    }
+  },
+});
+
+Deno.test({
+  name: "http_error - validate server errors",
+  fn() {
+    for (const errorStatus of serverErrorStatus) {
+      const error = createHttpError(errorStatus);
+      const errorExpose = createHttpError(
+        errorStatus,
+        STATUS_TEXT[errorStatus],
+        {
+          expose: true,
+        },
+      );
+      assertInstanceOf(error, HttpError);
+      assertInstanceOf(error, errors[Status[errorStatus] as ErrorStatusKeys]);
+      assertEquals(error.name, `${Status[errorStatus]}Error`);
+      assertEquals(error.message, STATUS_TEXT[errorStatus]);
+      assertEquals(error.status, errorStatus);
+      assert(!error.expose);
+      assert(errorExpose.expose);
+    }
+  },
+});

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -4,5 +4,6 @@
  * @module
  */
 export * from "./cookie.ts";
+export * from "./http_errors.ts";
 export * from "./http_status.ts";
 export * from "./server.ts";


### PR DESCRIPTION
This provides HTTP error classes for each HTTP error status code plus some utility functions.  This allows more structured handling of HTTP errors.  It is part of oak commons being contributed back to std.