### PR TITLE
fix(encoding/json): add `null` to JSONValue union

### DIFF
--- a/encoding/json/_parse.ts
+++ b/encoding/json/_parse.ts
@@ -8,7 +8,8 @@ export type JSONValue =
   | JSONValue[]
   | string
   | number
-  | boolean;
+  | boolean
+  | null;
 
 /** Optional object interface for `JSONParseStream` and `ConcatenatedJSONParseStream`. */
 export interface ParseStreamOptions {


### PR DESCRIPTION
[`null` is a valid JSON type](https://datatracker.ietf.org/doc/html/rfc8259#section-3), but was not included in the union in the initial PR.