### PR TITLE
fix(node): make performance object event target

### DIFF
--- a/node/perf_hooks.ts
+++ b/node/perf_hooks.ts
@@ -53,6 +53,15 @@ const performance:
     // @ts-ignore waiting on update in `deno`, but currently this is
     // a circular dependency
     toJSON: () => shimPerformance.toJSON(),
+    addEventListener: (
+      ...args: Parameters<typeof shimPerformance.addEventListener>
+    ) => shimPerformance.addEventListener(...args),
+    removeEventListener: (
+      ...args: Parameters<typeof shimPerformance.removeEventListener>
+    ) => shimPerformance.removeEventListener(...args),
+    dispatchEvent: (
+      ...args: Parameters<typeof shimPerformance.dispatchEvent>
+    ) => shimPerformance.dispatchEvent(...args),
   };
 
 const monitorEventLoopDelay = () =>

--- a/node/perf_hooks_test.ts
+++ b/node/perf_hooks_test.ts
@@ -2,6 +2,7 @@
 import * as perfHooks from "./perf_hooks.ts";
 import { performance } from "./perf_hooks.ts";
 import { assertEquals } from "../testing/asserts.ts";
+import { assertSpyCall, assertSpyCalls, spy } from "../testing/mock.ts";
 
 Deno.test({
   name: "[perf_hooks] performance",
@@ -34,5 +35,23 @@ Deno.test({
   name: "[perf_hooks] PerformanceEntry",
   fn() {
     assertEquals<unknown>(perfHooks.PerformanceEntry, PerformanceEntry);
+  },
+});
+
+Deno.test({
+  name: "[perf_hooks] EventTarget methods",
+  fn() {
+    const handler = spy();
+    performance.addEventListener("event", handler);
+    assertSpyCalls(handler, 0);
+    const e = new Event("event");
+    performance.dispatchEvent(e);
+    // handler is called once
+    assertSpyCalls(handler, 1);
+    assertSpyCall(handler, 0, { args: [e] });
+    performance.removeEventListener("event", handler);
+    performance.dispatchEvent(e);
+    // handler is not called anymore
+    assertSpyCalls(handler, 1);
   },
 });


### PR DESCRIPTION
We removed the omission of EventTarget methods from typing in https://github.com/denoland/deno_std/pull/2360, but we forgot to shim these actual methods for `std/node`'s `performance` object and that now causes type error in CI. This PR fixes it.

ref:
- https://github.com/denoland/deno/pull/14573
- https://github.com/denoland/deno_std/pull/2358
