### PR TITLE
fix(node/http(s)): Set the url protocol by default

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -90,6 +90,7 @@ export interface RequestOptions {
 
 /** ClientRequest represents the http(s) request from the client */
 class ClientRequest extends NodeWritable {
+  defaultProtocol = 'http:';
   body: null | ReadableStream = null;
   controller: ReadableStreamDefaultController | null = null;
   constructor(
@@ -173,7 +174,7 @@ class ClientRequest extends NodeWritable {
         path,
         port,
       } = opts;
-      return `${protocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${
+      return `${protocol ?? this.defaultProtocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${
         port ? `:${port}` : ""
       }${path}`;
     }

--- a/node/http.ts
+++ b/node/http.ts
@@ -90,7 +90,7 @@ export interface RequestOptions {
 
 /** ClientRequest represents the http(s) request from the client */
 class ClientRequest extends NodeWritable {
-  defaultProtocol = 'http:';
+  defaultProtocol = "http:";
   body: null | ReadableStream = null;
   controller: ReadableStreamDefaultController | null = null;
   constructor(
@@ -174,9 +174,9 @@ class ClientRequest extends NodeWritable {
         path,
         port,
       } = opts;
-      return `${protocol ?? this.defaultProtocol}//${auth ? `${auth}@` : ""}${host ?? hostname}${
-        port ? `:${port}` : ""
-      }${path}`;
+      return `${protocol ?? this.defaultProtocol}//${auth ? `${auth}@` : ""}${
+        host ?? hostname
+      }${port ? `:${port}` : ""}${path}`;
     }
   }
 }

--- a/node/http.ts
+++ b/node/http.ts
@@ -176,7 +176,7 @@ class ClientRequest extends NodeWritable {
       } = opts;
       return `${protocol ?? this.defaultProtocol}//${auth ? `${auth}@` : ""}${
         host ?? hostname
-      }${port ? `:${port}` : ""}${path}`;
+      }${port ? `:${port}` : ""}${path || ""}`;
     }
   }
 }

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -116,3 +116,25 @@ Deno.test("[node/http chunked response", async () => {
     await promise;
   }
 });
+
+Deno.test("[node/http] request default protocol", async () => {
+  const promise = deferred<void>();
+  const server = http.createServer((_, res) => {
+    res.end("ok");
+  });
+  server.listen(() => {
+    const req = http.request(
+      { host: "localhost", port: server.address().port },
+      (res) => {
+        res.on("data", () => {});
+        res.on("end", () => {
+          server.close();
+          promise.resolve();
+        });
+        assertEquals(res.statusCode, 200);
+      },
+    );
+    req.end();
+  });
+  await promise;
+});

--- a/node/https.ts
+++ b/node/https.ts
@@ -57,7 +57,7 @@ export function get(...args: any[]) {
 export const globalAgent = undefined;
 /** HttpsClientRequest class loosely follows http.ClientRequest class API. */
 class HttpsClientRequest extends ClientRequest {
-  defaultProtocol = 'https:';
+  override defaultProtocol = "https:";
   override async _createCustomClient(): Promise<
     DenoUnstable.HttpClient | undefined
   > {

--- a/node/https.ts
+++ b/node/https.ts
@@ -57,6 +57,7 @@ export function get(...args: any[]) {
 export const globalAgent = undefined;
 /** HttpsClientRequest class loosely follows http.ClientRequest class API. */
 class HttpsClientRequest extends ClientRequest {
+  defaultProtocol = 'https:';
   override async _createCustomClient(): Promise<
     DenoUnstable.HttpClient | undefined
   > {


### PR DESCRIPTION
Node automatically sets the protocol in http and https defaults, which makes some node modules break if they do not set a protocol in the options.

Feel free to improve the code added as I'm not that familiar with how ts works.