### PR TITLE
feat(message): Add new message interface

### DIFF
--- a/message/README.md
+++ b/message/README.md
@@ -1,0 +1,259 @@
+# Message
+
+Message is a module for categorized message logging designed to scale to
+hundreds of modules.
+
+Largely a port of the Qt C++ message logging framework, it allows modules to
+emit information without worrying about the presentation.
+
+Consider two use cases:
+
+1. A command-line app that wants to print only status messages and fatal errors.
+2. A server that wants to print every debug message, even from hundreds of
+   modules.
+
+By delegating the presentation to the application, modules can handle both use
+cases.
+
+Debug messages are disabled by default.
+
+## Usage
+
+```ts
+import {
+  debug,
+  disableCategory,
+  enableCategory,
+  formatLogMessage,
+  info,
+  installMessageHandler,
+  LOGGING_CATEGORY,
+  MessageLogContext,
+  MessageLogger,
+  MessageType,
+  setMessagePattern,
+  warning,
+} from "https://deno.land/std@$STD_VERSION/message/mod.ts";
+import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+
+// Create a new category.
+LOGGING_CATEGORY("driver.usb");
+
+warning("This is a test warning"); // Should print "This is a test warning"
+warning("driver.usb", "No USB devices found"); // Should print "driver.usb: No USB devices found"
+
+const logger = new MessageLogger("driver.gpu", MessageType.Debug);
+logger.debug("GPU Vendor = Intel"); // Should print "driver.gpu: GPU Vendor = Intel"
+
+// Shouldn't print anything (debug messages disabled by default).
+debug("driver.usb", "PCI device 1 found");
+
+enableCategory("driver.usb", MessageType.Debug);
+// Should print "driver.usb: PCI device 2 found"
+debug("driver.usb", "PCI device 2 found");
+
+disableCategory("driver.gpu"); // Disable all messages from `driver.gpu`
+warning("driver.gpu", "Old driver found"); // Shouldn't print anything
+
+// Only print fatal and info messages from "driver.usb" category.
+function myPrint(type: MessageType, context: MessageLogContext, str: string) {
+  if (context.category !== "driver.usb") {
+    return;
+  }
+  const msg = formatLogMessage(type, context, str);
+  if (type === MessageType.Info) {
+    log.info(msg);
+  } else if (type === MessageType.Fatal) {
+    log.critical(msg);
+  }
+}
+installMessageHandler(myPrint);
+info("driver.usb", "Colored message"); // Should print "INFO driver.usb: Colored message"
+installMessageHandler();
+
+setMessagePattern(
+  "[%{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] %{message}",
+);
+info("Successfully downloaded"); // Should print "[I] Successfully downloaded"
+setMessagePattern();
+```
+
+## Advanced usage
+
+### Message levels
+
+Different severity levels are exported in the `MessageType` enum type. By
+default, only `Info` messages and above are printed. Fatal error messages cannot
+be disabled, and will always exit with a failure code afterwards.
+
+### `MessageHandler`
+
+`MessageHandler` is the function responsible for printing messages. The default
+message handler will print info messages to stdout and all other messages to
+stderr.
+
+Register a new message handler with `installMessageHandler`. The old message
+handler will be returned. To restore the default message handler, call
+`installMessageHandler()` with no arguments.
+
+> _NOTE: There can only be one message handler at a time._
+
+> _NOTE: Modules should never need to register a message handler. Applications
+> should register their own message handler when they need to have full control
+> over messages._
+
+### Creating new categories
+
+Every category (except the default) must be created by registering it with
+`LOGGING_CATEGORY` before it is used, or the output will not be correct.
+
+### Enable/disable categories
+
+Category levels can be enabled or disabled by calling
+`enableCategory`/`disableCategory` with a `MessageType` level. If no level is
+given, all message levels except fatal are enabled/disabled.
+
+### Message patterns
+
+The output message format can be customized by registering a pattern with
+`setMessagePattern`. A message pattern may contain placeholders which will be
+replaced at runtime.
+
+The following placeholders are supported:
+
+| Placeholder          | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `{{category }}`      | Logging category.                                                 |
+| `{{filename}}`       | Filename (typically import.meta.url)                              |
+| `{{message}}`        | The actual message.                                               |
+| `{{type}}`           | `"debug"`, `"info"`, `"warning"`, `"critical"`, or `"fatal"`      |
+| `{{time [pattern]}}` | Current system time, formatted using the Deno datetime formatter. |
+| `{{if [condition]}}` | Only printed if the condition is true or defined.                 |
+| `{{endif}}`          | Closes the most recent `{{if}}` call.                             |
+
+The following conditions are supported: `{{if debug}}`, `{{if info}}`,
+`{{if warning}}`, `{{if critical}}`, `{{if fatal}}`, and `{{if category}}`.
+
+The text inside `{{if category}} ... {{endif}}` will only be printed if the
+category is not the default one.
+
+Example:
+
+```
+"[{{time MM-dd-yyyy HH:mm:ss.SSS}} {{if debug}}D{{endif}}{{if info}}I{{endif}}{{if warning}}W{{endif}}{{if critical}}C{{endif}}{{if fatal}}F{{endif}}] {{filename}}: - {{message}}"
+```
+
+The default pattern is `{{#if category}}{{category}}: {{/if}}{{message}}`.
+
+Custom message handlers can use `formatLogMessage()` to take the pattern into
+account.
+
+### `MessageLogger`
+
+The class responsible for printing log messages. Without any parameters, an
+instance of the default category will be created with the `Info` level. If a
+category name is given, a new category will be created.
+
+> _NOTE: A message category created with `LOGGING_CATEGORY` should never be
+> created using a `MessageLogger`._
+
+### `debug`/`info`/`warning`/`critical`/`fatal`
+
+These functions call the message handler with the appropriate level.
+
+Each function works by creating a new `MessageLogger` with the default category
+and calling the appropriate method.
+
+> _NOTE: When using a category, developers must register it using
+> `LOGGING_CATEGORY` first or the output will not be correct._
+
+## API
+
+```
+enum MessageType {
+  Debug = 1,
+  Info = 2,
+  Warning = 3,
+  Critical = 4,
+  Fatal = 5,
+}
+
+interface MessageLogContext {
+  category: string;
+  type: "debug" | "info" | "warning" | "critical" | "fatal";
+  filename: string;
+}
+
+class MessageLoggingCategory {
+  readonly categoryName: string;
+  critical: boolean;
+  debug: boolean;
+  info: boolean;
+  warning: boolean;
+
+  constructor(category: string, severityLevel = MessageType.Debug);
+}
+
+type MessageHandler = (
+  type: MessageType,
+  context: MessageLogContext,
+  str: string,
+) => void;
+
+function installMessageHandler(
+  handler: MessageHandler | undefined,
+): MessageHandler;
+
+function formatLogMessage(
+  type: MessageType,
+  context: MessageLogContext,
+  str: string,
+): string;
+
+function setMessagePattern(pattern: string): void;
+
+function enableCategory(name: string, level?: MessageType): void;
+function disableCategory(name: string, level?: MessageType): void;
+
+function LOGGING_CATEGORY(
+  categoryName: string,
+  level: MessageType = MessageType.Debug,
+);
+
+class MessageLogger {
+  constructor(
+    public readonly category: string = "",
+    public readonly level: MessageType = MessageType.Debug,
+  );
+
+  debug(msg: string, ...args: unknown[]): void;
+  debug(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  info(msg: string, ...args: unknown[]): void;
+  info(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  warning(msg: string, ...args: unknown[]): void;
+  warning(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  critical(msg: string, ...args: unknown[]): void;
+  critical(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  fatal(msg: string, ...args: unknown[]): void;
+  fatal(cat: MessageLoggingCategory, ...args: unknown[]): void;
+}
+
+function debug(msg: string, ...args: unknown[]): void;
+function debug(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+function info(msg: string, ...args: unknown[]): void;
+function info(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+function warning(msg: string, ...args: unknown[]): void;
+function warning(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+function critical(msg: string, ...args: unknown[]): void;
+function critical(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+function fatal(msg: string, ...args: unknown[]): void;
+function fatal(cat: MessageLoggingCategory, ...args: unknown[]): void;
+```

