### PR TITLE
test(encoding/json): fix parse stream test expectation

### DIFF
--- a/encoding/json/_parse_test.ts
+++ b/encoding/json/_parse_test.ts
@@ -31,7 +31,7 @@ async function assertInvalidParse(
   chunks: string[],
   options: ParseStreamOptions,
   // deno-lint-ignore no-explicit-any
-  ErrorClass: (new (...args: any[]) => Error),
+  ErrorClass: new (...args: any[]) => Error,
   msgIncludes: string | undefined,
 ) {
   const r = readableStreamFromIterable(chunks);

--- a/encoding/json/_parse_test.ts
+++ b/encoding/json/_parse_test.ts
@@ -301,7 +301,7 @@ Deno.test({
       [`{${"foo".repeat(100)}}`],
       {},
       SyntaxError,
-      `Unexpected token f in JSON at position 1 (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
+      `Expected property name or '}' in JSON at position 1 (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
     );
   },
 });

--- a/encoding/json/_stringify_test.ts
+++ b/encoding/json/_stringify_test.ts
@@ -23,7 +23,7 @@ async function assertInvalidStringify(
   chunks: unknown[],
   options: StringifyStreamOptions,
   // deno-lint-ignore no-explicit-any
-  ErrorClass: (new (...args: any[]) => Error),
+  ErrorClass: new (...args: any[]) => Error,
   msgIncludes: string | undefined,
 ) {
   const r = readableStreamFromIterable(chunks);


### PR DESCRIPTION
`ConcatenatedJSONParseStream` internally uses `JSON.parse` and the test cases depend on the error message of the native `JSON.parse`.

Recently the error message for invalid json like `{foo: 1}` has been changed from `Unexpected token f` to `Expected property name or '}'` in the latest v8 update denoland/deno#14874. We need to update these expectations in these test cases.