### PR TITLE
feat(node/process): `process.getuid()` and `process.getgid()`

### DIFF
--- a/node/process.ts
+++ b/node/process.ts
@@ -560,18 +560,6 @@ class Process extends EventEmitter {
     return 0o22;
   }
 
-  /** https://nodejs.org/api/process.html#processgetuid */
-  getuid(): number {
-    // TODO(kt3k): return user id in mac and linux
-    return NaN;
-  }
-
-  /** https://nodejs.org/api/process.html#processgetgid */
-  getgid(): number {
-    // TODO(kt3k): return group id in mac and linux
-    return NaN;
-  }
-
   // TODO(kt3k): Implement this when we added -e option to node compat mode
   _eval: string | undefined = undefined;
 
@@ -605,6 +593,25 @@ class Process extends EventEmitter {
 
 /** https://nodejs.org/api/process.html#process_process */
 const process = new Process();
+
+if (Deno.build.os !== "windows") {
+  Object.defineProperties(process, {
+    /** https://nodejs.org/api/process.html#processgetuid */
+    getuid: {
+      enumerable: false,
+      writable: false,
+      configurable: false,
+      value: (): number => Deno.getUid()!,
+    },
+    /** https://nodejs.org/api/process.html#processgetgid */
+    getgid: {
+      enumerable: false,
+      writable: false,
+      configurable: false,
+      value: (): number => Deno.getGid()!,
+    },
+  });
+}
 
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,

--- a/node/process.ts
+++ b/node/process.ts
@@ -560,6 +560,16 @@ class Process extends EventEmitter {
     return 0o22;
   }
 
+  /** This method is removed on Windows */
+  getgid?(): number {
+    return Deno.getGid()!;
+  }
+
+  /** This method is removed on Windows */
+  getuid?(): number {
+    return Deno.getUid()!;
+  }
+
   // TODO(kt3k): Implement this when we added -e option to node compat mode
   _eval: string | undefined = undefined;
 
@@ -591,27 +601,13 @@ class Process extends EventEmitter {
   features = { inspector: false };
 }
 
+if (Deno.build.os === "windows") {
+  delete Process.prototype.getgid;
+  delete Process.prototype.getuid;
+}
+
 /** https://nodejs.org/api/process.html#process_process */
 const process = new Process();
-
-if (Deno.build.os !== "windows") {
-  Object.defineProperties(process, {
-    /** https://nodejs.org/api/process.html#processgetuid */
-    getuid: {
-      enumerable: false,
-      writable: false,
-      configurable: false,
-      value: (): number => Deno.getUid()!,
-    },
-    /** https://nodejs.org/api/process.html#processgetgid */
-    getgid: {
-      enumerable: false,
-      writable: false,
-      configurable: false,
-      value: (): number => Deno.getGid()!,
-    },
-  });
-}
 
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -506,6 +506,22 @@ Deno.test("process.execPath is writable", () => {
   }
 });
 
+Deno.test("process.getuid", () => {
+  if (Deno.build.os === "windows") {
+    assertEquals(process.getuid, undefined);
+  } else {
+    assertEquals(process.getuid(), Deno.getUid());
+  }
+});
+
+Deno.test("process.getgid", () => {
+  if (Deno.build.os === "windows") {
+    assertEquals(process.getgid, undefined);
+  } else {
+    assertEquals(process.getgid(), Deno.getUid());
+  }
+});
+
 Deno.test({
   name: "process.exit",
   async fn() {

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -506,23 +506,19 @@ Deno.test("process.execPath is writable", () => {
   }
 });
 
-Deno.test("process.getuid", () => {
+Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
-    // @ts-ignore: temporary
-    assertEquals(process.getuid, undefined);
+    assertEquals(process.getgid, undefined);
   } else {
-    // @ts-ignore: temporary
-    assertEquals(process.getuid(), Deno.getUid());
+    assertEquals(process.getgid?.(), Deno.getGid());
   }
 });
 
-Deno.test("process.getgid", () => {
+Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
-    // @ts-ignore: temporary
-    assertEquals(process.getgid, undefined);
+    assertEquals(process.getuid, undefined);
   } else {
-    // @ts-ignore: temporary
-    assertEquals(process.getgid(), Deno.getGid());
+    assertEquals(process.getuid?.(), Deno.getUid());
   }
 });
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -508,17 +508,21 @@ Deno.test("process.execPath is writable", () => {
 
 Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
+    // @ts-ignore: temporary
     assertEquals(process.getuid, undefined);
   } else {
+    // @ts-ignore: temporary
     assertEquals(process.getuid(), Deno.getUid());
   }
 });
 
 Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
+    // @ts-ignore: temporary
     assertEquals(process.getgid, undefined);
   } else {
-    assertEquals(process.getgid(), Deno.getUid());
+    // @ts-ignore: temporary
+    assertEquals(process.getgid(), Deno.getGid());
   }
 });
 


### PR DESCRIPTION
1. Is this the best way to conditionally define a method of a class? These methods don't exist on Windows platforms in Node.
2. How can `// @ts-ignore` be avoided in the tests?
3. [`test-process-uid-gid.js`](https://github.com/nodejs/node/blob/main/test/parallel/test-process-uid-gid.js) wasn't added because `process.setuid()`, `process.seteuid()`, `process.setgid()` and `process.setegid()` aren't and cannot currently be implemented, meaning the majority of that test would fail.