### PR TITLE
chore(node): change Promise.All to Promise.all

### DIFF
--- a/node/internal/streams/duplex.mjs
+++ b/node/internal/streams/duplex.mjs
@@ -198,7 +198,7 @@ export const fromWeb = Duplex.fromWeb = function (pair, options) {
 
       writer.ready.then(
         () =>
-          Promise.All(
+          Promise.all(
             chunks.map((data) => writer.write(data.chunk)),
           ).then(done, done),
         done,
@@ -290,7 +290,7 @@ export const fromWeb = Duplex.fromWeb = function (pair, options) {
       }
 
       if (!writableClosed || !readableClosed) {
-        Promise.All([
+        Promise.all([
           closeWriter(),
           closeReader(),
         ]).then(done, done);

--- a/node/internal/streams/writable.mjs
+++ b/node/internal/streams/writable.mjs
@@ -934,7 +934,7 @@ export const fromWeb = Writable.fromWeb = function (
 
       writer.ready.then(
         () =>
-          Promise.All(
+          Promise.all(
             chunks.map((data) => writer.write(data.chunk)),
           ).then(done, done),
         done,


### PR DESCRIPTION
- fix #2566

I run `grep 'Promise.All' -nr .` in the repo and only found 3 typos. Let me know if I miss somewhere else.