### PR TITLE
fix(testing): break out of Set equality check on match

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -88,6 +88,7 @@ export function equal(c: unknown, d: unknown): boolean {
               (compare(aKey, bKey) && compare(aValue, bValue))
             ) {
               unmatchedEntries--;
+              break;
             }
           }
         }

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1552,3 +1552,22 @@ Deno.test("Assert False with truthy values", () => {
   assertThrows(() => assertFalse({}));
   assertThrows(() => assertFalse([]));
 });
+
+Deno.test("assertEquals same Set with object keys", () => {
+  const data = [
+    {
+      id: "_1p7ZED73OF98VbT1SzSkjn",
+      type: { id: "_ETGENUS" },
+      name: "Thuja",
+      friendlyId: "g-thuja",
+    },
+    {
+      id: "_567qzghxZmeQ9pw3q09bd3",
+      type: { id: "_ETGENUS" },
+      name: "Pinus",
+      friendlyId: "g-pinus",
+    },
+  ];
+  assertEquals(data, data);
+  assertEquals(new Set(data), new Set(data));
+});


### PR DESCRIPTION
This commit updates the equality checking logic of Sets to
break out of an inner loop when a match occurs. Prior to this
commit, it was possible to perform too many comparisons, which
incorrectly made a counter in the code go below zero.

Fixes: https://github.com/denoland/deno_std/issues/2295