### PR TITLE
feat(http): support cert, key options in serveTls

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -696,9 +696,8 @@ export async function serveTls(
     once: true,
   });
 
-  const key = options.key || await Deno.readTextFile(options.keyFile!);
-  const cert = options.cert || await Deno.readTextFile(options.certFile!);
-  if (server.closed) return;
+  const key = options.key || Deno.readTextFileSync(options.keyFile!);
+  const cert = options.cert || Deno.readTextFileSync(options.certFile!);
 
   const listener = Deno.listenTls({
     port,

--- a/http/server.ts
+++ b/http/server.ts
@@ -683,9 +683,6 @@ export async function serveTls(
     throw new Error("TLS config is given, but 'cert' is missing.");
   }
 
-  const key = options.key || await Deno.readTextFile(options.keyFile!);
-  const cert = options.cert || await Deno.readTextFile(options.certFile!);
-
   let port = options.port ?? 8443;
   const hostname = options.hostname ?? "0.0.0.0";
   const server = new Server({
@@ -698,6 +695,10 @@ export async function serveTls(
   options?.signal?.addEventListener("abort", () => server.close(), {
     once: true,
   });
+
+  const key = options.key || await Deno.readTextFile(options.keyFile!);
+  const cert = options.cert || await Deno.readTextFile(options.certFile!);
+  if (server.closed) return;
 
   const listener = Deno.listenTls({
     port,

--- a/http/server.ts
+++ b/http/server.ts
@@ -615,7 +615,7 @@ export interface ServeTlsInit extends ServeInit {
 
 /** Serves HTTPS requests with the given handler.
  *
- * You must specify `keyFile` and `certFile` options.
+ * You must specify `key` or `keyFile` and `cert` or `certFile` options.
  *
  * You can specify an object with a port and hostname option, which is the
  * address to listen on. The default is port 8443 on hostname "0.0.0.0".
@@ -624,6 +624,13 @@ export interface ServeTlsInit extends ServeInit {
  *
  * ```ts
  * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ *
+ * const cert = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n";
+ * const key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n";
+ * serveTls((_req) => new Response("Hello, world"), { cert, key });
+ *
+ * // Or
+ *
  * const certFile = "/path/to/certFile.crt";
  * const keyFile = "/path/to/keyFile.key";
  * serveTls((_req) => new Response("Hello, world"), { certFile, keyFile });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1458,7 +1458,7 @@ Deno.test("serveTls - cert, key can be injected directly from memory rather than
       assertEquals(hostname, "0.0.0.0");
       assertNotEquals(port, 0);
       const caCert = await Deno.readTextFile(
-        join(testdataDir, "tls/RootCA.pem")
+        join(testdataDir, "tls/RootCA.pem"),
       );
       const client = Deno.createHttpClient({ caCerts: [caCert] });
       const responseText = await (

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1447,3 +1447,27 @@ Deno.test("serveTls - onListen callback is called with ephemeral port", () => {
     signal: abortController.signal,
   });
 });
+
+Deno.test("serveTls - cert, key can be injected directly from memory rather than file system.", () => {
+  const abortController = new AbortController();
+  return serveTls((_) => new Response("hello"), {
+    port: 0,
+    cert: Deno.readTextFileSync(join(testdataDir, "tls/localhost.crt")),
+    key: Deno.readTextFileSync(join(testdataDir, "tls/localhost.key")),
+    async onListen({ hostname, port }) {
+      assertEquals(hostname, "0.0.0.0");
+      assertNotEquals(port, 0);
+      const caCert = await Deno.readTextFile(
+        join(testdataDir, "tls/RootCA.pem")
+      );
+      const client = Deno.createHttpClient({ caCerts: [caCert] });
+      const responseText = await (
+        await fetch(`https://localhost:${port}/`, { client })
+      ).text();
+      client.close();
+      assertEquals(responseText, "hello");
+      abortController.abort();
+    },
+    signal: abortController.signal,
+  });
+});


### PR DESCRIPTION
Since [`certFile` and `keyFile` option in `Deno.listenTls` is deprecated and will be removed in Deno 2.0](https://github.com/denoland/deno/pull/13740), so I changed to use `cert` and `key` option directly in `serveTls` and changed `ServeTlsInit` interface a bit.