### PR TITLE
ci: check deploy-compat only with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,22 +212,3 @@ jobs:
       - name: Rebuild Wasm and verify it hasn't changed
         if: success() && steps.source.outputs.modified == 'true'
         run: deno task build:varint --check
-
-  deploy-compat:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Deploy to Deno Deploy
-        uses: denoland/deployctl@v1
-        id: deploy
-        with:
-          project: std-deploy-compat-test
-          entrypoint: _tools/deploy.ts
-
-      - name: Check deployment
-        run: curl --fail ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: deploy-compat
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy-compat:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Deploy to Deno Deploy
+        uses: denoland/deployctl@v1
+        id: deploy
+        with:
+          project: std-deploy-compat-test
+          entrypoint: _tools/deploy.ts
+
+      - name: Check deployment
+        run: curl --fail ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
This PR disables the `deploy-compat` check for PRs. `denoland/deployctl` only works for origin branches. The check currently doesn't work for PRs from forks.