### PR TITLE
fix(node): bump node version to latest stable

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -88,7 +88,7 @@ export const platform = isWindows ? "win32" : Deno.build.os;
  * it pointed to Deno version, but that led to incompability
  * with some packages.
  */
-export const version = "v16.11.1";
+export const version = "v16.17.0";
 
 /**
  * https://nodejs.org/api/process.html#process_process_versions
@@ -99,19 +99,19 @@ export const version = "v16.11.1";
  * with some packages. Value of `v8` field is still taken from `Deno.version`.
  */
 export const versions = {
-  node: "16.11.1",
-  uv: "1.42.0",
+  node: "16.17.0",
+  uv: "1.43.0",
   zlib: "1.2.11",
   brotli: "1.0.9",
-  ares: "1.17.2",
+  ares: "1.18.1",
   modules: "93",
-  nghttp2: "1.45.1",
+  nghttp2: "1.47.0",
   napi: "8",
-  llhttp: "6.0.4",
-  openssl: "1.1.1l",
-  cldr: "39.0",
-  icu: "69.1",
-  tz: "2021a",
-  unicode: "13.0",
+  llhttp: "6.0.7",
+  openssl: "1.1.1q+quic",
+  cldr: "41.0",
+  icu: "71.1",
+  tz: "2022a",
+  unicode: "14.0",
   ...Deno.version,
 };


### PR DESCRIPTION
Uncovered this while attempting to run [wrangler](https://www.npmjs.com/package/wrangler) via
```console
$ deno run --unstable -A npm:wrangler
Wrangler requires at least node.js v16.13.0. You are using v16.11.1. Please update your version of node.js.

Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.
```

New versions derived from:

```console
$ docker run -it --rm node:16.17 --eval "console.log(process.versions)"
{
  node: '16.17.0',
  v8: '9.4.146.26-node.22',
  uv: '1.43.0',
  zlib: '1.2.11',
  brotli: '1.0.9',
  ares: '1.18.1',
  modules: '93',
  nghttp2: '1.47.0',
  napi: '8',
  llhttp: '6.0.7',
  openssl: '1.1.1q+quic',
  cldr: '41.0',
  icu: '71.1',
  tz: '2022a',
  unicode: '14.0',
  ngtcp2: '0.1.0-DEV',
  nghttp3: '0.1.0-DEV'
}
```