### PR TITLE
feat(http): add CookieMap and SecureCookieMap

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -292,3 +292,127 @@ const headers = new Headers([
 const cookies = getSetCookies(headers);
 console.log(cookies); // [{ name: "lulu", value: "meow", secure: true, maxAge: 3600 }, { name: "booya", value: "kahsa", httpOnly: true, path: "/ }]
 ```
+
+## Cookie maps
+
+An alternative to `cookie.ts` is `cookie_map.ts` which provides `CookieMap`,
+`SecureCookieMap`, and `mergeHeaders` to manage request and response cookies
+with the familiar `Map` interface.
+
+### CookieMap
+
+Provides methods that are aligned to the JavaScript `Map` interface to manage
+cookies:
+
+```ts
+import {
+  CookieMap,
+  mergeHeaders,
+} from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+
+const request = new Request("https://localhost/", {
+  headers: { "cookie": "foo=bar; bar=baz;" },
+});
+
+const cookies = new CookieMap(request);
+console.log(cookies.get("foo")); // logs "bar"
+cookies.set("session", "1234567");
+cookies.delete("bar");
+
+const response = new Response("test", {
+  headers: mergeHeaders({
+    "content-type": "text/plain",
+  }, cookies);
+});
+```
+
+If the headers or the response are available at the time of the construction of
+the `CookieMap`, they can be passed to the constructor and will have the cookies
+set on them directly, thereby not requiring use of `mergeHeaders`:
+
+```ts
+import { CookieMap } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+
+const request = new Request("https://localhost/", {
+  headers: { "cookie": "foo=bar; bar=baz;" },
+});
+
+const headers = new Headers({ "content-type": "text/plain" });
+
+const cookies = new CookieMap(request, { response: headers });
+console.log(cookies.get("foo")); // logs "bar"
+cookies.set("session", "1234567");
+cookies.delete("bar");
+
+const response = new Response("test", { headers });
+```
+
+### SecureCookieMap
+
+Provides methods that are aligned to the JavaScript `Map` interface to manage
+cookies. The biggest difference is that `SecureCookieMap` supports the use of a
+key ring adhering to the `KeyRing` interface to sign and verify cookies. This
+helps prevent client side tampering of cookies.
+
+While passing keys is optional to `SecureCookieMap`, if you are not using keys,
+consider just using `CookieMap` as all methods are synchronous and therefore
+more straight forward to use.
+
+```ts
+import {
+  SecureCookieMap,
+  mergeHeaders,
+  type KeyRing,
+} from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+
+const request = new Request("https://localhost/", {
+  headers: {
+    "cookie": "bar=foo; bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"
+  },
+});
+
+declare const keys: KeyRing;
+
+const cookies = new SecureCookieMap(request, { keys });
+console.log(await cookies.get("bar")); // logs "foo", with the signature being verified
+await cookies.set("session", "1234567"); // this will be automatically signed
+
+const response = new Response("test", {
+  headers: mergeHeaders({
+    "content-type": "text/plain",
+  }, cookies);
+});
+```
+
+```ts
+import {
+  type KeyRing,
+  SecureCookieMap,
+} from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+
+const request = new Request("https://localhost/", {
+  headers: {
+    "cookie": "bar=foo; bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro",
+  },
+});
+
+const headers = new Headers({ "content-type": "text/plain" });
+
+declare const keys: KeyRing;
+
+const cookies = new SecureCookieMap(request, { keys });
+console.log(await cookies.get("bar")); // logs "foo", with the signature being verified
+await cookies.set("session", "1234567"); // this will be automatically signed
+
+const response = new Response("test", { headers });
+```
+
+### mergeHeaders
+
+A function which takes various sources of headers and returns a single `Headers`
+instance. Intended to merge `CookieMap` and `SecureCookieMap` set cookie headers
+into a final response.
+
+Sources can be of type `HeadersInit`, `CookieMap`, `SecureCookieMap` or objects
+which have a `headers` property with a value of `Headers` (like a `Response`
+object).

--- a/http/README.md
+++ b/http/README.md
@@ -360,14 +360,14 @@ more straight forward to use.
 
 ```ts
 import {
-  SecureCookieMap,
-  mergeHeaders,
   type KeyRing,
+  mergeHeaders,
+  SecureCookieMap,
 } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
 
 const request = new Request("https://localhost/", {
   headers: {
-    "cookie": "bar=foo; bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"
+    "cookie": "bar=foo; bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro",
   },
 });
 
@@ -380,7 +380,7 @@ await cookies.set("session", "1234567"); // this will be automatically signed
 const response = new Response("test", {
   headers: mergeHeaders({
     "content-type": "text/plain",
-  }, cookies);
+  }, cookies),
 });
 ```
 

--- a/http/README.md
+++ b/http/README.md
@@ -322,7 +322,7 @@ cookies.delete("bar");
 const response = new Response("test", {
   headers: mergeHeaders({
     "content-type": "text/plain",
-  }, cookies);
+  }, cookies),
 });
 ```
 

