### PR TITLE
test: skip test-net-allow-half-open.js on darwin

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -671,6 +671,7 @@
   },
   "darwinIgnore": {
     "parallel": [
+      "test-net-allow-half-open.js",
       "test-net-socket-close-after-end.js"
     ]
   },


### PR DESCRIPTION
closes #2482 