### PR TITLE
fix(node/process): make execPath writable

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -277,6 +277,8 @@ function uncaughtExceptionHandler(err: any, origin: string) {
   process.emit("uncaughtException", err, origin);
 }
 
+let execPath: string | null = null;
+
 class Process extends EventEmitter {
   constructor() {
     super();
@@ -575,7 +577,15 @@ class Process extends EventEmitter {
 
   /** https://nodejs.org/api/process.html#processexecpath */
   get execPath() {
-    return argv[0];
+    if (execPath) {
+      return execPath;
+    }
+    execPath = Deno.execPath();
+    return execPath;
+  }
+
+  set execPath(path: string) {
+    execPath = path
   }
 
   #startTime = Date.now();

--- a/node/process.ts
+++ b/node/process.ts
@@ -585,7 +585,7 @@ class Process extends EventEmitter {
   }
 
   set execPath(path: string) {
-    execPath = path
+    execPath = path;
   }
 
   #startTime = Date.now();

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -462,6 +462,18 @@ Deno.test("process.execPath", () => {
   assertEquals(process.execPath, process.argv[0]);
 });
 
+Deno.test("process.execPath is writable", () => {
+  // pnpm writes to process.execPath
+  // https://github.com/pnpm/pnpm/blob/67d8b65d2e8da1df3725034b8c5b1fcf3af4ad81/packages/config/src/index.ts#L175
+  const originalExecPath = process.execPath;
+  try {
+    process.execPath = "/path/to/node";
+    assertEquals(process.execPath, "/path/to/node");
+  } finally {
+    process.execPath = originalExecPath;
+  }
+});
+
 Deno.test({
   name: "process.exit",
   async fn() {


### PR DESCRIPTION
fixes #2640 

We currently only define getter of `execPath` in process, but pnpm writes to `process.execPath` for some reason and is broken there (https://github.com/pnpm/pnpm/blob/67d8b65d2e8da1df3725034b8c5b1fcf3af4ad81/packages/config/src/index.ts#L175). This PR makes it writable and fixes the issue for pnpm.