### PR TITLE
BREAKING: replace ALL CAPS acronyms in public API names

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -522,13 +522,13 @@ supports the following formats:
 ### Basic usage
 
 If you want to parse JSON separated by a delimiter, use `TextLineStream` (or
-`TextDelimiterStream`) and `JSONParseStream`. `JSONParseStream` ignores chunks
+`TextDelimiterStream`) and `JsonParseStream`. `JsonParseStream` ignores chunks
 consisting of spaces, tab characters, or newline characters .
 
 ```ts
 // parse JSON lines or NDJSON
 import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
-import { JSONParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { JsonParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 const url =
   "https://deno.land/std@$STD_VERSION/encoding/testdata/json/test.jsonl";
@@ -537,7 +537,7 @@ const { body } = await fetch(url);
 const readable = body!
   .pipeThrough(new TextDecoderStream()) // convert Uint8Array to string
   .pipeThrough(new TextLineStream()) // transform into a stream where each chunk is divided by a newline
-  .pipeThrough(new JSONParseStream()); // parse each chunk as JSON
+  .pipeThrough(new JsonParseStream()); // parse each chunk as JSON
 
 for await (const data of readable) {
   console.log(data);
@@ -547,7 +547,7 @@ for await (const data of readable) {
 ```ts
 // parse JSON Text Sequences
 import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
