### PR TITLE
fix(http/file_server): handles path with reserved char

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -311,7 +311,8 @@ async function serveDirIndex(
       continue;
     }
     const filePath = posix.join(dirPath, entry.name);
-    const fileUrl = encodeURI(posix.join(dirUrl, entry.name));
+    const fileUrl = encodeURIComponent(posix.join(dirUrl, entry.name))
+      .replaceAll("%2F", "/");
     const fileInfo = await Deno.stat(filePath);
     if (entry.name === "index.html" && entry.isFile) {
       // in case index.html as dir...
@@ -633,7 +634,7 @@ function normalizeURL(url: string): string {
   }
 
   try {
-    normalizedUrl = decodeURI(normalizedUrl);
+    normalizedUrl = decodeURIComponent(normalizedUrl);
   } catch (e) {
     if (!(e instanceof URIError)) {
       throw e;

--- a/http/testdata/file#2.txt
+++ b/http/testdata/file#2.txt
@@ -1,0 +1,1 @@
+Plain text


### PR DESCRIPTION
Current implementation don't escape some reserved characters, which causing the browser to consider certain part is not the file path.