### PR TITLE
node: add stub for child_process.execSync

### DIFF
--- a/node/child_process.ts
+++ b/node/child_process.ts
@@ -443,5 +443,9 @@ export function execFile(
   return child;
 }
 
-export default { fork, spawn, execFile, ChildProcess };
+export function execSync() {
+  throw new Error("execSync is currently not supported");
+}
+
+export default { fork, spawn, execFile, execSync, ChildProcess };
 export { ChildProcess };


### PR DESCRIPTION
Vite complains about missing API but never uses it :)