### PR TITLE
feat(http/http_errors): Add headers property

### DIFF
--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -98,7 +98,7 @@ export type ErrorStatusKeys = keyof typeof ERROR_STATUS_MAP;
 
 export interface HttpErrorOptions extends ErrorOptions {
   expose?: boolean;
-  headers?: Headers;
+  headers?: HeadersInit;
 }
 
 /** The base class that all derivative HTTP extend, providing a `status` and an

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -139,7 +139,7 @@ function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
         this.#expose = false;
       }
       if (options?.headers) {
-        this.#headers = options.headers;
+        this.#headers = new Headers(options.headers);
       }
       Object.defineProperty(this, "name", {
         configurable: true,

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -98,6 +98,7 @@ export type ErrorStatusKeys = keyof typeof ERROR_STATUS_MAP;
 
 export interface HttpErrorOptions extends ErrorOptions {
   expose?: boolean;
+  headers?: Headers;
 }
 
 /** The base class that all derivative HTTP extend, providing a `status` and an
@@ -113,6 +114,10 @@ export class HttpError extends Error {
   get expose(): boolean {
     return false;
   }
+  /** The optional headers object that is set on the error. */
+  get headers(): Headers | undefined {
+    return undefined;
+  }
   /** The error status that is set on the error. */
   get status(): ErrorStatus {
     return Status.InternalServerError;
@@ -123,6 +128,7 @@ function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
   const name = `${Status[status]}Error`;
   const ErrorCtor = class extends HttpError {
     #expose = isClientErrorStatus(status);
+    #headers?: Headers;
 
     constructor(message = STATUS_TEXT[status], options?: HttpErrorOptions) {
       super(message, options);
@@ -131,6 +137,9 @@ function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
       }
       if (options?.expose === false) {
         this.#expose = false;
+      }
+      if (options?.headers) {
+        this.#headers = options.headers;
       }
       Object.defineProperty(this, "name", {
         configurable: true,
@@ -142,6 +151,10 @@ function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
 
     override get expose() {
       return this.#expose;
+    }
+
+    override get headers() {
+      return this.#headers;
     }
 
     override get status() {

--- a/http/http_errors_test.ts
+++ b/http/http_errors_test.ts
@@ -66,13 +66,15 @@ Deno.test({
         STATUS_TEXT[errorStatus],
         {
           expose: false,
+          headers: new Headers({ "WWW-Authenticate": "Bearer" }),
         },
       );
       assertInstanceOf(error, HttpError);
       assertInstanceOf(error, errors[Status[errorStatus] as ErrorStatusKeys]);
       assertEquals(error.name, `${Status[errorStatus]}Error`);
       assertEquals(error.message, STATUS_TEXT[errorStatus]);
-      assertEquals(error.status, errorStatus);
+      assertEquals(errorExpose.status, errorStatus);
+      assertEquals(errorExpose.headers?.get("WWW-Authenticate"), "Bearer");
       assert(error.expose);
       assert(!errorExpose.expose);
     }
@@ -98,6 +100,7 @@ Deno.test({
       assertEquals(error.status, errorStatus);
       assert(!error.expose);
       assert(errorExpose.expose);
+      assert(!error.headers);
     }
   },
 });


### PR DESCRIPTION
This PR closes https://github.com/denoland/deno_std/issues/2451 by adding an optional `headers` property. Through this option, error specific headers could be added to the error (response) data. For example, if JWT verification failed, the error creation could look like this:

```ts
const httpError = createHttpError(401, "Unauthorized", {
  headers: new Headers({ "WWW-Authenticate": "Bearer" }),
});
console.log(httpError.headers); // Headers { "www-authenticate": "Bearer" }
```