### PR TITLE
docs(encoding/front_matter): fix example

### DIFF
--- a/encoding/front_matter.ts
+++ b/encoding/front_matter.ts
@@ -31,7 +31,7 @@ export type Extract<T> = {
  * const { attrs, body, frontMatter } = extract<{ title: string }>("---\ntitle: Three dashes marks the spot\n---\n");
  * assertEquals(attrs.title, "Three dashes marks the spot");
  * assertEquals(body, "");
- * assertEquals(frontMatter, "---\ntitle: Three dashes marks the spot\n---\n");
+ * assertEquals(frontMatter, "title: Three dashes marks the spot");
  * ```
  */
 export function extract<T = unknown>(str: string): Extract<T> {


### PR DESCRIPTION
This PR fixes the doc example of `encoding/front_matter` module.

Thanks @geoffreypetri for reporting this ref https://github.com/denoland/deno_std/pull/2335#discussion_r918047909