### PR TITLE
docs(collections): fix code example in `include_value` function

### DIFF
--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -17,6 +17,7 @@
  * };
  *
  * assertEquals(includesValue(input, 34), true);
+ * ```
  */
 
 export function includesValue<T>(


### PR DESCRIPTION
This is a tiny fix for a code example of `collections/include_value` function. Added closing triple backquotes for the code block.

### Actual

![image](https://user-images.githubusercontent.com/41154684/182047770-20c93e39-9b81-42a5-ba28-757a98c4a972.png)

### Expected

![image](https://user-images.githubusercontent.com/41154684/182047910-18c1cf10-aeb3-496d-9af0-b80caadb7394.png)
