### PR TITLE
fix(node/process): does not throw with invalid env var names

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -31,6 +31,19 @@ export const cwd = Deno.cwd;
 /** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
 export const nextTick = _nextTick;
 
+/** Wrapper of Deno.env.get, which doesn't throw type error when
+ * the env name has "=" or "\0" in it. */
+function denoEnvGet(name: string) {
+  try {
+    return Deno.env.get(name);
+  } catch (e) {
+    if (e instanceof TypeError) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
 const OBJECT_PROTO_PROP_NAMES = Object.getOwnPropertyNames(Object.prototype);
 /**
  * https://nodejs.org/api/process.html#process_process_env
@@ -43,7 +56,7 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
         return target[prop];
       }
 
-      const envValue = Deno.env.get(prop);
+      const envValue = denoEnvGet(prop);
 
       if (envValue) {
         return envValue;
@@ -57,12 +70,12 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
     },
     ownKeys: () => Reflect.ownKeys(Deno.env.toObject()),
     getOwnPropertyDescriptor: (_target, name) => {
-      const value = Deno.env.get(String(name));
+      const value = denoEnvGet(String(name));
       if (value) {
         return {
           enumerable: true,
           configurable: true,
-          value: Deno.env.get(String(name)),
+          value,
         };
       }
     },
@@ -70,7 +83,7 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
       Deno.env.set(String(prop), String(value));
       return value;
     },
-    has: (_target, prop) => typeof Deno.env.get(String(prop)) === "string",
+    has: (_target, prop) => typeof denoEnvGet(String(prop)) === "string",
   });
 
 /** https://nodejs.org/api/process.html#process_process_pid */

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -5,6 +5,7 @@ import "./global.ts";
 import {
   assert,
   assertEquals,
+  assertFalse,
   assertObjectMatch,
   assertStrictEquals,
   assertThrows,
@@ -282,6 +283,21 @@ Deno.test({
     assertThrows(() => {
       Object.hasOwn(process.env, "BAR");
     });
+  },
+});
+
+Deno.test({
+  name: "process.env doesn't throw with invalid env var names",
+  fn() {
+    assertEquals(process.env[""], undefined);
+    assertEquals(process.env["\0"], undefined);
+    assertEquals(process.env["=c:"], undefined);
+    assertFalse(Object.hasOwn(process.env, ""));
+    assertFalse(Object.hasOwn(process.env, "\0"));
+    assertFalse(Object.hasOwn(process.env, "=c:"));
+    assertFalse("" in process.env);
+    assertFalse("\0" in process.env);
+    assertFalse("=c:" in process.env);
   },
 });
 


### PR DESCRIPTION
Currently `process.env` throws a TypeError when the env name has invalid chars or it's an empty string (because Deno.env.get throws with those inputs).

This PR prevents those behaviors and instead makes it return `undefined` with those invalid inputs.

closes #2665 