### PR TITLE
fix(node): Stricter checking of TypedArray

### DIFF
--- a/node/_tools/test/parallel/test-util-types.js
+++ b/node/_tools/test/parallel/test-util-types.js
@@ -225,11 +225,10 @@ for (const [ value, _method ] of [
       bigInt64Array, stealthyBigInt64Array,
       bigUint64Array, stealthyBigUint64Array,
     ],
-    // TODO(wafuwafu13): Enable all
     isTypedArray: [
       buffer,
-      uint8Array, /** stealthyUint8Array, */
-      uint8ClampedArray, /** stealthyUint8ClampedArray, */
+      uint8Array, stealthyUint8Array,
+      uint8ClampedArray, stealthyUint8ClampedArray,
       uint16Array, stealthyUint16Array,
       uint32Array, stealthyUint32Array,
       int8Array, stealthyInt8Array,
@@ -237,16 +236,14 @@ for (const [ value, _method ] of [
       int32Array, stealthyInt32Array,
       float32Array, stealthyFloat32Array,
       float64Array, stealthyFloat64Array,
-      /** bigInt64Array, stealthyBigInt64Array,
-      bigUint64Array, stealthyBigUint64Array, */
+      bigInt64Array, stealthyBigInt64Array,
+      bigUint64Array, stealthyBigUint64Array,
     ],
-    // TODO(wafuwafu13): Enable all
     isUint8Array: [
-      buffer, uint8Array, /** stealthyUint8Array, */
+      buffer, uint8Array, stealthyUint8Array,
     ],
-    // TODO(wafuwafu13): Enable all
     isUint8ClampedArray: [
-      uint8ClampedArray, /** stealthyUint8ClampedArray, */
+      uint8ClampedArray, stealthyUint8ClampedArray,
     ],
     isUint16Array: [
       uint16Array, stealthyUint16Array,

--- a/node/internal/util/types.ts
+++ b/node/internal/util/types.ts
@@ -24,86 +24,62 @@
 import * as bindingTypes from "../../internal_binding/types.ts";
 export { isCryptoKey, isKeyObject } from "../crypto/_keys.ts";
 
-const _toString = Object.prototype.toString;
-
-const _isObjectLike = (value: unknown): boolean =>
-  value !== null && typeof value === "object";
+// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
+const _typedArrayGetToStringTag = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array).prototype,
+  Symbol.toStringTag,
+)!.get!;
 
 export function isArrayBufferView(value: unknown): boolean {
   return ArrayBuffer.isView(value);
 }
 
 export function isBigInt64Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object BigInt64Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "BigInt64Array";
 }
 
 export function isBigUint64Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object BigUint64Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "BigUint64Array";
 }
 
 export function isFloat32Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Float32Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Float32Array";
 }
 
 export function isFloat64Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Float64Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Float64Array";
 }
 
 export function isInt8Array(value: unknown): boolean {
-  return _isObjectLike(value) && _toString.call(value) === "[object Int8Array]";
+  return _typedArrayGetToStringTag.call(value) === "Int8Array";
 }
 
 export function isInt16Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Int16Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Int16Array";
 }
 
 export function isInt32Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Int32Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Int32Array";
 }
 
