### PR TITLE
docs(flags): fix parse doc example

### DIFF
--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -338,8 +338,8 @@ function hasKey(obj: NestedMapping, keys: string[]): boolean {
  *
  * ```ts
  * import { parse } from "./mod.ts";
- * const parsedArgs = parse(["--foo", "--bar=baz", "--no-qux", "./quux.txt"]);
- * // parsedArgs: { foo: true, bar: "baz", qux: false, _: ["./quux.txt"] }
+ * const parsedArgs = parse(["--foo", "--bar=baz", "./quux.txt"]);
+ * // parsedArgs: { foo: true, bar: "baz", _: ["./quux.txt"] }
  * ```
  */
 export function parse<


### PR DESCRIPTION
We made the handling of `--no-foo` type arguments optional in #2301.

`"--no-qux"` isn't equal to `"--qux=false"` by default anymore. This PR fixes the example of parse API doc following that change.