### PR TITLE
chore: updates for using deno 1.23

### DIFF
--- a/_tools/release/02_create_pr.ts
+++ b/_tools/release/02_create_pr.ts
@@ -35,7 +35,7 @@ function getPrBody() {
     `Please ensure:\n` +
     `- [ ] Version in version.ts is updated correctly\n` +
     `- [ ] Releases.md is updated correctly\n` +
-    `- [ ] All the tests in this branch have been run against the CLI release being done (\`../deno/target/release/deno test -A --unstable\`)\n\n` +
+    `- [ ] All the tests in this branch have been run against the CLI release being done (\`../deno/target/release/deno task test\`)\n\n` +
     `To make edits to this PR:\n` +
     "```shell\n" +
     `git fetch upstream ${newBranchName} && git checkout -b ${newBranchName} upstream/${newBranchName}\n` +

--- a/_tools/release/02_create_pr.ts
+++ b/_tools/release/02_create_pr.ts
@@ -35,7 +35,9 @@ function getPrBody() {
     `Please ensure:\n` +
     `- [ ] Version in version.ts is updated correctly\n` +
     `- [ ] Releases.md is updated correctly\n` +
-    `- [ ] All the tests in this branch have been run against the CLI release being done (\`../deno/target/release/deno task test\`)\n\n` +
+    `- [ ] All the tests in this branch have been run against the CLI release being done ` +
+    `(\`../deno/target/release/deno task test && ../deno/target/release/deno task node:unit && ` +
+    `../deno/target/release/deno task node:test\`)\n\n` +
     `To make edits to this PR:\n` +
     "```shell\n" +
     `git fetch upstream ${newBranchName} && git checkout -b ${newBranchName} upstream/${newBranchName}\n` +

--- a/deno.json
+++ b/deno.json
@@ -46,8 +46,9 @@
     "node:test": "deno test --unstable --allow-all node/_tools/test.ts",
     "node:setup": "deno run --allow-read --allow-net --allow-write node/_tools/setup.ts",
     "node:check-unstable-api": "deno check --unstable ./node/module_all.ts",
-    "build:crypto": "cd _wasm_crypto && deno run --unstable -A --no-check https://deno.land/x/wasmbuild@0.5.0/main.ts --sync && mv lib/deno_std_wasm_crypto.generated.js lib/deno_std_wasm_crypto.generated.mjs",
-    "build:hash": "cd hash/_wasm && deno run --unstable -A --no-check https://deno.land/x/wasmbuild@0.5.0/main.ts --sync && mv lib/deno_hash.generated.js lib/deno_hash.generated.mjs",
-    "build:varint": "cd _wasm_varint && deno run --unstable -A --no-check https://deno.land/x/wasmbuild@0.5.0/main.ts --sync && mv lib/deno_std_wasm_varint.generated.js lib/deno_std_wasm_varint.generated.mjs"
+    "build:crypto": "cd _wasm_crypto && deno task --cwd . wasmbuild && mv lib/deno_std_wasm_crypto.generated.js lib/deno_std_wasm_crypto.generated.mjs",
+    "build:hash": "cd hash/_wasm && deno task --cwd . wasmbuild && mv lib/deno_hash.generated.js lib/deno_hash.generated.mjs",
+    "build:varint": "cd _wasm_varint && deno task --cwd . wasmbuild && mv lib/deno_std_wasm_varint.generated.js lib/deno_std_wasm_varint.generated.mjs",
+    "wasmbuild": "deno run --unstable -A --no-check https://deno.land/x/wasmbuild@0.5.0/main.ts --sync"
   }
 }


### PR DESCRIPTION
- Uses `deno task` because that uses the current executable when running deno commands now
- Uses `deno task --cwd .` in order to move wasmbuild to a new task