### PR TITLE
chore(node): temporarily disable dns-related node comapt tests on windows

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -689,6 +689,8 @@
       "test-console-log-throw-primitive.js",
       "test-console-no-swallow-stack-overflow.js",
       "test-console-sync-write-error.js",
+      "test-dns.js",
+      "test-dns-resolveany.js",
       "test-fs-access.js",
       "test-fs-readdir-stack-overflow.js",
       "test-fs-rm.js",


### PR DESCRIPTION
This PR temporarily disables `test-dns.js` and `test-dns-resolveany.js` on windows as they fail too often on CI recently.

closes #2682 