### PR TITLE
feat(node): add missing TTY methods to stdout,stderr

### DIFF
--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -6,6 +6,7 @@ import {
   assert,
   assertEquals,
   assertObjectMatch,
+  assertStrictEquals,
   assertThrows,
 } from "../testing/asserts.ts";
 import { stripColor } from "../fmt/colors.ts";
@@ -281,6 +282,18 @@ Deno.test({
       `${process.stdout.getWindowSize()}`,
       `${consoleSize && [consoleSize.columns, consoleSize.rows]}`,
     );
+
+    if (isTTY) {
+      assertStrictEquals(process.stdout.cursorTo(1, 2, () => {}), true);
+      assertStrictEquals(process.stdout.moveCursor(3, 4, () => {}), true);
+      assertStrictEquals(process.stdout.clearLine(1, () => {}), true);
+      assertStrictEquals(process.stdout.clearScreenDown(() => {}), true);
+    } else {
+      assertStrictEquals(process.stdout.cursorTo, undefined);
+      assertStrictEquals(process.stdout.moveCursor, undefined);
+      assertStrictEquals(process.stdout.clearLine, undefined);
+      assertStrictEquals(process.stdout.clearScreenDown, undefined);
+    }
   },
 });
 
@@ -297,6 +310,18 @@ Deno.test({
       `${process.stderr.getWindowSize()}`,
       `${consoleSize && [consoleSize.columns, consoleSize.rows]}`,
     );
+
+    if (isTTY) {
+      assertStrictEquals(process.stderr.cursorTo(1, 2, () => {}), true);
+      assertStrictEquals(process.stderr.moveCursor(3, 4, () => {}), true);
+      assertStrictEquals(process.stderr.clearLine(1, () => {}), true);
+      assertStrictEquals(process.stderr.clearScreenDown(() => {}), true);
+    } else {
+      assertStrictEquals(process.stderr.cursorTo, undefined);
+      assertStrictEquals(process.stderr.moveCursor, undefined);
+      assertStrictEquals(process.stderr.clearLine, undefined);
+      assertStrictEquals(process.stderr.clearScreenDown, undefined);
+    }
   },
 });
 


### PR DESCRIPTION
This commit adds `cursorTo()`, `moveCursor()`, `clearLine()`, and `clearScreenDown()` to the Node.js compat `stdout` and `stderr` streams.

Refs: https://github.com/denoland/deno_std/issues/2322 (this does not fix the issue, but should help unblock Vite in compat mode)
Refs: https://github.com/denoland/deno_std/issues/2055