### PR TITLE
docs: removed types from jsdoc directives

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -166,8 +166,8 @@ function validateDomain(domain: string): void {
 
 /**
  * Parse cookies of a header
- * @param {Headers} headers The headers instance to get cookies from
- * @return {Object} Object with cookie names as keys
+ * @param headers The headers instance to get cookies from
+ * @return Object with cookie names as keys
  */
 export function getCookies(headers: Headers): Record<string, string> {
   const cookie = headers.get("Cookie");
@@ -187,8 +187,8 @@ export function getCookies(headers: Headers): Record<string, string> {
 
 /**
  * Set the cookie header properly in the headers
- * @param {Headers} headers The headers instance to set the cookie to
- * @param {Object} cookie Cookie to set
+ * @param headers The headers instance to set the cookie to
+ * @param cookie Cookie to set
  */
 export function setCookie(headers: Headers, cookie: Cookie): void {
   // TODO(zekth) : Add proper parsing of Set-Cookie headers
@@ -202,9 +202,9 @@ export function setCookie(headers: Headers, cookie: Cookie): void {
 
 /**
  * Set the cookie header with empty value in the headers to delete it
- * @param {Headers} headers The headers instance to delete the cookie from
- * @param {string} name Name of cookie
- * @param {Object} attributes Additional cookie attributes
+ * @param headers The headers instance to delete the cookie from
+ * @param name Name of cookie
+ * @param attributes Additional cookie attributes
  */
 export function deleteCookie(
   headers: Headers,

--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -174,8 +174,8 @@ export function once<T = undefined>(
 }
 
 /**
- * @param {number} [expectedExecutions = 1]
- * @param {number} [timeout = 1000] Milliseconds to wait before the promise is forcefully exited */
+ * @param [expectedExecutions = 1]
+ * @param [timeout = 1000] Milliseconds to wait before the promise is forcefully exited */
 export function mustCall<T extends unknown[]>(
   fn: (...args: T) => void = () => {},
   expectedExecutions = 1,

--- a/node/child_process.ts
+++ b/node/child_process.ts
@@ -32,7 +32,7 @@ const denoCompatArgv = [
  * @param modulePath
  * @param args
  * @param option
- * @returns {ChildProcess}
+ * @returns
  */
 export function fork(
   modulePath: string, /* args?: string[], options?: ForkOptions*/

--- a/node/internal/errors.ts
+++ b/node/internal/errors.ts
@@ -2558,9 +2558,9 @@ codes.ERR_UNKNOWN_ENCODING = ERR_UNKNOWN_ENCODING;
 /**
  * This creates a generic Node.js error.
  *
- * @param {string} message The error message.
- * @param {object} errorProperties Object with additional properties to be added to the error.
- * @returns {Error}
+ * @param message The error message.
+ * @param errorProperties Object with additional properties to be added to the error.
+ * @returns
  */
 const genericNodeError = hideStackFrames(
   function genericNodeError(message, errorProperties) {

--- a/node/internal/idna.ts
+++ b/node/internal/idna.ts
@@ -159,8 +159,8 @@ function ucs2decode(str: string) {
  * @see `punycode.ucs2.decode`
  * @memberOf punycode.ucs2
  * @name encode
- * @param {Array} codePoints The array of numeric code points.
- * @returns {String} The new Unicode string (UCS-2).
+ * @param codePoints The array of numeric code points.
+ * @returns The new Unicode string (UCS-2).
  */
 function ucs2encode(array: number[]) {
   return String.fromCodePoint(...array);
@@ -430,9 +430,9 @@ export function encode(str: string) {
  * it doesn't matter if you call it on a string that has already been
  * converted to Unicode.
  * @memberOf punycode
- * @param {String} input The Punycoded domain name or email address to
+ * @param input The Punycoded domain name or email address to
  * convert to Unicode.
- * @returns {String} The Unicode representation of the given Punycode
+ * @returns The Unicode representation of the given Punycode
  * string.
  */
 export function toUnicode(input: string) {


### PR DESCRIPTION
Closes #2493. This was done by replacing `@param\s+\{.*\}` with `@param`. The same was done for `@return` and `@returns`.

Might be worth noting that keeping these directives type-free might have to be done via a new rule for `deno lint`. Otherwise, it has to be done manually like this.