### PR TITLE
fix(node): omit EventTarget methods from performance

### DIFF
--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -12,7 +12,8 @@ const constants = {};
 const performance:
   & Omit<
     Performance,
-    "clearMeasures" | "getEntries" | "getEntriesByName" | "getEntriesByType"
+    "clearMeasures" | "getEntries" | "getEntriesByName" | "getEntriesByType" |
+    "addEventListener" | "removeEventListener" | "dispatchEvent"
   >
   & {
     // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
This commit omits EventTarget methods from the performance
object so that Deno core can be updated in
https://github.com/denoland/deno/pull/14573.