### PR TITLE
fix: testing example pages failing to load

### DIFF
--- a/examples/catj.ts
+++ b/examples/catj.ts
@@ -9,7 +9,7 @@
  *
  * Install using `deno install`:
  *
- * ```ignore
+ * ```shellsession
  * $ deno install --allow-read https://deno.land/std/examples/catj.ts
  * ```
  *

--- a/examples/gist.ts
+++ b/examples/gist.ts
@@ -6,7 +6,7 @@
  *
  * Use the following to install it:
  *
- * ```ignore
+ * ```shellsession
  * $ deno install -f --allow-env --allow-read --allow-net=api.github.com https://deno.land/std/examples/gist.ts
  * ```
  *

--- a/testing/chai_example.ts
+++ b/testing/chai_example.ts
@@ -4,8 +4,8 @@
  *
  * Run this example with:
  *
- * ```ignore
- * deno test ./testing/chai_example.ts
+ * ```shellsession
+ * $ deno test ./testing/chai_example.ts
  * ```
  *
  * @module

--- a/testing/fast_check_example.ts
+++ b/testing/fast_check_example.ts
@@ -14,7 +14,7 @@
  * Since the nested testing API is used, the tests need to be run with the
  * unstable flag as indicated in the command:
  *
- * ```ignore
+ * ```shellsession
  * $ deno test --unstable ./testing/fast_check_example.ts
  * ```
  *

--- a/testing/sinon_example.ts
+++ b/testing/sinon_example.ts
@@ -5,8 +5,8 @@
  *
  * Run this example with:
  *
- * ```ignore
- * deno test ./testing/sinon_example.ts
+ * ```shellsession
+ * $ deno test ./testing/sinon_example.ts
  * ```
  *
  * @module


### PR DESCRIPTION
These pages were erroring out on loading due to the use of "ignored" language.

Lowlight was failing due to the use of "ignored" as language name, which is unsupported.
![image](https://user-images.githubusercontent.com/132584/192084335-fc4e99d1-f11b-4060-8bf1-a20bfd71fa01.png)
