### PR TITLE
node: add FreeBSD support

### DIFF
--- a/_util/os.ts
+++ b/_util/os.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-export type OSType = "windows" | "linux" | "darwin";
+export type OSType = "windows" | "linux" | "darwin" | "freebsd";
 
 export const osType: OSType = (() => {
   // deno-lint-ignore no-explicit-any

--- a/node/internal_binding/uv.ts
+++ b/node/internal_binding/uv.ts
@@ -310,6 +310,95 @@ const errorToCodeLinux: CodeMapData = codeToErrorLinux.map((
   [status, [code]],
 ) => [code, status]);
 
+const codeToErrorFreebsd: ErrorMapData = [
+  [-7, ["E2BIG", "argument list too long"]],
+  [-13, ["EACCES", "permission denied"]],
+  [-48, ["EADDRINUSE", "address already in use"]],
+  [-49, ["EADDRNOTAVAIL", "address not available"]],
+  [-47, ["EAFNOSUPPORT", "address family not supported"]],
+  [-35, ["EAGAIN", "resource temporarily unavailable"]],
+  [-3000, ["EAI_ADDRFAMILY", "address family not supported"]],
+  [-3001, ["EAI_AGAIN", "temporary failure"]],
+  [-3002, ["EAI_BADFLAGS", "bad ai_flags value"]],
+  [-3013, ["EAI_BADHINTS", "invalid value for hints"]],
+  [-3003, ["EAI_CANCELED", "request canceled"]],
+  [-3004, ["EAI_FAIL", "permanent failure"]],
+  [-3005, ["EAI_FAMILY", "ai_family not supported"]],
+  [-3006, ["EAI_MEMORY", "out of memory"]],
+  [-3007, ["EAI_NODATA", "no address"]],
+  [-3008, ["EAI_NONAME", "unknown node or service"]],
+  [-3009, ["EAI_OVERFLOW", "argument buffer overflow"]],
+  [-3014, ["EAI_PROTOCOL", "resolved protocol is unknown"]],
+  [-3010, ["EAI_SERVICE", "service not available for socket type"]],
+  [-3011, ["EAI_SOCKTYPE", "socket type not supported"]],
+  [-37, ["EALREADY", "connection already in progress"]],
+  [-9, ["EBADF", "bad file descriptor"]],
+  [-16, ["EBUSY", "resource busy or locked"]],
+  [-85, ["ECANCELED", "operation canceled"]],
+  [-4080, ["ECHARSET", "invalid Unicode character"]],
+  [-53, ["ECONNABORTED", "software caused connection abort"]],
+  [-61, ["ECONNREFUSED", "connection refused"]],
+  [-54, ["ECONNRESET", "connection reset by peer"]],
+  [-39, ["EDESTADDRREQ", "destination address required"]],
+  [-17, ["EEXIST", "file already exists"]],
+  [-14, ["EFAULT", "bad address in system call argument"]],
+  [-27, ["EFBIG", "file too large"]],
+  [-65, ["EHOSTUNREACH", "host is unreachable"]],
+  [-4, ["EINTR", "interrupted system call"]],
+  [-22, ["EINVAL", "invalid argument"]],
+  [-5, ["EIO", "i/o error"]],
+  [-56, ["EISCONN", "socket is already connected"]],
+  [-21, ["EISDIR", "illegal operation on a directory"]],
+  [-62, ["ELOOP", "too many symbolic links encountered"]],
+  [-24, ["EMFILE", "too many open files"]],
+  [-40, ["EMSGSIZE", "message too long"]],
+  [-63, ["ENAMETOOLONG", "name too long"]],
+  [-50, ["ENETDOWN", "network is down"]],
+  [-51, ["ENETUNREACH", "network is unreachable"]],
+  [-23, ["ENFILE", "file table overflow"]],
+  [-55, ["ENOBUFS", "no buffer space available"]],
+  [-19, ["ENODEV", "no such device"]],
+  [-2, ["ENOENT", "no such file or directory"]],
+  [-12, ["ENOMEM", "not enough memory"]],
+  [-4056, ["ENONET", "machine is not on the network"]],
+  [-42, ["ENOPROTOOPT", "protocol not available"]],
+  [-28, ["ENOSPC", "no space left on device"]],
+  [-78, ["ENOSYS", "function not implemented"]],
+  [-57, ["ENOTCONN", "socket is not connected"]],
+  [-20, ["ENOTDIR", "not a directory"]],
+  [-66, ["ENOTEMPTY", "directory not empty"]],
+  [-38, ["ENOTSOCK", "socket operation on non-socket"]],
+  [-45, ["ENOTSUP", "operation not supported on socket"]],
+  [-84, ["EOVERFLOW", "value too large for defined data type"]],
+  [-1, ["EPERM", "operation not permitted"]],
+  [-32, ["EPIPE", "broken pipe"]],
+  [-92, ["EPROTO", "protocol error"]],
+  [-43, ["EPROTONOSUPPORT", "protocol not supported"]],
+  [-41, ["EPROTOTYPE", "protocol wrong type for socket"]],
+  [-34, ["ERANGE", "result too large"]],
+  [-30, ["EROFS", "read-only file system"]],
+  [-58, ["ESHUTDOWN", "cannot send after transport endpoint shutdown"]],
+  [-29, ["ESPIPE", "invalid seek"]],
+  [-3, ["ESRCH", "no such process"]],
+  [-60, ["ETIMEDOUT", "connection timed out"]],
+  [-26, ["ETXTBSY", "text file is busy"]],
+  [-18, ["EXDEV", "cross-device link not permitted"]],
+  [-4094, ["UNKNOWN", "unknown error"]],
+  [-4095, ["EOF", "end of file"]],
+  [-6, ["ENXIO", "no such device or address"]],
+  [-31, ["EMLINK", "too many links"]],
+  [-64, ["EHOSTDOWN", "host is down"]],
+  [-4030, ["EREMOTEIO", "remote I/O error"]],
+  [-25, ["ENOTTY", "inappropriate ioctl for device"]],
+  [-79, ["EFTYPE", "inappropriate file type or format"]],
+  [-86, ["EILSEQ", "illegal byte sequence"]],
+  [-44, ["ESOCKTNOSUPPORT", "socket type not supported"]],
+];
+
+const errorToCodeFreebsd: CodeMapData = codeToErrorFreebsd.map((
+  [status, [code]],
+) => [code, status]);
+
 export const errorMap = new Map<number, [string, string]>(
   osType === "windows"
     ? codeToErrorWindows
@@ -317,6 +406,8 @@ export const errorMap = new Map<number, [string, string]>(
     ? codeToErrorDarwin
     : osType === "linux"
     ? codeToErrorLinux
+    : osType === "freebsd"
+    ? codeToErrorFreebsd
     : unreachable(),
 );
 
@@ -327,6 +418,8 @@ export const codeMap = new Map<string, number>(
     ? errorToCodeDarwin
     : osType === "linux"
     ? errorToCodeLinux
+    : osType === "freebsd"
+    ? errorToCodeFreebsd
     : unreachable(),
 );
 

--- a/node/os.ts
+++ b/node/os.ts
@@ -167,6 +167,7 @@ export function homedir(): string | null {
       return Deno.env.get("USERPROFILE") || null;
     case "linux":
     case "darwin":
+    case "freebsd":
       return Deno.env.get("HOME") || null;
     default:
       throw Error("unreachable");
@@ -278,13 +279,15 @@ export function totalmem(): number {
 
 /** Returns operating system type (i.e. 'Windows_NT', 'Linux', 'Darwin') */
 export function type(): string {
-  switch (Deno.build.os) {
+  switch (Deno.build.os as string) {
     case "windows":
       return "Windows_NT";
     case "linux":
       return "Linux";
     case "darwin":
       return "Darwin";
+    case "freebsd":
+      return "FreeBSD";
     default:
       throw Error("unreachable");
   }


### PR DESCRIPTION
This adds enough support for node compat to run on FreeBSD (which [has Deno packaged](https://www.freshports.org/www/deno), despite not being an official platform).