--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -1,0 +1,841 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+/** Provides a iterable map interfaces for managing cookies server side.
+ *
+ * ### Examples
+ *
+ * To access the keys in a request and have any set keys available for creating
+ * a response:
+ *
+ * ```ts
+ * import {
+ *   CookieMap,
+ *   mergeHeaders
+ * } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+ *
+ * const request = new Request("https://localhost/", {
+ *   headers: { "cookie": "foo=bar; bar=baz;"}
+ * });
+ *
+ * const cookies = new CookieMap(request, { secure: true });
+ * console.log(cookies.get("foo")); // logs "bar"
+ * cookies.set("session", "1234567", { secure: true });
+ *
+ * const response = new Response("hello", {
+ *   headers: mergeHeaders({
+ *     "content-type": "text/plain",
+ *   }, cookies),
+ * });
+ * ```
+ *
+ * To have automatic management of cryptographically signed cookies, you can use
+ * the {@linkcode SecureCookieMap} instead of {@linkcode CookieMap}. The biggest
+ * difference is that the methods operate async in order to be able to support
+ * async signing and validation of cookies:
+ *
+ * ```ts
+ * import {
+ *   SecureCookieMap,
+ *   mergeHeaders,
+ *   type KeyRing,
+ * } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+ *
+ * const request = new Request("https://localhost/", {
+ *   headers: { "cookie": "foo=bar; bar=baz;"}
+ * });
+ *
+ * // The keys must implement the `KeyRing` interface.
+ * declare const keys: KeyRing;
+ *
+ * const cookies = new SecureCookieMap(request, { keys, secure: true });
+ * console.log(await cookies.get("foo")); // logs "bar"
+ * // the cookie will be automatically signed using the supplied key ring.
+ * await cookies.set("session", "1234567");
+ *
+ * const response = new Response("hello", {
+ *   headers: mergeHeaders({
+ *     "content-type": "text/plain",
+ *   }, cookies),
+ * });
+ * ```
+ *
+ * In addition, if you have a {@linkcode Response} or {@linkcode Headers} for a
+ * response at construction of the cookies object, they can be passed and any
+ * set cookies will be added directly to those headers:
+ *
+ * ```ts
+ * import { CookieMap } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
+ *
+ * const request = new Request("https://localhost/", {
+ *   headers: { "cookie": "foo=bar; bar=baz;"}
+ * });
+ *
+ * const response = new Response("hello", {
+ *   headers: { "content-type": "text/plain" },
+ * });
+ *
+ * const cookies = new CookieMap(request, { response });
+ * console.log(cookies.get("foo")); // logs "bar"
+ * cookies.set("session", "1234567");
+ * ```
+ *
+ * @module
+ */
+
+export interface CookieMapOptions {
+  /** The {@linkcode Response} or the headers that will be used with the
+   * response. When provided, `Set-Cookie` headers will be set in the headers
+   * when cookies are set or deleted in the map.
+   *
+   * An alternative way to extract the headers is to pass the cookie map to the
+   * {@linkcode mergeHeaders} function to merge various sources of the
+   * headers to be provided when creating or updating a response.
+   */
+  response?: Headered | Headers;
+  /** A flag that indicates if the request and response are being handled over
+   * a secure (e.g. HTTPS/TLS) connection. Defaults to `false`. */
+  secure?: boolean;
+}
+
+export interface CookieMapSetDeleteOptions {
+  /** The domain to scope the cookie for. */
+  domain?: string;
+  /** When the cookie expires. */
+  expires?: Date;
+  /** A flag that indicates if the cookie is valid over HTTP only. */
+  httpOnly?: boolean;
+  /** Do not error when signing and validating cookies over an insecure
+   * connection. */
+  ignoreInsecure?: boolean;
+  /** Overwrite an existing value. */
+  overwrite?: boolean;
+  /** The path the cookie is valid for. */
+  path?: string;
+  /** Override the flag that was set when the instance was created. */
+  secure?: boolean;
+  /** Set the same-site indicator for a cookie. */
+  sameSite?: "strict" | "lax" | "none" | boolean;
+}
+
+/** An object which contains a `headers` property which has a value of an
+ * instance of {@linkcode Headers}, like {@linkcode Request} and
+ * {@linkcode Response}. */
+export interface Headered {
+  headers: Headers;
+}
+
+export interface Mergable {
+  [cookieMapHeadersInitSymbol](): [string, string][];
+}
+
+export interface SecureCookieMapOptions {
+  /** Keys which will be used to validate and sign cookies. The key ring should
+   * implement the {@linkcode KeyRing} interface. */
+  keys?: KeyRing;
+
+  /** The {@linkcode Response} or the headers that will be used with the
+   * response. When provided, `Set-Cookie` headers will be set in the headers
+   * when cookies are set or deleted in the map.
+   *
+   * An alternative way to extract the headers is to pass the cookie map to the
+   * {@linkcode mergeHeaders} function to merge various sources of the
+   * headers to be provided when creating or updating a response.
+   */
+  response?: Headered | Headers;
+
+  /** A flag that indicates if the request and response are being handled over
+   * a secure (e.g. HTTPS/TLS) connection. Defaults to `false`. */
+  secure?: boolean;
+}
+
+export interface SecureCookieMapGetOptions {
+  /** Overrides the flag that was set when the instance was created. */
+  signed?: boolean;
+}
+
+export interface SecureCookieMapSetDeleteOptions {
+  /** The domain to scope the cookie for. */
+  domain?: string;
+  /** When the cookie expires. */
+  expires?: Date;
+  /** A flag that indicates if the cookie is valid over HTTP only. */
+  httpOnly?: boolean;
+  /** Do not error when signing and validating cookies over an insecure
+   * connection. */
+  ignoreInsecure?: boolean;
+  /** Overwrite an existing value. */
+  overwrite?: boolean;
+  /** The path the cookie is valid for. */
+  path?: string;
+  /** Override the flag that was set when the instance was created. */
+  secure?: boolean;
+  /** Set the same-site indicator for a cookie. */
+  sameSite?: "strict" | "lax" | "none" | boolean;
+  /** Override the default behavior of signing the cookie. */
+  signed?: boolean;
+}
+
+type CookieAttributes = SecureCookieMapSetDeleteOptions;
+
+// deno-lint-ignore no-control-regex
+const FIELD_CONTENT_REGEXP = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/;
+const KEY_REGEXP = /(?:^|;) *([^=]*)=[^;]*/g;
+const SAME_SITE_REGEXP = /^(?:lax|none|strict)$/i;
+
+const matchCache: Record<string, RegExp> = {};
+function getPattern(name: string): RegExp {
+  if (name in matchCache) {
+    return matchCache[name];
+  }
+
+  return matchCache[name] = new RegExp(
+    `(?:^|;) *${name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")}=([^;]*)`,
+  );
+}
+
+function pushCookie(values: string[], cookie: Cookie): void {
+  if (cookie.overwrite) {
+    for (let i = values.length - 1; i >= 0; i--) {
+      if (values[i].indexOf(`${cookie.name}=`) === 0) {
+        values.splice(i, 1);
+      }
+    }
+  }
+  values.push(cookie.toHeaderValue());
+}
+
+function validateCookieProperty(
+  key: string,
+  value: string | undefined | null,
+): void {
+  if (value && !FIELD_CONTENT_REGEXP.test(value)) {
+    throw new TypeError(`The "${key}" of the cookie (${value}) is invalid.`);
+  }
+}
+
+/** An internal abstraction to manage cookies. */
+class Cookie implements CookieAttributes {
+  domain?: string;
+  expires?: Date;
+  httpOnly = true;
+  maxAge?: number;
+  name: string;
+  overwrite = false;
+  path = "/";
+  sameSite: "strict" | "lax" | "none" | boolean = false;
+  secure = false;
+  signed?: boolean;
+  value: string;
+
+  constructor(
+    name: string,
+    value: string | null,
+    attributes: CookieAttributes,
+  ) {
+    validateCookieProperty("name", name);
+    this.name = name;
+    validateCookieProperty("value", value);
+    this.value = value ?? "";
+    Object.assign(this, attributes);
+    if (!this.value) {
+      this.expires = new Date(0);
+      this.maxAge = undefined;
+    }
+
+    validateCookieProperty("path", this.path);
+    validateCookieProperty("domain", this.domain);
+    if (
+      this.sameSite && typeof this.sameSite === "string" &&
+      !SAME_SITE_REGEXP.test(this.sameSite)
+    ) {
+      throw new TypeError(
+        `The "sameSite" of the cookie ("${this.sameSite}") is invalid.`,
+      );
+    }
+  }
+
+  toHeaderValue(): string {
+    let value = this.toString();
+    if (this.maxAge) {
+      this.expires = new Date(Date.now() + (this.maxAge * 1000));
+    }
+    if (this.path) {
+      value += `; path=${this.path}`;
+    }
+    if (this.expires) {
+      value += `; expires=${this.expires.toUTCString()}`;
+    }
+    if (this.domain) {
+      value += `; domain=${this.domain}`;
+    }
+    if (this.sameSite) {
+      value += `; samesite=${
+        this.sameSite === true ? "strict" : this.sameSite.toLowerCase()
+      }`;
+    }
+    if (this.secure) {
+      value += "; secure";
+    }
+    if (this.httpOnly) {
+      value += "; httponly";
+    }
+    return value;
+  }
+
+  toString(): string {
+    return `${this.name}=${this.value}`;
+  }
+}
+
+/** Symbol which is used in {@link mergeHeaders} to extract a
+ * `[string | string][]` from an instance to generate the final set of
+ * headers. */
+export const cookieMapHeadersInitSymbol = Symbol.for(
+  "Deno.std.cookieMap.headersInit",
+);
+
+function isMergable(value: unknown): value is Mergable {
+  return value != null && typeof value === "object" &&
+    cookieMapHeadersInitSymbol in value;
+}
+
+/** Allows merging of various sources of headers into a final set of headers
+ * which can be used in a {@linkcode Response}.
+ *
+ * Note, that unlike when passing a `Response` or {@linkcode Headers} used in a
+ * response to {@linkcode CookieMap} or {@linkcode SecureCookieMap}, merging
+ * will not ensure that there are no other `Set-Cookie` headers from other
+ * sources, it will simply append the various headers together. */
+export function mergeHeaders(
+  ...sources: (Headered | HeadersInit | Mergable)[]
+): Headers {
+  const headers = new Headers();
+  for (const source of sources) {
+    let entries: Iterable<[string, string]>;
+    if (source instanceof Headers) {
+      entries = source;
+    } else if ("headers" in source && source.headers instanceof Headers) {
+      entries = source.headers;
+    } else if (isMergable(source)) {
+      entries = source[cookieMapHeadersInitSymbol]();
+    } else if (Array.isArray(source)) {
+      entries = source as [string, string][];
+    } else {
+      entries = Object.entries(source);
+    }
+    for (const [key, value] of entries) {
+      headers.append(key, value);
+    }
+  }
+  return headers;
+}
+
+/** Provides an way to manage cookies in a request and response on the server
+ * as a single iterable collection.
+ *
+ * The methods and properties align to {@linkcode Map}. When constructing a
+ * {@linkcode Request} or {@linkcode Headers} from the request need to be
+ * provided, as well as optionally the {@linkcode Response} or `Headers` for the
+ * response can be provided. Alternatively the {@linkcode mergeHeaders}
+ * function can be used to generate a final set of headers for sending in the
+ * response. */
+export class CookieMap implements Mergable {
+  #keys?: string[];
+  #requestHeaders: Headers;
+  #responseHeaders: Headers;
+  #secure: boolean;
+
+  #requestKeys(): string[] {
+    if (this.#keys) {
+      return this.#keys;
+    }
+    const result = this.#keys = [] as string[];
+    const header = this.#requestHeaders.get("cookie");
+    if (!header) {
+      return result;
+    }
+    let matches: RegExpExecArray | null;
+    while ((matches = KEY_REGEXP.exec(header))) {
+      const [, key] = matches;
+      result.push(key);
+    }
+    return result;
+  }
+
+  /** Contains the number of valid cookies in the request headers. */
+  get size(): number {
+    return [...this].length;
+  }
+
+  constructor(
+    request: Headers | Headered,
+    options: CookieMapOptions = {},
+  ) {
+    this.#requestHeaders = "headers" in request ? request.headers : request;
+    const { secure = false, response = new Headers() } = options;
+    this.#responseHeaders = "headers" in response ? response.headers : response;
+    this.#secure = secure;
+  }
+
+  /** Deletes all the cookies from the {@linkcode Request} in the response. */
+  clear(options: CookieMapSetDeleteOptions = {}): void {
+    for (const key of this.keys()) {
+      this.set(key, null, options);
+    }
+  }
+
+  /** Set a cookie to be deleted in the response.
+   *
+   * This is a convenience function for `set(key, null, options?)`.
+   */
+  delete(key: string, options: CookieMapSetDeleteOptions = {}): boolean {
+    this.set(key, null, options);
+    return true;
+  }
+
+  /** Return the value of a matching key present in the {@linkcode Request}. If
+   * the key is not present `undefined` is returned. */
+  get(key: string): string | undefined {
+    const headerValue = this.#requestHeaders.get("cookie");
+    if (!headerValue) {
+      return undefined;
+    }
+    const match = headerValue.match(getPattern(key));
+    if (!match) {
+      return undefined;
+    }
+    const [, value] = match;
+    return value;
+  }
+
+  /** Returns `true` if the matching key is present in the {@linkcode Request},
+   * otherwise `false`. */
+  has(key: string): boolean {
+    const headerValue = this.#requestHeaders.get("cookie");
+    if (!headerValue) {
+      return false;
+    }
+    return getPattern(key).test(headerValue);
+  }
+
+  /** Set a named cookie in the response. The optional
+   * {@linkcode CookieMapSetDeleteOptions} are applied to the cookie being set.
+   */
+  set(
+    key: string,
+    value: string | null,
+    options: CookieMapSetDeleteOptions = {},
+  ): this {
+    const responseHeaders = this.#responseHeaders;
+    const values: string[] = [];
+    for (const [key, value] of responseHeaders) {
+      if (key === "set-cookie") {
+        values.push(value);
+      }
+    }
+    const secure = this.#secure;
+
+    if (!secure && options.secure && !options.ignoreInsecure) {
+      throw new TypeError(
+        "Cannot send secure cookie over unencrypted connection.",
+      );
+    }
+
+    const cookie = new Cookie(key, value, options);
+    cookie.secure = options.secure ?? secure;
+    pushCookie(values, cookie);
+
+    responseHeaders.delete("set-cookie");
+    for (const value of values) {
+      responseHeaders.append("set-cookie", value);
+    }
+    return this;
+  }
+
+  /** Iterate over the cookie keys and values that are present in the
+   * {@linkcode Request}. This is an alias of the `[Symbol.iterator]` method
+   * present on the class. */
+  entries(): IterableIterator<[string, string]> {
+    return this[Symbol.iterator]();
+  }
+
+  /** Iterate over the cookie keys that are present in the
+   * {@linkcode Request}. */
+  *keys(): IterableIterator<string> {
+    for (const [key] of this) {
+      yield key;
+    }
+  }
+
+  /** Iterate over the cookie values that are present in the
+   * {@linkcode Request}. */
+  *values(): IterableIterator<string> {
+    for (const [, value] of this) {
+      yield value;
+    }
+  }
+
+  /** Iterate over the cookie keys and values that are present in the
+   * {@linkcode Request}. */
+  *[Symbol.iterator](): IterableIterator<[string, string]> {
+    const keys = this.#requestKeys();
+    for (const key of keys) {
+      const value = this.get(key);
+      if (value) {
+        yield [key, value];
+      }
+    }
+  }
+
+  /** A method used by {@linkcode mergeHeaders} to be able to merge
+   * headers from various sources when forming a {@linkcode Response}. */
+  [cookieMapHeadersInitSymbol](): [string, string][] {
+    const init: [string, string][] = [];
+    for (const [key, value] of this.#responseHeaders) {
+      if (key === "set-cookie") {
+        init.push([key, value]);
+      }
+    }
+    return init;
+  }
+
+  [Symbol.for("Deno.customInspect")]() {
+    return `${this.constructor.name} []`;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](
+    depth: number,
+    // deno-lint-ignore no-explicit-any
+    options: any,
+    inspect: (value: unknown, options?: unknown) => string,
+  ) {
+    if (depth < 0) {
+      return options.stylize(`[${this.constructor.name}]`, "special");
+    }
+
+    const newOptions = Object.assign({}, options, {
+      depth: options.depth === null ? null : options.depth - 1,
+    });
+    return `${options.stylize(this.constructor.name, "special")} ${
+      inspect([], newOptions)
+    }`;
+  }
+}
+
+/** Types of data that can be signed cryptographically. */
+export type Data = string | number[] | ArrayBuffer | Uint8Array;
+
+/** An interface which describes the methods that {@linkcode SecureCookieMap}
+ * uses to sign and verify cookies. */
+export interface KeyRing {
+  /** Given a set of data and a digest, return the key index of the key used
+   * to sign the data. The index is 0 based. A non-negative number indices the
+   * digest is valid and a key was found. */
+  indexOf(data: Data, digest: string): Promise<number> | number;
+  /** Sign the data, returning a string based digest of the data. */
+  sign(data: Data): Promise<string> | string;
+  /** Verifies the digest matches the provided data, indicating the data was
+   * signed by the keyring and has not been tampered with. */
+  verify(data: Data, digest: string): Promise<boolean> | boolean;
+}
+
+/** Provides an way to manage cookies in a request and response on the server
+ * as a single iterable collection, as well as the ability to sign and verify
+ * cookies to prevent tampering.
+ *
+ * The methods and properties align to {@linkcode Map}, but due to the need to
+ * support asynchronous cryptographic keys, all the APIs operate async. When
+ * constructing a {@linkcode Request} or {@linkcode Headers} from the request
+ * need to be provided, as well as optionally the {@linkcode Response} or
+ * `Headers` for the response can be provided. Alternatively the
+ * {@linkcode mergeHeaders} function can be used to generate a final set
+ * of headers for sending in the response.
+ *
+ * On construction, the optional set of keys implementing the
+ * {@linkcode KeyRing} interface. While it is optional, if you don't plan to use
+ * keys, you might want to consider using just the {@linkcode CookieMap}. */
+export class SecureCookieMap implements Mergable {
+  #keyRing?: KeyRing;
+  #keys?: string[];
+  #requestHeaders: Headers;
+  #responseHeaders: Headers;
+  #secure: boolean;
+
+  #requestKeys(): string[] {
+    if (this.#keys) {
+      return this.#keys;
+    }
+    const result = this.#keys = [] as string[];
+    const header = this.#requestHeaders.get("cookie");
+    if (!header) {
+      return result;
+    }
+    let matches: RegExpExecArray | null;
+    while ((matches = KEY_REGEXP.exec(header))) {
+      const [, key] = matches;
+      result.push(key);
+    }
+    return result;
+  }
+
+  /** Is set to a promise which resolves with the number of cookies in the
+   * {@linkcode Request}. */
+  get size(): Promise<number> {
+    return (async () => {
+      let size = 0;
+      for await (const _ of this) {
+        size++;
+      }
+      return size;
+    })();
+  }
+
+  constructor(
+    request: Headers | Headered,
+    options: SecureCookieMapOptions = {},
+  ) {
+    this.#requestHeaders = "headers" in request ? request.headers : request;
+    const { keys, secure = false, response = new Headers() } = options;
+    this.#keyRing = keys;
+    this.#responseHeaders = "headers" in response ? response.headers : response;
+    this.#secure = secure;
+  }
+
+  /** Sets all cookies in the {@linkcode Request} to be deleted in the
+   * response. */
+  async clear(options: SecureCookieMapSetDeleteOptions): Promise<void> {
+    for await (const key of this.keys()) {
+      await this.set(key, null, options);
+    }
+  }
+
+  /** Set a cookie to be deleted in the response.
+   *
+   * This is a convenience function for `set(key, null, options?)`. */
+  async delete(
+    key: string,
+    options: SecureCookieMapSetDeleteOptions = {},
+  ): Promise<boolean> {
+    await this.set(key, null, options);
+    return true;
+  }
+
+  /** Get the value of a cookie from the {@linkcode Request}.
+   *
+   * If the cookie is signed, and the signature is invalid, `undefined` will be
+   * returned and the cookie will be set to be deleted in the response. If the
+   * cookie is using an "old" key from the keyring, the cookie will be re-signed
+   * with the current key and be added to the response to be updated. */
+  async get(
+    key: string,
+    options: SecureCookieMapGetOptions = {},
+  ): Promise<string | undefined> {
+    const signed = options.signed ?? !!this.#keyRing;
+    const nameSig = `${key}.sig`;
+
+    const header = this.#requestHeaders.get("cookie");
+    if (!header) {
+      return;
+    }
+    const match = header.match(getPattern(key));
+    if (!match) {
+      return;
+    }
+    const [, value] = match;
+    if (!signed) {
+      return value;
+    }
+    const digest = await this.get(nameSig, { signed: false });
+    if (!digest) {
+      return;
+    }
+    const data = `${key}=${value}`;
+    if (!this.#keyRing) {
+      throw new TypeError("key ring required for signed cookies");
+    }
+    const index = await this.#keyRing.indexOf(data, digest);
+
+    if (index < 0) {
+      await this.delete(nameSig, { path: "/", signed: false });
+    } else {
+      if (index) {
+        await this.set(nameSig, await this.#keyRing.sign(data), {
+          signed: false,
+        });
+      }
+      return value;
+    }
+  }
+
+  /** Returns `true` if the key is in the {@linkcode Request}.
+   *
+   * If the cookie is signed, and the signature is invalid, `false` will be
+   * returned and the cookie will be set to be deleted in the response. If the
+   * cookie is using an "old" key from the keyring, the cookie will be re-signed
+   * with the current key and be added to the response to be updated. */
+  async has(
+    key: string,
+    options: SecureCookieMapGetOptions = {},
+  ): Promise<boolean> {
+    const signed = options.signed ?? !!this.#keyRing;
+    const nameSig = `${key}.sig`;
+
+    const header = this.#requestHeaders.get("cookie");
+    if (!header) {
+      return false;
+    }
+    const match = header.match(getPattern(key));
+    if (!match) {
+      return false;
+    }
+    if (!signed) {
+      return true;
+    }
+    const digest = await this.get(nameSig, { signed: false });
+    if (!digest) {
+      return false;
+    }
+    const [, value] = match;
+    const data = `${key}=${value}`;
+    if (!this.#keyRing) {
+      throw new TypeError("key ring required for signed cookies");
+    }
+    const index = await this.#keyRing.indexOf(data, digest);
+
+    if (index < 0) {
+      await this.delete(nameSig, { path: "/", signed: false });
+      return false;
+    } else {
+      if (index) {
+        await this.set(nameSig, await this.#keyRing.sign(data), {
+          signed: false,
+        });
+      }
+      return true;
+    }
+  }
+
+  /** Set a cookie in the response headers.
+   *
+   * If there was a keyring set, cookies will be automatically signed, unless
+   * overridden by the passed options. Cookies can be deleted by setting the
+   * value to `null`. */
+  async set(
+    key: string,
+    value: string | null,
+    options: SecureCookieMapSetDeleteOptions = {},
+  ): Promise<this> {
+    const responseHeaders = this.#responseHeaders;
+    const headers: string[] = [];
+    for (const [key, value] of responseHeaders.entries()) {
+      if (key === "set-cookie") {
+        headers.push(value);
+      }
+    }
+    const secure = this.#secure;
+    const signed = options.signed ?? !!this.#keyRing;
+
+    if (!secure && options.secure && !options.ignoreInsecure) {
+      throw new TypeError(
+        "Cannot send secure cookie over unencrypted connection.",
+      );
+    }
+
+    const cookie = new Cookie(key, value, options);
+    cookie.secure = options.secure ?? secure;
+    pushCookie(headers, cookie);
+
+    if (signed) {
+      if (!this.#keyRing) {
+        throw new TypeError("keys required for signed cookies.");
+      }
+      cookie.value = await this.#keyRing.sign(cookie.toString());
+      cookie.name += ".sig";
+      pushCookie(headers, cookie);
+    }
+
+    responseHeaders.delete("set-cookie");
+    for (const header of headers) {
+      responseHeaders.append("set-cookie", header);
+    }
+    return this;
+  }
+
+  /** Iterate over the {@linkcode Request} cookies, yielding up a tuple
+   * containing the key and value of each cookie.
+   *
+   * If a key ring was provided, only properly signed cookie keys and values are
+   * returned. */
+  entries(): AsyncIterableIterator<[string, string]> {
+    return this[Symbol.asyncIterator]();
+  }
+
+  /** Iterate over the request's cookies, yielding up the key of each cookie.
+   *
+   * If a keyring was provided, only properly signed cookie keys are
+   * returned. */
+  async *keys(): AsyncIterableIterator<string> {
+    for await (const [key] of this) {
+      yield key;
+    }
+  }
+
+  /** Iterate over the request's cookies, yielding up the value of each cookie.
+   *
+   * If a keyring was provided, only properly signed cookie values are
+   * returned. */
+  async *values(): AsyncIterableIterator<string> {
+    for await (const [, value] of this) {
+      yield value;
+    }
+  }
+
+  /** Iterate over the {@linkcode Request} cookies, yielding up a tuple
+   * containing the key and value of each cookie.
+   *
+   * If a key ring was provided, only properly signed cookie keys and values are
+   * returned. */
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<[string, string]> {
+    const keys = this.#requestKeys();
+    for (const key of keys) {
+      const value = await this.get(key);
+      if (value) {
+        yield [key, value];
+      }
+    }
+  }
+
+  /** A method used by {@linkcode mergeHeaders} to be able to merge
+   * headers from various sources when forming a {@linkcode Response}. */
+  [cookieMapHeadersInitSymbol](): [string, string][] {
+    const init: [string, string][] = [];
+    for (const [key, value] of this.#responseHeaders) {
+      if (key === "set-cookie") {
+        init.push([key, value]);
+      }
+    }
+    return init;
+  }
+
+  [Symbol.for("Deno.customInspect")]() {
+    return `${this.constructor.name} []`;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](
+    depth: number,
+    // deno-lint-ignore no-explicit-any
+    options: any,
+    inspect: (value: unknown, options?: unknown) => string,
+  ) {
+    if (depth < 0) {
+      return options.stylize(`[${this.constructor.name}]`, "special");
+    }
+
+    const newOptions = Object.assign({}, options, {
+      depth: options.depth === null ? null : options.depth - 1,
+    });
+    return `${options.stylize(this.constructor.name, "special")} ${
+      inspect([], newOptions)
+    }`;
+  }
+}