-import { JSONParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { JsonParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 const url =
   "https://deno.land/std@$STD_VERSION/encoding/testdata/json/test.json-seq";
@@ -557,7 +557,7 @@ const delimiter = "\x1E";
 const readable = body!
   .pipeThrough(new TextDecoderStream())
   .pipeThrough(new TextDelimiterStream(delimiter)) // transform into a stream where each chunk is divided by a delimiter
-  .pipeThrough(new JSONParseStream());
+  .pipeThrough(new JsonParseStream());
 
 for await (const data of readable) {
   console.log(data);
@@ -566,10 +566,10 @@ for await (const data of readable) {
 
 If you want to parse
 [Concatenated JSON](https://en.wikipedia.org/wiki/JSON_streaming#Concatenated_JSON),
-use `ConcatenatedJSONParseStream`.
+use `ConcatenatedJsonParseStream`.
 
 ```ts
-import { ConcatenatedJSONParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { ConcatenatedJsonParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 const url =
   "https://deno.land/std@$STD_VERSION/encoding/testdata/json/test.concatenated-json";
@@ -577,28 +577,28 @@ const { body } = await fetch(url);
 
 const readable = body!
   .pipeThrough(new TextDecoderStream()) // convert Uint8Array to string
-  .pipeThrough(new ConcatenatedJSONParseStream()); // parse Concatenated JSON
+  .pipeThrough(new ConcatenatedJsonParseStream()); // parse Concatenated JSON
 
 for await (const data of readable) {
   console.log(data);
 }
 ```
 
-Use `JSONStringifyStream` to transform streaming data to
+Use `JsonStringifyStream` to transform streaming data to
 [JSON lines](https://jsonlines.org/), [NDJSON](http://ndjson.org/),
 [NDJSON](http://ndjson.org/) or
 [Concatenated JSON](https://en.wikipedia.org/wiki/JSON_streaming#Concatenated_JSON).
 
-By default, `JSONStringifyStream` adds "\n" as a suffix after each chunk.
+By default, `JsonStringifyStream` adds "\n" as a suffix after each chunk.
 
 ```ts
 import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
-import { JSONStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 const file = await Deno.open("./tmp.jsonl", { create: true, write: true });
 
 readableStreamFromIterable([{ foo: "bar" }, { baz: 100 }])
-  .pipeThrough(new JSONStringifyStream()) // convert to JSON lines (ndjson)
+  .pipeThrough(new JsonStringifyStream()) // convert to JSON lines (ndjson)
   .pipeThrough(new TextEncoderStream()) // convert a string to a Uint8Array
   .pipeTo(file.writable)
   .then(() => console.log("write success"));
@@ -611,12 +611,12 @@ prefix to the delimiter "\x1E" as options.
 
 ```ts
 import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
-import { JSONStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 const file = await Deno.open("./tmp.jsonl", { create: true, write: true });
 
 readableStreamFromIterable([{ foo: "bar" }, { baz: 100 }])
-  .pipeThrough(new JSONStringifyStream({ prefix: "\x1E", suffix: "\n" })) // convert to JSON Text Sequences
+  .pipeThrough(new JsonStringifyStream({ prefix: "\x1E", suffix: "\n" })) // convert to JSON Text Sequences
   .pipeThrough(new TextEncoderStream())
   .pipeTo(file.writable)
   .then(() => console.log("write success"));
@@ -626,7 +626,7 @@ If you want to stream [JSON lines](https://jsonlines.org/) from the server:
 
 ```ts
 import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
-import { JSONStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
 
 // A server that streams one line of JSON every second
 serve(() => {
@@ -644,7 +644,7 @@ serve(() => {
   });
 
   const body = readable
-    .pipeThrough(new JSONStringifyStream()) // convert data to JSON lines
+    .pipeThrough(new JsonStringifyStream()) // convert data to JSON lines
     .pipeThrough(new TextEncoderStream()); // convert a string to a Uint8Array
 
   return new Response(body);

--- a/encoding/csv/stream.ts
+++ b/encoding/csv/stream.ts
@@ -3,10 +3,13 @@ import { defaultReadOptions, parseRecord } from "./_io.ts";
 import type { LineReader } from "./_io.ts";
 import { TextDelimiterStream } from "../../streams/delimiter.ts";
 
-export interface CSVStreamOptions {
+export interface CsvStreamOptions {
   separator?: string;
   comment?: string;
 }
+
+/** @deprecated Use CsvStreamOptions instead. */
+export type CSVStreamOptions = CsvStreamOptions;
 
 class StreamLineReader implements LineReader {
   #reader: ReadableStreamDefaultReader<string>;
@@ -39,9 +42,9 @@ function stripLastCR(s: string): string {
   return s.endsWith("\r") ? s.slice(0, -1) : s;
 }
 
-export class CSVStream implements TransformStream<string, Array<string>> {
+export class CsvStream implements TransformStream<string, Array<string>> {
   readonly #readable: ReadableStream<Array<string>>;
-  readonly #options: CSVStreamOptions;
+  readonly #options: CsvStreamOptions;
   readonly #lineReader: StreamLineReader;
   readonly #lines: TextDelimiterStream;
   #lineIndex = 0;
@@ -104,3 +107,6 @@ export class CSVStream implements TransformStream<string, Array<string>> {
     return this.#lines.writable;
   }
 }
+
+/** @deprecated Use CsvStream instead. */
+export const CSVStream = CsvStream;

--- a/encoding/csv/stream_test.ts
+++ b/encoding/csv/stream_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { CSVStream } from "./stream.ts";
-import type { CSVStreamOptions } from "./stream.ts";
+import { CsvStream } from "./stream.ts";
+import type { CsvStreamOptions } from "./stream.ts";
 import { ERR_QUOTE, ParseError } from "./_io.ts";
 import {
   readableStreamFromIterable,
@@ -19,7 +19,7 @@ const testdataDir = join(fromFileUrl(import.meta.url), "../../testdata");
 const encoder = new TextEncoder();
 
 Deno.test({
-  name: "[encoding/csv/stream] CSVStream should work with Deno.File",
+  name: "[encoding/csv/stream] CsvStream should work with Deno.File",
   permissions: {
     read: [testdataDir],
   },
@@ -27,7 +27,7 @@ Deno.test({
     const file = await Deno.open(join(testdataDir, "simple.csv"));
     const readable = file.readable
       .pipeThrough(new TextDecoderStream())
-      .pipeThrough(new CSVStream());
+      .pipeThrough(new CsvStream());
     const records = [] as Array<Array<string>>;
     for await (const record of readable) {
       records.push(record);
@@ -41,7 +41,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/csv/stream] CSVStream with invalid csv",
+  name: "[encoding/csv/stream] CsvStream with invalid csv",
   fn: async () => {
     const readable = readableStreamFromIterable([
       encoder.encode("id,name\n"),
@@ -49,7 +49,7 @@ Deno.test({
       encoder.encode("1,foo\n"),
       encoder.encode('2,"baz\n'),
     ]).pipeThrough(new TextDecoderStream()).pipeThrough(
-      new CSVStream(),
+      new CsvStream(),
     );
     const reader = readable.getReader();
     assertEquals(await reader.read(), { done: false, value: ["id", "name"] });
@@ -64,7 +64,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/csv/stream] CSVStream with various inputs",
+  name: "[encoding/csv/stream] CsvStream with various inputs",
   permissions: "none",
   fn: async (t) => {
     // These test cases were originally ported from Go:
@@ -271,7 +271,7 @@ x,,,
     ];
     for (const testCase of testCases) {
       await t.step(testCase.name, async () => {
-        const options: CSVStreamOptions = {};
+        const options: CsvStreamOptions = {};
         if (testCase.separator) {
           options.separator = testCase.separator;
         }
@@ -279,7 +279,7 @@ x,,,
           options.comment = testCase.comment;
         }
         const readable = createReadableStreamFromString(testCase.input)
-          .pipeThrough(new CSVStream(options));
+          .pipeThrough(new CsvStream(options));
         const actual = [] as Array<Array<string>>;
         for await (const record of readable) {
           actual.push(record);
@@ -312,12 +312,12 @@ export const MyTextDecoderStream = () => {
 
 Deno.test({
   name:
-    "[encoding/csv/stream] cancel CSVStream during iteration does not leak file",
+    "[encoding/csv/stream] cancel CsvStream during iteration does not leak file",
   permissions: { read: [testdataDir] },
   fn: async () => {
     const file = await Deno.open(join(testdataDir, "large.csv"));
     const readable = file.readable.pipeThrough(MyTextDecoderStream())
-      .pipeThrough(new CSVStream());
+      .pipeThrough(new CsvStream());
     for await (const _record of readable) {
       break;
     }

--- a/encoding/json/_parse.ts
+++ b/encoding/json/_parse.ts
@@ -3,20 +3,25 @@
 import { toTransformStream } from "../../streams/conversion.ts";
 
 /** The type of the result of parsing JSON. */
-export type JSONValue =
-  | { [key: string]: JSONValue | undefined }
-  | JSONValue[]
+export type JsonValue =
+  | { [key: string]: JsonValue | undefined }
+  | JsonValue[]
   | string
   | number
   | boolean
   | null;
+
+/** The type of the result of parsing JSON.
+ *
+ * @deprecated Use JsonValue instead. */
+export type JSONValue = JsonValue;
 
 /** Optional object interface for `JSONParseStream` and `ConcatenatedJSONParseStream`. */
 export interface ParseStreamOptions {
   /** Controls the buffer of the TransformStream used internally. Check https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream. */
   readonly writableStrategy?: QueuingStrategy<string>;
   /** Controls the buffer of the TransformStream used internally. Check https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream. */
-  readonly readableStrategy?: QueuingStrategy<JSONValue>;
+  readonly readableStrategy?: QueuingStrategy<JsonValue>;
 }
 
 /**
@@ -27,7 +32,7 @@ export interface ParseStreamOptions {
  *
  * ```ts
  * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
- * import { JSONParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
+ * import { JsonParseStream } from "https://deno.land/std@$STD_VERSION/encoding/json/stream.ts";
  *
  * const url = "https://deno.land/std@$STD_VERSION/encoding/testdata/json/test.jsonl";
  * const { body } = await fetch(url);
@@ -35,14 +40,14 @@ export interface ParseStreamOptions {
  * const readable = body!
  *   .pipeThrough(new TextDecoderStream())
  *   .pipeThrough(new TextLineStream()) // or `new TextDelimiterStream(delimiter)`
- *   .pipeThrough(new JSONParseStream());
+ *   .pipeThrough(new JsonParseStream());
  *
  * for await (const data of readable) {
  *   console.log(data);
  * }
  * ```
  */
-export class JSONParseStream extends TransformStream<string, JSONValue> {
+export class JsonParseStream extends TransformStream<string, JsonValue> {
   /**
    * @param options
    * @param options.writableStrategy Controls the buffer of the TransformStream used internally. Check https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream.
@@ -62,6 +67,11 @@ export class JSONParseStream extends TransformStream<string, JSONValue> {
     );
   }
 }
+
+/** Parse each chunk as JSON.
+ *
+ * @deprecated Use JsonParseStream instead. */
+export const JSONParseStream = JsonParseStream;
 
 const branks = /^[ \t\r\n]*$/;
 function isBrankString(str: string) {
@@ -86,10 +96,10 @@ function isBrankString(str: string) {
  * }
  * ```
  */
-export class ConcatenatedJSONParseStream
-  implements TransformStream<string, JSONValue> {
+export class ConcatenatedJsonParseStream
+  implements TransformStream<string, JsonValue> {
   readonly writable: WritableStream<string>;
-  readonly readable: ReadableStream<JSONValue>;
+  readonly readable: ReadableStream<JsonValue>;
   /**
    * @param options
    * @param options.writableStrategy Controls the buffer of the TransformStream used internally. Check https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream.
@@ -189,13 +199,18 @@ export class ConcatenatedJSONParseStream
   }
 }
 
+/** stream to parse [Concatenated JSON](https://en.wikipedia.org/wiki/JSON_streaming#Concatenated_JSON).
+ *
+ * @deprecated Use ConcatenatedJsonParseStream instead. */
+export const ConcatenatedJSONParseStream = ConcatenatedJsonParseStream;
+
 const blank = new Set(" \t\r\n");
 function isBrankChar(char: string) {
   return blank.has(char);
 }
 
 /** JSON.parse with detailed error message. */
-function parse(text: string): JSONValue {
+function parse(text: string): JsonValue {
   try {
     return JSON.parse(text);
   } catch (error: unknown) {

--- a/encoding/json/_parse_test.ts
+++ b/encoding/json/_parse_test.ts
@@ -7,13 +7,13 @@ import {
   TextLineStream,
 } from "../../streams/mod.ts";
 import {
-  ConcatenatedJSONParseStream,
-  JSONParseStream,
+  ConcatenatedJsonParseStream,
+  JsonParseStream,
   ParseStreamOptions,
 } from "./_parse.ts";
 
 async function assertValidParse(
-  transform: typeof ConcatenatedJSONParseStream | typeof JSONParseStream,
+  transform: typeof ConcatenatedJsonParseStream | typeof JsonParseStream,
   chunks: string[],
   expect: unknown[],
   options?: ParseStreamOptions,
@@ -27,7 +27,7 @@ async function assertValidParse(
 }
 
 async function assertInvalidParse(
-  transform: typeof ConcatenatedJSONParseStream | typeof JSONParseStream,
+  transform: typeof ConcatenatedJsonParseStream | typeof JsonParseStream,
   chunks: string[],
   options: ParseStreamOptions,
   // deno-lint-ignore no-explicit-any
@@ -45,35 +45,35 @@ async function assertInvalidParse(
 }
 
 Deno.test({
-  name: "[encoding/json/stream] ConcatenatedJSONParseStream",
+  name: "[encoding/json/stream] ConcatenatedJsonParseStream",
   async fn() {
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"}'],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"} '],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       [' {"foo": "bar"}'],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['[{"foo": "bar"}]'],
       [[{ foo: "bar" }]],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"}{"foo": "bar"}'],
       [{ foo: "bar" }, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"} {"foo": "bar"}'],
       [{ foo: "bar" }, { foo: "bar" }],
     );
@@ -81,129 +81,129 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] ConcatenatedJSONParseStream: primitive",
+  name: "[encoding/json/stream] ConcatenatedJsonParseStream: primitive",
   async fn() {
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["0"],
       [0],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["100"],
       [100],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['100 200"foo"'],
       [100, 200, "foo"],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['100 200{"foo": "bar"}'],
       [100, 200, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['100 200["foo"]'],
       [100, 200, ["foo"]],
     );
 
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['"foo"'],
       ["foo"],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['"foo""bar"{"foo": "bar"}'],
       ["foo", "bar", { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['"foo""bar"["foo"]'],
       ["foo", "bar", ["foo"]],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['"foo""bar"0'],
       ["foo", "bar", 0],
     );
 
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["null"],
       [null],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['null null{"foo": "bar"}'],
       [null, null, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['null null["foo"]'],
       [null, null, ["foo"]],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["null null 0"],
       [null, null, 0],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['null null"foo"'],
       [null, null, "foo"],
     );
 
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["true"],
       [true],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['true true{"foo": "bar"}'],
       [true, true, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['true true["foo"]'],
       [true, true, ["foo"]],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["true true 0"],
       [true, true, 0],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['true true"foo"'],
       [true, true, "foo"],
     );
 
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["false"],
       [false],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['false false{"foo": "bar"}'],
       [false, false, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['false false["foo"]'],
       [false, false, ["foo"]],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["false false 0"],
       [false, false, 0],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['false false"foo"'],
       [false, false, "foo"],
     );
@@ -211,45 +211,45 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] ConcatenatedJSONParseStream: chunk",
+  name: "[encoding/json/stream] ConcatenatedJsonParseStream: chunk",
   async fn() {
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["", '{"foo": "bar"}'],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ["{", '"foo": "bar"}'],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "b', 'ar"}'],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"', "}"],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"}', ""],
       [{ foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"}', '{"foo": "bar"}'],
       [{ foo: "bar" }, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"', '}{"foo": "bar"}'],
       [{ foo: "bar" }, { foo: "bar" }],
     );
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"}{', '"foo": "bar"}'],
       [{ foo: "bar" }, { foo: "bar" }],
     );
@@ -257,10 +257,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] ConcatenatedJSONParseStream: surrogate pair",
+  name: "[encoding/json/stream] ConcatenatedJsonParseStream: surrogate pair",
   async fn() {
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "👪"}{"foo": "👪"}'],
       [{ foo: "👪" }, { foo: "👪" }],
     );
@@ -269,10 +269,10 @@ Deno.test({
 
 Deno.test({
   name:
-    "[encoding/json/stream] ConcatenatedJSONParseStream: symbol between double quotes",
+    "[encoding/json/stream] ConcatenatedJsonParseStream: symbol between double quotes",
   async fn() {
     await assertValidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['"[], {}"'],
       ["[], {}"],
     );
@@ -280,10 +280,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] ConcatenatedJSONParseStream: halfway chunk",
+  name: "[encoding/json/stream] ConcatenatedJsonParseStream: halfway chunk",
   async fn() {
     await assertInvalidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       ['{"foo": "bar"} {"foo": '],
       {},
       SyntaxError,
@@ -294,10 +294,10 @@ Deno.test({
 
 Deno.test({
   name:
-    "[encoding/json/stream] ConcatenatedJSONParseStream: truncate error message",
+    "[encoding/json/stream] ConcatenatedJsonParseStream: truncate error message",
   async fn() {
     await assertInvalidParse(
-      ConcatenatedJSONParseStream,
+      ConcatenatedJsonParseStream,
       [`{${"foo".repeat(100)}}`],
       {},
       SyntaxError,
@@ -307,10 +307,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] JSONParseStream",
+  name: "[encoding/json/stream] JsonParseStream",
   async fn() {
     await assertValidParse(
-      JSONParseStream,
+      JsonParseStream,
       ['{"foo": "bar"}', '["foo"]', '"foo"', "0", "null", "true", "false"],
       [{ foo: "bar" }, ["foo"], "foo", 0, null, true, false],
     );
@@ -318,10 +318,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] JSONParseStream: empty line",
+  name: "[encoding/json/stream] JsonParseStream: empty line",
   async fn() {
     await assertValidParse(
-      JSONParseStream,
+      JsonParseStream,
       [" \t\r\n", ""],
       [],
     );
@@ -329,10 +329,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] JSONParseStream: special character",
+  name: "[encoding/json/stream] JsonParseStream: special character",
   async fn() {
     await assertValidParse(
-      JSONParseStream,
+      JsonParseStream,
       ['"👪"', '"🦕"', '"\u3053\u3093\u306b\u3061\u306f"'],
       ["👪", "🦕", "\u3053\u3093\u306b\u3061\u306f"],
     );
@@ -340,10 +340,10 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[encoding/json/stream] JSONParseStream: expect error",
+  name: "[encoding/json/stream] JsonParseStream: expect error",
   async fn() {
     await assertInvalidParse(
-      JSONParseStream,
+      JsonParseStream,
       ['{"foo": "bar"}', '{"foo": '],
       {},
       SyntaxError,
@@ -361,7 +361,7 @@ Deno.test({
     const readable = body!
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(new TextLineStream())
-      .pipeThrough(new JSONParseStream());
+      .pipeThrough(new JsonParseStream());
 
     const result = [];
     for await (const data of readable) {
@@ -385,7 +385,7 @@ Deno.test({
     const readable = body!
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(new TextLineStream())
-      .pipeThrough(new JSONParseStream());
+      .pipeThrough(new JsonParseStream());
 
     const result = [];
     for await (const data of readable) {
@@ -411,7 +411,7 @@ Deno.test({
     const readable = body!
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(new TextDelimiterStream(recordSeparator))
-      .pipeThrough(new JSONParseStream());
+      .pipeThrough(new JsonParseStream());
 
     const result = [];
     for await (const data of readable) {
@@ -434,7 +434,7 @@ Deno.test({
     const { body } = await fetch(new URL(url, import.meta.url).toString());
     const readable = body!
       .pipeThrough(new TextDecoderStream())
-      .pipeThrough(new ConcatenatedJSONParseStream());
+      .pipeThrough(new ConcatenatedJsonParseStream());
 
     const result = [];
     for await (const data of readable) {

--- a/encoding/json/_stringify.ts
+++ b/encoding/json/_stringify.ts
@@ -31,7 +31,7 @@ export interface StringifyStreamOptions {
  *   .then(() => console.log("write success"));
  * ```
  */
-export class JSONStringifyStream extends TransformStream<unknown, string> {
+export class JsonStringifyStream extends TransformStream<unknown, string> {
   /**
    * @param options
    * @param options.prefix Prefix to be added after stringify. The default is "".
@@ -56,3 +56,8 @@ export class JSONStringifyStream extends TransformStream<unknown, string> {
     );
   }
 }
+
+/** Convert each chunk to JSON string.
+ *
+ * @deprecated Use JsonStringifyStream instead. */
+export const JSONStringifyStream = JsonStringifyStream;

--- a/encoding/json/_stringify_test.ts
+++ b/encoding/json/_stringify_test.ts
@@ -2,10 +2,10 @@
 
 import { assertEquals, assertRejects } from "../../testing/asserts.ts";
 import { readableStreamFromIterable } from "../../streams/conversion.ts";
-import { JSONStringifyStream, StringifyStreamOptions } from "./_stringify.ts";
+import { JsonStringifyStream, StringifyStreamOptions } from "./_stringify.ts";
 
 async function assertValidStringify(
-  transformer: typeof JSONStringifyStream,
+  transformer: typeof JsonStringifyStream,
   chunks: unknown[],
   expect: string[],
   options?: StringifyStreamOptions,
@@ -19,7 +19,7 @@ async function assertValidStringify(
 }
 
 async function assertInvalidStringify(
-  transformer: typeof JSONStringifyStream,
+  transformer: typeof JsonStringifyStream,
   chunks: unknown[],
   options: StringifyStreamOptions,
   // deno-lint-ignore no-explicit-any
@@ -40,7 +40,7 @@ Deno.test({
   name: "[encoding/json/stream] JSONStringifyStream",
   async fn() {
     await assertValidStringify(
-      JSONStringifyStream,
+      JsonStringifyStream,
       [{ foo: "bar" }, { foo: "bar" }],
       ['{"foo":"bar"}\n', '{"foo":"bar"}\n'],
     );
@@ -53,7 +53,7 @@ Deno.test({
     const cyclic: Record<string, unknown> = {};
     cyclic.cyclic = cyclic;
     await assertInvalidStringify(
-      JSONStringifyStream,
+      JsonStringifyStream,
       [cyclic],
       {},
       TypeError,
@@ -66,7 +66,7 @@ Deno.test({
   name: "[encoding/json/stream] JSONStringifyStream: prefix and suffix",
   async fn() {
     await assertValidStringify(
-      JSONStringifyStream,
+      JsonStringifyStream,
       [{ foo: "bar" }, { foo: "bar" }],
       [
         '[[prefix]]{"foo":"bar"}[[suffix]]',

--- a/textproto/mod.ts
+++ b/textproto/mod.ts
@@ -42,7 +42,7 @@ export class TextProtoReader {
     return s === null ? null : str(s);
   }
 
-  /** ReadMIMEHeader reads a MIME-style header from r.
+  /** ReadMimeHeader reads a MIME-style header from r.
    * The header is a sequence of possibly continued Key: Value lines
    * ending in a blank line.
    * The returned map m maps CanonicalMIMEHeaderKey(key) to a
@@ -62,7 +62,7 @@ export class TextProtoReader {
    * 		"Long-Key": {"Even Longer Value"},
    * 	}
    */
-  async readMIMEHeader(): Promise<Headers | null> {
+  async readMimeHeader(): Promise<Headers | null> {
     const m = new Headers();
     let line: Uint8Array | undefined;
 
@@ -129,6 +129,13 @@ export class TextProtoReader {
         // Pass
       }
     }
+  }
+
+  /** ReadMIMEHeader reads a MIME-style header from r.
+   *
+   * @deprecated Use readMimeHeader instead. */
+  readMIMEHeader(): Promise<Headers | null> {
+    return this.readMimeHeader();
   }
 
   async readLineSlice(): Promise<Uint8Array | null> {

--- a/textproto/test.ts
+++ b/textproto/test.ts
@@ -24,7 +24,7 @@ Deno.test({
 
 Deno.test("[textproto] ReadEmpty", async () => {
   const r = reader("");
-  const m = await r.readMIMEHeader();
+  const m = await r.readMimeHeader();
   assertEquals(m, null);
 });
 
@@ -47,7 +47,7 @@ Deno.test({
       "my-key: Value 1  \r\nLong-key: Even Longer Value\r\nmy-Key: " +
       "Value 2\r\n\n";
     const r = reader(input);
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("My-Key"), "Value 1, Value 2");
     assertEquals(m.get("Long-key"), "Even Longer Value");
@@ -59,7 +59,7 @@ Deno.test({
   async fn() {
     const input = "Foo: bar\n\n";
     const r = reader(input);
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("Foo"), "bar");
   },
@@ -70,7 +70,7 @@ Deno.test({
   async fn() {
     const input = ": bar\ntest-1: 1\n\n";
     const r = reader(input);
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("Test-1"), "1");
   },
@@ -86,7 +86,7 @@ Deno.test({
     }
     const sdata = data.join("");
     const r = reader(`Cookie: ${sdata}\r\n\r\n`);
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("Cookie"), sdata);
   },
@@ -103,7 +103,7 @@ Deno.test({
       "Audio Mode : None\r\n" +
       "Privilege : 127\r\n\r\n";
     const r = reader(input);
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("Foo"), "bar");
     assertEquals(m.get("Content-Language"), "en");
@@ -132,7 +132,7 @@ Deno.test({
 
     let err;
     try {
-      await r.readMIMEHeader();
+      await r.readMimeHeader();
     } catch (e) {
       err = e;
     }
@@ -152,7 +152,7 @@ Deno.test({
     const r = reader(input);
     let err;
     try {
-      await r.readMIMEHeader();
+      await r.readMimeHeader();
     } catch (e) {
       err = e;
     }
@@ -170,7 +170,7 @@ Deno.test({
       "------WebKitFormBoundaryimeZ2Le9LjohiUiG--\r\n\n",
     ];
     const r = reader(input.join(""));
-    const m = await r.readMIMEHeader();
+    const m = await r.readMimeHeader();
     assert(m !== null);
     assertEquals(m.get("Accept"), "*/*");
     assertEquals(m.get("Content-Disposition"), 'form-data; name="test"');


### PR DESCRIPTION
We usually use camelCase and PascalCase for public API names, but there were some exceptions to this rule in std.

- `JSONParseStream`
- `ConcatenatedJSONParseStream`
- `JSONStringifyStream`
- `JSONValue` (type)
- `readMIMEHeader` method in `TextProtoReader` class

We discussed about these exceptions internally and decided to not allow these naming exceptions.

This PR replaces these ALL CAPS acronyms in API names with camelCased versions. (The old APIs are still aliased with `@deprecated` tags)

---
See also https://github.com/denoland/manual/pull/343
