### PR TITLE
feat(node): new child_process.fork (wip)

### DIFF
--- a/node/child_process.ts
+++ b/node/child_process.ts
@@ -17,12 +17,11 @@ import {
 import { getSystemErrorName } from "./util.ts";
 import { process } from "./process.ts";
 import { Buffer } from "./buffer.ts";
-import { notImplemented } from "./_utils.ts";
 
 const MAX_BUFFER = 1024 * 1024;
 
 /**
- * Spawns a new Node.js process + fork. Not implmeneted yet.
+ * Spawns a new Node.js process + fork.
  * @param modulePath
  * @param args
  * @param option
@@ -88,8 +87,9 @@ export function fork(
     stringifiedV8Flags.push("--v8-flags=" + v8Flags.join(","));
   }
   args = [
-    // TODO(kt3k): Find corrct args for `fork` execution
-    ...[],
+    "run",
+    "--unstable", // TODO(kt3k): Remove when npm: is stable
+    "-A",
     ...stringifiedV8Flags,
     ...execArgv,
     modulePath,
@@ -112,7 +112,12 @@ export function fork(
   options.execPath = options.execPath || Deno.execPath();
   options.shell = false;
 
-  notImplemented("child_process.fork");
+  Object.assign(options.env ??= {}, {
+    // deno-lint-ignore no-explicit-any
+    DENO_DONT_USE_INTERNAL_NODE_COMPAT_STATE: (Deno as any).core.ops.op_child_process_fork_state()
+  });
+
+  return spawn(options.execPath, args, options);
 }
 
 // deno-lint-ignore no-empty-interface


### PR DESCRIPTION
This PR is based on the branch of denoland/deno#15891

This PR is mainly for sharing the current status of child_process.fork

---

I tried `prisma generate` with this change and denoland/deno#15891 with the below command:

```
PRISMA_CLI_QUERY_ENGINE_TYPE=binary DENO_NODE_COMPAT_URL=file:///path/to/local/deno_std/ DEBUG=* ~/path/to/deno/target/debug/deno run --unstable -A npm:prisma generate
```

It fails with the below error:

```
Error: Error: Generator at /Users/kt3k/prisma-sandbox/starter/node_modules/@prisma/client/generator-build/index.js could not start:

error: could not find npm package for 'file:///Users/kt3k/prisma-sandbox/starter/node_modules/@prisma/client/generator-build/index.js'

    at Timeout.<anonymous> (file:///Users/kt3k/Library/Caches/deno/npm/registry.npmjs.org/prisma/4.3.1/build/index.js:90311:21)
    at file:///Users/kt3k/denoland/deno_std/node/timers.ts:21:21
    at Object.action (deno:ext/web/02_timers.js:148:13)
    at handleTimerMacrotask (deno:ext/web/02_timers.js:65:12)
```

What `prisma` tries to execute with `fork` is local `./node_modules/@prisma/client/generator-build/index.js` and it's not inside of our npm cache directory. So it can't find npm package for it.