### PR TITLE
fix(dotenv): support inline comment

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -19,16 +19,16 @@ export interface ConfigOptions {
   defaults?: string;
 }
 
-const RE_VariableStart = /^\s*[a-zA-Z_][a-zA-Z_0-9 ]*\s*=/
-const RE_SingleQuotes = /^'([\s\S]*)'$/
-const RE_DoubleQuotes = /^"([\s\S]*)"$/
+const RE_VariableStart = /^\s*[a-zA-Z_][a-zA-Z_0-9 ]*\s*=/;
+const RE_SingleQuotes = /^'([\s\S]*)'$/;
+const RE_DoubleQuotes = /^"([\s\S]*)"$/;
 
 export function parse(rawDotenv: string): DotenvConfig {
   const env: DotenvConfig = {};
 
   for (const line of rawDotenv.split("\n")) {
     if (!RE_VariableStart.test(line)) continue;
-    const eqIdx = line.indexOf("=")
+    const eqIdx = line.indexOf("=");
     const key = line.slice(0, eqIdx).trim();
     let value = line.slice(eqIdx + 1);
     const hashIdx = value.indexOf("#");

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -120,6 +120,16 @@ Deno.test("parser", () => {
   );
 });
 
+Deno.test("with comments", () => {
+  const testDotenv = Deno.readTextFileSync(
+    path.join(testdataDir, "./.env.comments"),
+  );
+
+  const config = parse(testDotenv);
+  assertEquals(config.FOO, "bar"); 
+  assertEquals(config.GREETING, "hello world"); 
+});
+
 Deno.test("configure", () => {
   let conf = configSync(testOptions);
 

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -126,8 +126,8 @@ Deno.test("with comments", () => {
   );
 
   const config = parse(testDotenv);
-  assertEquals(config.FOO, "bar"); 
-  assertEquals(config.GREETING, "hello world"); 
+  assertEquals(config.FOO, "bar");
+  assertEquals(config.GREETING, "hello world");
 });
 
 Deno.test("configure", () => {

--- a/dotenv/testdata/.env.comments
+++ b/dotenv/testdata/.env.comments
@@ -1,3 +1,3 @@
 # This is a comment
-FOO=bar # This is a inline comment
+FOO=bar # This is an inline comment
 GREETING= "hello world" # hello world

--- a/dotenv/testdata/.env.comments
+++ b/dotenv/testdata/.env.comments
@@ -1,0 +1,3 @@
+# This is a comment
+FOO=bar # This is a inline comment
+GREETING= "hello world" # hello world


### PR DESCRIPTION
support inline comment like:

```
FOO=bar # this is a comment
```