### PR TITLE
Fix WASI initialize()

### DIFF
--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1733,8 +1733,11 @@ export default class Context {
       );
     }
 
-    if (typeof _initialize == "function") {
-      _initialize();
+    if (_initialize && typeof _initialize != "function") {
+      throw new TypeError(
+        "WebAssembly.Instance export _start must be a function or not be defined",
+      );
     }
+    _initialize?.();
   }
 }

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1733,12 +1733,8 @@ export default class Context {
       );
     }
 
-    if (typeof _initialize != "function") {
-      throw new TypeError(
-        "WebAsembly.instance export _initialize must be a function",
-      );
+    if (typeof _initialize == "function") {
+      _initialize();
     }
-
-    _initialize();
   }
 }

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1735,7 +1735,7 @@ export default class Context {
 
     if (_initialize && typeof _initialize != "function") {
       throw new TypeError(
-        "WebAssembly.Instance export _start must be a function or not be defined",
+        "WebAssembly.Instance export _initialize must be a function or not be defined",
       );
     }
     _initialize?.();

--- a/wasi/snapshot_preview1_test.ts
+++ b/wasi/snapshot_preview1_test.ts
@@ -254,18 +254,6 @@ Deno.test("context_initialize", function () {
       context.initialize({
         exports: {
           memory: new WebAssembly.Memory({ initial: 1 }),
-        },
-      });
-    },
-    TypeError,
-    "export _initialize must be a function",
-  );
-  assertThrows(
-    () => {
-      const context = new Context({});
-      context.initialize({
-        exports: {
-          memory: new WebAssembly.Memory({ initial: 1 }),
           _initialize() {},
         },
       });
@@ -276,6 +264,20 @@ Deno.test("context_initialize", function () {
     Error,
     "WebAssembly.Instance has already started",
   );
+
+  {
+    let wasCalled = false;
+    const context = new Context({});
+    context.initialize({
+      exports: {
+        _initialize() {
+          wasCalled = true;
+        },
+        memory: new WebAssembly.Memory({ initial: 1 }),
+      },
+    });
+    assertEquals(wasCalled, true);
+  }
 });
 
 Deno.test("std_io_stdin.wasm with stdin as file", function () {


### PR DESCRIPTION
I have no idea where the official WASI spec lives, but according to the [Node documentation](https://nodejs.org/api/wasi.html#wasiinitializeinstance), `initialize()` invokes the exported `_initialize()` function on the Wasm module, if it exists. Currently, the function throws.