### PR TITLE
feat(crypto): add subtle.timingSafeEqual()

### DIFF
--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,5 +1,10 @@
 # crypto
 
+Extensions to the WebCrypto interface, which provides additional encryption
+algorithms that are not part of the web standard, as well as a
+`subtle.digest()`, `subtle.digestSync()`, and `subtle.timingSafeEqual()` methods
+which provide additional functionality not covered by web crypto.
+
 ## Usage
 
 ```typescript
@@ -76,4 +81,56 @@ export const digestAlgorithms = [
   "MD5",
   "SHA-1",
 ] as const;
+```
+
+## Timing safe comparison
+
+When checking the values of cryptographic hashes are equal, default comparisons
+can be susceptible to timing based attacks, where attacker is able to find out
+information about the host system by repeatedly checking response times to to
+equality comparisons of values.
+
+It is likely some form of timing safe equality will make its way to the
+WebCrypto standard (see:
+[w3c/webcrypto#270](https://github.com/w3c/webcrypto/issues/270)), but until
+that time, `timingSafeEqual()` is provided:
+
+```ts
+import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const a = await crypto.subtle.digest(
+  "SHA-384",
+  new TextEncoder().encode("hello world"),
+);
+const b = await crypto.subtle.digest(
+  "SHA-384",
+  new TextEncoder().encode("hello world"),
+);
+const c = await crypto.subtle.digest(
+  "SHA-384",
+  new TextEncoder().encode("hello deno"),
+);
+
+assert(crypto.subtle.timingSafeEqual(a, b));
+assert(!crypto.subtle.timingSafeEqual(a, c));
+```
+
+In addition to the method being part of the `crypto.subtle` interface, it is
+also loadable directly:
+
+```ts
+import { timingSafeEqual } from "https://deno.land/std@$STD_VERSION/crypto/timing_safe_equal.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+
+const a = await crypto.subtle.digest(
+  "SHA-384",
+  new TextEncoder().encode("hello world"),
+);
+const b = await crypto.subtle.digest(
+  "SHA-384",
+  new TextEncoder().encode("hello world"),
+);
+
+assert(timingSafeEqual(a, b));
 ```

--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -1,18 +1,28 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Extensions to the web {@linkcode Crypto} interface.
+ *
+ * Provides additional digest algorithms that are not part of the WebCrypto
+ * standard as well as a `subtle.digest` and `subtle.digestSync` methods. It
+ * also provide a `subtle.timingSafeEqual()` method to compare array buffers
+ * or data views in a way that isn't prone to timing based attacks.
+ *
+ * The "polyfill" delegates to `WebCrypto` where possible.
+ *
+ * @module
+ */
+
 import {
   DigestAlgorithm as WasmDigestAlgorithm,
   digestAlgorithms as wasmDigestAlgorithms,
   instantiateWasm,
 } from "../_wasm_crypto/mod.ts";
+import { timingSafeEqual } from "./timing_safe_equal.ts";
 
 import { fnv } from "./_fnv/index.ts";
 
-/**
- * A copy of the global WebCrypto interface, with methods bound so they're
- * safe to re-export.
- * @module
- */
-const webCrypto = ((crypto) => ({
+const webCrypto: Crypto = ((crypto) => ({
   getRandomValues: crypto.getRandomValues?.bind(crypto),
   randomUUID: crypto.randomUUID?.bind(crypto),
   subtle: {
@@ -43,20 +53,49 @@ const bufferSourceBytes = (data: BufferSource | unknown) => {
   return bytes;
 };
 
+/** Extensions to the web standard `SubtleCrypto` interface. */
+export interface StdSubtleCrypto extends SubtleCrypto {
+  /**
+   * Returns a new `Promise` object that will digest `data` using the specified
+   * `AlgorithmIdentifier`.
+   */
+  digest(
+    algorithm: DigestAlgorithm,
+    data: BufferSource | AsyncIterable<BufferSource> | Iterable<BufferSource>,
+  ): Promise<ArrayBuffer>;
+
+  /**
+   * Returns a ArrayBuffer with the result of digesting `data` using the
+   * specified `AlgorithmIdentifier`.
+   */
+  digestSync(
+    algorithm: DigestAlgorithm,
+    data: BufferSource | Iterable<BufferSource>,
+  ): ArrayBuffer;
+
+  /** Compare to array buffers or data views in a way that timing based attacks
+   * cannot gain information about the platform. */
+  timingSafeEqual(
+    a: ArrayBufferLike | DataView,
+    b: ArrayBufferLike | DataView,
+  ): boolean;
+}
+
+/** Extensions to the Web {@linkcode Crypto} interface. */
+export interface StdCrypto extends Crypto {
+  readonly subtle: StdSubtleCrypto;
+}
+
 /**
  * An wrapper for WebCrypto adding support for additional non-standard
  * algorithms, but delegating to the runtime WebCrypto implementation whenever
  * possible.
  */
-const stdCrypto = ((x) => x)({
+const stdCrypto: StdCrypto = ((x) => x)({
   ...webCrypto,
   subtle: {
     ...webCrypto.subtle,
 
-    /**
-     * Returns a new `Promise` object that will digest `data` using the specified
-     * `AlgorithmIdentifier`.
-     */
     async digest(
       algorithm: DigestAlgorithm,
       data: BufferSource | AsyncIterable<BufferSource> | Iterable<BufferSource>,
@@ -118,10 +157,6 @@ const stdCrypto = ((x) => x)({
       }
     },
 
-    /**
-     * Returns a ArrayBuffer with the result of digesting `data` using the
-     * specified `AlgorithmIdentifier`.
-     */
     digestSync(
       algorithm: DigestAlgorithm,
       data: BufferSource | Iterable<BufferSource>,
@@ -154,6 +189,9 @@ const stdCrypto = ((x) => x)({
         );
       }
     },
+
+    // TODO(@kitsonk): rework when https://github.com/w3c/webcrypto/issues/270 resolved
+    timingSafeEqual,
   },
 });
 

--- a/crypto/test.ts
+++ b/crypto/test.ts
@@ -1359,3 +1359,12 @@ const toHexString = (bytes: ArrayBuffer): string =>
     (str, byte) => str + byte.toString(16).padStart(2, "0"),
     "",
   );
+
+Deno.test({
+  name: "[crypto/subtle/timeSafeEqual] - is present",
+  fn() {
+    const a = new Uint8Array([212, 213]);
+    const b = new Uint8Array([212, 213]);
+    assert(stdCrypto.subtle.timingSafeEqual(a.buffer, b.buffer));
+  },
+});

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -1,0 +1,27 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import { assert } from "../testing/asserts.ts";
+
+/** Compare to array buffers or data views in a way that timing based attacks
+ * cannot gain information about the platform. */
+export function timingSafeEqual(
+  a: ArrayBufferView | ArrayBufferLike | DataView,
+  b: ArrayBufferView | ArrayBufferLike | DataView,
+): boolean {
+  assert(a.byteLength === b.byteLength, "Byte lengths must match.");
+  if (!(a instanceof DataView)) {
+    a = new DataView(ArrayBuffer.isView(a) ? a.buffer : a);
+  }
+  if (!(b instanceof DataView)) {
+    b = new DataView(ArrayBuffer.isView(b) ? b.buffer : b);
+  }
+  assert(a instanceof DataView);
+  assert(b instanceof DataView);
+  const length = a.byteLength;
+  let out = 0;
+  let i = -1;
+  while (++i < length) {
+    out |= a.getUint8(i) ^ b.getUint8(i);
+  }
+  return out === 0;
+}

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -8,7 +8,9 @@ export function timingSafeEqual(
   a: ArrayBufferView | ArrayBufferLike | DataView,
   b: ArrayBufferView | ArrayBufferLike | DataView,
 ): boolean {
-  assert(a.byteLength === b.byteLength, "Byte lengths must match.");
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
   if (!(a instanceof DataView)) {
     a = new DataView(ArrayBuffer.isView(a) ? a.buffer : a);
   }

--- a/crypto/timing_safe_equal_test.ts
+++ b/crypto/timing_safe_equal_test.ts
@@ -1,0 +1,72 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import { assert } from "../testing/asserts.ts";
+import { timingSafeEqual } from "./timing_safe_equal.ts";
+
+Deno.test({
+  name: "[timingSafeEqual] - ArrayBuffer comparison - equal",
+  fn() {
+    const a = new ArrayBuffer(2);
+    const va = new DataView(a);
+    va.setUint8(0, 212);
+    va.setUint8(1, 213);
+    const b = new ArrayBuffer(2);
+    const vb = new DataView(b);
+    vb.setUint8(0, 212);
+    vb.setUint8(1, 213);
+    assert(timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - ArrayBuffer comparison - not equal",
+  fn() {
+    const a = new ArrayBuffer(2);
+    const va = new DataView(a);
+    va.setUint8(0, 212);
+    va.setUint8(1, 213);
+    const b = new ArrayBuffer(2);
+    const vb = new DataView(b);
+    vb.setUint8(0, 212);
+    vb.setUint8(1, 212);
+    assert(!timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array comparison - equal",
+  fn() {
+    const a = new Uint8Array([212, 213]);
+    const b = new Uint8Array([212, 213]);
+    assert(timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array comparison - not equal",
+  fn() {
+    const a = new Uint8Array([212, 213]);
+    const b = new Uint8Array([212, 212]);
+    assert(!timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array comparison - equal",
+  fn() {
+    const encoder = new TextEncoder();
+    const a = encoder.encode("hello deno");
+    const b = encoder.encode("hello deno");
+    assert(timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array comparison - not equal",
+  fn() {
+    const encoder = new TextEncoder();
+    const a = encoder.encode("hello deno");
+    const b = encoder.encode("hello Deno");
+    assert(!timingSafeEqual(a, b));
+  },
+});

--- a/node/internal_binding/_timingSafeEqual.ts
+++ b/node/internal_binding/_timingSafeEqual.ts
@@ -1,24 +1,12 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { Buffer } from "../buffer.ts";
+import { timingSafeEqual as stdTimingSafeEqual } from "../../crypto/timing_safe_equal.ts";
 
 export const timingSafeEqual = (
   a: Buffer | DataView | ArrayBuffer,
   b: Buffer | DataView | ArrayBuffer,
 ): boolean => {
-  if (a instanceof DataView) a = Buffer.from(a.buffer);
-  if (b instanceof DataView) b = Buffer.from(b.buffer);
-  if (a instanceof ArrayBuffer) a = Buffer.from(a);
-  if (b instanceof ArrayBuffer) b = Buffer.from(b);
-
-  let result = 0;
-  if (a.byteLength !== b.byteLength) {
-    b = a;
-    result = 1;
-  }
-
-  for (let i = 0; i < a.byteLength; i++) {
-    result |= (a as Buffer)[i] ^ (b as Buffer)[i];
-  }
-
-  return result === 0;
+  if (a instanceof Buffer) a = new DataView(a.buffer);
+  if (a instanceof Buffer) b = new DataView(a.buffer);
+  return stdTimingSafeEqual(a, b);
 };


### PR DESCRIPTION
This adds `subtle.timingSafeEqual()` to `std/crypto` which is used to compare array buffers in a way that cannot be exploited in timing based attacks.

This is like to be added to WebCrypto at some point in the near future (see: https://github.com/w3c/webcrypto/issues/270) but until that point, we should have it in std. It is required #2303 which I am refactoring as part of the migration of oak commons to std.

It also refactors `node/crypto/timingSafeEqual` to use this instead of its own implementation (which is very close to this implementation, but supports Node.js's `Buffer` as well).