-// Adapted from Lodash
 export function isTypedArray(value: unknown): boolean {
-  /** Used to match `toStringTag` values of typed arrays. */
-  const reTypedTag =
-    /^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)Array\]$/;
-  return _isObjectLike(value) && reTypedTag.test(_toString.call(value));
+  return _typedArrayGetToStringTag.call(value) !== undefined;
 }
 
 export function isUint8Array(value: unknown): value is Uint8Array {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Uint8Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Uint8Array";
 }
 
 export function isUint8ClampedArray(value: unknown): boolean {
-  return (
-    _isObjectLike(value) &&
-    _toString.call(value) === "[object Uint8ClampedArray]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Uint8ClampedArray";
 }
 
 export function isUint16Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Uint16Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Uint16Array";
 }
 
 export function isUint32Array(value: unknown): boolean {
-  return (
-    _isObjectLike(value) && _toString.call(value) === "[object Uint32Array]"
-  );
+  return _typedArrayGetToStringTag.call(value) === "Uint32Array";
 }
 
 export const {

--- a/node/internal/util/types.ts
+++ b/node/internal/util/types.ts
@@ -25,7 +25,7 @@ import * as bindingTypes from "../../internal_binding/types.ts";
 export { isCryptoKey, isKeyObject } from "../crypto/_keys.ts";
 
 // https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
-const _typedArrayGetToStringTag = Object.getOwnPropertyDescriptor(
+const _getTypedArrayToStringTag = Object.getOwnPropertyDescriptor(
   Object.getPrototypeOf(Uint8Array).prototype,
   Symbol.toStringTag,
 )!.get!;
@@ -35,51 +35,51 @@ export function isArrayBufferView(value: unknown): boolean {
 }
 
 export function isBigInt64Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "BigInt64Array";
+  return _getTypedArrayToStringTag.call(value) === "BigInt64Array";
 }
 
 export function isBigUint64Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "BigUint64Array";
+  return _getTypedArrayToStringTag.call(value) === "BigUint64Array";
 }
 
 export function isFloat32Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Float32Array";
+  return _getTypedArrayToStringTag.call(value) === "Float32Array";
 }
 
 export function isFloat64Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Float64Array";
+  return _getTypedArrayToStringTag.call(value) === "Float64Array";
 }
 
 export function isInt8Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Int8Array";
+  return _getTypedArrayToStringTag.call(value) === "Int8Array";
 }
 
 export function isInt16Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Int16Array";
+  return _getTypedArrayToStringTag.call(value) === "Int16Array";
 }
 
 export function isInt32Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Int32Array";
+  return _getTypedArrayToStringTag.call(value) === "Int32Array";
 }
 
 export function isTypedArray(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) !== undefined;
+  return _getTypedArrayToStringTag.call(value) !== undefined;
 }
 
 export function isUint8Array(value: unknown): value is Uint8Array {
-  return _typedArrayGetToStringTag.call(value) === "Uint8Array";
+  return _getTypedArrayToStringTag.call(value) === "Uint8Array";
 }
 
 export function isUint8ClampedArray(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Uint8ClampedArray";
+  return _getTypedArrayToStringTag.call(value) === "Uint8ClampedArray";
 }
 
 export function isUint16Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Uint16Array";