--- a/message/mod.ts
+++ b/message/mod.ts
@@ -1,0 +1,616 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+/**
+ * Messaging interface designed to scale to hundreds of modules. Suitable for
+ * @module
+ */
+import { sprintf } from "../fmt/printf.ts";
+import { format } from "../datetime/mod.ts";
+
+/** Message logging levels. */
+export enum MessageType {
+  /** Information for developers. (typically very verbose) */
+  Debug = 1,
+  /** Status information. (typically intended for users) */
+  Info = 2,
+  /** An abnormal situation. (for users and/or developers) */
+  Warning = 3,
+  /** An error. (intended for users) */
+  Critical = 4,
+  /** An error that requires the program to quit. (developers and users) */
+  Fatal = 5,
+}
+
+/** Metadata about a message. */
+export interface MessageLogContext {
+  /**
+   * Category this message belongs to.
+   */
+  category: string;
+  /**
+   * Message level/severity.
+   */
+  type: "debug" | "info" | "warning" | "critical" | "fatal";
+  /**
+   * Filename (typically import.meta.url) of the caller.
+   */
+  filename: string;
+}
+
+/**
+ * A class representing a certain category, or 'area' in the logging infrastructure.
+ * Each category is identified by a string. A category can be enabled or
+ * disabled, and it can be configured to enable or disable logging of specific
+ * message types.
+ *
+ * Each category is registered in a global registry. As such, an error will be
+ * thrown if the same category is created more than once. It is recommended
+ * that modules have subcategories (`driver.usb`, `driver.bluetooth`), especially
+ * for debug messages.
+ */
+export class MessageLoggingCategory {
+  critical: boolean;
+  debug: boolean;
+  info: boolean;
+  warning: boolean;
+
+  constructor(
+    public readonly categoryName: string,
+    public readonly level = MessageType.Info,
+  ) {
+    this.critical = level <= MessageType.Critical;
+    this.debug = level <= MessageType.Debug;
+    this.info = level <= MessageType.Info;
+    this.warning = level <= MessageType.Warning;
+  }
+}
+
+let msgHandler: MessageHandler = defaultMessageHandler;
+
+/** Callback responsible for printing messages. */
+export type MessageHandler = (
+  type: MessageType,
+  context: MessageLogContext,
+  str: string,
+) => void;
+
+// Returns true for -DIS_THIS_ENABLED=1, false otherwise.
+function checkEnv(v: string): boolean {
+  try {
+    const val = Deno.env.get(v)!;
+    if (val === "1") return true;
+    return false;
+  } catch (_err) {
+    return false;
+  }
+}
+
+function isFatal(msgType: MessageType) {
+  if (msgType === MessageType.Fatal) return true;
+  if (checkEnv("DENO_FATAL_CRITICALS")) return msgType >= MessageType.Critical;
+  if (checkEnv("DENO_FATAL_WARNINGS")) return msgType >= MessageType.Warning;
+  return false;
+}
+
+function isDefaultCategory(cat: string | undefined) {
+  return !cat || cat === "default";
+}
+
+/**
+ * Registers a message logger.
+ * The message handler function is responsible for printing debug messages, warnings, and critical and fatal errors.
+ * By implementing a custom message handler, you get full control over these output messages.
+ *
+ * The default message handler prints the message to standard output.
+ * If it is a fatal message, the application aborts immediately after printing it.
+ *
+ * Only one message handler can be enabled, since this is usually handled on an application-wide basis to control the output.
+ *
+ * To restore the default handler, call `installMessageHandler()`.
+ * @param handler
+ */
+export function installMessageHandler(
+  handler?: MessageHandler,
+): MessageHandler {
+  const old = msgHandler;
+  msgHandler = handler ?? defaultMessageHandler;
+  return old ?? defaultMessageHandler;
+}
+
+const OPEN = "%{";
+const CLOSE = "}";
+const IF_MARKER = "if-";
+const ENDIF_MARKER = "endif";
+const DEFAULT_TEMPLATE = "%{if-category}%{category}: %{endif}%{message}";
+
+let messagePattern = DEFAULT_TEMPLATE;
+
+/**
+ * Generates a formatted string out of the type, context, and str parameters.
+ * This function returns a string formatted to the current message pattern.
+ * Custom message handlers may use this to format output similar to the
+ * default message format.
+ */
+export function formatLogMessage(
+  type: MessageType,
+  context: MessageLogContext,
+  str: string,
+): string {
+  const isDebug = type === MessageType.Debug;
+  const isInfo = type === MessageType.Info;
+  const isWarn = type === MessageType.Warning;
+  const isCritical = type === MessageType.Critical;
+  const isFatal = type === MessageType.Fatal;
+
+  const shouldSkip = (keyword: string) => {
+    switch (keyword) {
+      case "category":
+        return isDefaultCategory(context.category);
+      case "debug":
+        return !isDebug;
+      case "info":
+        return !isInfo;
+      case "warning":
+        return !isWarn;
+      case "critical":
+        return !isCritical;
+      case "fatal":
+        return !isFatal;
+    }
+    // TODO: log or Error if unrecognized keyword?
+    return true;
+  };
+
+  const r = new RegExp(`${OPEN}([\\s\\S]+?)${CLOSE}`, "g");
+  let skipCount = 0;
+  let result = messagePattern.replace(r, (_: string, key: string): string => {
+    if (key.startsWith(IF_MARKER)) {
+      const keyword = key.replace(IF_MARKER, "");
+      if (shouldSkip(keyword)) {
+        skipCount++;
+        if (skipCount === 1) {
+          return `${OPEN}remove${CLOSE}`;
+        }
+      }
+      return "";
+    } else if (key === ENDIF_MARKER) {
+      if (skipCount === 1) {
+        skipCount--;
+        return `${OPEN}endremove${CLOSE}`;
+      }
+      skipCount = Math.max(skipCount - 1, 0);
+      return "";
+    } else if (skipCount > 0) {
+      return "";
+    } else if (key === "category") {
+      return context.category;
+    } else if (key === "type") {
+      return context.type;
+    } else if (key === "filename") {
+      return context.filename;
+    } else if (key === "message") {
+      return str;
+    } else if (key.startsWith("time ")) {
+      const formatString = key.replace("time ", "");
+      return format(new Date(), formatString);
+    }
+
+    // TODO: unrecognized key.
+    return key;
+  });
+
+  const remover = new RegExp(
+    `${OPEN}remove${CLOSE}[\\s\\S]+?${OPEN}endremove${CLOSE}`,
+    "g",
+  );
+
+  result = result.replaceAll(remover, "");
+
+  return result;
+}
+
+/**
+ * Changes the output of the default message handler.
+ * The output of {@link MessageLogger}, {@link debug}, {@link info},
+ * {@link warning}, {@link critical}, and {@link fatal} can be customized using
+ * this. This allows developers to specify information in their modules
+ * (such as debug information) without worrying about how user applications
+ * will *present* that information. Developers use
+ * `debug("driver.usb", "Found 1080p UVC Camera on port 3")` in their modules,
+ * then applications will decide if or how to print the information from
+ * modules.
+ *
+ * The following placeholders are supported:
+ *
+ * | Placeholder | Description |
+ * | ----------- | ----------- |
+ * | `%{category}` | Logging category. |
+ * | `%{filename}` | Filename (typically import.meta.url) |
+ * | `%{message}` | The actual message. |
+ * | `%{type}` | `"debug"`, `"info"`, `"warning"`, `"critical"`, or `"fatal"` |
+ * | `%{time [pattern]}` | Current system time, formatted using the Deno datetime formatter. |
+ * | `%{if-[condition]}` | Only printed if the condition is true or defined. |
+ * | `%{endif}` | Closes the most recent `%{if}` call.
+ *
+ * The following conditions are supported: `%{if-debug}`, `%{if-info}`,
+ * `%{if-warning}`, `%{if-critical}`, `%{if-fatal}`, and `%{if-category}`.
+ *
+ * The text inside `%{if-category}} ... %{endif}` will only be printed if the
+ * category is not the default one.
+ *
+ * Example:
+ * ```
+ * "[%{time MM-dd-yyyy HH:mm:ss.SSS} %{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] %{filename} - %{message}"
+ * ```
+ *
+ * The default pattern is `%{if-category}%{category}: %{endif}%{message}`.
+ *
+ * Custom message handlers can use formatLogMessage() to take the pattern into account.
+ *
+ * If no pattern is given, the default one will be restored.
+ * @param pattern
+ */
+export function setMessagePattern(pattern?: string): void {
+  messagePattern = pattern ?? DEFAULT_TEMPLATE;
+}
+
+/** Get the string name of a message type. */
+export function getMessageTypeName(msgType: MessageType) {
+  switch (msgType) {
+    case MessageType.Critical:
+      return "critical";
+    case MessageType.Fatal:
+      return "fatal";
+    case MessageType.Info:
+      return "info";
+    case MessageType.Warning:
+      return "warning";
+    case MessageType.Debug:
+    default:
+      return "debug";
+  }
+}
+
+// Registry of categories.
+const categories = new Map<string, MessageLoggingCategory>([
+  ["default", new MessageLoggingCategory("default", MessageType.Info)],
+]);
+
+function setCategory(name: string, status: boolean, level?: MessageType) {
+  const cat = categories.get(name);
+  if (!cat) {
+    return;
+  }
+  if (!level) {
+    cat.critical = status;
+    cat.debug = status;
+    cat.info = status;
+    cat.warning = status;
+    return;
+  }
+  switch (level) {
+    case MessageType.Critical:
+      cat.critical = status;
+      break;
+    case MessageType.Debug:
+      cat.debug = status;
+      break;
+    case MessageType.Info:
+      cat.info = status;
+      break;
+    case MessageType.Warning:
+      cat.warning = status;
+      break;
+  }
+}
+
+/**
+ * Disable messages from a category.
+ * @param name
+ * @param level
+ */
+export function disableCategory(name: string, level?: MessageType): void {
+  setCategory(name, false, level);
+}
+
+/**
+ * Enable messages from a category.
+ * @param name
+ */
+export function enableCategory(name: string, level?: MessageType): void {
+  setCategory(name, true, level);
+}
+
+/**
+ * Registers a new category.
+ * Every new category name must be created with this before it is used, or
+ * the output will be incorrect.
+ * @param categoryName
+ * @param level
+ */
+export function LOGGING_CATEGORY(
+  categoryName: string,
+  level: MessageType = MessageType.Info,
+) {
+  if (categories.has(categoryName)) {
+    throw new TypeError(`Category ${categoryName} already created`);
+  }
+  const cat = new MessageLoggingCategory(categoryName, level);
+  categories.set(categoryName, cat);
+}
+
+/** Class responsible for printing messages. */
+export class MessageLogger {
+  constructor(
+    public readonly category: string = "",
+    public readonly level: MessageType = MessageType.Info,
+  ) {
+    if (!isDefaultCategory(category)) {
+      LOGGING_CATEGORY(category, level);
+    }
+  }
+
+  debug(msg: string, ...args: unknown[]): void;
+  debug(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  /** Print a debug message. */
+  debug(arg: string | MessageLoggingCategory, ...args: unknown[]) {
+    // deno-lint-ignore no-explicit-any
+    this.#print(MessageType.Debug, arg as any, ...args);
+    if (isFatal(MessageType.Debug)) {
+      Deno.exit(1);
+    }
+  }
+
+  info(msg: string, ...args: unknown[]): void;
+  info(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  /** Print an informational message. */
+  info(arg: string | MessageLoggingCategory, ...args: unknown[]) {
+    // deno-lint-ignore no-explicit-any
+    this.#print(MessageType.Info, arg as any, ...args);
+    if (isFatal(MessageType.Info)) {
+      Deno.exit(1);
+    }
+  }
+
+  warning(msg: string, ...args: unknown[]): void;
+  warning(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  /** Print a warning message. */
+  warning(arg: string | MessageLoggingCategory, ...args: unknown[]) {
+    // deno-lint-ignore no-explicit-any
+    this.#print(MessageType.Warning, arg as any, ...args);
+    if (isFatal(MessageType.Warning)) {
+      Deno.exit(1);
+    }
+  }
+
+  critical(msg: string, ...args: unknown[]): void;
+  critical(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  /** Print an error message. */
+  critical(arg: string | MessageLoggingCategory, ...args: unknown[]) {
+    // deno-lint-ignore no-explicit-any
+    this.#print(MessageType.Critical, arg as any, ...args);
+    if (isFatal(MessageType.Critical)) {
+      Deno.exit(1);
+    }
+  }
+
+  fatal(msg: string, ...args: unknown[]): void;
+  fatal(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+  /** Print a fatal error message. */
+  fatal(arg: string | MessageLoggingCategory, ...args: unknown[]) {
+    // deno-lint-ignore no-explicit-any
+    this.#print(MessageType.Fatal, arg as any, ...args);
+    Deno.exit(1);
+  }
+
+  #print(msgType: MessageType, msg: string, ...args: unknown[]): void;
+  #print(
+    msgType: MessageType,
+    cat: MessageLoggingCategory,
+    ...args: unknown[]
+  ): void;
+
+  /**
+   * @internal
+   */
+  #print(
+    msgType: MessageType,
+    msg: string | MessageLoggingCategory,
+    ...args: unknown[]
+  ) {
+    if (!msg) {
+      return;
+    }
+
+    let baseMsg = msg;
+    let cat = categories.get("default")!;
+    let params = args;
+    if (baseMsg instanceof MessageLoggingCategory) {
+      cat = msg as MessageLoggingCategory;
+      baseMsg = args[0] as string;
+      params = args.slice(1);
+    } else if (args.length > 0 && categories.has(baseMsg)) {
+      cat = categories.get(baseMsg) as MessageLoggingCategory;
+      baseMsg = args[0] as string;
+      params = args.slice(1);
+    } else if (!isDefaultCategory(this.category)) {
+      cat = categories.get(this.category) as MessageLoggingCategory;
+    }
+
+    if (!this.#isLevelEnabled(msgType, cat)) {
+      return;
+    }
+    const ctx: MessageLogContext = {
+      category: cat.categoryName,
+      type: getMessageTypeName(msgType),
+      filename: import.meta.url,
+    };
+    const message = params.length > 0 ? sprintf(baseMsg, params) : baseMsg;
+    print_message(msgType, ctx, message);
+  }
+
+  #isLevelEnabled(msgType: MessageType, cat: MessageLoggingCategory) {
+    switch (msgType) {
+      case MessageType.Critical:
+        return cat.critical;
+      case MessageType.Fatal:
+        return true;
+      case MessageType.Info:
+        return cat.info;
+      case MessageType.Warning:
+        return cat.warning;
+      case MessageType.Debug:
+        return cat.debug;
+    }
+  }
+}
+
+export function debug(msg: string, ...args: unknown[]): void;
+export function debug(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+/**
+ * Prints a debug message (if enabled).
+ * `arg` may be a MessageLoggingCategory or a string. If `arg` is a string and
+ * is the name of a registered category, then the rest of `args` are treated
+ * as the message. Otherwise, the message is printed to the default category.
+ * @param arg
+ * @param args
+ */
+export function debug(
+  arg: string | MessageLoggingCategory,
+  ...args: unknown[]
+): void {
+  const logger = new MessageLogger();
+  if (typeof arg === "string") {
+    logger.debug(arg, ...args);
+  } else {
+    const cat = arg as MessageLoggingCategory;
+    logger.debug(cat, ...args);
+  }
+}
+
+export function info(msg: string, ...args: unknown[]): void;
+export function info(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+/**
+ * Prints an informational message (if enabled).
+ * `arg` may be a MessageLoggingCategory or a string. If `arg` is a string and
+ * is the name of a registered category, then the rest of `args` are treated
+ * as the message. Otherwise, the message is printed to the default category.
+ * @param arg
+ * @param args
+ */
+export function info(
+  arg: string | MessageLoggingCategory,
+  ...args: unknown[]
+): void {
+  const logger = new MessageLogger();
+  if (typeof arg === "string") {
+    logger.info(arg, ...args);
+  } else {
+    const cat = arg as MessageLoggingCategory;
+    logger.info(cat, ...args);
+  }
+}
+
+export function warning(msg: string, ...args: unknown[]): void;
+export function warning(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+/**
+ * Prints an informational message (if enabled).
+ * `arg` may be a MessageLoggingCategory or a string. If `arg` is a string and
+ * is the name of a registered category, then the rest of `args` are treated
+ * as the message. Otherwise, the message is printed to the default category.
+ * @param arg
+ * @param args
+ */
+export function warning(
+  arg: string | MessageLoggingCategory,
+  ...args: unknown[]
+): void {
+  const logger = new MessageLogger();
+  if (typeof arg === "string") {
+    logger.warning(arg, ...args);
+  } else {
+    const cat = arg as MessageLoggingCategory;
+    logger.warning(cat, ...args);
+  }
+}
+
+export function critical(msg: string, ...args: unknown[]): void;
+export function critical(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+/**
+ * Prints an critical error message (if enabled).
+ * `arg` may be a MessageLoggingCategory or a string. If `arg` is a string and
+ * is the name of a registered category, then the rest of `args` are treated
+ * as the message. Otherwise, the message is printed to the default category.
+ * @param arg
+ * @param args
+ */
+export function critical(
+  arg: string | MessageLoggingCategory,
+  ...args: unknown[]
+): void {
+  const logger = new MessageLogger();
+  if (typeof arg === "string") {
+    logger.critical(arg, ...args);
+  } else {
+    const cat = arg as MessageLoggingCategory;
+    logger.critical(cat, ...args);
+  }
+}
+
+export function fatal(msg: string, ...args: unknown[]): void;
+export function fatal(cat: MessageLoggingCategory, ...args: unknown[]): void;
+
+/**
+ * Prints a fatal error message.
+ * `arg` may be a MessageLoggingCategory or a string. If `arg` is a string and
+ * is the name of a registered category, then the rest of `args` are treated
+ * as the message. Otherwise, the message is printed to the default category.
+ * @param arg
+ * @param args
+ */
+export function fatal(
+  arg: string | MessageLoggingCategory,
+  ...args: unknown[]
+): void {
+  const logger = new MessageLogger();
+  if (typeof arg === "string") {
+    logger.fatal(arg, ...args);
+  } else {
+    const cat = arg as MessageLoggingCategory;
+    logger.fatal(cat, ...args);
+  }
+}
+
+function defaultMessageHandler(
+  msgType: MessageType,
+  context: MessageLogContext,
+  message: string,
+) {
+  const formattedMessage = formatLogMessage(msgType, context, message);
+  if (!formattedMessage) {
+    return;
+  }
+  const encoder = new TextEncoder();
+  const msg = encoder.encode(formattedMessage + "\n");
+  if (msgType === MessageType.Info) {
+    Deno.stdout.writeSync(msg);
+  } else {
+    Deno.stderr.writeSync(msg);
+  }
+}
+
+function print_message(
+  msgType: MessageType,
+  context: MessageLogContext,
+  message: string,
+) {
+  msgHandler(msgType, context, message);
+}

--- a/message/mod_test.ts
+++ b/message/mod_test.ts
@@ -1,0 +1,53 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../testing/asserts.ts";
+import {
+  formatLogMessage,
+  getMessageTypeName,
+  MessageLogContext,
+  MessageType,
+} from "./mod.ts";
+
+function createContext(
+  category: string,
+  msgType: MessageType,
+): MessageLogContext {
+  return {
+    category,
+    type: getMessageTypeName(msgType),
+    filename: import.meta.url,
+  };
+}
+
+Deno.test("formatLogMessage", function (): void {
+  const defaultDebugCtx = createContext("default", MessageType.Debug);
+  const defaultDebugMsg = formatLogMessage(
+    MessageType.Debug,
+    defaultDebugCtx,
+    "Debug message 1",
+  );
+  assertEquals(defaultDebugMsg, "Debug message 1");
+
+  const defaultInfoCtx = createContext("default", MessageType.Info);
+  const defaultInfoMsg = formatLogMessage(
+    MessageType.Info,
+    defaultInfoCtx,
+    "Info message 1",
+  );
+  assertEquals(defaultInfoMsg, "Info message 1");
+
+  const usbDebugCtx = createContext("driver.usb", MessageType.Debug);
+  const usbDebugMsg = formatLogMessage(
+    MessageType.Debug,
+    usbDebugCtx,
+    "Debug message 2",
+  );
+  assertEquals(usbDebugMsg, "driver.usb: Debug message 2");
+
+  const usbInfoCtx = createContext("driver.usb", MessageType.Info);
+  const usbInfoMsg = formatLogMessage(
+    MessageType.Info,
+    usbInfoCtx,
+    "Info message 2",
+  );
+  assertEquals(usbInfoMsg, "driver.usb: Info message 2");
+});


### PR DESCRIPTION
This is a port of the Qt Message logging framework. In contrast to the application-oriented `log` standard library module, this is specifically designed to scale to hundreds or thousands of modules while giving applications full control over the output.

It does this by separating messages from their presentation. Modules emit messages, and the application takes care of if/how to present them.

This isn't a replacement for the `log` framework. Handler functions can use the logging module to print messages. This is intended for modules to emit categorized information that can be handled by the application.

## What it offers

+ **Message patterns**: An application can simply set a message pattern (e.g. `[%{time yyyy/mm/dd}] %{message}`) and all messages from every module will be printed in this format.
+ **Categorized messages**: This is the key point. By categorizing modules, applications can control the output on a per-module basis.
+ **Message handlers**: A global message handler can be installed to handle all messages. The function will be passed the message string as well as the category, to determine if the message should be printed or not.

## Use cases

Consider two opposing use cases:

1. A command-line app that wants to print only its own messages and fatal errors from every module. No colors or message prefixes like "INFO"
2. A server that wants to print as much information as possible, including debug messages from hundreds of modules, possibly disabling messages from a few specific modules.

This accommodates both use cases. Because the application is responsible for the presentation, modules do not need to worry about printing too much information. Debug messages are disabled by default and must be enabled by the application.

-----

Related issue: #2398

See also:
* https://doc.qt.io/qt-6/qmessagelogger.html
* https://doc.qt.io/qt-6/qloggingcategory.html
* https://doc.qt.io/qt-6/qtglobal.html#qInstallMessageHandler