### PR TITLE
docs: update `path.dirname` to be clear it returns the directory path

### DIFF
--- a/path/posix.ts
+++ b/path/posix.ts
@@ -216,8 +216,8 @@ export function toNamespacedPath(path: string): string {
 }
 
 /**
- * Return the directory name of a `path`.
- * @param path to determine name for
+ * Return the full directory path of a `path`.
+ * @param path to determine the directory path for
  */
 export function dirname(path: string): string {
   assertPath(path);

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -216,7 +216,7 @@ export function toNamespacedPath(path: string): string {
 }
 
 /**
- * Return the full directory path of a `path`.
+ * Return the directory path of a `path`.
  * @param path to determine the directory path for
  */
 export function dirname(path: string): string {

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -535,7 +535,7 @@ export function toNamespacedPath(path: string): string {
 }
 
 /**
- * Return the full directory path of a `path`.
+ * Return the directory path of a `path`.
  * @param path to determine the directory path for
  */
 export function dirname(path: string): string {

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -535,8 +535,8 @@ export function toNamespacedPath(path: string): string {
 }
 
 /**
- * Return the directory name of a `path`.
- * @param path to determine name for
+ * Return the full directory path of a `path`.
+ * @param path to determine the directory path for
  */
 export function dirname(path: string): string {
   assertPath(path);


### PR DESCRIPTION
`dirname` is a little ambiguous (when not coming from a linux or Node.js background) because it's not clear if it returns the name (base name) of the directory (ex. "directory" for `/some/directory/file.txt`) or the directory path (ex. `/some/directory/` for `/some/directory/file.txt`). I think using the terminology "path" to mean an absolute or relative path to a file and "name" to mean the actual basename is a bit more clear. So I think it would be good to say "path" here instead of "name".