### PR TITLE
feat: add envalid module

### DIFF
--- a/envalid/README.md
+++ b/envalid/README.md
@@ -1,0 +1,118 @@
+# envalid
+
+Validate environment variables.
+
+## Usage
+
+```ts
+// You can also use it with dotenv:
+// import "https://deno.land/std@$STD_VERSION/dotenv/load.ts";
+import {
+  bool,
+  cleanEnv,
+  num,
+  str,
+} from "https://deno.land/std@$STD_VERSION/envalid/mod.ts";
+
+// You can also do
+// export default cleanEnv(
+// to be importable from other locations.
+const env = cleanEnv(Deno.env.toObject(), {
+  TEXT: str(),
+  IS_X: bool(),
+  APP_ID: num(),
+  SOMETHING: str({
+    default: "default value",
+    example: "some string",
+    desc: "description",
+    docs: "https://example.com/configuration#SOMETHING",
+  }),
+  CHOICE: str({ choices: ["can be this", "or this"] }),
+});
+```
+
+## Validators
+
+- `url()` - Requires the value to be a URL.
+- `email()` - Requires the value to be an email address.
+- `num()` - Parses values like "42", "0.23", and "1e5" into numbers.
+- `json()` - Requires the value to be JSON, and calls `JSON.parse()` on it.
+- `str()` - Requires the value to be set if a default value was not provided.
+- `port()` - Requires the value to be a port (1-6553), and converts it to
+  number.
+- `host()` - Requires the value to be either a fully-qualified domain name or a
+  v4/v6 IP address.
+- `bool()` - Requires the value to be one of "1", "0", "true", "false", "t", or
+  "f", and converts it to boolean.
+
+## Custom Validators
+
+You can create your own validators with `makeValidator()`. It takes a single
+parameter which should be a function that returns either the cleaned value, or
+throws if the value is not acceptable.
+
+```ts
+import {
+  cleanEnv,
+  makeValidator,
+} from "https://deno.land/std@$STD_VERSION/envalid/mod.ts";
+
+const twoUppercaseLetters = makeValidator((x) => {
+  if (/^[A-Za-z]{2}$/.test(x)) {
+    return x.toUpperCase();
+  } else {
+    throw new Error("Expected two letters");
+  }
+});
+
+const env = cleanEnv(Deno.env.toObject(), {
+  TWO_UPPERCASE_LETTERS: twoUppercaseLetters(),
+});
+```
+
+## Reporting Errors
+
+By default, if any variable is missing or has an invalid value, an error message
+will be displayed and the process exits with 1. You can override this behavior
+by using your own reporter:
+
+```ts
+const env = cleanEnv(Deno.env.toObject(), myValidators, {
+  reporter: ({ errors, env }) => {
+    report("Invalid environment variables: " + Object.keys(errors));
+  },
+});
+```
+
+The error classes `EnvError` and `EnvMissingError` can also be used to examine
+the errors:
+
+```ts
+const env = cleanEnv(Deno.env.toObject(), myValidators, {
+  reporter: ({ errors, env }) => {
+    for (const [envVar, err] of Object.entries(errors)) {
+      if (err instanceof envalid.EnvError) {
+        //
+      } else if (err instanceof envalid.EnvMissingError) {
+        //
+      } else {
+        //
+      }
+    }
+  },
+});
+```
+
+## Custom Middleware (Advanced)
+
+The `customCleanEnv()` function allows you to completely override the
+preprocessing and validations. Its arguments are similar to `cleanEnv()` except
+for the third one being the custom middleware function.
+
+The custom middleware function can modify the variables after they have been
+cleaned and validated. The default middleware function,
+`applyDefaultMiddleware()` can also be combined with it.
+
+## Credits
+
+- [af/envalid](https://github.com/af/envalid).

--- a/envalid/README.md
+++ b/envalid/README.md
@@ -85,7 +85,7 @@ const report = (error: string) => {
   //
 };
 
-const env = cleanEnv(Deno.env.toObject(), myValidators, {
+const env = cleanEnv(Deno.env.toObject(), {}, {
   reporter: ({ errors, env }) => {
     report("Invalid environment variables: " + Object.keys(errors));
   },
@@ -102,7 +102,7 @@ import {
   EnvMissingError,
 } from "https://deno.land/std@$STD_VERSION/envalid/mod.ts";
 
-const env = cleanEnv(Deno.env.toObject(), myValidators, {
+const env = cleanEnv(Deno.env.toObject(), {}, {
   reporter: ({ errors, env }) => {
     for (const [envVar, err] of Object.entries(errors)) {
       if (err instanceof EnvError) {

--- a/envalid/README.md
+++ b/envalid/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright 2018-2022 the Deno authors. All rights reserved. MIT license. -->
+
 # envalid
 
 Validate environment variables.

--- a/envalid/README.md
+++ b/envalid/README.md
@@ -79,6 +79,12 @@ will be displayed and the process exits with 1. You can override this behavior
 by using your own reporter:
 
 ```ts
+import { cleanEnv } from "https://deno.land/std@$STD_VERSION/envalid/mod.ts";
+
+const report = (error: string) => {
+  //
+};
+
 const env = cleanEnv(Deno.env.toObject(), myValidators, {
   reporter: ({ errors, env }) => {
     report("Invalid environment variables: " + Object.keys(errors));
@@ -90,12 +96,18 @@ The error classes `EnvError` and `EnvMissingError` can also be used to examine
 the errors:
 
 ```ts
+import {
+  cleanEnv,
+  EnvError,
+  EnvMissingError,
+} from "https://deno.land/std@$STD_VERSION/envalid/mod.ts";
+
 const env = cleanEnv(Deno.env.toObject(), myValidators, {
   reporter: ({ errors, env }) => {
     for (const [envVar, err] of Object.entries(errors)) {
-      if (err instanceof envalid.EnvError) {
+      if (err instanceof EnvError) {
         //
-      } else if (err instanceof envalid.EnvMissingError) {
+      } else if (err instanceof EnvMissingError) {
         //
       } else {
         //

--- a/envalid/core.ts
+++ b/envalid/core.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 import { EnvError, EnvMissingError } from "./errors.ts";
 import { CleanOptions, Spec, ValidatorSpec } from "./types.ts";

--- a/envalid/core.ts
+++ b/envalid/core.ts
@@ -1,0 +1,105 @@
+// deno-lint-ignore-file no-explicit-any
+import { EnvError, EnvMissingError } from "./errors.ts";
+import { CleanOptions, Spec, ValidatorSpec } from "./types.ts";
+import { defaultReporter } from "./reporter.ts";
+
+export const testOnlySymbol = Symbol("envalid - test only");
+
+/**
+ * Validate a single variable.
+ *
+ * @throws {EnvError} if unsuccessful
+ * @return The cleaned value
+ */
+function validateVar<T>({
+  spec,
+  name,
+  rawValue,
+}: {
+  name: string;
+  rawValue: string | T;
+  spec: ValidatorSpec<T>;
+}) {
+  if (typeof spec._parse !== "function") {
+    throw new EnvError(`Invalid spec for "${name}"`);
+  }
+  const value = spec._parse(rawValue as string);
+
+  if (spec.choices) {
+    if (!Array.isArray(spec.choices)) {
+      throw new TypeError(`"choices" must be an array (in spec for "${name}")`);
+    } else if (!spec.choices.includes(value)) {
+      throw new EnvError(`Value "${value}" not in choices [${spec.choices}]`);
+    }
+  }
+  if (value == null) throw new EnvError(`Invalid value for env var "${name}"`);
+  return value;
+}
+
+/**
+ * Returns the error message for a missing variable.
+ */
+function formatSpecDescription<T>(spec: Spec<T>) {
+  const egText = spec.example ? ` (eg. "${spec.example}")` : "";
+  const docsText = spec.docs ? `. See ${spec.docs}` : "";
+  return `${spec.desc}${egText}${docsText}`;
+}
+
+const readRawEnvValue = <T>(
+  env: unknown,
+  k: keyof T,
+): string | T[keyof T] => {
+  return (env as any)[k];
+};
+
+const isTestOnlySymbol = (value: any): value is symbol =>
+  value === testOnlySymbol;
+
+/**
+ * Perform the central validation/sanitization on the environment object.
+ */
+export function getSanitizedEnv<T>(
+  environment: unknown,
+  specs: { [K in keyof T]: ValidatorSpec<T[K]> },
+  options: CleanOptions<T> = {},
+): T {
+  const cleanedEnv = {} as T;
+  const errors: Partial<Record<keyof T, Error>> = {};
+  const varKeys = Object.keys(specs) as Array<keyof T>;
+
+  for (const k of varKeys) {
+    const spec = specs[k];
+    const rawValue = readRawEnvValue(environment, k);
+
+    // If no value was given and default was provided, return the appropriate default
+    // value without passing it through validation
+    if (rawValue === undefined) {
+      if (Object.prototype.hasOwnProperty.call(spec, "default")) {
+        // @ts-expect-error default values can break the rules slightly by being explicitly set to undefined
+        cleanedEnv[k] = spec.default;
+        continue;
+      }
+    }
+
+    try {
+      if (isTestOnlySymbol(rawValue)) {
+        throw new EnvMissingError(formatSpecDescription(spec));
+      }
+
+      if (rawValue === undefined) {
+        // @ts-ignore (fixes af/envalid#138) Need to figure out why explicitly undefined default breaks inference
+        cleanedEnv[k] = undefined;
+        throw new EnvMissingError(formatSpecDescription(spec));
+      } else {
+        cleanedEnv[k] = validateVar({ name: k as string, spec, rawValue });
+      }
+    } catch (err) {
+      if (options?.reporter === null) throw err;
+      if (err instanceof Error) errors[k] = err;
+    }
+  }
+
+  const reporter = options?.reporter || defaultReporter;
+  reporter({ errors, env: cleanedEnv });
+  return cleanedEnv;
+}

--- a/envalid/envalid.ts
+++ b/envalid/envalid.ts
@@ -1,0 +1,40 @@
+import { CleanOptions, ValidatorSpec } from "./types.ts";
+import { getSanitizedEnv } from "./core.ts";
+import { applyDefaultMiddleware } from "./middleware.ts";
+
+/**
+ * Returns a sanitized, immutable environment object. _Only_ the variables
+ * specified in the `specs` parameter will be accessible on the returned
+ * object.
+ *
+ * @param environment An object containing the variables, e.g. `Deno.env.toObject()`.
+ * @param specs The specification to enforce on the environment.
+ * @param options
+ */
+export function cleanEnv<T extends Record<never, never>>(
+  environment: unknown,
+  specs: { [K in keyof T]: ValidatorSpec<T[K]> },
+  options: CleanOptions<T> = {},
+): Readonly<T> {
+  const cleaned = getSanitizedEnv(environment, specs, options);
+  return Object.freeze(applyDefaultMiddleware(cleaned, environment));
+}
+
+/**
+ * Returns a sanitized, immutable environment object, and passes it through a custom
+ * `applyMiddleware` function. This won't be required in most use cases.
+ *
+ * @param environment An object containing the variables, e.g. `Deno.env.toObject()`.
+ * @param specs  The specification to enforce on the environment.
+ * @param applyMiddleware A function that applies transformations to the cleaned environment.
+ * @param options
+ */
+export function customCleanEnv<T, MW>(
+  environment: unknown,
+  specs: { [K in keyof T]: ValidatorSpec<T[K]> },
+  applyMiddleware: (cleaned: T, rawEnv: unknown) => MW,
+  options: CleanOptions<T> = {},
+): Readonly<MW> {
+  const cleaned = getSanitizedEnv(environment, specs, options);
+  return Object.freeze(applyMiddleware(cleaned, environment));
+}

--- a/envalid/envalid.ts
+++ b/envalid/envalid.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { CleanOptions, ValidatorSpec } from "./types.ts";
 import { getSanitizedEnv } from "./core.ts";
 import { applyDefaultMiddleware } from "./middleware.ts";

--- a/envalid/errors.ts
+++ b/envalid/errors.ts
@@ -1,0 +1,20 @@
+// Surprisingly involved error subclassing
+// See https://stackoverflow.com/questions/41102060/typescript-extending-error-class
+
+export class EnvError extends TypeError {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    Error.captureStackTrace(this, EnvError);
+    this.name = this.constructor.name;
+  }
+}
+
+export class EnvMissingError extends ReferenceError {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    Error.captureStackTrace(this, EnvMissingError);
+    this.name = this.constructor.name;
+  }
+}

--- a/envalid/errors.ts
+++ b/envalid/errors.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // Surprisingly involved error subclassing
 // See https://stackoverflow.com/questions/41102060/typescript-extending-error-class
 

--- a/envalid/errors_test.ts
+++ b/envalid/errors_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
 import { EnvError, EnvMissingError } from "./mod.ts";
 

--- a/envalid/errors_test.ts
+++ b/envalid/errors_test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "../testing/asserts.ts";
+import { EnvError, EnvMissingError } from "./mod.ts";
+
+Deno.test("EnvError", () => {
+  const e = new EnvError("baz");
+  assertEquals(e instanceof EnvError, true);
+  assertEquals(e instanceof TypeError, true);
+  assertEquals(e.name, "EnvError");
+});
+
+Deno.test("EnvMissingError", () => {
+  const e = new EnvMissingError("baz");
+  assertEquals(e instanceof EnvMissingError, true);
+  assertEquals(e instanceof ReferenceError, true);
+  assertEquals(e.name, "EnvMissingError");
+});

--- a/envalid/middleware.ts
+++ b/envalid/middleware.ts
@@ -1,0 +1,66 @@
+export const strictProxyMiddleware = <T extends Record<never, never>>(
+  envObj: T,
+  rawEnv: unknown,
+) => {
+  const inspectables = [
+    "constructor",
+    "length",
+    "inspect",
+    "hasOwnProperty",
+    "toJSON", // Allow JSON.stringify() on output. See af/envalid#157
+    Symbol.toStringTag,
+    Symbol.iterator,
+
+    // For libs that use `then` checks to see if objects are Promises (see af/envalid#74):
+    "then",
+    // For usage with TypeScript esModuleInterop flag
+    "__esModule",
+  ];
+
+  return new Proxy(envObj, {
+    get(target, name: string) {
+      // These checks are needed because calling console.log on a
+      // proxy that throws crashes the entire process. This permits access on
+      // the necessary properties for `console.log(envObj)`, `envObj.length`,
+      // `Object.prototype.hasOwnProperty.call(envObj, 'string')` to work.
+      if (inspectables.includes(name)) {
+        // @ts-expect-error TS doesn't like symbol types as indexers
+        return target[name];
+      }
+
+      const varExists = Object.prototype.hasOwnProperty.call(target, name);
+
+      if (!varExists) {
+        if (
+          typeof rawEnv === "object" && rawEnv &&
+          Object.prototype.hasOwnProperty.call(rawEnv, name)
+        ) {
+          throw new ReferenceError(
+            `[envalid] Env var ${name} was accessed but not validated. This var is set in the environment; please add an envalid validator for it.`,
+          );
+        }
+
+        throw new ReferenceError(`[envalid] Env var not found: ${name}`);
+      }
+
+      return target[name as keyof T];
+    },
+
+    set(_target, name: string) {
+      throw new TypeError(
+        `[envalid] Attempt to mutate environment value: ${name}`,
+      );
+    },
+  });
+};
+
+export const applyDefaultMiddleware = <T extends Record<string, unknown>>(
+  cleanedEnv: T,
+  rawEnv: unknown,
+) => {
+  // Note: Ideally we would declare the default middlewares in an array and apply them in series with
+  // a generic pipe() function. However, a generically typed variadic pipe() appears to not be possible
+  // in TypeScript as of 4.x, so we just manually apply them below. See
+  // https://github.com/microsoft/TypeScript/pull/39094#issuecomment-647042984
+  return strictProxyMiddleware(cleanedEnv, rawEnv);
+};

--- a/envalid/middleware.ts
+++ b/envalid/middleware.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 export const strictProxyMiddleware = <T extends Record<never, never>>(
   envObj: T,
   rawEnv: unknown,

--- a/envalid/middleware_test.ts
+++ b/envalid/middleware_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import { cleanEnv, customCleanEnv, str } from "./mod.ts";
 

--- a/envalid/middleware_test.ts
+++ b/envalid/middleware_test.ts
@@ -1,0 +1,134 @@
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import { cleanEnv, customCleanEnv, str } from "./mod.ts";
+
+Deno.test("customCleanEnv middleware type inference", async (t) => {
+  await t.step("allows access to properties on the output object", () => {
+    const raw = { FOO: "bar" };
+    const cleaned = customCleanEnv(raw, { FOO: str() }, (inputEnv) => ({
+      ...inputEnv,
+      FOO: inputEnv.FOO.toUpperCase(),
+      ADDED: 123,
+    }));
+
+    assertEquals(cleaned, { FOO: "BAR", ADDED: 123 });
+  });
+
+  await t.step("flags errors on input env", () => {
+    const noop = (x: unknown) => x;
+    const raw = { FOO: "bar" };
+    const cleaned = customCleanEnv(raw, { FOO: str() }, (inputEnv) => {
+      // @ts-expect-error Inference should tell us this property is invalid
+      noop(inputEnv.WRONG_NAME);
+      return inputEnv;
+    });
+
+    assertEquals(cleaned, raw);
+  });
+});
+
+Deno.test("proxy middleware", async (t) => {
+  await t.step(
+    "only specified fields are passed through from validation",
+    () => {
+      const env = cleanEnv(
+        { FOO: "bar", BAZ: "baz" },
+        {
+          FOO: str(),
+        },
+      );
+      assertEquals(env, { FOO: "bar" });
+    },
+  );
+
+  await t.step("proxy throws when invalid attrs are accessed", () => {
+    const env = cleanEnv(
+      { FOO: "bar", BAZ: "baz" },
+      {
+        FOO: str(),
+      },
+    );
+    assertEquals(env.FOO, "bar");
+    // @ts-expect-error This invalid usage should trigger a type error
+    assertThrows(() => env.ASDF);
+  });
+
+  await t.step("proxy throws when attempting to mutate", () => {
+    const env = cleanEnv(
+      { FOO: "bar", BAZ: "baz" },
+      {
+        FOO: str(),
+      },
+    );
+    assertThrows(
+      // @ts-expect-error This invalid usage should trigger a type error
+      () => (env.FOO = "foooooo"),
+      "[envalid] Attempt to mutate environment value: FOO",
+    );
+  });
+
+  await t.step(
+    "proxy throws and suggests to add a validator if name is in orig env",
+    () => {
+      const env = cleanEnv(
+        { FOO: "foo", BAR: "wat" },
+        {
+          BAR: str(),
+        },
+      );
+
+      assertThrows(
+        // @ts-expect-error This invalid usage should trigger a type error
+        () => env.FOO,
+        "[envalid] Env var FOO was accessed but not validated. This var is set in the environment; please add an envalid validator for it.",
+      );
+    },
+  );
+
+  await t.step("proxy does not error out on .length checks (#70)", () => {
+    const env = cleanEnv(
+      { FOO: "foo" },
+      {
+        FOO: str(),
+      },
+    );
+
+    // @ts-expect-error This invalid usage should trigger a type error
+    assertThrows(() => assertThrows(() => env.length));
+  });
+
+  await t.step("proxy allows `then` on self", () => {
+    const env = cleanEnv(
+      { FOO: "foo" },
+      {
+        FOO: str(),
+      },
+    );
+
+    // @ts-expect-error This invalid usage should trigger a type error
+    assertThrows(() => assertThrows(() => env.then));
+  });
+
+  await t.step("proxy allows `__esModule` on self", () => {
+    const env = cleanEnv(
+      { FOO: "foo" },
+      {
+        FOO: str(),
+      },
+    );
+
+    // @ts-expect-error This invalid usage should trigger a type error
+    assertThrows(() => assertThrows(() => env.__esModule));
+  });
+
+  await t.step("proxy allows JSON.stringify to be called on output", () => {
+    const env = cleanEnv(
+      { FOO: "foo" },
+      {
+        FOO: str(),
+      },
+    );
+
+    assertThrows(() => assertThrows(() => JSON.stringify(env)));
+    assertEquals(JSON.stringify(env), '{"FOO":"foo"}');
+  });
+});

--- a/envalid/mod.ts
+++ b/envalid/mod.ts
@@ -1,0 +1,6 @@
+export * from "./envalid.ts";
+export * from "./errors.ts";
+export * from "./middleware.ts";
+export * from "./types.ts";
+export * from "./validators.ts";
+export * from "./reporter.ts";

--- a/envalid/mod.ts
+++ b/envalid/mod.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 export * from "./envalid.ts";
 export * from "./errors.ts";
 export * from "./middleware.ts";

--- a/envalid/reporter.ts
+++ b/envalid/reporter.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 import { blue, white, yellow } from "../fmt/colors.ts";
 import { EnvMissingError } from "./errors.ts";

--- a/envalid/reporter.ts
+++ b/envalid/reporter.ts
@@ -1,0 +1,82 @@
+// deno-lint-ignore-file no-explicit-any
+import { blue, white, yellow } from "../fmt/colors.ts";
+import { EnvMissingError } from "./errors.ts";
+import { ReporterOptions } from "./types.ts";
+
+type Errors<T> = Partial<Record<keyof T, Error>>;
+type Logger = (data: any, ...args: any[]) => void;
+
+// The default reporter is supports a second argument, for consumers
+// who want to use it with only small customizations
+type ExtraOptions<T> = {
+  onError?: (errors: Errors<T>) => void;
+  logger: (output: string) => void;
+};
+
+const defaultLogger = console.error.bind(console);
+
+const RULE = white("================================");
+
+// Takes the provided errors, formats them all to an output string, and passes that string output to the
+// provided "logger" function.
+//
+// This is exposed in the public API so third-party reporters can leverage this logic if desired
+export const envalidErrorFormatter = <T = any>(
+  errors: Errors<T>,
+  logger: Logger = defaultLogger,
+) => {
+  const missingVarsOutput: string[] = [];
+  const invalidVarsOutput: string[] = [];
+  for (const [k, err] of Object.entries(errors)) {
+    if (err instanceof EnvMissingError) {
+      missingVarsOutput.push(
+        `    ${blue(k)}: ${err.message || "(required)"}`,
+      );
+    } else {
+      invalidVarsOutput.push(
+        `    ${blue(k)}: ${(err as Error)?.message || "(invalid format)"}`,
+      );
+    }
+  }
+
+  // Prepend "header" output for each section of the output:
+  if (invalidVarsOutput.length) {
+    invalidVarsOutput.unshift(
+      ` ${yellow("Invalid")} environment variables:`,
+    );
+  }
+  if (missingVarsOutput.length) {
+    missingVarsOutput.unshift(
+      ` ${yellow("Missing")} environment variables:`,
+    );
+  }
+
+  const output = [
+    RULE,
+    invalidVarsOutput.sort().join("\n"),
+    missingVarsOutput.sort().join("\n"),
+    RULE,
+  ]
+    .filter((x) => !!x)
+    .join("\n");
+
+  logger(output);
+};
+
+export const defaultReporter = <T = any>(
+  { errors = {} }: ReporterOptions<T>,
+  { onError, logger }: ExtraOptions<T> = { logger: defaultLogger },
+) => {
+  if (!Object.keys(errors).length) return;
+
+  envalidErrorFormatter(errors, logger);
+
+  if (onError) {
+    onError(errors);
+  } else if (!Deno.noColor) {
+    logger(yellow("\n Exiting with error code 1"));
+    Deno.exit(1);
+  } else {
+    throw new TypeError("Environment validation failed");
+  }
+};

--- a/envalid/reporter_test.ts
+++ b/envalid/reporter_test.ts
@@ -143,7 +143,7 @@ Deno.test("envalidErrorFormatter", async (t) => {
     const messages = new Array<string>();
     envalidErrorFormatter(
       { FOO: new EnvMissingError() },
-      (msg:string)=>messages.push(msg)
+      (msg: string) => messages.push(msg),
     );
 
     const output = messages[0];

--- a/envalid/reporter_test.ts
+++ b/envalid/reporter_test.ts
@@ -9,27 +9,9 @@ import {
   envalidErrorFormatter as mainEnvalidErrorFormatter,
 } from "./mod.ts";
 import { defaultReporter, envalidErrorFormatter } from "./reporter.ts";
-import { EnvError, EnvMissingError } from "./errors.ts";
-
-class Tracker {
-  // deno-lint-ignore no-explicit-any
-  calls = new Array<any>();
-
-  // deno-lint-ignore no-explicit-any
-  func(...args: any[]) {
-    this.calls.push(args);
-  }
-
-  reset() {
-    this.calls = [];
-  }
-}
+import { EnvMissingError } from "./errors.ts";
 
 Deno.test("default reporter", async (t) => {
-  const exitTracker = new Tracker();
-
-  Object.assign(globalThis.Deno, { exit: exitTracker.func.bind(exitTracker) });
-
   await t.step(
     "default reporter should be exported from the top-level module",
     () => {
@@ -37,100 +19,115 @@ Deno.test("default reporter", async (t) => {
     },
   );
 
-  await t.step("simple usage for reporting a missing variable error", () => {
-    exitTracker.reset();
-
-    const tracker = new Tracker();
-    defaultReporter(
-      {
-        errors: { FOO: new EnvMissingError() },
-        env: {},
-      },
-      { logger: tracker.func.bind(tracker) },
-    );
-    assertEquals(tracker.calls.length, 2);
-
-    const output1 = tracker.calls[0]?.[0];
-    assertMatch(output1, /Missing\S+ environment variables:/);
-    assertMatch(output1, /FOO\S+/);
-    assertMatch(output1, /\(required\)/);
-    assertNotMatch(output1, /Invalid\S+ environment variables:/);
-
-    const output2 = tracker.calls[1]?.[0];
-    assertMatch(output2, /Exiting with error code 1/);
-
-    assertEquals(exitTracker.calls.length, 1);
-    assertEquals(exitTracker.calls[0]?.[0], 1);
-  });
-
-  await t.step("simple usage for reporting an invalid variable error", () => {
-    exitTracker.reset();
-
-    const tracker = new Tracker();
-    defaultReporter(
-      {
-        errors: { FOO: new EnvError() },
-        env: { FOO: 123 },
-      },
-      { logger: tracker.func.bind(tracker) },
-    );
-    assertEquals(tracker.calls.length, 2);
-
-    const output1 = tracker.calls[0]?.[0];
-    assertMatch(output1, /Invalid\S+ environment variables:/);
-    assertMatch(output1, /FOO\S+/);
-    assertMatch(output1, /\(invalid format\)/);
-    assertNotMatch(output1, /Missing\S+ environment variables:/);
-
-    const output2 = tracker.calls[1]?.[0];
-    assertMatch(output2, /Exiting with error code 1/);
-
-    assertEquals(exitTracker.calls.length, 1);
-    assertEquals(exitTracker.calls[0]?.[0], 1);
-  });
-
   await t.step(
-    "reporting an invalid variable error with a custom error message",
-    () => {
-      exitTracker.reset();
+    "simple usage for reporting a missing variable error",
+    async () => {
+      const { code, stderr } = await Deno.spawn(Deno.execPath(), {
+        args: [
+          "eval",
+          `
+          import { defaultReporter } from "./envalid/reporter.ts";
+          import { EnvMissingError } from "./envalid/errors.ts";
+          defaultReporter(
+            {
+              errors: { FOO: new EnvMissingError() },
+              env: {},
+            },
+          );
+        `,
+        ],
+      });
 
-      const tracker = new Tracker();
-      defaultReporter(
-        {
-          errors: { FOO: new EnvError("custom msg") },
-          env: { FOO: 123 },
-        },
-        { logger: tracker.func.bind(tracker) },
-      );
-      assertEquals(tracker.calls.length, 2);
+      const output = new TextDecoder().decode(stderr);
 
-      const output1 = tracker.calls[0]?.[0];
-      assertMatch(output1, /Invalid\S+ environment variables:/);
-      assertMatch(output1, /FOO\S+/);
-      assertMatch(output1, /custom msg/);
-
-      const output2 = tracker.calls[1]?.[0];
-      assertMatch(output2, /Exiting with error code 1/);
-
-      assertEquals(exitTracker.calls.length, 1);
-      assertEquals(exitTracker.calls[0]?.[0], 1);
+      assertMatch(output, /Missing\S+ environment variables:/);
+      assertMatch(output, /FOO\S+/);
+      assertMatch(output, /\(required\)/);
+      assertNotMatch(output, /Invalid\S+ environment variables:/);
+      assertMatch(output, /Exiting with error code 1/);
+      assertEquals(code, 1);
     },
   );
 
-  await t.step("does nothing when there are no errors", () => {
-    exitTracker.reset();
+  await t.step(
+    "simple usage for reporting an invalid variable error",
+    async () => {
+      const { code, stderr } = await Deno.spawn(Deno.execPath(), {
+        args: [
+          "eval",
+          `
+            import { defaultReporter } from "./envalid/reporter.ts";
+            import { EnvError } from "./envalid/errors.ts";
+            defaultReporter(
+              {
+                errors: { FOO: new EnvError() },
+                env: { FOO: 123 },
+              },
+            );
+          `,
+        ],
+      });
 
-    const tracker = new Tracker();
-    defaultReporter(
-      {
-        errors: {},
-        env: { FOO: "great success" },
-      },
-      { logger: tracker.func.bind(this) },
-    );
+      const output = new TextDecoder().decode(stderr);
 
-    assertEquals(tracker.calls.length, 0);
-    assertEquals(exitTracker.calls.length, 0);
+      assertMatch(output, /Invalid\S+ environment variables:/);
+      assertMatch(output, /FOO\S+/);
+      assertMatch(output, /\(invalid format\)/);
+      assertNotMatch(output, /Missing\S+ environment variables:/);
+      assertMatch(output, /Exiting with error code 1/);
+      assertEquals(code, 1);
+    },
+  );
+
+  await t.step(
+    "reporting an invalid variable error with a custom error message",
+    async () => {
+      const { code, stderr } = await Deno.spawn(Deno.execPath(), {
+        args: [
+          "eval",
+          `
+            import { defaultReporter } from "./envalid/reporter.ts";
+            import { EnvError } from "./envalid/errors.ts";
+            defaultReporter(
+              {
+                errors: { FOO: new EnvError("custom msg") },
+                env: { FOO: 123 },
+              },
+            );
+          `,
+        ],
+      });
+
+      const output = new TextDecoder().decode(stderr);
+
+      assertMatch(output, /Invalid\S+ environment variables:/);
+      assertMatch(output, /FOO\S+/);
+      assertMatch(output, /custom msg/);
+      assertMatch(output, /Exiting with error code 1/);
+      assertEquals(code, 1);
+    },
+  );
+
+  await t.step("does nothing when there are no errors", async () => {
+    const { code, stderr } = await Deno.spawn(Deno.execPath(), {
+      args: [
+        "eval",
+        `
+          import { defaultReporter } from "./envalid/reporter.ts";
+          defaultReporter(
+            {
+              errors: {},
+              env: { FOO: "great success" },
+            },
+          );
+        `,
+      ],
+    });
+
+    const output = new TextDecoder().decode(stderr);
+
+    assertEquals(output, "");
+    assertEquals(code, 0);
   });
 });
 
@@ -143,15 +140,15 @@ Deno.test("envalidErrorFormatter", async (t) => {
   );
 
   await t.step("simple usage for formatting a single error", () => {
-    const tracker = new Tracker();
-    assertEquals(tracker.calls.length, 0);
+    const messages = new Array<string>();
     envalidErrorFormatter(
       { FOO: new EnvMissingError() },
-      tracker.func.bind(tracker),
+      (msg:string)=>messages.push(msg)
     );
-    assertEquals(tracker.calls.length, 1);
 
-    const output = tracker.calls[0]?.[0];
+    const output = messages[0];
+
+    assertEquals(messages.length, 1);
     assertMatch(output, /Missing\S+ environment variables:/);
     assertMatch(output, /FOO\S+/);
     assertMatch(output, /\(required\)/);

--- a/envalid/reporter_test.ts
+++ b/envalid/reporter_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import {
   assertEquals,
   assertMatch,

--- a/envalid/reporter_test.ts
+++ b/envalid/reporter_test.ts
@@ -1,0 +1,158 @@
+import {
+  assertEquals,
+  assertMatch,
+  assertNotMatch,
+} from "../testing/asserts.ts";
+import {
+  defaultReporter as mainReporterExport,
+  envalidErrorFormatter as mainEnvalidErrorFormatter,
+} from "./mod.ts";
+import { defaultReporter, envalidErrorFormatter } from "./reporter.ts";
+import { EnvError, EnvMissingError } from "./errors.ts";
+
+class Tracker {
+  // deno-lint-ignore no-explicit-any
+  calls = new Array<any>();
+
+  // deno-lint-ignore no-explicit-any
+  func(...args: any[]) {
+    this.calls.push(args);
+  }
+
+  reset() {
+    this.calls = [];
+  }
+}
+
+Deno.test("default reporter", async (t) => {
+  const exitTracker = new Tracker();
+
+  Object.assign(globalThis.Deno, { exit: exitTracker.func.bind(exitTracker) });
+
+  await t.step(
+    "default reporter should be exported from the top-level module",
+    () => {
+      assertEquals(mainReporterExport, defaultReporter);
+    },
+  );
+
+  await t.step("simple usage for reporting a missing variable error", () => {
+    exitTracker.reset();
+
+    const tracker = new Tracker();
+    defaultReporter(
+      {
+        errors: { FOO: new EnvMissingError() },
+        env: {},
+      },
+      { logger: tracker.func.bind(tracker) },
+    );
+    assertEquals(tracker.calls.length, 2);
+
+    const output1 = tracker.calls[0]?.[0];
+    assertMatch(output1, /Missing\S+ environment variables:/);
+    assertMatch(output1, /FOO\S+/);
+    assertMatch(output1, /\(required\)/);
+    assertNotMatch(output1, /Invalid\S+ environment variables:/);
+
+    const output2 = tracker.calls[1]?.[0];
+    assertMatch(output2, /Exiting with error code 1/);
+
+    assertEquals(exitTracker.calls.length, 1);
+    assertEquals(exitTracker.calls[0]?.[0], 1);
+  });
+
+  await t.step("simple usage for reporting an invalid variable error", () => {
+    exitTracker.reset();
+
+    const tracker = new Tracker();
+    defaultReporter(
+      {
+        errors: { FOO: new EnvError() },
+        env: { FOO: 123 },
+      },
+      { logger: tracker.func.bind(tracker) },
+    );
+    assertEquals(tracker.calls.length, 2);
+
+    const output1 = tracker.calls[0]?.[0];
+    assertMatch(output1, /Invalid\S+ environment variables:/);
+    assertMatch(output1, /FOO\S+/);
+    assertMatch(output1, /\(invalid format\)/);
+    assertNotMatch(output1, /Missing\S+ environment variables:/);
+
+    const output2 = tracker.calls[1]?.[0];
+    assertMatch(output2, /Exiting with error code 1/);
+
+    assertEquals(exitTracker.calls.length, 1);
+    assertEquals(exitTracker.calls[0]?.[0], 1);
+  });
+
+  await t.step(
+    "reporting an invalid variable error with a custom error message",
+    () => {
+      exitTracker.reset();
+
+      const tracker = new Tracker();
+      defaultReporter(
+        {
+          errors: { FOO: new EnvError("custom msg") },
+          env: { FOO: 123 },
+        },
+        { logger: tracker.func.bind(tracker) },
+      );
+      assertEquals(tracker.calls.length, 2);
+
+      const output1 = tracker.calls[0]?.[0];
+      assertMatch(output1, /Invalid\S+ environment variables:/);
+      assertMatch(output1, /FOO\S+/);
+      assertMatch(output1, /custom msg/);
+
+      const output2 = tracker.calls[1]?.[0];
+      assertMatch(output2, /Exiting with error code 1/);
+
+      assertEquals(exitTracker.calls.length, 1);
+      assertEquals(exitTracker.calls[0]?.[0], 1);
+    },
+  );
+
+  await t.step("does nothing when there are no errors", () => {
+    exitTracker.reset();
+
+    const tracker = new Tracker();
+    defaultReporter(
+      {
+        errors: {},
+        env: { FOO: "great success" },
+      },
+      { logger: tracker.func.bind(this) },
+    );
+
+    assertEquals(tracker.calls.length, 0);
+    assertEquals(exitTracker.calls.length, 0);
+  });
+});
+
+Deno.test("envalidErrorFormatter", async (t) => {
+  await t.step(
+    "default formatter should be exported from the top-level module",
+    () => {
+      assertEquals(mainEnvalidErrorFormatter, envalidErrorFormatter);
+    },
+  );
+
+  await t.step("simple usage for formatting a single error", () => {
+    const tracker = new Tracker();
+    assertEquals(tracker.calls.length, 0);
+    envalidErrorFormatter(
+      { FOO: new EnvMissingError() },
+      tracker.func.bind(tracker),
+    );
+    assertEquals(tracker.calls.length, 1);
+
+    const output = tracker.calls[0]?.[0];
+    assertMatch(output, /Missing\S+ environment variables:/);
+    assertMatch(output, /FOO\S+/);
+    assertMatch(output, /\(required\)/);
+  });
+});

--- a/envalid/types.ts
+++ b/envalid/types.ts
@@ -1,0 +1,45 @@
+type DefaultType<T> = T extends string ? string
+  : T extends number ? number
+  : T extends boolean ? boolean
+  : T extends Record<string, unknown> ? Record<string, unknown>
+  : // deno-lint-ignore no-explicit-any
+  any;
+
+export interface Spec<T> {
+  /**
+   * An array of permitted values
+   */
+  choices?: ReadonlyArray<T>;
+  /**
+   * A fallback value to use if the variable was not set. Providing this effectively makes the variable optional.
+   */
+  default?: DefaultType<T>;
+  /**
+   * Description of the variable
+   */
+  desc?: string;
+  /**
+   * Example value
+   */
+  example?: string;
+  /**
+   * Documentation URL
+   */
+  docs?: string;
+}
+
+export interface ValidatorSpec<T> extends Spec<T> {
+  _parse: (input: string) => T;
+}
+
+export interface ReporterOptions<T> {
+  errors: Partial<Record<keyof T, Error>>;
+  env: unknown;
+}
+
+export interface CleanOptions<T> {
+  /**
+   * A function that overrides the default reporter
+   */
+  reporter?: ((opts: ReporterOptions<T>) => void) | null;
+}

--- a/envalid/types.ts
+++ b/envalid/types.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 type DefaultType<T> = T extends string ? string
   : T extends number ? number
   : T extends boolean ? boolean

--- a/envalid/utils.ts
+++ b/envalid/utils.ts
@@ -1,0 +1,12 @@
+import { assertEquals } from "../testing/asserts.ts";
+import { cleanEnv, ValidatorSpec } from "./mod.ts";
+
+// Ensure that a given environment spec passes through all values from the given
+// env object
+export const assertPassthrough = <T>(
+  env: T,
+  // deno-lint-ignore no-explicit-any
+  spec: { [k in keyof T]: ValidatorSpec<any> },
+) => {
+  assertEquals(cleanEnv(env, spec), env);
+};

--- a/envalid/utils.ts
+++ b/envalid/utils.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../testing/asserts.ts";
 import { cleanEnv, ValidatorSpec } from "./mod.ts";
 

--- a/envalid/validators.ts
+++ b/envalid/validators.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { Spec, ValidatorSpec } from "./types.ts";
 import { EnvError } from "./errors.ts";
 

--- a/envalid/validators.ts
+++ b/envalid/validators.ts
@@ -118,15 +118,7 @@ export function url<T extends string = string>(spec?: Spec<T>) {
 
 /**
  * It's recommended that you provide an explicit type parameter for json validation
- * if you're using TypeScript:
- *
- * ```
- * cleanEnv({
- *   MY_VAR: json<{ foo: number }>({ default: { foo: 123 } }),
- * })
- * ```
- *
- * Otherwise, the output will be typed as `any`.
+ * if you're using TypeScript. Otherwise, the output will be typed as `any`.
  */
 // deno-lint-ignore no-explicit-any
 export function json<T = any>(spec?: Spec<T>) {

--- a/envalid/validators.ts
+++ b/envalid/validators.ts
@@ -1,0 +1,139 @@
+import { Spec, ValidatorSpec } from "./types.ts";
+import { EnvError } from "./errors.ts";
+
+// Simplified adaptation of https://github.com/validatorjs/validator.js/blob/master/src/lib/isFQDN.js
+const isFQDN = (input: string) => {
+  if (!input.length) return false;
+  const parts = input.split(".");
+  for (let part, i = 0; i < parts.length; i++) {
+    part = parts[i];
+    if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) return false;
+    if (/[\uff01-\uff5e]/.test(part)) return false; // disallow full-width chars
+    if (part[0] === "-" || part[part.length - 1] === "-") return false;
+  }
+  return true;
+};
+
+// "best effort" regex-based IP address check
+// If you want a more exhaustive check, create your own custom validator, perhaps wrapping this
+// implementation (the source of the ipv4 regex below): https://github.com/validatorjs/validator.js/blob/master/src/lib/isIP.js
+const ipv4Regex =
+  /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
+const ipv6Regex = /([a-f0-9]+:+)+[a-f0-9]+/;
+const isIP = (input: string) => {
+  if (!input.length) return false;
+  return ipv4Regex.test(input) || ipv6Regex.test(input);
+};
+
+const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/; // intentionally non-exhaustive
+
+export const makeValidator = <T>(parseFn: (input: string) => T) => {
+  return function (spec?: Spec<T>): ValidatorSpec<T> {
+    return { ...spec, _parse: parseFn };
+  };
+};
+
+// The reason for the function wrapper is to enable the <T extends boolean = boolean> type parameter
+// that enables better type inference. For more context, see
+// https://github.com/af/envalid/pull/118
+export function bool<T extends boolean = boolean>(spec?: Spec<T>) {
+  return makeValidator((input: string | boolean) => {
+    switch (input) {
+      case true:
+      case "true":
+      case "t":
+      case "1":
+        return true as T;
+      case false:
+      case "false":
+      case "f":
+      case "0":
+        return false as T;
+      default:
+        throw new EnvError(`Invalid bool input: "${input}"`);
+    }
+  })(spec);
+}
+
+export function num<T extends number = number>(spec?: Spec<T>) {
+  return makeValidator((input: string) => {
+    const coerced = parseFloat(input);
+    if (Number.isNaN(coerced)) {
+      throw new EnvError(`Invalid number input: "${input}"`);
+    }
+    return coerced as T;
+  })(spec);
+}
+
+export function str<T extends string = string>(spec?: Spec<T>) {
+  return makeValidator((input: string) => {
+    if (typeof input === "string") return input as T;
+    throw new EnvError(`Not a string: "${input}"`);
+  })(spec);
+}
+
+export function email<T extends string = string>(spec?: Spec<T>) {
+  return makeValidator((x: string) => {
+    if (EMAIL_REGEX.test(x)) return x as T;
+    throw new EnvError(`Invalid email address: "${x}"`);
+  })(spec);
+}
+
+export function host<T extends string = string>(spec?: Spec<T>) {
+  return makeValidator((input: string) => {
+    if (!isFQDN(input) && !isIP(input)) {
+      throw new EnvError(`Invalid host (domain or ip): "${input}"`);
+    }
+    return input as T;
+  })(spec);
+}
+
+export function port<T extends number = number>(spec?: Spec<T>) {
+  return makeValidator((input: string) => {
+    const coerced = +input;
+    if (
+      Number.isNaN(coerced) ||
+      `${coerced}` !== `${input}` ||
+      coerced % 1 !== 0 ||
+      coerced < 1 ||
+      coerced > 65535
+    ) {
+      throw new EnvError(`Invalid port input: "${input}"`);
+    }
+    return coerced as T;
+  })(spec);
+}
+
+export function url<T extends string = string>(spec?: Spec<T>) {
+  return makeValidator((x: string) => {
+    try {
+      new URL(x);
+      return x as T;
+    } catch (_err) {
+      throw new EnvError(`Invalid url: "${x}"`);
+    }
+  })(spec);
+}
+
+/**
+ * It's recommended that you provide an explicit type parameter for json validation
+ * if you're using TypeScript:
+ *
+ * ```
+ * cleanEnv({
+ *   MY_VAR: json<{ foo: number }>({ default: { foo: 123 } }),
+ * })
+ * ```
+ *
+ * Otherwise, the output will be typed as `any`.
+ */
+// deno-lint-ignore no-explicit-any
+export function json<T = any>(spec?: Spec<T>) {
+  return makeValidator<T>((x: string) => {
+    try {
+      return JSON.parse(x) as T;
+    } catch (_err) {
+      throw new EnvError(`Invalid json: "${x}"`);
+    }
+  })(spec);
+}

--- a/envalid/validators_test.ts
+++ b/envalid/validators_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import {
   bool,

--- a/envalid/validators_test.ts
+++ b/envalid/validators_test.ts
@@ -1,0 +1,158 @@
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import {
+  bool,
+  cleanEnv,
+  email,
+  host,
+  json,
+  makeValidator,
+  num,
+  port,
+  str,
+  url,
+} from "./mod.ts";
+import { assertPassthrough } from "./utils.ts";
+
+const makeSilent = { reporter: null };
+
+Deno.test("bool()", () => {
+  assertThrows(() => cleanEnv({ FOO: "asfd" }, { FOO: bool() }, makeSilent));
+
+  const trueBool = cleanEnv({ FOO: true }, { FOO: bool() });
+  assertEquals(trueBool, { FOO: true });
+
+  const falseBool = cleanEnv({ FOO: false }, { FOO: bool() });
+  assertEquals(falseBool, { FOO: false });
+
+  const truthyNum = cleanEnv({ FOO: "1" }, { FOO: bool() });
+  assertEquals(truthyNum, { FOO: true });
+  const falsyNum = cleanEnv({ FOO: "0" }, { FOO: bool() });
+  assertEquals(falsyNum, { FOO: false });
+
+  const trueStr = cleanEnv({ FOO: "true" }, { FOO: bool() });
+  assertEquals(trueStr, { FOO: true });
+
+  const falseStr = cleanEnv({ FOO: "false" }, { FOO: bool() });
+  assertEquals(falseStr, { FOO: false });
+
+  const t = cleanEnv({ FOO: "t" }, { FOO: bool() });
+  assertEquals(t, { FOO: true });
+  const f = cleanEnv({ FOO: "f" }, { FOO: bool() });
+  assertEquals(f, { FOO: false });
+
+  const defaultF = cleanEnv({}, { FOO: bool({ default: false }) });
+  assertEquals(defaultF, { FOO: false });
+});
+
+Deno.test("num()", () => {
+  const withInt = cleanEnv({ FOO: "1" }, { FOO: num() });
+  assertEquals(withInt, { FOO: 1 });
+
+  const withFloat = cleanEnv({ FOO: "0.34" }, { FOO: num() });
+  assertEquals(withFloat, { FOO: 0.34 });
+
+  const withExponent = cleanEnv({ FOO: "1e3" }, { FOO: num() });
+  assertEquals(withExponent, { FOO: 1000 });
+
+  const withZero = cleanEnv({ FOO: 0 }, { FOO: num() });
+  assertEquals(withZero, { FOO: 0 });
+
+  assertThrows(() => cleanEnv({ FOO: "asdf" }, { FOO: num() }, makeSilent));
+
+  assertThrows(() => cleanEnv({ FOO: "" }, { FOO: num() }, makeSilent));
+});
+
+Deno.test("email()", () => {
+  const spec = { FOO: email() };
+  assertPassthrough({ FOO: "foo@example.com" }, spec);
+  assertPassthrough({ FOO: "foo.bar@my.example.com" }, spec);
+
+  assertThrows(() => cleanEnv({ FOO: "asdf@asdf" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "1" }, spec, makeSilent));
+});
+
+Deno.test("host()", () => {
+  const spec = { FOO: host() };
+  assertPassthrough({ FOO: "example.com" }, spec);
+  assertPassthrough({ FOO: "localhost" }, spec);
+  assertPassthrough({ FOO: "192.168.0.1" }, spec);
+  assertPassthrough({ FOO: "2001:0db8:85a3:0000:0000:8a2e:0370:7334" }, spec);
+
+  assertThrows(() => cleanEnv({ FOO: "" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "example.com." }, spec, makeSilent));
+});
+
+Deno.test("port()", () => {
+  const spec = { FOO: port() };
+
+  const with1 = cleanEnv({ FOO: "1" }, spec);
+  assertEquals(with1, { FOO: 1 });
+  const with80 = cleanEnv({ FOO: "80" }, spec);
+  assertEquals(with80, { FOO: 80 });
+  const with80Num = cleanEnv({ FOO: 80 }, spec);
+  assertEquals(with80Num, { FOO: 80 });
+  const with65535 = cleanEnv({ FOO: "65535" }, spec);
+  assertEquals(with65535, { FOO: 65535 });
+
+  assertThrows(() => cleanEnv({ FOO: "" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "0" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "65536" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "042" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "42.0" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "42.42" }, spec, makeSilent));
+  assertThrows(() => cleanEnv({ FOO: "hello" }, spec, makeSilent));
+});
+
+Deno.test("json()", () => {
+  const env = cleanEnv({ FOO: '{"x": 123}' }, { FOO: json() });
+  assertEquals(env, { FOO: { x: 123 } });
+
+  assertThrows(() => cleanEnv({ FOO: "abc" }, { FOO: json() }, makeSilent));
+
+  // default value should be passed through without running through JSON.parse()
+  assertEquals(
+    cleanEnv(
+      {},
+      {
+        FOO: json({ default: { x: 999 } }),
+      },
+    ),
+    { FOO: { x: 999 } },
+  );
+});
+
+Deno.test("url()", () => {
+  assertPassthrough({ FOO: "http://foo.com" }, { FOO: url() });
+  assertPassthrough({ FOO: "http://foo.com/bar/baz" }, { FOO: url() });
+  assertPassthrough({ FOO: "custom://foo.com/bar/baz?hi=1" }, { FOO: url() });
+
+  assertThrows(() => cleanEnv({ FOO: "abc" }, { FOO: url() }, makeSilent));
+});
+
+Deno.test("str()", () => {
+  const withEmpty = cleanEnv({ FOO: "" }, { FOO: str() });
+  assertEquals(withEmpty, { FOO: "" });
+
+  assertThrows(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent));
+});
+
+Deno.test("custom validators", () => {
+  const alwaysFoo = makeValidator((_x) => "foo");
+
+  const fooEnv = cleanEnv({ FOO: "asdf" }, { FOO: alwaysFoo() });
+  assertEquals(fooEnv, { FOO: "foo" });
+
+  const hex10 = makeValidator((x) => {
+    if (/^[a-f0-9]{10}$/.test(x)) return x;
+    throw new Error("need 10 hex chars");
+  });
+  assertPassthrough({ FOO: "a0d9aacbde" }, { FOO: hex10() });
+  assertThrows(
+    () => cleanEnv({ FOO: "abc" }, { FOO: hex10() }, makeSilent),
+    Error,
+  );
+
+  // Default values work with custom validators as well
+  const withDefault = cleanEnv({}, { FOO: hex10({ default: "abcabcabc0" }) });
+  assertEquals(withDefault, { FOO: "abcabcabc0" });
+});


### PR DESCRIPTION
https://deno.land/x/envalid ([roj1512/envalid](https://github.com/roj1512/envalid)) is a port of the [npm.im/envalid](https://npm.im/envalid) ([af/envalid](https://github.com/af/envalid)) with slight modifications.

It makes using environment variables super easy and type-safe.