### PR TITLE
fix(node/process): reduce required env permission range

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -57,21 +57,20 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
     },
     ownKeys: () => Reflect.ownKeys(Deno.env.toObject()),
     getOwnPropertyDescriptor: (_target, name) => {
-      const e = Deno.env.toObject();
-      if (name in Deno.env.toObject()) {
-        const o = { enumerable: true, configurable: true };
-        if (typeof name === "string") {
-          // @ts-ignore we do want to set it only when name is of type string
-          o.value = e[name];
-        }
-        return o;
+      const value = Deno.env.get(String(name));
+      if (value) {
+        return {
+          enumerable: true,
+          configurable: true,
+          value: Deno.env.get(String(name)),
+        };
       }
     },
     set(_target, prop, value) {
       Deno.env.set(String(prop), String(value));
       return value;
     },
-    has: (_target, prop) => Reflect.ownKeys(Deno.env.toObject()).includes(prop),
+    has: (_target, prop) => typeof Deno.env.get(String(prop)) === "string",
   });
 
 /** https://nodejs.org/api/process.html#process_process_pid */

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -270,6 +270,22 @@ Deno.test({
 });
 
 Deno.test({
+  name: "process.env requires scoped env permission",
+  permissions: { env: ["FOO"] },
+  fn() {
+    Deno.env.set("FOO", "1");
+    assert("FOO" in process.env);
+    assertThrows(() => {
+      "BAR" in process.env;
+    });
+    assert(Object.hasOwn(process.env, "FOO"));
+    assertThrows(() => {
+      Object.hasOwn(process.env, "BAR");
+    });
+  },
+});
+
+Deno.test({
   name: "process.stdin",
   fn() {
     assertEquals(process.stdin.fd, Deno.stdin.rid);


### PR DESCRIPTION
This PR reduces the required env permission range for `x in process.env` and `process.env.hasOwnProperty(x)`.