+  return _getTypedArrayToStringTag.call(value) === "Uint16Array";
 }
 
 export function isUint32Array(value: unknown): boolean {
-  return _typedArrayGetToStringTag.call(value) === "Uint32Array";
+  return _getTypedArrayToStringTag.call(value) === "Uint32Array";
 }
 
 export const {

--- a/node/internal/util/types_test.ts
+++ b/node/internal/util/types_test.ts
@@ -142,7 +142,10 @@ Deno.test("Should return false for invalid BigInt64Array types", () => {
   assertStrictEquals(isBigInt64Array(new BigUint64Array()), false);
   assertStrictEquals(isBigInt64Array(new Float32Array()), false);
   assertStrictEquals(isBigInt64Array(new Int32Array()), false);
-  assertStrictEquals(isBigInt64Array({ [Symbol.toStringTag]: "BigInt64Array" }), false);
+  assertStrictEquals(
+    isBigInt64Array({ [Symbol.toStringTag]: "BigInt64Array" }),
+    false,
+  );
 });
 
 // isBigUint64Array
@@ -154,7 +157,10 @@ Deno.test("Should return false for invalid BigUint64Array types", () => {
   assertStrictEquals(isBigUint64Array(new BigInt64Array()), false);
   assertStrictEquals(isBigUint64Array(new Float32Array()), false);
   assertStrictEquals(isBigUint64Array(new Int32Array()), false);
-  assertStrictEquals(isBigUint64Array({ [Symbol.toStringTag]: "BigUint64Array" }), false);
+  assertStrictEquals(
+    isBigUint64Array({ [Symbol.toStringTag]: "BigUint64Array" }),
+    false,
+  );
 });
 
 // isBooleanObject
@@ -215,7 +221,10 @@ Deno.test("Should return true for valid Float32Array types", () => {
 Deno.test("Should return false for invalid Float32Array types", () => {
   assertStrictEquals(isFloat32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isFloat32Array(new Float64Array(0)), false);
-  assertStrictEquals(isFloat32Array({ [Symbol.toStringTag]: "Float32Array" }), false);
+  assertStrictEquals(
+    isFloat32Array({ [Symbol.toStringTag]: "Float32Array" }),
+    false,
+  );
 });
 
 // isFloat64Array
@@ -226,7 +235,10 @@ Deno.test("Should return true for valid Float64Array types", () => {
 Deno.test("Should return false for invalid Float64Array types", () => {
   assertStrictEquals(isFloat64Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isFloat64Array(new Uint8Array(0)), false);
-  assertStrictEquals(isFloat64Array({ [Symbol.toStringTag]: "Float64Array" }), false);
+  assertStrictEquals(
+    isFloat64Array({ [Symbol.toStringTag]: "Float64Array" }),
+    false,
+  );
 });
 
 // isGeneratorFunction
@@ -276,7 +288,10 @@ Deno.test("Should return true for valid Int16Array types", () => {
 Deno.test("Should return false for invalid Int16Array type", () => {
   assertStrictEquals(isInt16Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isInt16Array(new Float64Array(0)), false);
-  assertStrictEquals(isInt16Array({ [Symbol.toStringTag]: "Int16Array" }), false);
+  assertStrictEquals(
+    isInt16Array({ [Symbol.toStringTag]: "Int16Array" }),
+    false,
+  );
 });
 
 // isInt32Array
@@ -287,7 +302,10 @@ Deno.test("Should return true for valid Int32Array types", () => {
 Deno.test("Should return false for invalid Int32Array type", () => {
   assertStrictEquals(isInt32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isInt32Array(new Float64Array(0)), false);
-  assertStrictEquals(isInt32Array({ [Symbol.toStringTag]: "Int32Array" }), false);
+  assertStrictEquals(
+    isInt32Array({ [Symbol.toStringTag]: "Int32Array" }),
+    false,
+  );
 });
 
 // isStringObject
@@ -453,7 +471,10 @@ Deno.test("Should return true for valid TypedArray types", () => {
 
 Deno.test("Should return false for invalid TypedArray types", () => {
   assertStrictEquals(isTypedArray(new ArrayBuffer(0)), false);
-  assertStrictEquals(isTypedArray({ [Symbol.toStringTag]: "Uint8Array" }), false);
+  assertStrictEquals(
+    isTypedArray({ [Symbol.toStringTag]: "Uint8Array" }),
+    false,
+  );
 });
 
 // isUint8Array
@@ -464,7 +485,10 @@ Deno.test("Should return true for valid Uint8Array types", () => {
 Deno.test("Should return false for invalid Uint8Array types", () => {
   assertStrictEquals(isUint8Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint8Array(new Float64Array(0)), false);
-  assertStrictEquals(isUint8Array({ [Symbol.toStringTag]: "Uint8Array" }), false);
+  assertStrictEquals(
+    isUint8Array({ [Symbol.toStringTag]: "Uint8Array" }),
+    false,
+  );
 });
 
 // isUint8ClampedArray
@@ -475,7 +499,10 @@ Deno.test("Should return true for valid Uint8ClampedArray types", () => {
 Deno.test("Should return false for invalid Uint8ClampedArray types", () => {
   assertStrictEquals(isUint8ClampedArray(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint8ClampedArray(new Float64Array(0)), false);
-  assertStrictEquals(isUint8ClampedArray({ [Symbol.toStringTag]: "Uint8ClampedArray" }), false);
+  assertStrictEquals(
+    isUint8ClampedArray({ [Symbol.toStringTag]: "Uint8ClampedArray" }),
+    false,
+  );
 });
 
 // isUint16Array
@@ -486,7 +513,10 @@ Deno.test("Should return true for valid Uint16Array types", () => {
 Deno.test("Should return false for invalid Uint16Array types", () => {
   assertStrictEquals(isUint16Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint16Array(new Float64Array(0)), false);
-  assertStrictEquals(isUint16Array({ [Symbol.toStringTag]: "Uint16Array" }), false);
+  assertStrictEquals(
+    isUint16Array({ [Symbol.toStringTag]: "Uint16Array" }),
+    false,
+  );
 });
 
 // isUint32Array
@@ -497,7 +527,10 @@ Deno.test("Should return true for valid Uint32Array types", () => {
 Deno.test("Should return false for invalid Uint32Array types", () => {
   assertStrictEquals(isUint32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint32Array(new Float64Array(0)), false);
-  assertStrictEquals(isUint32Array({ [Symbol.toStringTag]: "Uint32Array" }), false);
+  assertStrictEquals(
+    isUint32Array({ [Symbol.toStringTag]: "Uint32Array" }),
+    false,
+  );
 });
 
 // isWeakMap

--- a/node/internal/util/types_test.ts
+++ b/node/internal/util/types_test.ts
@@ -142,17 +142,19 @@ Deno.test("Should return false for invalid BigInt64Array types", () => {
   assertStrictEquals(isBigInt64Array(new BigUint64Array()), false);
   assertStrictEquals(isBigInt64Array(new Float32Array()), false);
   assertStrictEquals(isBigInt64Array(new Int32Array()), false);
+  assertStrictEquals(isBigInt64Array({ [Symbol.toStringTag]: "BigInt64Array" }), false);
 });
 
 // isBigUint64Array
-Deno.test("Should return true for valid isBigUint64Array types", () => {
+Deno.test("Should return true for valid BigUint64Array types", () => {
   assertStrictEquals(isBigUint64Array(new BigUint64Array()), true);
 });
 
-Deno.test("Should return false for invalid isBigUint64Array types", () => {
+Deno.test("Should return false for invalid BigUint64Array types", () => {
   assertStrictEquals(isBigUint64Array(new BigInt64Array()), false);
   assertStrictEquals(isBigUint64Array(new Float32Array()), false);
   assertStrictEquals(isBigUint64Array(new Int32Array()), false);
+  assertStrictEquals(isBigUint64Array({ [Symbol.toStringTag]: "BigUint64Array" }), false);
 });
 
 // isBooleanObject
@@ -161,7 +163,7 @@ Deno.test("Should return true for valid Boolean object types", () => {
   assertStrictEquals(isBooleanObject(new Boolean(true)), true);
 });
 
-Deno.test("Should return false for invalid isBigUint64Array types", () => {
+Deno.test("Should return false for invalid Boolean object types", () => {
   assertStrictEquals(isBooleanObject(false), false);
   assertStrictEquals(isBooleanObject(true), false);
   assertStrictEquals(isBooleanObject(Boolean(false)), false);
@@ -213,6 +215,7 @@ Deno.test("Should return true for valid Float32Array types", () => {
 Deno.test("Should return false for invalid Float32Array types", () => {
   assertStrictEquals(isFloat32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isFloat32Array(new Float64Array(0)), false);
+  assertStrictEquals(isFloat32Array({ [Symbol.toStringTag]: "Float32Array" }), false);
 });
 
 // isFloat64Array
@@ -223,6 +226,7 @@ Deno.test("Should return true for valid Float64Array types", () => {
 Deno.test("Should return false for invalid Float64Array types", () => {
   assertStrictEquals(isFloat64Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isFloat64Array(new Uint8Array(0)), false);
+  assertStrictEquals(isFloat64Array({ [Symbol.toStringTag]: "Float64Array" }), false);
 });
 
 // isGeneratorFunction
@@ -261,6 +265,7 @@ Deno.test("Should return true for valid Int8Array types", () => {
 Deno.test("Should return false for invalid Int8Array types", () => {
   assertStrictEquals(isInt8Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isInt8Array(new Float64Array(0)), false);
+  assertStrictEquals(isInt8Array({ [Symbol.toStringTag]: "Int8Array" }), false);
 });
 
 // isInt16Array
@@ -271,16 +276,18 @@ Deno.test("Should return true for valid Int16Array types", () => {
 Deno.test("Should return false for invalid Int16Array type", () => {
   assertStrictEquals(isInt16Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isInt16Array(new Float64Array(0)), false);
+  assertStrictEquals(isInt16Array({ [Symbol.toStringTag]: "Int16Array" }), false);
 });
 
 // isInt32Array
-Deno.test("Should return true for valid isInt32Array types", () => {
+Deno.test("Should return true for valid Int32Array types", () => {
   assertStrictEquals(isInt32Array(new Int32Array(0)), true);
 });
 
-Deno.test("Should return false for invalid isInt32Array type", () => {
+Deno.test("Should return false for invalid Int32Array type", () => {
   assertStrictEquals(isInt32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isInt32Array(new Float64Array(0)), false);
+  assertStrictEquals(isInt32Array({ [Symbol.toStringTag]: "Int32Array" }), false);
 });
 
 // isStringObject
@@ -446,6 +453,7 @@ Deno.test("Should return true for valid TypedArray types", () => {
 
 Deno.test("Should return false for invalid TypedArray types", () => {
   assertStrictEquals(isTypedArray(new ArrayBuffer(0)), false);
+  assertStrictEquals(isTypedArray({ [Symbol.toStringTag]: "Uint8Array" }), false);
 });
 
 // isUint8Array
@@ -456,6 +464,7 @@ Deno.test("Should return true for valid Uint8Array types", () => {
 Deno.test("Should return false for invalid Uint8Array types", () => {
   assertStrictEquals(isUint8Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint8Array(new Float64Array(0)), false);
+  assertStrictEquals(isUint8Array({ [Symbol.toStringTag]: "Uint8Array" }), false);
 });
 
 // isUint8ClampedArray
@@ -463,19 +472,21 @@ Deno.test("Should return true for valid Uint8ClampedArray types", () => {
   assertStrictEquals(isUint8ClampedArray(new Uint8ClampedArray(0)), true);
 });
 
-Deno.test("Should return false for invalid Uint8Array types", () => {
+Deno.test("Should return false for invalid Uint8ClampedArray types", () => {
   assertStrictEquals(isUint8ClampedArray(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint8ClampedArray(new Float64Array(0)), false);
+  assertStrictEquals(isUint8ClampedArray({ [Symbol.toStringTag]: "Uint8ClampedArray" }), false);
 });
 
 // isUint16Array
-Deno.test("Should return true for valid isUint16Array types", () => {
+Deno.test("Should return true for valid Uint16Array types", () => {
   assertStrictEquals(isUint16Array(new Uint16Array(0)), true);
 });
 
 Deno.test("Should return false for invalid Uint16Array types", () => {
   assertStrictEquals(isUint16Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint16Array(new Float64Array(0)), false);
+  assertStrictEquals(isUint16Array({ [Symbol.toStringTag]: "Uint16Array" }), false);
 });
 
 // isUint32Array
@@ -483,9 +494,10 @@ Deno.test("Should return true for valid Uint32Array types", () => {
   assertStrictEquals(isUint32Array(new Uint32Array(0)), true);
 });
 
-Deno.test("Should return false for invalid isUint16Array types", () => {
+Deno.test("Should return false for invalid Uint32Array types", () => {
   assertStrictEquals(isUint32Array(new ArrayBuffer(0)), false);
   assertStrictEquals(isUint32Array(new Float64Array(0)), false);
+  assertStrictEquals(isUint32Array({ [Symbol.toStringTag]: "Uint32Array" }), false);
 });
 
 // isWeakMap


### PR DESCRIPTION
Changed to use [get %TypedArray%.prototype [ @@toStringTag ]](https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag) for checking TypedArray.