### PR TITLE
Pass resolved ephemeral port to onListen

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -573,7 +573,7 @@ export async function serve(
   handler: Handler,
   options: ServeInit = {},
 ): Promise<void> {
-  const port = options.port ?? 8000;
+  let port = options.port ?? 8000;
   const hostname = options.hostname ?? "0.0.0.0";
   const server = new Server({
     port,
@@ -587,6 +587,8 @@ export async function serve(
   });
 
   const s = server.listenAndServe();
+
+  port = (server.addrs[0] as Deno.NetAddr).port;
 
   if ("onListen" in options) {
     options.onListen?.({ port, hostname });
@@ -668,7 +670,7 @@ export async function serveTls(
     throw new Error("TLS config is given, but 'certFile' is missing.");
   }
 
-  const port = options.port ?? 8443;
+  let port = options.port ?? 8443;
   const hostname = options.hostname ?? "0.0.0.0";
   const server = new Server({
     port,
@@ -682,6 +684,8 @@ export async function serveTls(
   });
 
   const s = server.listenAndServeTls(options.certFile, options.keyFile);
+
+  port = (server.addrs[0] as Deno.NetAddr).port;
 
   if ("onListen" in options) {
     options.onListen?.({ port, hostname });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1378,10 +1378,10 @@ Deno.test("serve - onListen callback is called with ephemeral port", () => {
   return serve((_) => new Response("hello"), {
     port: 0,
     async onListen({ hostname, port }) {
-      const responseText = await (await fetch(`http://localhost:${port}/`))
-        .text();
       assertEquals(hostname, "0.0.0.0");
       assertNotEquals(port, 0);
+      const responseText = await (await fetch(`http://localhost:${port}/`))
+        .text();
       assertEquals(responseText, "hello");
       abortController.abort();
     },
@@ -1431,6 +1431,8 @@ Deno.test("serveTls - onListen callback is called with ephemeral port", () => {
     certFile: join(testdataDir, "tls/localhost.crt"),
     keyFile: join(testdataDir, "tls/localhost.key"),
     async onListen({ hostname, port }) {
+      assertEquals(hostname, "0.0.0.0");
+      assertNotEquals(port, 0);
       const caCert = await Deno.readTextFile(
         join(testdataDir, "tls/RootCA.pem"),
       );
@@ -1439,8 +1441,6 @@ Deno.test("serveTls - onListen callback is called with ephemeral port", () => {
         await (await fetch(`https://localhost:${port}/`, { client }))
           .text();
       client.close();
-      assertEquals(hostname, "0.0.0.0");
-      assertNotEquals(port, 0);
       assertEquals(responseText, "hello");
       abortController.abort();
     },

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -7,6 +7,7 @@ import { deferred, delay } from "../async/mod.ts";
 import {
   assert,
   assertEquals,
+  assertNotEquals,
   assertRejects,
   assertStrictEquals,
   assertThrows,
@@ -1380,6 +1381,7 @@ Deno.test("serve - onListen callback is called with ephemeral port", () => {
       const responseText = await (await fetch(`http://localhost:${port}/`))
         .text();
       assertEquals(hostname, "0.0.0.0");
+      assertNotEquals(port, 0);
       assertEquals(responseText, "hello");
       abortController.abort();
     },

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1372,6 +1372,21 @@ Deno.test("serve - onListen callback is called when the server started listening
   });
 });
 
+Deno.test("serve - onListen callback is called with ephemeral port", () => {
+  const abortController = new AbortController();
+  return serve((_) => new Response("hello"), {
+    port: 0,
+    async onListen({ hostname, port }) {
+      const responseText = await (await fetch(`http://localhost:${port}/`))
+        .text();
+      assertEquals(hostname, "0.0.0.0");
+      assertEquals(responseText, "hello");
+      abortController.abort();
+    },
+    signal: abortController.signal,
+  });
+});
+
 Deno.test("serve - doesn't print the message when onListen set to undefined", async () => {
   const { status, stdout } = await Deno.spawn(Deno.execPath(), {
     args: [


### PR DESCRIPTION
Provides valid `port` to `ServeInit.onListen`.  
Fixes default `Listening on http://hostname:0/` message.