### PR TITLE
fix(node/process): revert workaround for stdin.isTTY (#2590)

### DIFF
--- a/node/_process/streams.mjs
+++ b/node/_process/streams.mjs
@@ -131,10 +131,9 @@ stdin.fd = Deno.stdin?.rid ?? -1;
 Object.defineProperty(stdin, "isTTY", {
   enumerable: true,
   configurable: true,
-  // TODO(kt3k): This should be a getter property, but we use
-  // `value` for now to work around the below issue:
-  // https://github.com/denoland/deno/issues/15708
-  value: Deno.isatty?.(Deno.stdin.rid),
+  get() {
+    return Deno.isatty?.(Deno.stdin.rid);
+  },
 });
 stdin._isRawMode = false;
 stdin.setRawMode = (enable) => {


### PR DESCRIPTION
This reverts commit 336da79918798704e2b4dff4616de5d117cf4d63.

The root issue (https://github.com/denoland/deno/issues/15708) has been resolved by https://github.com/denoland/deno/pull/15747