### PR TITLE
fix(node): fs.existsSync never throws

### DIFF
--- a/node/_fs/_fs_exists.ts
+++ b/node/_fs/_fs_exists.ts
@@ -34,7 +34,7 @@ export function existsSync(path: string | URL): boolean {
   try {
     Deno.lstatSync(path);
     return true;
-  } catch (err) {
+  } catch (_err) {
     return false;
   }
 }

--- a/node/_fs/_fs_exists.ts
+++ b/node/_fs/_fs_exists.ts
@@ -35,9 +35,6 @@ export function existsSync(path: string | URL): boolean {
     Deno.lstatSync(path);
     return true;
   } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      return false;
-    }
-    throw err;
+    return false;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_std/issues/2494

`fs.existsSync` should never throw as per Node implementation