### PR TITLE
remove: `Doctest /node` step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,6 @@ jobs:
         shell: bash
         run: deno task node:check-unstable-api
 
-      # FIXME(bartlomieju): currently doc tests are failing, we need --compat mode in "deno test" to get them working
-      # - name: Doctest node/
-      #   run: deno test --doc --unstable --allow-all --import-map=test_import_map.json --config strict-ts44.tsconfig.json node/
-
       - name: Unit test node/
         run: deno task node:unit
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,6 @@ accepted.
 - wasm crypto check
 - CLA
 
-_Typechecking code in Markdown files_:
-
-If you want to run `deno test --doc x.md` you will need to specify the flag
-`--import-map=test_import_map.json`, this import map is in the root of deno_std.
-
 _For maintainers_:
 
 To release a new version a tag in the form of `x.y.z` should be added.


### PR DESCRIPTION
If this test is still desired, we can work towards bringing it back. Otherwise, reasons for removing:
1. There aren't many markdown files in `std/node` anyway.
2. The step uses a `strict-ts44.tsconfig.json` config file, which doesn't exist.
3. The comment hasn't been actioned since late 2021 (#1590).

https://github.com/denoland/deno_std/blob/d3b14b2aa06db78dd642ba816a6388e88d5008e2/.github/workflows/ci.yml#L100-L102