### PR TITLE
chore(streams): remove deprecated `Deno.copy` from example

### DIFF
--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -14,7 +14,7 @@ function isCloser(value: unknown): value is Deno.Closer {
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
  * ```ts
- *      import { readerFromIterable } from "./conversion.ts";
+ *      import { readerFromIterable, copy } from "./conversion.ts";
  *
  *      const file = await Deno.open("metrics.txt", { write: true });
  *      const reader = readerFromIterable((async function* () {
@@ -24,7 +24,7 @@ function isCloser(value: unknown): value is Deno.Closer {
  *          yield new TextEncoder().encode(message);
  *        }
  *      })());
- *      await Deno.copy(reader, file);
+ *      await copy(reader, file);
  * ```
  */
 export function readerFromIterable(


### PR DESCRIPTION
> `Deno.copy` will be removed in Deno 2.0.

There's also a reference of `Deno.copy` here:

https://github.com/denoland/deno_std/blob/e72e13db63328cf8a91c2e274f175229653f5637/examples/curl.ts#L6

Not sure how to handle that because of different context.