### PR TITLE
fix(node/net): fix socket events order

### DIFF
--- a/node/internal_binding/handle_wrap.ts
+++ b/node/internal_binding/handle_wrap.ts
@@ -34,7 +34,7 @@ export class HandleWrap extends AsyncWrap {
 
   close(cb: () => void = () => {}) {
     this._onClose();
-    cb();
+    queueMicrotask(cb);
   }
 
   ref() {

--- a/node/net.ts
+++ b/node/net.ts
@@ -1420,11 +1420,10 @@ export class Socket extends Duplex {
         this._handle = null;
         this._sockname = undefined;
 
-        cb(exception);
-
         debug("emit close");
         this.emit("close", isException);
       });
+      cb(exception);
     } else {
       cb(exception);
       nextTick(_emitCloseNT, this);

--- a/node/net_test.ts
+++ b/node/net_test.ts
@@ -1,0 +1,24 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import * as net from "./net.ts";
+import { assertEquals } from "../testing/asserts.ts";
+import { deferred } from "../async/deferred.ts";
+
+Deno.test("[node/net] close event emits after error event", async () => {
+  const socket = net.createConnection(27009, "doesnotexist");
+  const events: ("error" | "close")[] = [];
+  const errorEmitted = deferred();
+  const closeEmitted = deferred();
+  socket.once("error", () => {
+    events.push("error");
+    errorEmitted.resolve();
+  });
+  socket.once("close", () => {
+    events.push("close");
+    closeEmitted.resolve();
+  });
+  await Promise.all([errorEmitted, closeEmitted]);
+
+  // `error` happens before `close`
+  assertEquals(events, ["error", "close"]);
+});


### PR DESCRIPTION
When `net.connect` fails with an immediate error, `error` event happens before `close` event in node.js, but in `std/node` the events happen in the opposite order. This PR fixes it.

closes #2666
ref https://github.com/denoland/deno/issues/15824