### PR TITLE
fix(node/process): fix BadResource issue of stdin.isTTY

### DIFF
--- a/node/_process/streams.mjs
+++ b/node/_process/streams.mjs
@@ -131,9 +131,7 @@ stdin.fd = Deno.stdin?.rid ?? -1;
 Object.defineProperty(stdin, "isTTY", {
   enumerable: true,
   configurable: true,
-  get() {
-    return Deno.isatty?.(Deno.stdin.rid);
-  },
+  value: Deno.isatty?.(Deno.stdin.rid),
 });
 stdin._isRawMode = false;
 stdin.setRawMode = (enable) => {

--- a/node/_process/streams.mjs
+++ b/node/_process/streams.mjs
@@ -131,6 +131,9 @@ stdin.fd = Deno.stdin?.rid ?? -1;
 Object.defineProperty(stdin, "isTTY", {
   enumerable: true,
   configurable: true,
+  // TODO(kt3k): This should be a getter property, but we use
+  // `value` for now to work around the below issue:
+  // https://github.com/denoland/deno/issues/15708
   value: Deno.isatty?.(Deno.stdin.rid),
 });
 stdin._isRawMode = false;


### PR DESCRIPTION
This PR fixes `BadResource` error while executing `DEBUG=* PRISMA_CLI_QUERY_ENGINE_TYPE=binary deno run --unstable -A npm:prisma db pull` command. (The root cause is https://github.com/denoland/deno/issues/15708 )

This PR stores `Deno.isatty?.(Deno.stdin.rid)` value at the start of program, instead of evaluating it each time. This works around the issue above.