### PR TITLE
feat(encoding/csv): sync parse

### DIFF
--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -4,17 +4,11 @@
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { BufReader } from "../io/buffer.ts";
-import { TextProtoReader } from "../textproto/mod.ts";
-import { StringReader } from "../io/readers.ts";
+// This module is browser compatible.
+
 import { assert } from "../_util/assert.ts";
-import {
-  ERR_FIELD_COUNT,
-  ERR_INVALID_DELIM,
-  ParseError,
-  readRecord,
-} from "./csv/_io.ts";
-import type { LineReader, ReadOptions } from "./csv/_io.ts";
+import type { ReadOptions } from "./csv/_io.ts";
+import { Parser } from "./csv/_parser.ts";
 
 export {
   ERR_BARE_QUOTE,
@@ -32,111 +26,6 @@ export type {
   DataItem,
   StringifyOptions,
 } from "./csv_stringify.ts";
-
-class TextProtoLineReader implements LineReader {
-  #tp: TextProtoReader;
-  constructor(bufReader: BufReader) {
-    this.#tp = new TextProtoReader(bufReader);
-  }
-
-  async readLine() {
-    let line: string;
-    const r = await this.#tp.readLine();
-    if (r === null) return null;
-    line = r;
-
-    // For backwards compatibility, drop trailing \r before EOF.
-    if (
-      (await this.isEOF()) && line.length > 0 && line[line.length - 1] === "\r"
-    ) {
-      line = line.substring(0, line.length - 1);
-    }
-
-    // Normalize \r\n to \n on all input lines.
-    if (
-      line.length >= 2 &&
-      line[line.length - 2] === "\r" &&
-      line[line.length - 1] === "\n"
-    ) {
-      line = line.substring(0, line.length - 2);
-      line = line + "\n";
-    }
-
-    return line;
-  }
-
-  async isEOF() {
-    return (await this.#tp.r.peek(0)) === null;
-  }
-}
-
-const INVALID_RUNE = ["\r", "\n", '"'];
-
-function chkOptions(opt: ReadOptions): void {
-  if (!opt.separator) {
-    opt.separator = ",";
-  }
-  if (!opt.trimLeadingSpace) {
-    opt.trimLeadingSpace = false;
-  }
-  if (
-    INVALID_RUNE.includes(opt.separator) ||
-    (typeof opt.comment === "string" && INVALID_RUNE.includes(opt.comment)) ||
-    opt.separator === opt.comment
-  ) {
-    throw new Error(ERR_INVALID_DELIM);
-  }
-}
-
-/**
- * Parse the CSV from the `reader` with the options provided and return `string[][]`.
- *
- * @param reader provides the CSV data to parse
- * @param opt controls the parsing behavior
- */
-export async function readMatrix(
-  reader: BufReader,
-  opt: ReadOptions = {
-    separator: ",",
-    trimLeadingSpace: false,
-    lazyQuotes: false,
-  },
-): Promise<string[][]> {
-  const result: string[][] = [];
-  let _nbFields: number | undefined;
-  let lineResult: string[];
-  let first = true;
-  let lineIndex = 0;
-  chkOptions(opt);
-
-  const lineReader = new TextProtoLineReader(reader);
-  for (;;) {
-    const r = await readRecord(lineIndex, lineReader, opt);
-    if (r === null) break;
-    lineResult = r;
-    lineIndex++;
-    // If fieldsPerRecord is 0, Read sets it to
-    // the number of fields in the first record
-    if (first) {
-      first = false;
-      if (opt.fieldsPerRecord !== undefined) {
-        if (opt.fieldsPerRecord === 0) {
-          _nbFields = lineResult.length;
-        } else {
-          _nbFields = opt.fieldsPerRecord;
-        }
-      }
-    }
-
-    if (lineResult.length > 0) {
-      if (_nbFields && _nbFields !== lineResult.length) {
-        throw new ParseError(lineIndex, lineIndex, null, ERR_FIELD_COUNT);
-      }
-      result.push(lineResult);
-    }
-  }
-  return result;
-}
 
 /**
  * Parse the CSV string/buffer with the options provided.
@@ -168,46 +57,43 @@ export interface ParseOptions extends ReadOptions {
 /**
  * Csv parse helper to manipulate data.
  * Provides an auto/custom mapper for columns.
- * @param input Input to parse. Can be a string or BufReader.
+ * @param input Input to parse.
  * @param opt options of the parser.
  * @returns If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns `string[][]`.
  *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unkown>[]`.
  */
-export async function parse(
-  input: string | BufReader,
-): Promise<string[][]>;
-export async function parse(
-  input: string | BufReader,
+export function parse(
+  input: string,
+): string[][];
+export function parse(
+  input: string,
   opt: Omit<ParseOptions, "columns" | "skipFirstRow">,
-): Promise<string[][]>;
-export async function parse(
-  input: string | BufReader,
+): string[][];
+export function parse(
+  input: string,
   opt: Omit<ParseOptions, "columns"> & {
     columns: string[] | ColumnOptions[];
   },
-): Promise<Record<string, unknown>[]>;
-export async function parse(
-  input: string | BufReader,
+): Record<string, unknown>[];
+export function parse(
+  input: string,
   opt: Omit<ParseOptions, "skipFirstRow"> & {
     skipFirstRow: true;
   },
-): Promise<Record<string, unknown>[]>;
-export async function parse(
-  input: string | BufReader,
+): Record<string, unknown>[];
+export function parse(
+  input: string,
   opt: ParseOptions,
-): Promise<string[][] | Record<string, unknown>[]>;
-export async function parse(
-  input: string | BufReader,
+): string[][] | Record<string, unknown>[];
+export function parse(
+  input: string,
   opt: ParseOptions = {
     skipFirstRow: false,
   },
-): Promise<string[][] | Record<string, unknown>[]> {
-  let r: string[][];
-  if (input instanceof BufReader) {
-    r = await readMatrix(input, opt);
-  } else {
-    r = await readMatrix(new BufReader(new StringReader(input)), opt);
-  }
+): string[][] | Record<string, unknown>[] {
+  const parser = new Parser(opt);
+  const r = parser.parse(input);
+
   if (opt.skipFirstRow || opt.columns) {
     let headers: ColumnOptions[] = [];
     let i = 0;

--- a/encoding/csv/_parser.ts
+++ b/encoding/csv/_parser.ts
@@ -1,0 +1,275 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { assert } from "../../_util/assert.ts";
+import {
+  ERR_BARE_QUOTE,
+  ERR_FIELD_COUNT,
+  ERR_INVALID_DELIM,
+  ERR_QUOTE,
+  ParseError,
+  ReadOptions,
+} from "./_io.ts";
+
+export class Parser {
+  #input = "";
+  #cursor = 0;
+  #options: {
+    separator: string;
+    trimLeadingSpace: boolean;
+    comment?: string;
+    lazyQuotes?: boolean;
+    fieldsPerRecord?: number;
+  };
+  constructor({
+    separator = ",",
+    trimLeadingSpace = false,
+    comment,
+    lazyQuotes,
+    fieldsPerRecord,
+  }: ReadOptions = {}) {
+    this.#options = {
+      separator,
+      trimLeadingSpace,
+      comment,
+      lazyQuotes,
+      fieldsPerRecord,
+    };
+  }
+  #readLine(): string | null {
+    if (this.#isEOF()) return null;
+
+    if (
+      !this.#input.startsWith("\r\n", this.#cursor) ||
+      !this.#input.startsWith("\n", this.#cursor)
+    ) {
+      let buffer = "";
+      let hadNewline = false;
+      while (this.#cursor < this.#input.length) {
+        if (this.#input.startsWith("\r\n", this.#cursor)) {
+          hadNewline = true;
+          this.#cursor += 2;
+          break;
+        }
+        if (
+          this.#input.startsWith("\n", this.#cursor)
+        ) {
+          hadNewline = true;
+          this.#cursor += 1;
+          break;
+        }
+        buffer += this.#input[this.#cursor];
+        this.#cursor += 1;
+      }
+      if (!hadNewline && buffer.endsWith("\r")) {
+        buffer = buffer.slice(0, -1);
+      }
+
+      return buffer;
+    }
+    return null;
+  }
+  #isEOF(): boolean {
+    return this.#cursor >= this.#input.length;
+  }
+  #parseRecord(startLine: number): string[] | null {
+    let line = this.#readLine();
+    if (line === null) return null;
+    if (line.length === 0) {
+      return [];
+    }
+
+    function runeCount(s: string): number {
+      // Array.from considers the surrogate pair.
+      return Array.from(s).length;
+    }
+
+    let lineIndex = startLine + 1;
+
+    // line starting with comment character is ignored
+    if (this.#options.comment && line[0] === this.#options.comment) {
+      return [];
+    }
+
+    assert(this.#options.separator != null);
+
+    let fullLine = line;
+    let quoteError: ParseError | null = null;
+    const quote = '"';
+    const quoteLen = quote.length;
+    const separatorLen = this.#options.separator.length;
+    let recordBuffer = "";
+    const fieldIndexes = [] as number[];
+    parseField:
+    for (;;) {
+      if (this.#options.trimLeadingSpace) {
+        line = line.trimStart();
+      }
+
+      if (line.length === 0 || !line.startsWith(quote)) {
+        // Non-quoted string field
+        const i = line.indexOf(this.#options.separator);
+        let field = line;
+        if (i >= 0) {
+          field = field.substring(0, i);
+        }
+        // Check to make sure a quote does not appear in field.
+        if (!this.#options.lazyQuotes) {
+          const j = field.indexOf(quote);
+          if (j >= 0) {
+            const col = runeCount(
+              fullLine.slice(0, fullLine.length - line.slice(j).length),
+            );
+            quoteError = new ParseError(
+              startLine + 1,
+              lineIndex,
+              col,
+              ERR_BARE_QUOTE,
+            );
+            break parseField;
+          }
+        }
+        recordBuffer += field;
+        fieldIndexes.push(recordBuffer.length);
+        if (i >= 0) {
+          line = line.substring(i + separatorLen);
+          continue parseField;
+        }
+        break parseField;
+      } else {
+        // Quoted string field
+        line = line.substring(quoteLen);
+        for (;;) {
+          const i = line.indexOf(quote);
+          if (i >= 0) {
+            // Hit next quote.
+            recordBuffer += line.substring(0, i);
+            line = line.substring(i + quoteLen);
+            if (line.startsWith(quote)) {
+              // `""` sequence (append quote).
+              recordBuffer += quote;
+              line = line.substring(quoteLen);
+            } else if (line.startsWith(this.#options.separator)) {
+              // `","` sequence (end of field).
+              line = line.substring(separatorLen);
+              fieldIndexes.push(recordBuffer.length);
+              continue parseField;
+            } else if (0 === line.length) {
+              // `"\n` sequence (end of line).
+              fieldIndexes.push(recordBuffer.length);
+              break parseField;
+            } else if (this.#options.lazyQuotes) {
+              // `"` sequence (bare quote).
+              recordBuffer += quote;
+            } else {
+              // `"*` sequence (invalid non-escaped quote).
+              const col = runeCount(
+                fullLine.slice(0, fullLine.length - line.length - quoteLen),
+              );
+              quoteError = new ParseError(
+                startLine + 1,
+                lineIndex,
+                col,
+                ERR_QUOTE,
+              );
+              break parseField;
+            }
+          } else if (line.length > 0 || !(this.#isEOF())) {
+            // Hit end of line (copy all data so far).
+            recordBuffer += line;
+            const r = this.#readLine();
+            lineIndex++;
+            line = r ?? ""; // This is a workaround for making this module behave similarly to the encoding/csv/reader.go.
+            fullLine = line;
+            if (r === null) {
+              // Abrupt end of file (EOF or error).
+              if (!this.#options.lazyQuotes) {
+                const col = runeCount(fullLine);
+                quoteError = new ParseError(
+                  startLine + 1,
+                  lineIndex,
+                  col,
+                  ERR_QUOTE,
+                );
+                break parseField;
+              }
+              fieldIndexes.push(recordBuffer.length);
+              break parseField;
+            }
+            recordBuffer += "\n"; // preserve line feed (This is because TextProtoReader removes it.)
+          } else {
+            // Abrupt end of file (EOF on error).
+            if (!this.#options.lazyQuotes) {
+              const col = runeCount(fullLine);
+              quoteError = new ParseError(
+                startLine + 1,
+                lineIndex,
+                col,
+                ERR_QUOTE,
+              );
+              break parseField;
+            }
+            fieldIndexes.push(recordBuffer.length);
+            break parseField;
+          }
+        }
+      }
+    }
+    if (quoteError) {
+      throw quoteError;
+    }
+    const result = [] as string[];
+    let preIdx = 0;
+    for (const i of fieldIndexes) {
+      result.push(recordBuffer.slice(preIdx, i));
+      preIdx = i;
+    }
+    return result;
+  }
+  parse(input: string): string[][] {
+    this.#input = input;
+    this.#cursor = 0;
+    const result: string[][] = [];
+    let _nbFields: number | undefined;
+    let lineResult: string[];
+    let first = true;
+    let lineIndex = 0;
+
+    const INVALID_RUNE = ["\r", "\n", '"'];
+
+    const options = this.#options;
+    if (
+      INVALID_RUNE.includes(options.separator) ||
+      (typeof options.comment === "string" &&
+        INVALID_RUNE.includes(options.comment)) ||
+      options.separator === options.comment
+    ) {
+      throw new Error(ERR_INVALID_DELIM);
+    }
+
+    for (;;) {
+      const r = this.#parseRecord(lineIndex);
+      if (r === null) break;
+      lineResult = r;
+      lineIndex++;
+      // If fieldsPerRecord is 0, Read sets it to
+      // the number of fields in the first record
+      if (first) {
+        first = false;
+        if (options.fieldsPerRecord !== undefined) {
+          if (options.fieldsPerRecord === 0) {
+            _nbFields = lineResult.length;
+          } else {
+            _nbFields = options.fieldsPerRecord;
+          }
+        }
+      }
+
+      if (lineResult.length > 0) {
+        if (_nbFields && _nbFields !== lineResult.length) {
+          throw new ParseError(lineIndex, lineIndex, null, ERR_FIELD_COUNT);
+        }
+        result.push(lineResult);
+      }
+    }
+    return result;
+  }
+}

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -4,25 +4,25 @@
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertRejects } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { parse, ParseError } from "./csv.ts";
 
 Deno.test({
   name: "Simple",
-  async fn() {
+  fn() {
     const input = "a,b,c\n";
     assertEquals(
-      await parse(input),
+      parse(input),
       [["a", "b", "c"]],
     );
   },
 });
 Deno.test({
   name: "CRLF",
-  async fn() {
+  fn() {
     const input = "a,b\r\nc,d\r\n";
     assertEquals(
-      await parse(input),
+      parse(input),
       [
         ["a", "b"],
         ["c", "d"],
@@ -33,10 +33,10 @@ Deno.test({
 
 Deno.test({
   name: "BareCR",
-  async fn() {
+  fn() {
     const input = "a,b\rc,d\r\n";
     assertEquals(
-      await parse(input),
+      parse(input),
       [["a", "b\rc", "d"]],
     );
   },
@@ -44,11 +44,11 @@ Deno.test({
 
 Deno.test({
   name: "RFC4180test",
-  async fn() {
+  fn() {
     const input =
       '#field1,field2,field3\n"aaa","bbb","ccc"\n"a,a","bbb","ccc"\nzzz,yyy,xxx';
     assertEquals(
-      await parse(input),
+      parse(input),
       [
         ["#field1", "field2", "field3"],
         ["aaa", "bbb", "ccc"],
@@ -60,10 +60,10 @@ Deno.test({
 });
 Deno.test({
   name: "NoEOLTest",
-  async fn() {
+  fn() {
     const input = "a,b,c";
     assertEquals(
-      await parse(input),
+      parse(input),
       [["a", "b", "c"]],
     );
   },
@@ -71,10 +71,10 @@ Deno.test({
 
 Deno.test({
   name: "Semicolon",
-  async fn() {
+  fn() {
     const input = "a;b;c\n";
     assertEquals(
-      await parse(input, { separator: ";" }),
+      parse(input, { separator: ";" }),
       [["a", "b", "c"]],
     );
   },
@@ -82,10 +82,10 @@ Deno.test({
 
 Deno.test({
   name: "MultiLine",
-  async fn() {
+  fn() {
     const input = '"two\nline","one line","three\nline\nfield"';
     assertEquals(
-      await parse(input),
+      parse(input),
       [["two\nline", "one line", "three\nline\nfield"]],
     );
   },
@@ -93,10 +93,10 @@ Deno.test({
 
 Deno.test({
   name: "BlankLine",
-  async fn() {
+  fn() {
     const input = "a,b,c\n\nd,e,f\n\n";
     assertEquals(
-      await parse(input),
+      parse(input),
       [
         ["a", "b", "c"],
         ["d", "e", "f"],
@@ -107,10 +107,10 @@ Deno.test({
 
 Deno.test({
   name: "BlankLineFieldCount",
-  async fn() {
+  fn() {
     const input = "a,b,c\n\nd,e,f\n\n";
     assertEquals(
-      await parse(input, { fieldsPerRecord: 0 }),
+      parse(input, { fieldsPerRecord: 0 }),
       [
         ["a", "b", "c"],
         ["d", "e", "f"],
@@ -121,10 +121,10 @@ Deno.test({
 
 Deno.test({
   name: "TrimSpace",
-  async fn() {
+  fn() {
     const input = " a,  b,   c\n";
     assertEquals(
-      await parse(input, { trimLeadingSpace: true }),
+      parse(input, { trimLeadingSpace: true }),
       [["a", "b", "c"]],
     );
   },
@@ -132,61 +132,61 @@ Deno.test({
 
 Deno.test({
   name: "LeadingSpace",
-  async fn() {
+  fn() {
     const input = " a,  b,   c\n";
     const output = [[" a", "  b", "   c"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "Comment",
-  async fn() {
+  fn() {
     const input = "#1,2,3\na,b,c\n#comment";
     const output = [["a", "b", "c"]];
-    assertEquals(await parse(input, { comment: "#" }), output);
+    assertEquals(parse(input, { comment: "#" }), output);
   },
 });
 Deno.test({
   name: "NoComment",
-  async fn() {
+  fn() {
     const input = "#1,2,3\na,b,c";
     const output = [
       ["#1", "2", "3"],
       ["a", "b", "c"],
     ];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "LazyQuotes",
-  async fn() {
+  fn() {
     const input = `a "word","1"2",a","b`;
     const output = [[`a "word"`, `1"2`, `a"`, `b`]];
-    assertEquals(await parse(input, { lazyQuotes: true }), output);
+    assertEquals(parse(input, { lazyQuotes: true }), output);
   },
 });
 Deno.test({
   name: "BareQuotes",
-  async fn() {
+  fn() {
     const input = `a "word","1"2",a"`;
     const output = [[`a "word"`, `1"2`, `a"`]];
-    assertEquals(await parse(input, { lazyQuotes: true }), output);
+    assertEquals(parse(input, { lazyQuotes: true }), output);
   },
 });
 Deno.test({
   name: "BareDoubleQuotes",
-  async fn() {
+  fn() {
     const input = `a""b,c`;
     const output = [[`a""b`, `c`]];
-    assertEquals(await parse(input, { lazyQuotes: true }), output);
+    assertEquals(parse(input, { lazyQuotes: true }), output);
   },
 });
 Deno.test({
   name: "BadDoubleQuotes",
-  async fn() {
+  fn() {
     const input = `a""b,c`;
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       'parse error on line 1, column 1: bare " in non-quoted-field',
     );
@@ -194,18 +194,18 @@ Deno.test({
 });
 Deno.test({
   name: "TrimQuote",
-  async fn() {
+  fn() {
     const input = ` "a"," b",c`;
     const output = [["a", " b", "c"]];
-    assertEquals(await parse(input, { trimLeadingSpace: true }), output);
+    assertEquals(parse(input, { trimLeadingSpace: true }), output);
   },
 });
 Deno.test({
   name: "BadBareQuote",
-  async fn() {
+  fn() {
     const input = `a "word","b"`;
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       'parse error on line 1, column 2: bare " in non-quoted-field',
     );
@@ -213,10 +213,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadTrailingQuote",
-  async fn() {
+  fn() {
     const input = `"a word",b"`;
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       'parse error on line 1, column 10: bare " in non-quoted-field',
     );
@@ -224,10 +224,10 @@ Deno.test({
 });
 Deno.test({
   name: "ExtraneousQuote",
-  async fn() {
+  fn() {
     const input = `"a "word","b"`;
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       `parse error on line 1, column 3: extraneous or missing " in quoted-field`,
     );
@@ -235,10 +235,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadFieldCount",
-  async fn() {
+  fn() {
     const input = "a,b,c\nd,e";
-    await assertRejects(
-      async () => await parse(input, { fieldsPerRecord: 0 }),
+    assertThrows(
+      () => parse(input, { fieldsPerRecord: 0 }),
       ParseError,
       "record on line 2: wrong number of fields",
     );
@@ -246,10 +246,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadFieldCount1",
-  async fn() {
+  fn() {
     const input = `a,b,c`;
-    await assertRejects(
-      async () => await parse(input, { fieldsPerRecord: 2 }),
+    assertThrows(
+      () => parse(input, { fieldsPerRecord: 2 }),
       ParseError,
       "record on line 1: wrong number of fields",
     );
@@ -257,70 +257,70 @@ Deno.test({
 });
 Deno.test({
   name: "FieldCount",
-  async fn() {
+  fn() {
     const input = "a,b,c\nd,e";
     const output = [
       ["a", "b", "c"],
       ["d", "e"],
     ];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "TrailingCommaEOF",
-  async fn() {
+  fn() {
     const input = "a,b,c,";
     const output = [["a", "b", "c", ""]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "TrailingCommaEOL",
-  async fn() {
+  fn() {
     const input = "a,b,c,\n";
     const output = [["a", "b", "c", ""]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "TrailingCommaSpaceEOF",
-  async fn() {
+  fn() {
     const input = "a,b,c, ";
     const output = [["a", "b", "c", ""]];
-    assertEquals(await parse(input, { trimLeadingSpace: true }), output);
+    assertEquals(parse(input, { trimLeadingSpace: true }), output);
   },
 });
 Deno.test({
   name: "TrailingCommaSpaceEOL",
-  async fn() {
+  fn() {
     const input = "a,b,c, \n";
     const output = [["a", "b", "c", ""]];
-    assertEquals(await parse(input, { trimLeadingSpace: true }), output);
+    assertEquals(parse(input, { trimLeadingSpace: true }), output);
   },
 });
 Deno.test({
   name: "TrailingCommaLine3",
-  async fn() {
+  fn() {
     const input = "a,b,c\nd,e,f\ng,hi,";
     const output = [
       ["a", "b", "c"],
       ["d", "e", "f"],
       ["g", "hi", ""],
     ];
-    assertEquals(await parse(input, { trimLeadingSpace: true }), output);
+    assertEquals(parse(input, { trimLeadingSpace: true }), output);
   },
 });
 Deno.test({
   name: "NotTrailingComma3",
-  async fn() {
+  fn() {
     const input = "a,b,c, \n";
     const output = [["a", "b", "c", " "]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "CommaFieldTest",
-  async fn() {
+  fn() {
     const input =
       `x,y,z,w\nx,y,z,\nx,y,,\nx,,,\n,,,\n"x","y","z","w"\n"x","y","z",""\n"x","y","",""\n"x","","",""\n"","","",""\n`;
     const output = [
@@ -335,38 +335,38 @@ Deno.test({
       ["x", "", "", ""],
       ["", "", "", ""],
     ];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "TrailingCommaIneffective1",
-  async fn() {
+  fn() {
     const input = "a,b,\nc,d,e";
     const output = [
       ["a", "b", ""],
       ["c", "d", "e"],
     ];
-    assertEquals(await parse(input, { trimLeadingSpace: true }), output);
+    assertEquals(parse(input, { trimLeadingSpace: true }), output);
   },
 });
 Deno.test({
   name: "ReadAllReuseRecord",
-  async fn() {
+  fn() {
     const input = "a,b\nc,d";
     const output = [
       ["a", "b"],
       ["c", "d"],
     ];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
     // ReuseRecord: true,
   },
 });
 Deno.test({
   name: "StartLine1", // Issue 19019
-  async fn() {
+  fn() {
     const input = 'a,"b\nc"d,e';
-    await assertRejects(
-      async () => await parse(input, { fieldsPerRecord: 2 }),
+    assertThrows(
+      () => parse(input, { fieldsPerRecord: 2 }),
       ParseError,
       'record on line 1; parse error on line 2, column 1: extraneous or missing " in quoted-field',
     );
@@ -374,10 +374,10 @@ Deno.test({
 });
 Deno.test({
   name: "StartLine2",
-  async fn() {
+  fn() {
     const input = 'a,b\n"d\n\n,e';
-    await assertRejects(
-      async () => await parse(input, { fieldsPerRecord: 2 }),
+    assertThrows(
+      () => parse(input, { fieldsPerRecord: 2 }),
       ParseError,
       'record on line 2; parse error on line 5, column 0: extraneous or missing " in quoted-field',
     );
@@ -385,42 +385,42 @@ Deno.test({
 });
 Deno.test({
   name: "CRLFInQuotedField", // Issue 21201
-  async fn() {
+  fn() {
     const input = 'A,"Hello\r\nHi",B\r\n';
     const output = [["A", "Hello\nHi", "B"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "BinaryBlobField", // Issue 19410
-  async fn() {
+  fn() {
     const input = "x09\x41\xb4\x1c,aktau";
     const output = [["x09A\xb4\x1c", "aktau"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "TrailingCR",
-  async fn() {
+  fn() {
     const input = "field1,field2\r";
     const output = [["field1", "field2"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "QuotedTrailingCR",
-  async fn() {
+  fn() {
     const input = '"field"\r';
     const output = [["field"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "QuotedTrailingCRCR",
-  async fn() {
+  fn() {
     const input = '"field"\r\r';
-    await assertRejects(
-      async () => await parse(input, { fieldsPerRecord: 2 }),
+    assertThrows(
+      () => parse(input, { fieldsPerRecord: 2 }),
       ParseError,
       'parse error on line 1, column 6: extraneous or missing " in quoted-field',
     );
@@ -428,63 +428,63 @@ Deno.test({
 });
 Deno.test({
   name: "FieldCR",
-  async fn() {
+  fn() {
     const input = "field\rfield\r";
     const output = [["field\rfield"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "FieldCRCR",
-  async fn() {
+  fn() {
     const input = "field\r\rfield\r\r";
     const output = [["field\r\rfield\r"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "FieldCRCRLF",
-  async fn() {
+  fn() {
     const input = "field\r\r\nfield\r\r\n";
     const output = [["field\r"], ["field\r"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "FieldCRCRLFCR",
-  async fn() {
+  fn() {
     const input = "field\r\r\n\rfield\r\r\n\r";
     const output = [["field\r"], ["\rfield\r"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "FieldCRCRLFCRCR",
-  async fn() {
+  fn() {
     const input = "field\r\r\n\r\rfield\r\r\n\r\r";
     const output = [["field\r"], ["\r\rfield\r"], ["\r"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "MultiFieldCRCRLFCRCR",
-  async fn() {
+  fn() {
     const input = "field1,field2\r\r\n\r\rfield1,field2\r\r\n\r\r,";
     const output = [
       ["field1", "field2\r"],
       ["\r\rfield1", "field2\r"],
       ["\r\r", ""],
     ];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "NonASCIICommaAndComment",
-  async fn() {
+  fn() {
     const input = "a£b,c£ \td,e\n€ comment\n";
     const output = [["a", "b,c", "d,e"]];
     assertEquals(
-      await parse(input, {
+      parse(input, {
         trimLeadingSpace: true,
         separator: "£",
         comment: "€",
@@ -495,11 +495,11 @@ Deno.test({
 });
 Deno.test({
   name: "NonASCIICommaAndCommentWithQuotes",
-  async fn() {
+  fn() {
     const input = 'a€"  b,"€ c\nλ comment\n';
     const output = [["a", "  b,", " c"]];
     assertEquals(
-      await parse(input, { separator: "€", comment: "λ" }),
+      parse(input, { separator: "€", comment: "λ" }),
       output,
     );
   },
@@ -509,11 +509,11 @@ Deno.test(
     // λ and θ start with the same byte.
     // This tests that the parser doesn't confuse such characters.
     name: "NonASCIICommaConfusion",
-    async fn() {
+    fn() {
       const input = '"abθcd"λefθgh';
       const output = [["abθcd", "efθgh"]];
       assertEquals(
-        await parse(input, { separator: "λ", comment: "€" }),
+        parse(input, { separator: "λ", comment: "€" }),
         output,
       );
     },
@@ -521,26 +521,26 @@ Deno.test(
 );
 Deno.test({
   name: "NonASCIICommentConfusion",
-  async fn() {
+  fn() {
     const input = "λ\nλ\nθ\nλ\n";
     const output = [["λ"], ["λ"], ["λ"]];
-    assertEquals(await parse(input, { comment: "θ" }), output);
+    assertEquals(parse(input, { comment: "θ" }), output);
   },
 });
 Deno.test({
   name: "QuotedFieldMultipleLF",
-  async fn() {
+  fn() {
     const input = '"\n\n\n\n"';
     const output = [["\n\n\n\n"]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "MultipleCRLF",
-  async fn() {
+  fn() {
     const input = "\r\n\r\n\r\n\r\n";
     const output: string[][] = [];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
   /**
    * The implementation may read each line in several chunks if
@@ -550,20 +550,20 @@ Deno.test({
 } /* TODO(kt3k): Enable this test case)
  Deno.test({
     name: "HugeLines",
-    async fn() {
+    fn() {
     const input = "#ignore\n".repeat(10000) + "@".repeat(5000) + ","
       "*".repeat(5000),
     const output = [["@".repeat(5000), "*".repeat(5000)]]
-    assertEquals(await parse(input), output)
+    assertEquals(parse(input), output)
     Comment: "#",
   },
   }*/);
 Deno.test({
   name: "QuoteWithTrailingCRLF",
-  async fn() {
+  fn() {
     const input = '"foo"bar"\r\n';
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       `parse error on line 1, column 4: extraneous or missing " in quoted-field`,
     );
@@ -571,34 +571,34 @@ Deno.test({
 });
 Deno.test({
   name: "LazyQuoteWithTrailingCRLF",
-  async fn() {
+  fn() {
     const input = '"foo"bar"\r\n';
     const output = [[`foo"bar`]];
-    assertEquals(await parse(input, { lazyQuotes: true }), output);
+    assertEquals(parse(input, { lazyQuotes: true }), output);
   },
 });
 Deno.test({
   name: "DoubleQuoteWithTrailingCRLF",
-  async fn() {
+  fn() {
     const input = '"foo""bar"\r\n';
     const output = [[`foo"bar`]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "EvenQuotes",
-  async fn() {
+  fn() {
     const input = `""""""""`;
     const output = [[`"""`]];
-    assertEquals(await parse(input), output);
+    assertEquals(parse(input), output);
   },
 });
 Deno.test({
   name: "OddQuotes",
-  async fn() {
+  fn() {
     const input = `"""""""`;
-    await assertRejects(
-      async () => await parse(input),
+    assertThrows(
+      () => parse(input),
       ParseError,
       `parse error on line 1, column 7: extraneous or missing " in quoted-field`,
     );
@@ -606,18 +606,18 @@ Deno.test({
 });
 Deno.test({
   name: "LazyOddQuotes",
-  async fn() {
+  fn() {
     const input = `"""""""`;
     const output = [[`"""`]];
-    assertEquals(await parse(input, { lazyQuotes: true }), output);
+    assertEquals(parse(input, { lazyQuotes: true }), output);
   },
 });
 Deno.test({
   name: "BadComma1",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { separator: "\n" }),
+    assertThrows(
+      () => parse(input, { separator: "\n" }),
       Error,
       "Invalid Delimiter",
     );
@@ -625,10 +625,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadComma2",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { separator: "\r" }),
+    assertThrows(
+      () => parse(input, { separator: "\r" }),
       Error,
       "Invalid Delimiter",
     );
@@ -636,10 +636,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadComma3",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { separator: '"' }),
+    assertThrows(
+      () => parse(input, { separator: '"' }),
       Error,
       "Invalid Delimiter",
     );
@@ -647,10 +647,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadComment1",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { comment: "\n" }),
+    assertThrows(
+      () => parse(input, { comment: "\n" }),
       Error,
       "Invalid Delimiter",
     );
@@ -658,10 +658,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadComment2",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { comment: "\r" }),
+    assertThrows(
+      () => parse(input, { comment: "\r" }),
       Error,
       "Invalid Delimiter",
     );
@@ -669,10 +669,10 @@ Deno.test({
 });
 Deno.test({
   name: "BadCommaComment",
-  async fn() {
+  fn() {
     const input = "";
-    await assertRejects(
-      async () => await parse(input, { separator: "X", comment: "X" }),
+    assertThrows(
+      () => parse(input, { separator: "X", comment: "X" }),
       Error,
       "Invalid Delimiter",
     );
@@ -681,63 +681,63 @@ Deno.test({
 
 Deno.test({
   name: "simple",
-  async fn() {
+  fn() {
     const input = "a,b,c";
     const output = [["a", "b", "c"]];
-    assertEquals(await parse(input, { skipFirstRow: false }), output);
+    assertEquals(parse(input, { skipFirstRow: false }), output);
   },
 });
 Deno.test({
   name: "simple Bufreader",
-  async fn() {
+  fn() {
     const input = "a,b,c";
     const output = [["a", "b", "c"]];
-    assertEquals(await parse(input, { skipFirstRow: false }), output);
+    assertEquals(parse(input, { skipFirstRow: false }), output);
   },
 });
 Deno.test({
   name: "multiline",
-  async fn() {
+  fn() {
     const input = "a,b,c\ne,f,g\n";
     const output = [
       ["a", "b", "c"],
       ["e", "f", "g"],
     ];
-    assertEquals(await parse(input, { skipFirstRow: false }), output);
+    assertEquals(parse(input, { skipFirstRow: false }), output);
   },
 });
 Deno.test({
   name: "header mapping boolean",
-  async fn() {
+  fn() {
     const input = "a,b,c\ne,f,g\n";
     const output = [{ a: "e", b: "f", c: "g" }];
-    assertEquals(await parse(input, { skipFirstRow: true }), output);
+    assertEquals(parse(input, { skipFirstRow: true }), output);
   },
 });
 Deno.test({
   name: "header mapping array",
-  async fn() {
+  fn() {
     const input = "a,b,c\ne,f,g\n";
     const output = [
       { this: "a", is: "b", sparta: "c" },
       { this: "e", is: "f", sparta: "g" },
     ];
     assertEquals(
-      await parse(input, { columns: ["this", "is", "sparta"] }),
+      parse(input, { columns: ["this", "is", "sparta"] }),
       output,
     );
   },
 });
 Deno.test({
   name: "header mapping object",
-  async fn() {
+  fn() {
     const input = "a,b,c\ne,f,g\n";
     const output = [
       { this: "a", is: "b", sparta: "c" },
       { this: "e", is: "f", sparta: "g" },
     ];
     assertEquals(
-      await parse(input, {
+      parse(input, {
         columns: [{ name: "this" }, { name: "is" }, { name: "sparta" }],
       }),
       output,
@@ -746,14 +746,14 @@ Deno.test({
 });
 Deno.test({
   name: "provides both opts.skipFirstRow and opts.columns",
-  async fn() {
+  fn() {
     const input = "a,b,1\nc,d,2\ne,f,3";
     const output = [
       { foo: "c", bar: "d", baz: "2" },
       { foo: "e", bar: "f", baz: "3" },
     ];
     assertEquals(
-      await parse(input, {
+      parse(input, {
         skipFirstRow: true,
         columns: [{ name: "foo" }, { name: "bar" }, { name: "baz" }],
       }),
@@ -763,11 +763,11 @@ Deno.test({
 });
 Deno.test({
   name: "mismatching number of headers and fields",
-  async fn() {
+  fn() {
     const input = "a,b,c\nd,e";
-    await assertRejects(
-      async () =>
-        await parse(input, {
+    assertThrows(
+      () =>
+        parse(input, {
           skipFirstRow: true,
           columns: [{ name: "foo" }, { name: "bar" }, { name: "baz" }],
         }),

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -6,8 +6,6 @@
 
 import { assertEquals, assertRejects } from "../testing/asserts.ts";
 import { parse, ParseError } from "./csv.ts";
-import { StringReader } from "../io/readers.ts";
-import { BufReader } from "../io/buffer.ts";
 
 Deno.test({
   name: "Simple",
@@ -692,7 +690,7 @@ Deno.test({
 Deno.test({
   name: "simple Bufreader",
   async fn() {
-    const input = new BufReader(new StringReader("a,b,c"));
+    const input = "a,b,c";
     const output = [["a", "b", "c"]];
     assertEquals(await parse(input, { skipFirstRow: false }), output);
   },


### PR DESCRIPTION
- removes BufReader as input for `parse`
- makes `parse` sync and browser compatible