### PR TITLE
fix(encoding/json): Improve safety of `JSONValue` object type

### DIFF
--- a/encoding/json/_parse.ts
+++ b/encoding/json/_parse.ts
@@ -4,7 +4,7 @@ import { toTransformStream } from "../../streams/conversion.ts";
 
 /** The type of the result of parsing JSON. */
 export type JSONValue =
-  | { [key: string]: JSONValue }
+  | { [key: string]: JSONValue | undefined }
   | JSONValue[]
   | string
   | number


### PR DESCRIPTION
Improves type safety by adding `undefined` to the union of values of the string-indexed object type union member of `JSONValue`: now its values are effectively optional, which better represents that no object will have a not-undefined value at every possible key.