### PR TITLE
feat(node): add types to fs/promises

### DIFF
--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -4,6 +4,7 @@ import { type CallbackWithError, makeCallback } from "./_fs_common.ts";
 import { fs, os } from "../internal_binding/constants.ts";
 import { getValidatedPath, getValidMode } from "../internal/fs/utils.mjs";
 import type { Buffer } from "../buffer.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function access(
   path: string | Buffer | URL,
@@ -58,6 +59,11 @@ export function access(
     }
   });
 }
+
+export const accessPromise = promisify(access) as (
+  path: string | Buffer | URL,
+  mode?: number,
+) => Promise<void>;
 
 export function accessSync(path: string | Buffer | URL, mode?: number): void {
   path = getValidatedPath(path).toString();

--- a/node/_fs/_fs_appendFile.ts
+++ b/node/_fs/_fs_appendFile.ts
@@ -8,6 +8,7 @@ import {
 import { Encodings } from "../_utils.ts";
 import { copyObject, getOptions } from "../internal/fs/utils.mjs";
 import { writeFile, writeFileSync } from "./_fs_writeFile.ts";
+import { promisify } from "../internal/util.mjs";
 
 /**
  * TODO: Also accept 'data' parameter as a Node polyfill Buffer type once these
@@ -32,6 +33,16 @@ export function appendFile(
 
   writeFile(path, data, options, callback);
 }
+
+/**
+ * TODO: Also accept 'data' parameter as a Node polyfill Buffer type once these
+ * are implemented. See https://github.com/denoland/deno/issues/3403
+ */
+export const appendFilePromise = promisify(appendFile) as (
+  path: string | number | URL,
+  data: string | Uint8Array,
+  options?: Encodings | WriteFileOptions,
+) => Promise<void>;
 
 /**
  * TODO: Also accept 'data' parameter as a Node polyfill Buffer type once these

--- a/node/_fs/_fs_chmod.ts
+++ b/node/_fs/_fs_chmod.ts
@@ -25,7 +25,6 @@ export const chmodPromise = promisify(chmod) as (
   mode: string | number,
 ) => Promise<void>;
 
-
 export function chmodSync(path: string | URL, mode: string | number): void {
   path = getValidatedPath(path).toString();
   mode = parseFileMode(mode, "mode");

--- a/node/_fs/_fs_chmod.ts
+++ b/node/_fs/_fs_chmod.ts
@@ -4,6 +4,7 @@ import { getValidatedPath } from "../internal/fs/utils.mjs";
 import * as pathModule from "../../path/mod.ts";
 import { parseFileMode } from "../internal/validators.mjs";
 import { Buffer } from "../buffer.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function chmod(
   path: string | Buffer | URL,
@@ -18,6 +19,12 @@ export function chmod(
     callback,
   );
 }
+
+export const chmodPromise = promisify(chmod) as (
+  path: string | Buffer | URL,
+  mode: string | number,
+) => Promise<void>;
+
 
 export function chmodSync(path: string | URL, mode: string | number): void {
   path = getValidatedPath(path).toString();

--- a/node/_fs/_fs_chown.ts
+++ b/node/_fs/_fs_chown.ts
@@ -3,8 +3,8 @@ import { type CallbackWithError, makeCallback } from "./_fs_common.ts";
 import { getValidatedPath, kMaxUserId } from "../internal/fs/utils.mjs";
 import * as pathModule from "../../path/mod.ts";
 import { validateInteger } from "../internal/validators.mjs";
-
 import type { Buffer } from "../buffer.ts";
+import { promisify } from "../internal/util.mjs";
 
 /**
  * Asynchronously changes the owner and group
@@ -26,6 +26,12 @@ export function chown(
     callback,
   );
 }
+
+export const chownPromise = promisify(chown) as (
+  path: string | Buffer | URL,
+  uid: number,
+  gid: number,
+) => Promise<void>;
 
 /**
  * Synchronously changes the owner and group

--- a/node/_fs/_fs_copy.ts
+++ b/node/_fs/_fs_copy.ts
@@ -4,6 +4,7 @@ import { makeCallback } from "./_fs_common.ts";
 import { Buffer } from "../buffer.ts";
 import { getValidatedPath, getValidMode } from "../internal/fs/utils.mjs";
 import { fs, os } from "../internal_binding/constants.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function copyFile(
   src: string | Buffer | URL,
@@ -51,6 +52,12 @@ export function copyFile(
     Deno.copyFile(srcStr, destStr).then(() => cb(null), cb);
   }
 }
+
+export const copyFilePromise = promisify(copyFile) as (
+  src: string | Buffer | URL,
+  dest: string | Buffer | URL,
+  mode?: number,
+) => Promise<void>;
 
 export function copyFileSync(
   src: string | Buffer | URL,

--- a/node/_fs/_fs_link.ts
+++ b/node/_fs/_fs_link.ts
@@ -24,7 +24,7 @@ export function link(
  * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
  * are implemented. See https://github.com/denoland/deno/issues/3403
  */
- export const linkPromise = promisify(link) as (
+export const linkPromise = promisify(link) as (
   existingPath: string | URL,
   newPath: string | URL,
 ) => Promise<void>;

--- a/node/_fs/_fs_link.ts
+++ b/node/_fs/_fs_link.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 /**
  * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
@@ -18,6 +19,15 @@ export function link(
 
   Deno.link(existingPath, newPath).then(() => callback(null), callback);
 }
+
+/**
+ * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
+ * are implemented. See https://github.com/denoland/deno/issues/3403
+ */
+ export const linkPromise = promisify(link) as (
+  existingPath: string | URL,
+  newPath: string | URL,
+) => Promise<void>;
 
 /**
  * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these

--- a/node/_fs/_fs_lstat.ts
+++ b/node/_fs/_fs_lstat.ts
@@ -7,6 +7,7 @@ import {
   statOptions,
   Stats,
 } from "./_fs_stat.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function lstat(path: string | URL, callback: statCallback): void;
 export function lstat(
@@ -41,6 +42,12 @@ export function lstat(
     (err) => callback(err),
   );
 }
+
+export const lstatPromise = promisify(lstat) as (
+  & ((path: string | URL) => Promise<Stats>)
+  & ((path: string | URL, options: { bigint: false }) => Promise<Stats>)
+  & ((path: string | URL, options: { bigint: true }) => Promise<BigIntStats>)
+);
 
 export function lstatSync(path: string | URL): Stats;
 export function lstatSync(

--- a/node/_fs/_fs_mkdir.ts
+++ b/node/_fs/_fs_mkdir.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 /**
  * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
@@ -47,6 +48,11 @@ export function mkdir(
       }
     });
 }
+
+export const mkdirPromise = promisify(mkdir) as (
+  path: string | URL,
+  options?: MkdirOptions,
+) => Promise<void>;
 
 export function mkdirSync(path: string | URL, options?: MkdirOptions): void {
   path = path instanceof URL ? fromFileUrl(path) : path;

--- a/node/_fs/_fs_mkdtemp.ts
+++ b/node/_fs/_fs_mkdtemp.ts
@@ -6,6 +6,7 @@ import {
   ERR_INVALID_CALLBACK,
   ERR_INVALID_OPT_VALUE_ENCODING,
 } from "../internal/errors.ts";
+import { promisify } from "../internal/util.mjs";
 
 export type mkdtempCallback = (
   err: Error | null,
@@ -40,6 +41,11 @@ export function mkdtemp(
     },
   );
 }
+
+export const mkdtempPromise = promisify(mkdtemp) as (
+  prefix: string,
+  options?: { encoding: string } | string,
+) => Promise<string>;
 
 // https://nodejs.org/dist/latest-v15.x/docs/api/fs.html#fs_fs_mkdtempsync_prefix_options
 export function mkdtempSync(

--- a/node/_fs/_fs_open.ts
+++ b/node/_fs/_fs_open.ts
@@ -2,6 +2,7 @@
 import { existsSync } from "../../fs/exists.ts";
 import { fromFileUrl } from "../path.ts";
 import { getOpenOptions } from "./_fs_common.ts";
+import { promisify } from "../internal/util.mjs";
 
 export type openFlags =
   | "a"
@@ -84,6 +85,13 @@ export function open(
     );
   }
 }
+
+export const openPromise = promisify(open) as (
+  & ((path: string | URL) => Promise<number>)
+  & ((path: string | URL, flags: openFlags) => Promise<number>)
+  & ((path: string | URL, mode?: number) => Promise<number>)
+  & ((path: string | URL, flags?: openFlags, mode?: number) => Promise<number>)
+);
 
 export function openSync(path: string | URL): number;
 export function openSync(path: string | URL, flags?: openFlags): number;

--- a/node/_fs/_fs_readFile.ts
+++ b/node/_fs/_fs_readFile.ts
@@ -8,6 +8,7 @@ import {
 import { Buffer } from "../buffer.ts";
 import { fromFileUrl } from "../path.ts";
 import { BinaryEncodings, Encodings, TextEncodings } from "../_utils.ts";
+import { promisify } from "../internal/util.mjs";
 
 function maybeDecode(data: Uint8Array, encoding: TextEncodings): string;
 function maybeDecode(
@@ -72,6 +73,12 @@ export function readFile(
     }, (err) => cb && cb(err));
   }
 }
+
+export const readFilePromise = promisify(readFile) as (
+  & ((path: string | URL, opt: TextOptionsArgument) => Promise<string>)
+  & ((path: string | URL, opt?: BinaryOptionsArgument) => Promise<Buffer>)
+  & ((path: string | URL, opt?: FileOptionsArgument) => Promise<Buffer>)
+);
 
 export function readFileSync(
   path: string | URL,

--- a/node/_fs/_fs_readdir.ts
+++ b/node/_fs/_fs_readdir.ts
@@ -4,6 +4,7 @@ import Dirent from "./_fs_dirent.ts";
 import { denoErrorToNodeError } from "../internal/errors.ts";
 import { getValidatedPath } from "../internal/fs/utils.mjs";
 import { Buffer } from "../buffer.ts";
+import { promisify } from "../internal/util.mjs";
 
 function toDirent(val: Deno.DirEntry): Dirent {
   return new Dirent(val);
@@ -86,6 +87,17 @@ function decode(str: string, encoding?: string): string {
     return decoder.decode(encoder.encode(str));
   }
 }
+
+export const readdirPromise = promisify(readdir) as (
+  & ((path: string | Buffer | URL, options: {
+    withFileTypes: true;
+    encoding?: string;
+  }) => Promise<Dirent[]>)
+  & ((path: string | Buffer | URL, options?: {
+    withFileTypes?: false;
+    encoding?: string;
+  }) => Promise<string[]>)
+);
 
 export function readdirSync(
   path: string | Buffer | URL,

--- a/node/_fs/_fs_readlink.ts
+++ b/node/_fs/_fs_readlink.ts
@@ -5,6 +5,7 @@ import {
   notImplemented,
 } from "../_utils.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 type ReadlinkCallback = (
   err: MaybeEmpty<Error>,
@@ -70,6 +71,11 @@ export function readlink(
     path,
   );
 }
+
+export const readlinkPromise = promisify(readlink) as (
+  path: string | URL,
+  opt?: ReadlinkOptions,
+) => Promise<string | Uint8Array>;
 
 export function readlinkSync(
   path: string | URL,

--- a/node/_fs/_fs_realpath.ts
+++ b/node/_fs/_fs_realpath.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { promisify } from "../internal/util.mjs";
+
 type Options = { encoding: string };
 type Callback = (err: Error | null, path?: string) => void;
 
@@ -20,6 +22,11 @@ export function realpath(
 }
 
 realpath.native = realpath;
+
+export const realpathPromise = promisify(realpath) as (
+  path: string,
+  options?: Options,
+) => Promise<string>;
 
 export function realpathSync(path: string): string {
   return Deno.realPathSync(path);

--- a/node/_fs/_fs_rename.ts
+++ b/node/_fs/_fs_rename.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function rename(
   oldPath: string | URL,
@@ -13,6 +14,11 @@ export function rename(
 
   Deno.rename(oldPath, newPath).then((_) => callback(), callback);
 }
+
+export const renamePromise = promisify(rename) as (
+  oldPath: string | URL,
+  newPath: string | URL,
+) => Promise<void>;
 
 export function renameSync(oldPath: string | URL, newPath: string | URL) {
   oldPath = oldPath instanceof URL ? fromFileUrl(oldPath) : oldPath;

--- a/node/_fs/_fs_rm.ts
+++ b/node/_fs/_fs_rm.ts
@@ -4,6 +4,8 @@ import {
   validateRmOptionsSync,
 } from "../internal/fs/utils.mjs";
 import { denoErrorToNodeError } from "../internal/errors.ts";
+import { promisify } from "../internal/util.mjs";
+
 type rmOptions = {
   force?: boolean;
   maxRetries?: number;
@@ -56,6 +58,11 @@ export function rm(
     },
   );
 }
+
+export const rmPromise = promisify(rm) as (
+  path: string | URL,
+  options?: rmOptions,
+) => Promise<void>;
 
 export function rmSync(path: string | URL, options?: rmOptions) {
   options = validateRmOptionsSync(path, options, false);

--- a/node/_fs/_fs_rmdir.ts
+++ b/node/_fs/_fs_rmdir.ts
@@ -12,6 +12,7 @@ import {
   ERR_FS_RMDIR_ENOTDIR,
 } from "../internal/errors.ts";
 import { Buffer } from "../buffer.ts";
+import { promisify } from "../internal/util.mjs";
 
 type rmdirOptions = {
   maxRetries?: number;
@@ -73,6 +74,11 @@ export function rmdir(
       });
   }
 }
+
+export const rmdirPromise = promisify(rmdir) as (
+  path: string | Buffer | URL,
+  options?: rmdirOptions,
+) => Promise<void>;
 
 export function rmdirSync(path: string | Buffer | URL, options?: rmdirOptions) {
   path = getValidatedPath(path);

--- a/node/_fs/_fs_stat.ts
+++ b/node/_fs/_fs_stat.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { denoErrorToNodeError } from "../internal/errors.ts";
+import { promisify } from "../internal/util.mjs";
 
 export type statOptions = {
   bigint: boolean;
@@ -274,6 +275,12 @@ export function stat(
     (err) => callback(denoErrorToNodeError(err, { syscall: "stat" })),
   );
 }
+
+export const statPromise = promisify(stat) as (
+  & ((path: string | URL) => Promise<Stats>)
+  & ((path: string | URL, options: { bigint: false }) => Promise<Stats>)
+  & ((path: string | URL, options: { bigint: true }) => Promise<BigIntStats>)
+);
 
 export function statSync(path: string | URL): Stats;
 export function statSync(

--- a/node/_fs/_fs_symlink.ts
+++ b/node/_fs/_fs_symlink.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 type SymlinkType = "file" | "dir";
 
@@ -25,6 +26,12 @@ export function symlink(
 
   Deno.symlink(target, path, { type }).then(() => callback(null), callback);
 }
+
+export const symlinkPromise = promisify(symlink) as (
+  target: string | URL,
+  path: string | URL,
+  type?: SymlinkType,
+) => Promise<void>;
 
 export function symlinkSync(
   target: string | URL,

--- a/node/_fs/_fs_truncate.ts
+++ b/node/_fs/_fs_truncate.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 export function truncate(
   path: string | URL,
@@ -19,6 +20,11 @@ export function truncate(
 
   Deno.truncate(path, len).then(() => callback(null), callback);
 }
+
+export const truncatePromise = promisify(truncate) as (
+  path: string | URL,
+  len?: number,
+) => Promise<void>;
 
 export function truncateSync(path: string | URL, len?: number) {
   path = path instanceof URL ? fromFileUrl(path) : path;

--- a/node/_fs/_fs_unlink.ts
+++ b/node/_fs/_fs_unlink.ts
@@ -1,8 +1,14 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { promisify } from "../internal/util.mjs";
+
 export function unlink(path: string | URL, callback: (err?: Error) => void) {
   if (!callback) throw new Error("No callback function supplied");
   Deno.remove(path).then((_) => callback(), callback);
 }
+
+export const unlinkPromise = promisify(unlink) as (
+  path: string | URL,
+) => Promise<void>;
 
 export function unlinkSync(path: string | URL) {
   Deno.removeSync(path);

--- a/node/_fs/_fs_utimes.ts
+++ b/node/_fs/_fs_utimes.ts
@@ -2,6 +2,7 @@
 import * as DenoUnstable from "../../_deno_unstable.ts";
 import type { CallbackWithError } from "./_fs_common.ts";
 import { fromFileUrl } from "../path.ts";
+import { promisify } from "../internal/util.mjs";
 
 function getValidTime(
   time: number | string | Date,
@@ -40,6 +41,12 @@ export function utimes(
 
   DenoUnstable.utime(path, atime, mtime).then(() => callback(null), callback);
 }
+
+export const utimesPromise = promisify(utimes) as (
+  path: string | URL,
+  atime: number | string | Date,
+  mtime: number | string | Date,
+) => Promise<void>;
 
 export function utimesSync(
   path: string | URL,

--- a/node/_fs/_fs_watch.ts
+++ b/node/_fs/_fs_watch.ts
@@ -152,6 +152,23 @@ export function watch(
   return fsWatcher;
 }
 
+export const watchPromise = promisify(watch) as (
+  & ((
+    filename: string | URL,
+    options: watchOptions,
+    listener: watchListener,
+  ) => Promise<FSWatcher>)
+  & ((
+    filename: string | URL,
+    listener: watchListener,
+  ) => Promise<FSWatcher>)
+  & ((
+    filename: string | URL,
+    options: watchOptions,
+  ) => Promise<FSWatcher>)
+  & ((filename: string | URL) => Promise<FSWatcher>)
+);
+
 type WatchFileListener = (curr: Stats, prev: Stats) => void;
 type WatchFileOptions = {
   bigint?: boolean;

--- a/node/_fs/_fs_writeFile.ts
+++ b/node/_fs/_fs_writeFile.ts
@@ -14,6 +14,7 @@ import {
 import { isWindows } from "../../_util/os.ts";
 import { AbortError, denoErrorToNodeError } from "../internal/errors.ts";
 import { validateStringAfterArrayBufferView } from "../internal/fs/utils.mjs";
+import { promisify } from "../internal/util.mjs";
 
 export function writeFile(
   pathOrRid: string | number | URL,
@@ -80,6 +81,13 @@ export function writeFile(
     }
   })();
 }
+
+export const writeFilePromise = promisify(writeFile) as (
+  pathOrRid: string | number | URL,
+  // deno-lint-ignore ban-types
+  data: string | Uint8Array | Object,
+  options?: Encodings | WriteFileOptions,
+) => Promise<void>;
 
 export function writeFileSync(
   pathOrRid: string | number | URL,

--- a/node/fs.ts
+++ b/node/fs.ts
@@ -1,12 +1,16 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { access, accessSync } from "./_fs/_fs_access.ts";
-import { appendFile, appendFileSync } from "./_fs/_fs_appendFile.ts";
-import { chmod, chmodSync } from "./_fs/_fs_chmod.ts";
-import { chown, chownSync } from "./_fs/_fs_chown.ts";
+import { access, accessPromise, accessSync } from "./_fs/_fs_access.ts";
+import {
+  appendFile,
+  appendFilePromise,
+  appendFileSync,
+} from "./_fs/_fs_appendFile.ts";
+import { chmod, chmodPromise, chmodSync } from "./_fs/_fs_chmod.ts";
+import { chown, chownPromise, chownSync } from "./_fs/_fs_chown.ts";
 import { close, closeSync } from "./_fs/_fs_close.ts";
 import { createReadStream, ReadStream } from "./_fs/_fs_streams.ts";
 import * as constants from "./_fs/_fs_constants.ts";
-import { copyFile, copyFileSync } from "./_fs/_fs_copy.ts";
+import { copyFile, copyFilePromise, copyFileSync } from "./_fs/_fs_copy.ts";
 import Dir from "./_fs/_fs_dir.ts";
 import Dirent from "./_fs/_fs_dirent.ts";
 import { exists, existsSync } from "./_fs/_fs_exists.ts";
@@ -15,34 +19,41 @@ import { fstat, fstatSync } from "./_fs/_fs_fstat.ts";
 import { fsync, fsyncSync } from "./_fs/_fs_fsync.ts";
 import { ftruncate, ftruncateSync } from "./_fs/_fs_ftruncate.ts";
 import { futimes, futimesSync } from "./_fs/_fs_futimes.ts";
-import { link, linkSync } from "./_fs/_fs_link.ts";
-import { lstat, lstatSync } from "./_fs/_fs_lstat.ts";
-import { mkdir, mkdirSync } from "./_fs/_fs_mkdir.ts";
-import { mkdtemp, mkdtempSync } from "./_fs/_fs_mkdtemp.ts";
-import { open, openSync } from "./_fs/_fs_open.ts";
+import { link, linkPromise, linkSync } from "./_fs/_fs_link.ts";
+import { lstat, lstatPromise, lstatSync } from "./_fs/_fs_lstat.ts";
+import { mkdir, mkdirPromise, mkdirSync } from "./_fs/_fs_mkdir.ts";
+import { mkdtemp, mkdtempPromise, mkdtempSync } from "./_fs/_fs_mkdtemp.ts";
+import { open, openPromise, openSync } from "./_fs/_fs_open.ts";
 import { read, readSync } from "./_fs/_fs_read.ts";
-import { readdir, readdirSync } from "./_fs/_fs_readdir.ts";
-import { readFile, readFileSync } from "./_fs/_fs_readFile.ts";
-import { readlink, readlinkSync } from "./_fs/_fs_readlink.ts";
-import { realpath, realpathSync } from "./_fs/_fs_realpath.ts";
-import { rename, renameSync } from "./_fs/_fs_rename.ts";
-import { rmdir, rmdirSync } from "./_fs/_fs_rmdir.ts";
-import { rm, rmSync } from "./_fs/_fs_rm.ts";
-import { stat, statSync } from "./_fs/_fs_stat.ts";
-import { symlink, symlinkSync } from "./_fs/_fs_symlink.ts";
-import { truncate, truncateSync } from "./_fs/_fs_truncate.ts";
-import { unlink, unlinkSync } from "./_fs/_fs_unlink.ts";
-import { utimes, utimesSync } from "./_fs/_fs_utimes.ts";
-import { unwatchFile, watch, watchFile } from "./_fs/_fs_watch.ts";
+import { readdir, readdirPromise, readdirSync } from "./_fs/_fs_readdir.ts";
+import { readFile, readFilePromise, readFileSync } from "./_fs/_fs_readFile.ts";
+import { readlink, readlinkPromise, readlinkSync } from "./_fs/_fs_readlink.ts";
+import { realpath, realpathPromise, realpathSync } from "./_fs/_fs_realpath.ts";
+import { rename, renamePromise, renameSync } from "./_fs/_fs_rename.ts";
+import { rmdir, rmdirPromise, rmdirSync } from "./_fs/_fs_rmdir.ts";
+import { rm, rmPromise, rmSync } from "./_fs/_fs_rm.ts";
+import { stat, statPromise, statSync } from "./_fs/_fs_stat.ts";
+import { symlink, symlinkPromise, symlinkSync } from "./_fs/_fs_symlink.ts";
+import { truncate, truncatePromise, truncateSync } from "./_fs/_fs_truncate.ts";
+import { unlink, unlinkPromise, unlinkSync } from "./_fs/_fs_unlink.ts";
+import { utimes, utimesPromise, utimesSync } from "./_fs/_fs_utimes.ts";
+import {
+  unwatchFile,
+  watch,
+  watchFile,
+  watchPromise,
+} from "./_fs/_fs_watch.ts";
 // @deno-types="./_fs/_fs_write.d.ts"
 import { write, writeSync } from "./_fs/_fs_write.mjs";
 // @deno-types="./_fs/_fs_writev.d.ts"
 import { writev, writevSync } from "./_fs/_fs_writev.mjs";
-import { writeFile, writeFileSync } from "./_fs/_fs_writeFile.ts";
+import {
+  writeFile,
+  writeFilePromise,
+  writeFileSync,
+} from "./_fs/_fs_writeFile.ts";
 import { Stats } from "./internal/fs/utils.mjs";
 import { createWriteStream, WriteStream } from "./internal/fs/streams.ts";
-
-import { promisify } from "./util.ts";
 
 const {
   F_OK,
@@ -52,34 +63,34 @@ const {
 } = constants;
 
 const promises = {
-  access: promisify(access),
-  copyFile: promisify(copyFile),
-  open: promisify(open),
+  access: accessPromise,
+  copyFile: copyFilePromise,
+  open: openPromise,
   // opendir: promisify(opendir),
-  rename: promisify(rename),
-  truncate: promisify(truncate),
-  rm: promisify(rm),
-  rmdir: promisify(rmdir),
-  mkdir: promisify(mkdir),
-  readdir: promisify(readdir),
-  readlink: promisify(readlink),
-  symlink: promisify(symlink),
-  lstat: promisify(lstat),
-  stat: promisify(stat),
-  link: promisify(link),
-  unlink: promisify(unlink),
-  chmod: promisify(chmod),
+  rename: renamePromise,
+  truncate: truncatePromise,
+  rm: rmPromise,
+  rmdir: rmdirPromise,
+  mkdir: mkdirPromise,
+  readdir: readdirPromise,
+  readlink: readlinkPromise,
+  symlink: symlinkPromise,
+  lstat: lstatPromise,
+  stat: statPromise,
+  link: linkPromise,
+  unlink: unlinkPromise,
+  chmod: chmodPromise,
   // lchmod: promisify(lchmod),
   // lchown: promisify(lchown),
-  chown: promisify(chown),
-  utimes: promisify(utimes),
+  chown: chownPromise,
+  utimes: utimesPromise,
   // lutimes = promisify(lutimes),
-  realpath: promisify(realpath),
-  mkdtemp: promisify(mkdtemp),
-  writeFile: promisify(writeFile),
-  appendFile: promisify(appendFile),
-  readFile: promisify(readFile),
-  watch: promisify(watch),
+  realpath: realpathPromise,
+  mkdtemp: mkdtempPromise,
+  writeFile: writeFilePromise,
+  appendFile: appendFilePromise,
+  readFile: readFilePromise,
+  watch: watchPromise,
 };
 
 export default {

--- a/node/fs/_fs_writeFile_test.ts
+++ b/node/fs/_fs_writeFile_test.ts
@@ -14,7 +14,11 @@ const decoder = new TextDecoder("utf-8");
 Deno.test("Invalid encoding results in error()", async function testEncodingErrors() {
   await assertRejects(
     async () => {
-      await writeFile("some/path", "some data", "made-up-encoding");
+      await writeFile(
+        "some/path",
+        "some data",
+        "made-up-encoding" as TextEncodings,
+      );
     },
     Error,
     `The value "made-up-encoding" is invalid for option "encoding"`,
@@ -22,7 +26,7 @@ Deno.test("Invalid encoding results in error()", async function testEncodingErro
   await assertRejects(
     async () => {
       await writeFile("some/path", "some data", {
-        encoding: "made-up-encoding",
+        encoding: "made-up-encoding" as TextEncodings,
       });
     },
     Error,


### PR DESCRIPTION
This fixes #2510 by adding types to the `node/fs/promises.ts` exports.

1. Moved the `promisfy()` calls from `node/fs.ts` to the individual modules in the `_fs/` folder. (Some of the arguments types aren't exported from those files, this seemed like the right thing to do)
2. Manually typed the promisified functions via `as`
3. Fixed a type error in `node/fs/_fs_writeFile_test.ts` (created by the new types) by typecasting the `made-up-encoding` string to the TextEncodings type