### PR TITLE
fix(io) StringWriter retaining references after write

### DIFF
--- a/io/writers.ts
+++ b/io/writers.ts
@@ -22,7 +22,7 @@ export class StringWriter implements Writer, WriterSync {
   }
 
   writeSync(p: Uint8Array): number {
-    this.#chunks.push(p);
+    this.#chunks.push(new Uint8Array(p));
     this.#byteLength += p.byteLength;
     this.#cache = undefined;
     return p.byteLength;

--- a/io/writers_test.ts
+++ b/io/writers_test.ts
@@ -22,3 +22,20 @@ Deno.test("ioStringWriterSync", function (): void {
   w.writeSync(encoder.encode("\nland"));
   assertEquals(w.toString(), "deno\nland");
 });
+
+Deno.test("ioStringWriterIsolationTest", async function () {
+  const encoder = new TextEncoder();
+  const src =  "ABC";
+  const srcChunks = src.split("").map(c => encoder.encode(c))
+
+  const w = new StringWriter();
+  for (const c of srcChunks) {
+    const written = await w.write(c);
+    assertEquals(written, 1)
+  }
+
+  // These chunks all been written... but manipulating
+  // their values still changes the value of `w.toString()`
+  srcChunks[0][0] = 88;
+  assertEquals(w.toString(), src);
+});

--- a/io/writers_test.ts
+++ b/io/writers_test.ts
@@ -25,13 +25,13 @@ Deno.test("ioStringWriterSync", function (): void {
 
 Deno.test("ioStringWriterIsolationTest", async function () {
   const encoder = new TextEncoder();
-  const src =  "ABC";
-  const srcChunks = src.split("").map(c => encoder.encode(c))
+  const src = "ABC";
+  const srcChunks = src.split("").map((c) => encoder.encode(c));
 
   const w = new StringWriter();
   for (const c of srcChunks) {
     const written = await w.write(c);
-    assertEquals(written, 1)
+    assertEquals(written, 1);
   }
   srcChunks[0][0] = 88;
   assertEquals(w.toString(), src);

--- a/io/writers_test.ts
+++ b/io/writers_test.ts
@@ -33,9 +33,6 @@ Deno.test("ioStringWriterIsolationTest", async function () {
     const written = await w.write(c);
     assertEquals(written, 1)
   }
-
-  // These chunks all been written... but manipulating
-  // their values still changes the value of `w.toString()`
   srcChunks[0][0] = 88;
   assertEquals(w.toString(), src);
 });


### PR DESCRIPTION
The PR fixes  an error I'm seeing in a real-world use case when I try to copy entries from https://deno.land/std@0.141.0/archive/README.md#untar into a `StringWriter`, like:

```ts
const sw = new StringWriter();
const res = await copy(entry, sw);
 ```

~~I'm not sure whose responsibility it is to keep the buffered chunks inside `StringWriter.#chunks` isolated from the inputs to `.write`.~~

Given:
https://github.com/denoland/deno_std/blob/255f3fa8b2c7bd666018178e6dd3bea5422f23a3/io/types.d.ts#L62

... it's the `StringWriter`'s responsibility to copy data out of `p` during `write(p)`, rather than maintaining references to `p`.