### PR TITLE
remove: outdated std import

### DIFF
--- a/test_import_map.json
+++ b/test_import_map.json
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "https://deno.land/std@$STD_VERSION/": "./",
-    "https://deno.land/std@0.104.0/": "./"
+    "https://deno.land/std@$STD_VERSION/": "./"
   }
 }


### PR DESCRIPTION
[This line](https://github.com/denoland/deno_std/blob/d3b14b2aa06db78dd642ba816a6388e88d5008e2/test_import_map.json#L4) doesn't seem right. This PR removes it.