### PR TITLE
feat(dotenv): include missing vars in MissingEnvVarsError

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -175,14 +175,19 @@ function assertSafe(
       `If you expect any of these variables to be empty, you can set the allowEmptyValues option to true.`,
     ];
 
-    throw new MissingEnvVarsError(errorMessages.filter(Boolean).join("\n\n"));
+    throw new MissingEnvVarsError(
+      errorMessages.filter(Boolean).join("\n\n"),
+      missing,
+    );
   }
 }
 
 export class MissingEnvVarsError extends Error {
-  constructor(message?: string) {
+  missing: string[];
+  constructor(message: string, missing: string[]) {
     super(message);
     this.name = "MissingEnvVarsError";
+    this.missing = missing;
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -220,8 +220,10 @@ Deno.test("configureSafe", () => {
     "accepts paths to fetch env and env example from",
   );
 
+  let error: MissingEnvVarsError;
+
   // Throws if not all required vars are there
-  assertThrows(() => {
+  error = assertThrows(() => {
     configSync({
       path: path.join(testdataDir, "./.env.safe.test"),
       safe: true,
@@ -229,14 +231,18 @@ Deno.test("configureSafe", () => {
     });
   }, MissingEnvVarsError);
 
+  assertEquals(error.missing, ["ANOTHER"]);
+
   // Throws if any of the required vars is empty
-  assertThrows(() => {
+  error = assertThrows(() => {
     configSync({
       path: path.join(testdataDir, "./.env.safe.empty.test"),
       safe: true,
       example: path.join(testdataDir, "./.env.example2.test"),
     });
   }, MissingEnvVarsError);
+
+  assertEquals(error.missing, ["ANOTHER"]);
 
   // Does not throw if required vars are provided by example
   configSync({
@@ -358,8 +364,10 @@ Deno.test("configureSafe async", async () => {
     "accepts paths to fetch env and env example from",
   );
 
+  let error: MissingEnvVarsError;
+
   // Throws if not all required vars are there
-  assertRejects(async () => {
+  error = await assertRejects(async () => {
     await config({
       path: path.join(testdataDir, "./.env.safe.test"),
       safe: true,
@@ -367,14 +375,18 @@ Deno.test("configureSafe async", async () => {
     });
   }, MissingEnvVarsError);
 
+  assertEquals(error.missing, ["ANOTHER"]);
+
   // Throws if any of the required vars is empty
-  assertRejects(async () => {
+  error = await assertRejects(async () => {
     await config({
       path: path.join(testdataDir, "./.env.safe.empty.test"),
       safe: true,
       example: path.join(testdataDir, "./.env.example2.test"),
     });
   }, MissingEnvVarsError);
+
+  assertEquals(error.missing, ["ANOTHER"]);
 
   // Does not throw if required vars are provided by example
   await config({


### PR DESCRIPTION
- Closes #2366 

Note that this PR makes the `message` parameter for `MissingEnvVarsError` **required** (was optional) in order to maintain a reasonable param order while ensuring the `missing` param is required.  
If this is an issue it can be reverted, but I believe the `missing` param should remain required for consistency.