### PR TITLE
fix:2516 remove new used declared 'GenericFunction'

### DIFF
--- a/node/internal/errors.ts
+++ b/node/internal/errors.ts
@@ -68,9 +68,6 @@ export class AbortError extends Error {
   }
 }
 
-// deno-lint-ignore no-explicit-any
-type GenericFunction = (...args: any[]) => any;
-
 let maxStack_ErrorName: string | undefined;
 let maxStack_ErrorMessage: string | undefined;
 /**


### PR DESCRIPTION
The function hideStackFrames had been moved to another file, didn't remove declared type

closes #2516 