--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -124,7 +124,7 @@ export interface Headered {
   headers: Headers;
 }
 
-export interface Mergable {
+export interface Mergeable {
   [cookieMapHeadersInitSymbol](): [string, string][];
 }
 
@@ -294,7 +294,7 @@ export const cookieMapHeadersInitSymbol = Symbol.for(
   "Deno.std.cookieMap.headersInit",
 );
 
-function isMergable(value: unknown): value is Mergable {
+function isMergeable(value: unknown): value is Mergeable {
   return value != null && typeof value === "object" &&
     cookieMapHeadersInitSymbol in value;
 }
@@ -307,7 +307,7 @@ function isMergable(value: unknown): value is Mergable {
  * will not ensure that there are no other `Set-Cookie` headers from other
  * sources, it will simply append the various headers together. */
 export function mergeHeaders(
-  ...sources: (Headered | HeadersInit | Mergable)[]
+  ...sources: (Headered | HeadersInit | Mergeable)[]
 ): Headers {
   const headers = new Headers();
   for (const source of sources) {
@@ -316,7 +316,7 @@ export function mergeHeaders(
       entries = source;
     } else if ("headers" in source && source.headers instanceof Headers) {
       entries = source.headers;
-    } else if (isMergable(source)) {
+    } else if (isMergeable(source)) {
       entries = source[cookieMapHeadersInitSymbol]();
     } else if (Array.isArray(source)) {
       entries = source as [string, string][];
@@ -339,7 +339,7 @@ export function mergeHeaders(
  * response can be provided. Alternatively the {@linkcode mergeHeaders}
  * function can be used to generate a final set of headers for sending in the
  * response. */
-export class CookieMap implements Mergable {
+export class CookieMap implements Mergeable {
   #keys?: string[];
   #requestHeaders: Headers;
   #responseHeaders: Headers;
@@ -554,7 +554,7 @@ export interface KeyRing {
  * On construction, the optional set of keys implementing the
  * {@linkcode KeyRing} interface. While it is optional, if you don't plan to use
  * keys, you might want to consider using just the {@linkcode CookieMap}. */
-export class SecureCookieMap implements Mergable {
+export class SecureCookieMap implements Mergeable {
   #keyRing?: KeyRing;
   #keys?: string[];
   #requestHeaders: Headers;

--- a/http/cookie_map_test.ts
+++ b/http/cookie_map_test.ts
@@ -1,0 +1,788 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../testing/asserts.ts";
+import { encode } from "../encoding/base64url.ts";
+
+import {
+  CookieMap,
+  cookieMapHeadersInitSymbol,
+  type Data,
+  type KeyRing,
+  mergeHeaders,
+  SecureCookieMap,
+} from "./cookie_map.ts";
+
+export type Key = string | number[] | ArrayBuffer | Uint8Array;
+
+const encoder = new TextEncoder();
+
+function importKey(key: Key): Promise<CryptoKey> {
+  if (typeof key === "string") {
+    key = encoder.encode(key);
+  } else if (Array.isArray(key)) {
+    key = new Uint8Array(key);
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    key,
+    {
+      name: "HMAC",
+      hash: { name: "SHA-256" },
+    },
+    true,
+    ["sign", "verify"],
+  );
+}
+
+function sign(data: Data, key: CryptoKey): Promise<ArrayBuffer> {
+  if (typeof data === "string") {
+    data = encoder.encode(data);
+  } else if (Array.isArray(data)) {
+    data = Uint8Array.from(data);
+  }
+  return crypto.subtle.sign("HMAC", key, data);
+}
+
+function compareArrayBuffer(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  assert(a.byteLength === b.byteLength, "ArrayBuffer lengths must match.");
+  const va = new DataView(a);
+  const vb = new DataView(b);
+  const length = va.byteLength;
+  let out = 0;
+  let i = -1;
+  while (++i < length) {
+    out |= va.getUint8(i) ^ vb.getUint8(i);
+  }
+  return out === 0;
+}
+
+async function compare(a: Data, b: Data): Promise<boolean> {
+  const key = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(key);
+  const cryptoKey = await importKey(key);
+  const ah = await sign(a, cryptoKey);
+  const bh = await sign(b, cryptoKey);
+  return compareArrayBuffer(ah, bh);
+}
+
+export class KeyStack implements KeyRing {
+  #cryptoKeys = new Map<Key, CryptoKey>();
+  #keys: Key[];
+
+  async #toCryptoKey(key: Key): Promise<CryptoKey> {
+    if (!this.#cryptoKeys.has(key)) {
+      this.#cryptoKeys.set(key, await importKey(key));
+    }
+    return this.#cryptoKeys.get(key)!;
+  }
+
+  get length(): number {
+    return this.#keys.length;
+  }
+
+  constructor(keys: Iterable<Key>) {
+    const values = Array.isArray(keys) ? keys : [...keys];
+    if (!(values.length)) {
+      throw new TypeError("keys must contain at least one value");
+    }
+    this.#keys = values;
+  }
+
+  /** Take `data` and return a SHA256 HMAC digest that uses the current 0 index
+   * of the `keys` passed to the constructor.  This digest is in the form of a
+   * URL safe base64 encoded string. */
+  async sign(data: Data): Promise<string> {
+    const key = await this.#toCryptoKey(this.#keys[0]);
+    return encode(await sign(data, key));
+  }
+
+  /** Given `data` and a `digest`, verify that one of the `keys` provided the
+   * constructor was used to generate the `digest`.  Returns `true` if one of
+   * the keys was used, otherwise `false`. */
+  async verify(data: Data, digest: string): Promise<boolean> {
+    return (await this.indexOf(data, digest)) > -1;
+  }
+
+  /** Given `data` and a `digest`, return the current index of the key in the
+   * `keys` passed the constructor that was used to generate the digest.  If no
+   * key can be found, the method returns `-1`. */
+  async indexOf(data: Data, digest: string): Promise<number> {
+    for (let i = 0; i < this.#keys.length; i++) {
+      const cryptoKey = await this.#toCryptoKey(this.#keys[i]);
+      if (
+        await compare(digest, encode(await sign(data, cryptoKey)))
+      ) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  [Symbol.for("Deno.customInspect")](inspect: (value: unknown) => string) {
+    const { length } = this;
+    return `${this.constructor.name} ${inspect({ length })}`;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](
+    depth: number,
+    // deno-lint-ignore no-explicit-any
+    options: any,
+    inspect: (value: unknown, options?: unknown) => string,
+  ) {
+    if (depth < 0) {
+      return options.stylize(`[${this.constructor.name}]`, "special");
+    }
+
+    const newOptions = Object.assign({}, options, {
+      depth: options.depth === null ? null : options.depth - 1,
+    });
+    const { length } = this;
+    return `${options.stylize(this.constructor.name, "special")} ${
+      inspect({ length }, newOptions)
+    }`;
+  }
+}
+
+function isNode(): boolean {
+  return "process" in globalThis && "global" in globalThis;
+}
+
+function createHeaders(cookies?: string[]) {
+  return new Headers(
+    cookies ? [["cookie", cookies.join("; ")]] : undefined,
+  );
+}
+
+Deno.test({
+  name: "CookieMap - get cookie value",
+  fn() {
+    const request = createHeaders(["foo=bar"]);
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    assertEquals(cookies.get("foo"), "bar");
+    assertEquals(cookies.get("bar"), undefined);
+    assertEquals([...response], []);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set cookie",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("foo", "bar");
+    assertEquals([...response], [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - pass request and response",
+  fn() {
+    const request = new Request("http://localhost:8080/");
+    const response = new Response(null);
+    const cookies = new CookieMap(request, { response });
+    cookies.set("foo", "bar");
+    assertEquals([...response.headers], [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - omit response",
+  fn() {
+    const request = createHeaders();
+    const cookies = new CookieMap(request);
+    cookies.set("foo", "bar");
+    assertEquals(cookies[cookieMapHeadersInitSymbol](), [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set multiple cookies",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("a", "a");
+    cookies.set("b", "b");
+    cookies.set("c", "c");
+    const expected = isNode()
+      ? [[
+        "set-cookie",
+        "a=a; path=/; httponly, b=b; path=/; httponly, c=c; path=/; httponly",
+      ]]
+      : [
+        ["set-cookie", "a=a; path=/; httponly"],
+        ["set-cookie", "b=b; path=/; httponly"],
+        ["set-cookie", "c=c; path=/; httponly"],
+      ];
+    assertEquals([...response], expected);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set cookie with options",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("foo", "bar", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/foo",
+      sameSite: "strict",
+    });
+    assertEquals(
+      response.get("set-cookie"),
+      "foo=bar; path=/foo; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict",
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set secure cookie",
+  fn() {
+    const request = createHeaders([]);
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response, secure: true });
+    cookies.set("bar", "foo", { secure: true });
+
+    assertEquals(
+      response.get("set-cookie"),
+      "bar=foo; path=/; secure; httponly",
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set secure cookie on insecure context fails",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    assertThrows(
+      () => {
+        cookies.set("bar", "foo", { secure: true });
+      },
+      TypeError,
+      "Cannot send secure cookie over unencrypted connection.",
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set secure cookie on insecure context with ignoreInsecure",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("bar", "foo", { secure: true, ignoreInsecure: true });
+
+    assertEquals(
+      response.get("set-cookie"),
+      "bar=foo; path=/; secure; httponly",
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - iterate cookies",
+  fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    const actual = [...cookies];
+    assertEquals(
+      actual,
+      [["bar", "foo"], ["foo", "baz"], ["baz", "1234"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - has",
+  fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    assert(cookies.has("baz"));
+    assert(!cookies.has("qat"));
+  },
+});
+
+Deno.test({
+  name: "CookieMap - size",
+  fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    assertEquals(cookies.size, 3);
+  },
+});
+
+Deno.test({
+  name: "CookieMap - inspecting",
+  fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    assertEquals(
+      Deno.inspect(new CookieMap(request, { response })),
+      `CookieMap []`,
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set multiple cookies with options",
+  fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("foo", "bar", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/foo",
+      sameSite: "strict",
+    });
+    cookies.set("a", "b", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/a",
+      sameSite: "strict",
+    });
+    cookies.set("foo", "baz", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: true,
+      path: "/baz",
+      sameSite: "strict",
+    });
+    const expected = isNode()
+      ? "foo=baz; path=/baz; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict"
+      : "a=b; path=/a; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict, foo=baz; path=/baz; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict";
+    assertEquals(response.get("set-cookie"), expected);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - get cookie value",
+  async fn() {
+    const request = createHeaders(["foo=bar"]);
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    assertEquals(await cookies.get("foo"), "bar");
+    assertEquals(await cookies.get("bar"), undefined);
+    assertEquals([...response], []);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - pass request and response",
+  async fn() {
+    const request = new Request("http://localhost:8080/");
+    const response = new Response(null);
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("foo", "bar");
+    assertEquals([...response.headers], [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - omit response",
+  async fn() {
+    const request = createHeaders();
+    const cookies = new SecureCookieMap(request);
+    await cookies.set("foo", "bar");
+    assertEquals(cookies[cookieMapHeadersInitSymbol](), [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - get signed cookie",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(
+      request,
+      { response, keys: new KeyStack(["secret1"]) },
+    );
+    assertEquals(await cookies.get("bar"), "foo");
+    assertEquals([...response], []);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - get signed cookie requiring re-signing",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(
+      request,
+      { response, keys: new KeyStack(["secret2", "secret1"]) },
+    );
+    assertEquals(await cookies.get("bar"), "foo");
+    assertEquals([...response], [[
+      "set-cookie",
+      "bar.sig=ar46bgP3n0ZRazFOfiZ4SyZVFxKUvG1-zQZCb9lbcPI; path=/; httponly",
+    ]]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - get invalid signed cookie",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "bar.sig=tampered", "foo=baz"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(
+      request,
+      { response, keys: new KeyStack(["secret1"]) },
+    );
+    assertEquals(await cookies.get("bar"), undefined);
+    assertEquals(await cookies.get("foo"), undefined);
+    assertEquals([...response], [
+      [
+        "set-cookie",
+        "bar.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly",
+      ],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set cookie",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("foo", "bar");
+    assertEquals([...response], [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set multiple cookies",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("a", "a");
+    await cookies.set("b", "b");
+    await cookies.set("c", "c");
+    const expected = isNode()
+      ? [[
+        "set-cookie",
+        "a=a; path=/; httponly, b=b; path=/; httponly, c=c; path=/; httponly",
+      ]]
+      : [
+        ["set-cookie", "a=a; path=/; httponly"],
+        ["set-cookie", "b=b; path=/; httponly"],
+        ["set-cookie", "c=c; path=/; httponly"],
+      ];
+    assertEquals([...response], expected);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set cookie with options",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("foo", "bar", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/foo",
+      sameSite: "strict",
+    });
+    assertEquals(
+      response.get("set-cookie"),
+      "foo=bar; path=/foo; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict",
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set signed cookie",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(
+      request,
+      { response, keys: new KeyStack(["secret1"]) },
+    );
+    await cookies.set("bar", "foo");
+
+    assertEquals(
+      response.get("set-cookie"),
+      "bar=foo; path=/; httponly, bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro; path=/; httponly",
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set secure cookie",
+  async fn() {
+    const request = createHeaders([]);
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response, secure: true });
+    await cookies.set("bar", "foo", { secure: true });
+
+    assertEquals(
+      response.get("set-cookie"),
+      "bar=foo; path=/; secure; httponly",
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set secure cookie on insecure context fails",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await assertRejects(
+      async () => {
+        await cookies.set("bar", "foo", { secure: true });
+      },
+      TypeError,
+      "Cannot send secure cookie over unencrypted connection.",
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "SecureCookieMap - set secure cookie on insecure context with ignoreInsecure",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("bar", "foo", { secure: true, ignoreInsecure: true });
+
+    assertEquals(
+      response.get("set-cookie"),
+      "bar=foo; path=/; secure; httponly",
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - iterate cookies",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    const actual = [];
+    for await (const cookie of cookies) {
+      actual.push(cookie);
+    }
+    assertEquals(
+      actual,
+      [["bar", "foo"], ["foo", "baz"], ["baz", "1234"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - iterate signed cookie",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(
+      request,
+      { response, keys: new KeyStack(["secret1"]) },
+    );
+    const actual = [];
+    for await (const cookie of cookies) {
+      actual.push(cookie);
+    }
+    assertEquals(actual, [["bar", "foo"]]);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - has",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    assert(await cookies.has("baz"));
+    assert(!await cookies.has("qat"));
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - size",
+  async fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    assertEquals(await cookies.size, 3);
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - inspecting",
+  fn() {
+    const request = createHeaders(
+      ["bar=foo", "foo=baz", "baz=1234"],
+    );
+    const response = createHeaders();
+    assertEquals(
+      Deno.inspect(new SecureCookieMap(request, { response })),
+      `SecureCookieMap []`,
+    );
+  },
+});
+
+Deno.test({
+  name: "SecureCookieMap - set multiple cookies with options",
+  async fn() {
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new SecureCookieMap(request, { response });
+    await cookies.set("foo", "bar", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/foo",
+      sameSite: "strict",
+    });
+    await cookies.set("a", "b", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: false,
+      path: "/a",
+      sameSite: "strict",
+    });
+    await cookies.set("foo", "baz", {
+      domain: "*.example.com",
+      expires: new Date("2020-01-01T00:00:00+00:00"),
+      httpOnly: false,
+      overwrite: true,
+      path: "/baz",
+      sameSite: "strict",
+    });
+    const expected = isNode()
+      ? "foo=baz; path=/baz; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict"
+      : "a=b; path=/a; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict, foo=baz; path=/baz; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict";
+    assertEquals(response.get("set-cookie"), expected);
+  },
+});
+
+Deno.test({
+  name: "mergeHeaders() - passing cookies/mergable",
+  async fn() {
+    const request = createHeaders();
+    const secureCookies = new SecureCookieMap(request);
+    await secureCookies.set("foo", "bar");
+    const cookies = new CookieMap(request);
+    cookies.set("bar", "baz");
+    const headers = mergeHeaders(secureCookies, cookies);
+    assertEquals([...headers], [
+      ["set-cookie", "foo=bar; path=/; httponly"],
+      ["set-cookie", "bar=baz; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "mergeHeaders() - passing headers",
+  fn() {
+    const request = createHeaders();
+    const cookies = new CookieMap(request);
+    cookies.set("bar", "baz");
+    const upstreamHeaders = new Headers({ "Content-Type": "application/json" });
+    const headers = mergeHeaders(upstreamHeaders, cookies);
+    assertEquals([...headers], [
+      ["content-type", "application/json"],
+      ["set-cookie", "bar=baz; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "mergeHeaders() - passing response object",
+  fn() {
+    const request = createHeaders();
+    const cookies = new CookieMap(request);
+    cookies.set("bar", "baz");
+    const response = new Response(null, {
+      headers: { "Content-Type": "application/json" },
+    });
+    const headers = mergeHeaders(response, cookies);
+    assertEquals([...headers], [
+      ["content-type", "application/json"],
+      ["set-cookie", "bar=baz; path=/; httponly"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "mergeHeaders() - passing headers init",
+  fn() {
+    const request = createHeaders();
+    const cookies = new CookieMap(request);
+    cookies.set("bar", "baz");
+    const headers = mergeHeaders(
+      { "Content-Type": "application/json" },
+      [["vary", "accept"]],
+      cookies,
+    );
+    assertEquals([...headers], [
+      ["content-type", "application/json"],
+      ["set-cookie", "bar=baz; path=/; httponly"],
+      ["vary", "accept"],
+    ]);
+  },
+});

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./cookie.ts";
+export * from "./cookie_map.ts";
 export * from "./http_errors.ts";
 export * from "./http_status.ts";
 export * from "./negotiation.ts";


### PR DESCRIPTION
This PR adds `CookieMap` and `SecureCookieMap` to `std/http`. It is part of the ongoing effort to migrate parts of oak/oak_commons into `std`.

`CookieMap` provides a `Map` like interface to request and response cookies, while `SecureCookieMap` provides a similar interface, but accepts a key ring object for transparent verifying and signing cookies, helping ensure cookies cannot be tampered with client side.  These features have been present in oak for an extended period of time and are well liked and used.

Because of the async nature that built in encryption, `SecureCookieMap` methods operate asynchronously.  Because of this, when @kt3k and I paired on it, we agreed that having a sync `CookieMap` which didn't support key signing would be useful.

Also, @lucacasonato was concerned about the need to provide response headers at construction time of such an object. During pairing @kt3k and I discussed it and this PR provides `mergeHeaders()` which makes it trivial to set the headers on a response, including anything that needs to be set from the cookie map, when formulating the response, and the maps do not require the headers or response object to be passed on construction.

The most straight forward use case, with automatic cookie signing and verification would look like this:

```ts
import {
  SecureCookieMap,
  mergeHeaders,
  type KeyRing,
} from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";

const request = new Request("https://localhost/", {
  headers: {
    "cookie": "bar=foo; bar.sig=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro"
  },
});

declare const keys: KeyRing;

const cookies = new SecureCookieMap(request, { keys });
console.log(await cookies.get("bar")); // logs "foo", with the signature being verified
await cookies.set("session", "1234567"); // this will be automatically signed

const response = new Response("test", {
  headers: mergeHeaders({
    "content-type": "text/plain",
  }, cookies);
});
```

This PR does not provide an implementation of the `KeyRing` interface, I already had a PR open for that (#2303) and will refresh it.