### PR TITLE
Revert "fix(node): omit EventTarget methods from performance (#2358)"

### DIFF
--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -12,13 +12,7 @@ const constants = {};
 const performance:
   & Omit<
     Performance,
-    | "clearMeasures"
-    | "getEntries"
-    | "getEntriesByName"
-    | "getEntriesByType"
-    | "addEventListener"
-    | "removeEventListener"
-    | "dispatchEvent"
+    "clearMeasures" | "getEntries" | "getEntriesByName" | "getEntriesByType"
   >
   & {
     // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
This reverts commit 2e180b039369a06d46adf506142b597c7ea28f35.

The commit is being reverted because the necessary changes were
made in https://github.com/denoland/deno/pull/14573.