### PR TITLE
fix(node/fs): fix accessSync permission handling

### DIFF
--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -71,10 +71,14 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
   try {
     const info = Deno.lstatSync(path.toString());
     const m = +mode! || 0;
-    const fileMode = +info.mode! || 0;
-    // FIXME(kt3k): use the last digit of file mode as its mode for now
-    // This is not correct if the user is the owner of the file
-    // or is a member of the owner group
+    let fileMode = +info.mode! || 0;
+    if (Deno.build.os !== "windows" && info.uid === DenoUnstable.getUid()) {
+      // If the user is the owner of the file, then use the owner bits of
+      // the file permission
+      fileMode >>= 6;
+    }
+    // TODO(kt3k): Also check the case when the user belong to the group
+    // of the file
     if ((m & fileMode) === m) {
       // all required flags exist
     } else {

--- a/node/_fs/_fs_access_test.ts
+++ b/node/_fs/_fs_access_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 import * as fs from "../fs.ts";
-import { assertRejects } from "../../testing/asserts.ts";
+import { assertRejects, assertThrows } from "../../testing/asserts.ts";
 
 Deno.test(
   "[node/fs.access] Uses the owner permission when the user is the owner",
@@ -16,6 +16,24 @@ Deno.test(
       });
     } finally {
       await Deno.remove(file);
+    }
+  },
+);
+
+Deno.test(
+  "[node/fs.accessSync] Uses the owner permission when the user is the owner",
+  { ignore: Deno.build.os === "windows" },
+  () => {
+    const file = Deno.makeTempFileSync();
+    try {
+      Deno.chmod(file, 0o600);
+      fs.accessSync(file, fs.constants.R_OK);
+      fs.accessSync(file, fs.constants.W_OK);
+      assertThrows(() => {
+        fs.accessSync(file, fs.constants.X_OK);
+      });
+    } finally {
+      Deno.remove(file);
     }
   },
 );


### PR DESCRIPTION
This PR fixes the permission handling of accessSync when the process uid is the owner of the given file.