### PR TITLE
fix: `lint:deprecations` typo within `lint` task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -45,7 +45,7 @@
     "lint:circular-deps": "deno run --allow-read --allow-net=deno.land ./_tools/check_circular_deps.ts",
     "lint:licence-headers": "deno run --allow-read ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",
-    "lint": "deno lint && deno task lint:circular-deps && deno task lint:licence-headers && deno task lint:depreactions",
+    "lint": "deno lint && deno task lint:circular-deps && deno task lint:licence-headers && deno task lint:deprecations",
     "node:unit": "deno test --unstable --allow-all node/ --ignore=node/_tools/test.ts,node/_tools/versions/",
     "node:test": "deno test --unstable --allow-all node/_tools/test.ts",
     "node:setup": "deno run --allow-read --allow-net --allow-write node/_tools/setup.ts",


### PR DESCRIPTION
`lint:deprecations` was previously incorrectly `lint:depreactions` within the `lint` task.