### PR TITLE
fix(node/readline): fix Interface constructor

### DIFF
--- a/node/_readline.mjs
+++ b/node/_readline.mjs
@@ -32,6 +32,7 @@ import { emitKeypressEvents } from "./internal/readline/emitKeypressEvents.mjs";
 import { validateAbortSignal } from "./internal/validators.mjs";
 import { promisify } from "./internal/util.mjs";
 import { AbortError } from "./internal/errors.ts";
+import { process } from "./process.ts";
 
 import {
   Interface as _Interface,

--- a/node/readline_test.ts
+++ b/node/readline_test.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { createInterface, Interface } from "./readline.ts";
+import { assertInstanceOf } from "../testing/asserts.ts";
+import { Readable, Writable } from "./stream.ts";
+
+Deno.test("[node/readline] createInstance", () => {
+  const rl = createInterface({
+    input: new Readable({ read() {} }),
+    output: new Writable(),
+  });
+
+  // deno-lint-ignore no-explicit-any
+  assertInstanceOf(rl, Interface as any);
+});


### PR DESCRIPTION
`readline.Interface` constructor currently has a reference to global `process` object, but it doesn't work without `--compat` mode. This PR fixes it.

(Note: `deno run --unstable -A npm:prisma db pull` seems now blocked by this error)