### PR TITLE
refactor: add back collections/mod.ts with a warning

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -1,0 +1,58 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+/** This module is browser compatible.
+ * @module
+ */
+
+// Not sure what's causing this warning? Run `deno info <entry-point-path>` to
+// analyze the module graph.
+console.warn(
+  "%c[WARN] deno_std/collections/mod.ts: prefer importing " +
+    "collections/<function-name>.ts",
+  "color: yellow;",
+);
+
+export * from "./aggregate_groups.ts";
+export * from "./associate_by.ts";
+export * from "./associate_with.ts";
+export * from "./chunk.ts";
+export * from "./deep_merge.ts";
+export * from "./distinct.ts";
+export * from "./distinct_by.ts";
+export * from "./drop_while.ts";
+export * from "./filter_entries.ts";
+export * from "./filter_keys.ts";
+export * from "./filter_values.ts";
+export * from "./group_by.ts";
+export * from "./intersect.ts";
+export * from "./map_entries.ts";
+export * from "./map_keys.ts";
+export * from "./map_not_nullish.ts";
+export * from "./map_values.ts";
+export * from "./partition.ts";
+export * from "./permutations.ts";
+export * from "./find_single.ts";
+export * from "./sliding_windows.ts";
+export * from "./sum_of.ts";
+export * from "./max_by.ts";
+export * from "./max_of.ts";
+export * from "./min_by.ts";
+export * from "./min_of.ts";
+export * from "./sort_by.ts";
+export * from "./union.ts";
+export * from "./without_all.ts";
+export * from "./unzip.ts";
+export * from "./zip.ts";
+export * from "./join_to_string.ts";
+export * from "./max_with.ts";
+export * from "./min_with.ts";
+export * from "./includes_value.ts";
+export * from "./take_last_while.ts";
+export * from "./take_while.ts";
+export * from "./first_not_nullish_of.ts";
+export * from "./drop_last_while.ts";
+export * from "./reduce_groups.ts";
+export * from "./sample.ts";
+export * from "./running_reduce.ts";
+export * from "./binary_heap.ts";
+export * from "./bs_tree.ts";
+export * from "./rb_tree.ts";

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -6,8 +6,8 @@
 // Not sure what's causing this warning? Run `deno info <entry-point-path>` to
 // analyze the module graph.
 console.warn(
-  "%c[WARN] deno_std/collections/mod.ts: prefer importing " +
-    "collections/<function-name>.ts",
+  "%c[WARN] deno_std: prefer importing collections/<function-name>.ts " +
+    "instead of collections/mod.ts",
   "color: yellow;",
 );
 

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -4,9 +4,10 @@
  */
 
 // Not sure what's causing this warning? Run `deno info <entry-point-path>` to
-// analyze the module graph.
+// analyze the module graph. It's not recommended to import directly from
+// mod.ts here because it adds a lot of bloat.
 console.warn(
-  "%c[WARN] deno_std: prefer importing collections/<function-name>.ts " +
+  "%c[WARN] deno_std: prefer importing collections/<function_name_in_snake_case>.ts " +
     "instead of collections/mod.ts",
   "color: yellow;",
 );


### PR DESCRIPTION
This adds back collections/mod.ts that was removed in https://github.com/denoland/deno_std/pull/2321 , but adds it back with a warning. This will allow people to use collecitons/mod.ts in non-production scenarios for quick hacking and then convert their code to use the specific imports before deployment to make the module graph lean (see https://github.com/denoland/deno_std/pull/2321#issuecomment-1152423433 for more rationale about why we should have a mod.ts).

Overall, my preference would be to not even have a warning here and instead just document to not use it when publishing modules, but it was discussed during the design meeting that this would be a good compromise to try to get people away from using mod.ts when distributing or deploying modules, but still be able to use it in quick scripts.