### PR TITLE
fix(encoding/jsonc): Improve safety of `JSONValue` object type in `jsonc.ts`

### DIFF
--- a/encoding/jsonc.ts
+++ b/encoding/jsonc.ts
@@ -43,7 +43,7 @@ export function parse(
 
 /** Valid types as a result of JSON parsing */
 export type JSONValue =
-  | { [key: string]: JSONValue }
+  | { [key: string]: JSONValue | undefined }
   | JSONValue[]
   | string
   | number


### PR DESCRIPTION
As a continuation of #2565, I'd like to improve not only `encoding/json/_parse.ts` but also `encoding/jsonc.ts` types.

I should have suggested it when I commented on https://github.com/denoland/deno_std/pull/2565#issuecomment-1228053348, but I forgot.