### PR TITLE
feat(http): `accept-language` header parser

### DIFF
--- a/http/util.ts
+++ b/http/util.ts
@@ -12,3 +12,22 @@ export function compareEtag(a: string, b: string): boolean {
   }
   return false;
 }
+
+/**
+ * Parses `accept-language` header
+ * @param header Request header value
+ * @returns Array of locale identifiers, ordered by q-factor from highest to lowest. A wildcard (`*`) identifier is returns as a `null` value.
+ */
+export function parseAcceptLanguage(header: string): (Intl.Locale | string)[] {
+  return header
+    .split(", ")
+    .map((tag) => {
+      const [language, q] = tag.split(";q=");
+      return {
+        locale: language === "*" ? "*" : new Intl.Locale(language),
+        q: Number(q) || 1,
+      };
+    })
+    .sort((a, b) => b.q - a.q)
+    .map(({ locale }) => locale);
+}

--- a/http/util_test.ts
+++ b/http/util_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { compareEtag } from "./util.ts";
-import { assert } from "../testing/asserts.ts";
+import { compareEtag, parseAcceptLanguage } from "./util.ts";
+import { assert, assertEquals } from "../testing/asserts.ts";
 
 Deno.test("createEtag", () => {
   const ETAG_A = `"d64dea47ee6fd90800ec546c2544abfb"`;
@@ -9,4 +9,20 @@ Deno.test("createEtag", () => {
   assert(!compareEtag(ETAG_A, ETAG_B));
   assert(compareEtag(ETAG_A, `W/${ETAG_A}`));
   assert(compareEtag(`W/${ETAG_A}`, ETAG_A));
+});
+
+Deno.test({
+  name: "parseAcceptLanguage",
+  fn() {
+    assertEquals(
+      parseAcceptLanguage("fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5"),
+      [
+        new Intl.Locale("fr-CH"),
+        new Intl.Locale("fr"),
+        new Intl.Locale("en"),
+        new Intl.Locale("de"),
+        "*",
+      ],
+    );
+  },
 });


### PR DESCRIPTION
For #2426. My questions are:
1. Is this located in the correct place or should it be in [http/negotiation.ts](https://github.com/denoland/deno_std/blob/main/http/negotiation.ts)?
2. Should we aim to replace [`parseAcceptLanguage`](https://github.com/denoland/deno_std/blob/2e7f2f521c77d6c20edd3fd19107ff31b5ed097f/http/_negotiation/language.ts#L69-L80) and make this function externally accessible?