### PR TITLE
chore(bytes): rename `equalsSimd` to `equals32Bit`

### DIFF
--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -19,7 +19,7 @@ export function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
  * @param a first array to check equality
  * @param b second array to check equality
  */
-export function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
+export function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   const len = a.length;
   const compressable = Math.floor(len / 4);
@@ -40,5 +40,5 @@ export function equalsSimd(a: Uint8Array, b: Uint8Array): boolean {
  */
 export function equals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length < 1000) return equalsNaive(a, b);
-  return equalsSimd(a, b);
+  return equals32Bit(a, b);
 }

--- a/bytes/equals_bench.ts
+++ b/bytes/equals_bench.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { bench, runBenchmarks } from "../testing/bench.ts";
-import { equalsNaive, equalsSimd } from "./equals.ts";
+import { equals32Bit, equalsNaive } from "./equals.ts";
 
 console.log("generating benchmarks...");
 const testCases: [Uint8Array, Uint8Array][] = [];
@@ -33,7 +33,7 @@ bench({
   func(b): void {
     b.start();
     for (const [a, b] of testCases) {
-      equalsSimd(a, b);
+      equals32Bit(a, b);
     }
     b.stop();
   },


### PR DESCRIPTION
Closes #2334.