### PR TITLE
fix(collections): Fix edge cases for BinaryHeap

### DIFF
--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -11,6 +11,11 @@ function swap<T>(array: T[], a: number, b: number) {
   array[b] = temp;
 }
 
+/** Returns the parent index for a child index. */
+function getParentIndex(index: number) {
+  return Math.floor((index + 1) / 2) - 1;
+}
+
 /**
  * A priority queue implemented with a binary heap. The heap is in decending order by default,
  * using JavaScript's built in comparison operators to sort the values.
@@ -87,18 +92,13 @@ export class BinaryHeap<T> implements Iterable<T> {
     let right: number = 2 * (parent + 1);
     let left: number = right - 1;
     while (left < size) {
-      if (
-        this.compare(this.#data[left], this.#data[parent]) < 0 &&
-        (right === size ||
-          this.compare(this.#data[left], this.#data[right]) < 0)
-      ) {
-        swap(this.#data, parent, left);
-        parent = left;
-      } else if (
-        right < size && this.compare(this.#data[right], this.#data[parent]) < 0
-      ) {
-        swap(this.#data, parent, right);
-        parent = right;
+      const greatestChild =
+        right === size || this.compare(this.#data[left], this.#data[right]) <= 0
+          ? left
+          : right;
+      if (this.compare(this.#data[greatestChild], this.#data[parent]) < 0) {
+        swap(this.#data, parent, greatestChild);
+        parent = greatestChild;
       } else {
         break;
       }
@@ -112,14 +112,14 @@ export class BinaryHeap<T> implements Iterable<T> {
   push(...values: T[]): number {
     for (const value of values) {
       let index: number = this.#data.length;
-      let parent: number = Math.floor(index / 2);
+      let parent: number = getParentIndex(index);
       this.#data.push(value);
       while (
         index !== 0 && this.compare(this.#data[index], this.#data[parent]) < 0
       ) {
         swap(this.#data, parent, index);
         index = parent;
-        parent = Math.floor(index / 2);
+        parent = getParentIndex(index);
       }
     }
     return this.#data.length;

--- a/collections/binary_heap_test.ts
+++ b/collections/binary_heap_test.ts
@@ -258,6 +258,56 @@ Deno.test("[collections/BinaryHeap] from BinaryHeap with ascend comparator", () 
   assertEquals([...heap].reverse(), expected.map((v: number) => 3 * v));
 });
 
+Deno.test("[collections/BinaryHeap] edge case 1", () => {
+  const minHeap = new BinaryHeap<number>(ascend);
+  minHeap.push(4, 2, 8, 1, 10, 7, 3, 6, 5);
+  assertEquals(minHeap.pop(), 1);
+  minHeap.push(9);
+
+  const expected = [2, 3, 4, 5, 6, 7, 8, 9, 10];
+  assertEquals([...minHeap], expected);
+});
+
+Deno.test("[collections/BinaryHeap] edge case 2", () => {
+  interface Point {
+    x: number;
+    y: number;
+  }
+  const minHeap = new BinaryHeap<Point>((a, b) => ascend(a.x, b.x));
+  minHeap.push({ x: 0, y: 1 }, { x: 0, y: 2 }, { x: 0, y: 3 });
+
+  const expected = [{ x: 0, y: 1 }, { x: 0, y: 3 }, { x: 0, y: 2 }];
+  assertEquals([...minHeap], expected);
+});
+
+Deno.test("[collections/BinaryHeap] edge case 3", () => {
+  interface Point {
+    x: number;
+    y: number;
+  }
+  const minHeap = new BinaryHeap<Point>((a, b) => ascend(a.x, b.x));
+  minHeap.push(
+    { x: 0, y: 1 },
+    { x: 1, y: 2 },
+    { x: 1, y: 3 },
+    { x: 2, y: 4 },
+    { x: 2, y: 5 },
+    { x: 2, y: 6 },
+    { x: 2, y: 7 },
+  );
+
+  const expected = [
+    { x: 0, y: 1 },
+    { x: 1, y: 2 },
+    { x: 1, y: 3 },
+    { x: 2, y: 5 },
+    { x: 2, y: 4 },
+    { x: 2, y: 6 },
+    { x: 2, y: 7 },
+  ];
+  assertEquals([...minHeap], expected);
+});
+
 Deno.test("[collections/BinaryHeap] README example", () => {
   const maxHeap = new BinaryHeap<number>();
   maxHeap.push(4, 1, 3, 5, 2);


### PR DESCRIPTION
There were 2 issues and I fixed both. I found them while investigating issue https://github.com/denoland/deno_std/issues/2522.

1. push was using the wrong algorithm for finding the parent index. It would end up comparing and swapping with the wrong index in some cases. The first test case below pins the correct behavior. The test case passes for the heap npm module too.
2. pop would swap with the wrong child if both were less than the parent value. It would always swap with the left instead of the one that is lowest.

Below are 2 quotes from the [Binary Heap Wikipedia page](https://en.wikipedia.org/wiki/Binary_heap).

Steps for insertion:
> 1. Add the element to the bottom level of the heap at the leftmost open space.
> 2. Compare the added element with its parent; if they are in the correct order, stop.
> 3. If not, swap the element with its parent and return to the previous step.

Steps for extraction:
> 1. Replace the root of the heap with the last element on the last level.
> 2. Compare the new root with its children; if they are in the correct order, stop.
> 3. If not, swap the element with one of its children and return to the previous step. (Swap with its smaller child in a min-heap and its larger child in a max-heap.)

Here are all 3 edge case tests I wrote for collections/BinaryHeap. They all pass now with the fixes I've made to push and pop.

```ts
Deno.test("[collections/BinaryHeap] edge case 1", () => {
  const minHeap = new BinaryHeap<number>(ascend);
  minHeap.push(4, 2, 8, 1, 10, 7, 3, 6, 5);
  assertEquals(minHeap.pop(), 1);
  minHeap.push(9);

  const expected = [2, 3, 4, 5, 6, 7, 8, 9, 10];
  assertEquals([...minHeap], expected);
});

Deno.test("[collections/BinaryHeap] edge case 2", () => {
  interface Point {
    x: number;
    y: number;
  }
  const minHeap = new BinaryHeap<Point>((a, b) => ascend(a.x, b.x));
  minHeap.push({ x: 0, y: 1 }, { x: 0, y: 2 }, { x: 0, y: 3 });

  const expected = [{ x: 0, y: 1 }, { x: 0, y: 3 }, { x: 0, y: 2 }];
  assertEquals([...minHeap], expected);
});

Deno.test("[collections/BinaryHeap] edge case 3", () => {
  interface Point {
    x: number;
    y: number;
  }
  const minHeap = new BinaryHeap<Point>((a, b) => ascend(a.x, b.x));
  minHeap.push(
    { x: 0, y: 1 },
    { x: 1, y: 2 },
    { x: 1, y: 3 },
    { x: 2, y: 4 },
    { x: 2, y: 5 },
    { x: 2, y: 6 },
    { x: 2, y: 7 },
  );

  const expected = [
    { x: 0, y: 1 },
    { x: 1, y: 2 },
    { x: 1, y: 3 },
    { x: 2, y: 5 },
    { x: 2, y: 4 },
    { x: 2, y: 6 },
    { x: 2, y: 7 },
  ];
  assertEquals([...minHeap], expected);
});
```

Here are what the 3 different heaps from these test cases look like before the values are removed for comparing their pop order.

```
Edge case 1 heap:
  Before pop:
               1
          2        3
      4     10   8   7
    6   5
  After pop:
               2
          4        3
      5     10   8   7
    6
  After push:
               2
          4        3
      5     10   8   7
    6   9


Edge case 2 heap:
      0,1
  0,2     0,3

Edge case 3 heap:
              0,1
      1,2             1,3
  2,4     2,5     2,6     2,7
```