### PR TITLE
fix(collections): deepMerge ignoring 'replace' options for nested properties

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -133,7 +133,7 @@ function mergeObjects(
 ): Readonly<NonNullable<object>> {
   // Recursively merge mergeable objects
   if (isMergeable(left) && isMergeable(right)) {
-    return deepMergeInternal(left, right, seen);
+    return deepMergeInternal(left, right, seen, options);
   }
 
   if (isIterable(left) && isIterable(right)) {

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -299,6 +299,39 @@ Deno.test("deepMerge: sets merge (merge)", () => {
   );
 });
 
+Deno.test("deepMerge: nested replace", () => {
+  assertEquals(
+    deepMerge(
+      {
+        a: "A1",
+        b: ["B11", "B12"],
+        c: {
+          d: "D1",
+          e: ["E11"],
+        },
+      },
+      {
+        b: [],
+        c: {
+          d: "D2",
+          e: [],
+        },
+      },
+      {
+        arrays: "replace",
+      },
+    ),
+    {
+      a: "A1",
+      b: [],
+      c: {
+        d: "D2",
+        e: [],
+      },
+    },
+  );
+});
+
 Deno.test("deepMerge: complex test", () => {
   assertEquals(
     deepMerge({


### PR DESCRIPTION
Fix #2673