### PR TITLE
feat(testing/asserts): assertNotInstanceOf

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -23,6 +23,8 @@ pretty-printed diff of failing assertion.
   `expected`, according to a given `epsilon` _(defaults to `1e-7`)_
 - `assertInstanceOf()` - Make an assertion that `actual` is an instance of
   `expectedType`.
+- `assertNotInstanceOf()` - Make an assertion that `actual` is not an instance
+  of `expectedType`.
 - `assertStringIncludes()` - Make an assertion that `actual` includes
   `expected`.
 - `assertMatch()` - Make an assertion that `actual` match RegExp `expected`.

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -375,6 +375,18 @@ export function assertInstanceOf<T extends AnyConstructor>(
 }
 
 /**
+ * Make an assertion that `obj` is not an instance of `type`.
+ * If so, then throw.
+ */
+export function assertNotInstanceOf<T extends AnyConstructor>(
+  actual: unknown,
+  unexpectedType: T,
+  msg = `Expected object to not be an instance of "${typeof unexpectedType}"`,
+) {
+  assertFalse(actual instanceof unexpectedType, msg);
+}
+
+/**
  * Make an assertion that actual is not null or undefined.
  * If not then throw.
  */

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -11,6 +11,7 @@ import {
   assertIsError,
   assertMatch,
   assertNotEquals,
+  assertNotInstanceOf,
   assertNotMatch,
   assertNotStrictEquals,
   assertObjectMatch,
@@ -1421,6 +1422,15 @@ Deno.test({
       // @ts-expect-error: `x` is now `Number` rather than `number`, so this should still give a type error.
       x += 5;
     }
+  },
+});
+
+Deno.test({
+  name: "assertNotInstanceOf",
+  fn() {
+    assertNotInstanceOf("not a number", Number);
+    assertNotInstanceOf(42, String);
+    assertNotInstanceOf(new URL("http://example.com"), Boolean);
   },
 });
 


### PR DESCRIPTION
For #2444. Deliberately kept simple as to not mess with the natural order of things (`typeof actual` and `unexpectedType`).

closes #2309 