### PR TITLE
fix(node): export createReadStream() from fs

### DIFF
--- a/node/fs.ts
+++ b/node/fs.ts
@@ -180,6 +180,7 @@ export {
   constants,
   copyFile,
   copyFileSync,
+  createReadStream,
   createWriteStream,
   Dir,
   Dirent,


### PR DESCRIPTION
`createReadStream()` was previously only available via the `default` export. This commit fixes that.

Fixes: https://github.com/denoland/deno_std/issues/2389