### PR TITLE
feat(node): add Server.setTimeout() stub

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -587,6 +587,10 @@ class ServerImpl extends EventEmitter {
     ).then(() => this.#servePromise!.resolve());
   }
 
+  setTimeout() {
+    console.error("Not implemented: Server.setTimeout()");
+  }
+
   close(cb?: (err?: Error) => void): this {
     const listening = this.listening;
     this.listening = false;


### PR DESCRIPTION
This stub makes Fastify work in Deno.

```js
import f from "npm:fastify";
const fastify = f({ logger: true })

// Declare a route
fastify.get('/', async (request, reply) => {
  return { hello: 'world' }
})

// Run the server!
const start = async () => {
  try {
    await fastify.listen({ port: 3000 })
  } catch (err) {
    fastify.log.error(err)
    process.exit(1)
  }
}
start()
```

CC @mcollina