### PR TITLE
feat(tools/check_deprecation): use deno_doc for jsdoc parsing

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -78,7 +78,6 @@ async function walk(dir: string) {
           switch (tag.kind) {
             case "deprecated": {
               const message = tag.doc;
-              console.log(message);
               if (!message) {
                 console.error(
                   colors.red("Error"),

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -5,7 +5,7 @@ import * as semver from "../semver/mod.ts";
 import * as colors from "../fmt/colors.ts";
 import { doc } from "https://deno.land/x/deno_doc/mod.ts";
 
-const EXTENSIONS = [".mjs", ".js", ".ts", ".rs"];
+const EXTENSIONS = [".mjs", ".js", ".ts"];
 const EXCLUDED_PATHS = [
   ".git",
   "node/",

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -3,6 +3,7 @@
 import { VERSION } from "../version.ts";
 import * as semver from "../semver/mod.ts";
 import * as colors from "../fmt/colors.ts";
+import { doc } from "https://deno.land/x/deno_doc/mod.ts";
 
 const EXTENSIONS = [".mjs", ".js", ".ts", ".rs"];
 const EXCLUDED_PATHS = [
@@ -22,9 +23,9 @@ console.warn(
 EXCLUDED_PATHS.push("fs/exists.ts");
 
 const ROOT = new URL("../", import.meta.url).pathname.slice(0, -1);
+
 const FAIL_FAST = Deno.args.includes("--fail-fast");
 
-const DEPRECATED_REGEX = /\*\s+@deprecated\s+(?<text>.+)/;
 const DEPRECATION_IN_FORMAT_REGEX =
   /^\(will be removed in (?<version>\d+\.\d+\.\d+)\)/;
 const DEPRECATION_AFTER_FORMAT_REGEX =
@@ -47,7 +48,7 @@ const DEFAULT_DEPRECATED_VERSION = semver.inc(
 const DEPRECATION_IN_FORMAT =
   `(will be removed in ${DEFAULT_DEPRECATED_VERSION})`;
 
-function walk(dir: string) {
+async function walk(dir: string) {
   for (const x of Deno.readDirSync(dir)) {
     const filePath = `${dir}/${x.name}`;
 
@@ -66,69 +67,76 @@ function walk(dir: string) {
       continue;
     }
 
-    const content = Deno.readTextFileSync(filePath);
-    const lines = content.split("\n");
-    let lineIndex = 1;
-    for (const line of lines) {
-      const match = DEPRECATED_REGEX.exec(line);
-      if (match) {
-        const text = match.groups?.text;
-        if (!text) {
-          console.error(
-            colors.red("Error"),
-            `${
-              colors.bold("@deprecated")
-            } tag must have a version: ${filePath}:${lineIndex}`,
-          );
-          shouldFail = true;
-          if (FAIL_FAST) Deno.exit(1);
-          continue;
-        }
-        const { version: afterVersion } =
-          DEPRECATION_AFTER_FORMAT_REGEX.exec(text)?.groups || {};
+    // deno_doc only takes urls.
+    const url = new URL(filePath, "file://");
+    const docs = await doc(url.href);
 
-        if (afterVersion) {
-          if (semver.lt(afterVersion, VERSION)) {
-            console.warn(
-              colors.yellow("Warn"),
-              `${
-                colors.bold("@deprecated")
-              } tag is expired and export should be removed: ${filePath}:${lineIndex}`,
-            );
+    for (const d of docs) {
+      const tags = d.jsDoc?.tags;
+      if (tags) {
+        for (const tag of tags) {
+          switch (tag.kind) {
+            case "deprecated": {
+              const message = tag.doc;
+              console.log(message);
+              if (!message) {
+                console.error(
+                  colors.red("Error"),
+                  `${
+                    colors.bold("@deprecated")
+                  } tag must have a version: ${filePath}:${d.location.line}`,
+                );
+                shouldFail = true;
+                if (FAIL_FAST) Deno.exit(1);
+                continue;
+              }
+              const { version: afterVersion } =
+                DEPRECATION_AFTER_FORMAT_REGEX.exec(message)?.groups || {};
+
+              if (afterVersion) {
+                if (semver.lt(afterVersion, VERSION)) {
+                  console.warn(
+                    colors.yellow("Warn"),
+                    `${
+                      colors.bold("@deprecated")
+                    } tag is expired and export should be removed: ${filePath}:${d.location.line}`,
+                  );
+                }
+                continue;
+              }
+
+              const { version: inVersion } =
+                DEPRECATION_IN_FORMAT_REGEX.exec(message)?.groups || {};
+              if (!inVersion) {
+                console.error(
+                  colors.red("Error"),
+                  `${
+                    colors.bold("@deprecated")
+                  } tag version is missing. Append '${DEPRECATION_IN_FORMAT}' after @deprecated tag: ${filePath}:${d.location.line}`,
+                );
+                shouldFail = true;
+                if (FAIL_FAST) Deno.exit(1);
+                continue;
+              }
+
+              if (!semver.gt(inVersion, VERSION)) {
+                console.error(
+                  colors.red("Error"),
+                  `${
+                    colors.bold("@deprecated")
+                  } tag is expired and export must be removed: ${filePath}:${d.location.line}`,
+                );
+                if (FAIL_FAST) Deno.exit(1);
+                shouldFail = true;
+                continue;
+              }
+            }
           }
-          continue;
-        }
-
-        const { version: inVersion } =
-          DEPRECATION_IN_FORMAT_REGEX.exec(text)?.groups || {};
-        if (!inVersion) {
-          console.error(
-            colors.red("Error"),
-            `${
-              colors.bold("@deprecated")
-            } tag version is missing. Append '${DEPRECATION_IN_FORMAT}' after @deprecated tag: ${filePath}:${lineIndex}`,
-          );
-          shouldFail = true;
-          if (FAIL_FAST) Deno.exit(1);
-          continue;
-        }
-
-        if (!semver.gt(inVersion, VERSION)) {
-          console.error(
-            colors.red("Error"),
-            `${
-              colors.bold("@deprecated")
-            } tag is expired and export must be removed: ${filePath}:${lineIndex}`,
-          );
-          if (FAIL_FAST) Deno.exit(1);
-          shouldFail = true;
-          continue;
         }
       }
-      lineIndex += 1;
     }
   }
 }
 
-walk(ROOT);
+await walk(ROOT);
 if (shouldFail) Deno.exit(1);

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -53,7 +53,7 @@ async function walk(dir: string) {
     const filePath = `${dir}/${x.name}`;
 
     if (x.isDirectory) {
-      walk(filePath);
+      await walk(filePath);
       continue;
     }
 

--- a/deno.json
+++ b/deno.json
@@ -44,7 +44,7 @@
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | xargs deno cache --check --reload --config browser-compat.tsconfig.json",
     "lint:circular-deps": "deno run --allow-read --allow-net=deno.land ./_tools/check_circular_deps.ts",
     "lint:licence-headers": "deno run --allow-read ./_tools/check_licence.ts",
-    "lint:deprecations": "deno run --allow-read ./_tools/check_deprecation.ts",
+    "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",
     "lint": "deno lint && deno task lint:circular-deps && deno task lint:licence-headers && deno task lint:depreactions",
     "node:unit": "deno test --unstable --allow-all node/ --ignore=node/_tools/test.ts,node/_tools/versions/",
     "node:test": "deno test --unstable --allow-all node/_tools/test.ts",


### PR DESCRIPTION
- replace jsdoc regex with [deno_doc](https://github.com/denoland/deno_doc) for more consistency.