### PR TITLE
fix(http/file_server): serveFile returns 404 when the path is directory

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -147,6 +147,14 @@ export async function serveFile(
     }
   }
 
+  if (fileInfo.isDirectory) {
+    file.close();
+    await req.body?.cancel();
+    const status = Status.NotFound;
+    const statusText = STATUS_TEXT[status];
+    return new Response(statusText, { status, statusText });
+  }
+
   const headers = setBaseHeaders();
 
   // Set mime-type using the file extension in filePath

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -945,6 +945,16 @@ Deno.test(
 );
 
 Deno.test(
+  "file_server `serveFile` returns 404 when the given path is a directory",
+  async () => {
+    const req = new Request("http://localhost:4507/testdata/");
+    const res = await serveFile(req, testdataDir);
+    assertEquals(res.status, 404);
+    assertEquals(res.statusText, "Not Found");
+  },
+);
+
+Deno.test(
   "file_server `serveFile` should return 416 due to a bad range request (500-200)",
   async () => {
     const req = new Request("http://localhost:4507/testdata/test file.txt");


### PR DESCRIPTION
This supercedes #2504

This PR makes `serveFile` return 404 response when the requested path is a directory.

Currently `serveFile` returns 200 response for directory paths and the response object throws when its body is read. This PR fixes this confusing behavior.

BTW if file_server is used as CLI tools, the path is checked if it's directory or not before passed to `serveFile`. So this change only affects users who use `serveFile` API directly.