### PR TITLE
fix(node/fs): position option of fs.read and fs.readSync works the same as Node

### DIFF
--- a/node/_fs/_fs_read.ts
+++ b/node/_fs/_fs_read.ts
@@ -98,20 +98,20 @@ export function read(
   let err: Error | null = null,
     numberOfBytesRead: number | null = null;
 
-  let currentPosition = 0;
-  if (typeof position === "number" && position >= 0) {
-    currentPosition = Deno.seekSync(fd, 0, Deno.SeekMode.Current);
-    Deno.seekSync(fd, position, Deno.SeekMode.Start);
-  }
-
   try {
+    let currentPosition = 0;
+    if (typeof position === "number" && position >= 0) {
+      currentPosition = Deno.seekSync(fd, 0, Deno.SeekMode.Current);
+      Deno.seekSync(fd, position, Deno.SeekMode.Start);
+    }
+
     numberOfBytesRead = Deno.readSync(fd, buffer);
+
+    if (typeof position === "number" && position >= 0) {
+      Deno.seekSync(fd, currentPosition, Deno.SeekMode.Start);
+    }
   } catch (error) {
     err = error instanceof Error ? error : new Error("[non-error thrown]");
-  }
-
-  if (typeof position === "number" && position >= 0) {
-    Deno.seekSync(fd, currentPosition, Deno.SeekMode.Start);
   }
 
   if (err) {

--- a/node/_fs/_fs_read.ts
+++ b/node/_fs/_fs_read.ts
@@ -98,14 +98,20 @@ export function read(
   let err: Error | null = null,
     numberOfBytesRead: number | null = null;
 
-  if (position) {
-    Deno.seekSync(fd, position, Deno.SeekMode.Current);
+  let currentPosition = 0;
+  if (typeof position === "number" && position >= 0) {
+    currentPosition = Deno.seekSync(fd, 0, Deno.SeekMode.Current);
+    Deno.seekSync(fd, position, Deno.SeekMode.Start);
   }
 
   try {
     numberOfBytesRead = Deno.readSync(fd, buffer);
   } catch (error) {
     err = error instanceof Error ? error : new Error("[non-error thrown]");
+  }
+
+  if (typeof position === "number" && position >= 0) {
+    Deno.seekSync(fd, currentPosition, Deno.SeekMode.Start);
   }
 
   if (err) {
@@ -168,11 +174,17 @@ export function readSync(
     }`,
   );
 
-  if (position) {
-    Deno.seekSync(fd, position, Deno.SeekMode.Current);
+  let currentPosition = 0;
+  if (typeof position === "number" && position >= 0) {
+    currentPosition = Deno.seekSync(fd, 0, Deno.SeekMode.Current);
+    Deno.seekSync(fd, position, Deno.SeekMode.Start);
   }
 
   const numberOfBytesRead = Deno.readSync(fd, buffer);
+
+  if (typeof position === "number" && position >= 0) {
+    Deno.seekSync(fd, currentPosition, Deno.SeekMode.Start);
+  }
 
   return numberOfBytesRead ?? 0;
 }

--- a/node/_fs/_fs_read_test.ts
+++ b/node/_fs/_fs_read_test.ts
@@ -87,25 +87,43 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[std/node/fs] Specifies where to begin reading from in the file",
+  name:
+    "[std/node/fs] position option of fs.read() specifies where to begin reading from in the file",
   async fn() {
     const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
     const testData = path.resolve(moduleDir, "testdata", "hello.txt");
-    const buf = Buffer.alloc(11);
-    await readTest(
-      testData,
-      buf,
-      buf.byteOffset,
-      buf.byteLength,
-      6,
-      (_fd, bytesRead, data) => {
-        assertStrictEquals(bytesRead, 5);
-        assertEquals(
-          data,
-          Buffer.from([119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0]),
+    const fd = openSync(testData);
+    const buf = Buffer.alloc(5);
+    const positions = [6, 0, -1, null];
+    const expected = [
+      [119, 111, 114, 108, 100],
+      [104, 101, 108, 108, 111],
+      [104, 101, 108, 108, 111],
+      [32, 119, 111, 114, 108],
+    ];
+    for (const [i, position] of positions.entries()) {
+      await new Promise((resolve) => {
+        read(
+          fd,
+          {
+            buffer: buf,
+            offset: buf.byteOffset,
+            length: buf.byteLength,
+            position,
+          },
+          (err, bytesRead, data) => {
+            assertEquals(err, null);
+            assertStrictEquals(bytesRead, 5);
+            assertEquals(
+              data,
+              Buffer.from(expected[i]),
+            );
+            return resolve(true);
+          },
         );
-      },
-    );
+      });
+    }
+    closeSync(fd);
   },
 });
 
@@ -180,6 +198,39 @@ Deno.test({
     const fd = openSync(testData);
     const bytesRead = readSync(fd, buffer, buffer.byteOffset, 2, null);
     assertStrictEquals(bytesRead, 2);
+    closeSync(fd);
+  },
+});
+
+Deno.test({
+  name:
+    "[std/node/fs] position option of fs.readSync() specifies where to begin reading from in the file",
+  fn() {
+    const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+    const testData = path.resolve(moduleDir, "testdata", "hello.txt");
+    const fd = openSync(testData);
+    const buf = Buffer.alloc(5);
+    const positions = [6, 0, -1, null];
+    const expected = [
+      [119, 111, 114, 108, 100],
+      [104, 101, 108, 108, 111],
+      [104, 101, 108, 108, 111],
+      [32, 119, 111, 114, 108],
+    ];
+    for (const [i, position] of positions.entries()) {
+      const bytesRead = readSync(
+        fd,
+        buf,
+        buf.byteOffset,
+        buf.byteLength,
+        position,
+      );
+      assertStrictEquals(bytesRead, 5);
+      assertEquals(
+        buf,
+        Buffer.from(expected[i]),
+      );
+    }
     closeSync(fd);
   },
 });


### PR DESCRIPTION
The behavior of `position` option in `fs.read` and `fs.readSync` is different between Deno and Node.
This PR fixes the behavior of Deno to be the same as Node's.

## Actual Behavior

### Node v18.9.0

If `position` is an integer, 

- Specifies the number of bytes to start reading counting from the ***beginning*** of the file
- The file position will be ***unchanged***

Ref: https://nodejs.org/api/fs.html#fsreadfd-buffer-offset-length-position-callback

### Deno 1.25.3 with std@0.156.0

If `position` is an integer, 

- Specifies the number of bytes to start reading counting from the ***current position*** of the file
- The file position will be ***updated***

## Sample code

```mjs
// import for Node
import fs from 'fs';
import { Buffer } from 'node:buffer';
// or
// import for Deno
import fs from "https://deno.land/std@0.156.0/node/fs.ts";
import { Buffer } from "https://deno.land/std@0.156.0/node/buffer.ts";


const file = "./test.txt";
const text = "hello, world!";
const bufSize = 3;
const positions = [2, null, 2];
const data = [];

fs.writeFileSync(file, text);
const fd = fs.openSync(file);

for (const pos of positions) {
  const buf = Buffer.alloc(bufSize);
  fs.readSync(fd, buf, 0, buf.byteLength, pos);
  data.push(buf.toString("utf8"));
}

fs.closeSync(fd);
console.log(data);
```

### Execution result in Node

```mjs
[ 'llo', 'hel', 'llo' ] // [ 2-4 byte, 0-2 byte, 2-4 byte ]
```

### Execution result in Deno

```mjs
[ "llo", ", w", "ld!" ] // [ 2-4 byte, 5-7 byte, 10-12 byte ]
```

## Tests

No applicable test for this issue has been found in the Node test suite. Unit tests have been updated.

## Remarks

This issue has been found while implementing compatibility improvements to fs.ReadStream. #2653
