### PR TITLE
chore(stream/conversion.ts): handle errors in `toTransformStream` correctly

### DIFF
--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -243,7 +243,7 @@ export function toTransformStream<I, O>(
         } catch (error) {
           // Propagate error to stream from iterator
           // If the stream status is "errored", it will be thrown, but ignore.
-          await readable.cancel(error).catch();
+          await readable.cancel(error).catch(() => {});
           controller.error(error);
           return;
         }


### PR DESCRIPTION
> Hi, just letting you know, that an empty `catch` handler doesn't catch anything. You have to pass an empty function at least.

_Originally posted by @thekondr in https://github.com/denoland/deno_std/pull/2227#discussion_r890269446_

Based on the comments above, use `promise.catch(()=>{})` instead of `promise.catch()` that does nothing, and ignore the error correctly.