### PR TITLE
fix(node/module): improve error message of createRequire

### DIFF
--- a/node/module.ts
+++ b/node/module.ts
@@ -684,13 +684,11 @@ class Module {
       try {
         filepath = fileURLToPath(filename);
       } catch (err) {
-        if (
-          err instanceof Deno.errors.InvalidData &&
-          err.message.includes("invalid url scheme")
-        ) {
+        // deno-lint-ignore no-explicit-any
+        if ((err as any).code === "ERR_INVALID_URL_SCHEME") {
           // Provide a descriptive error when url scheme is invalid.
           throw new Error(
-            `${createRequire.name} only supports 'file://' URLs for the 'filename' parameter`,
+            `${createRequire.name} only supports 'file://' URLs for the 'filename' parameter. Received '${filename}'`,
           );
         } else {
           throw err;

--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -217,3 +217,16 @@ Deno.test("require in a web worker", async () => {
   });
   worker.terminate();
 });
+
+Deno.test("createRequire with http(s):// URL  throws with correct error message", () => {
+  assertThrows(
+    () => createRequire("http://example.com/foo.js"),
+    Error,
+    "createRequire only supports 'file://' URLs for the 'filename' parameter. Received 'http://example.com/foo.js'",
+  );
+  assertThrows(
+    () => createRequire("https://example.com/foo.js"),
+    Error,
+    "createRequire only supports 'file://' URLs for the 'filename' parameter. Received 'https://example.com/foo.js'",
+  );
+});


### PR DESCRIPTION
This PR fixes the error message when the http(s) urls are given to `createRequire`.

This addresses the issue reported in https://github.com/denoland/deno_std/issues/955#issuecomment-1180179073