### PR TITLE
fix(node): re-enable `test-fs-readdir-stack-overflow.js` on Windows

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -726,7 +726,6 @@
       "test-dns.js",
       "test-dns-resolveany.js",
       "test-fs-access.js",
-      "test-fs-readdir-stack-overflow.js",
       "test-fs-rm.js",
       "test-fs-watchfile.js",
       "test-fs-write-file-invalid-path.js",


### PR DESCRIPTION
Closes #1761, as the issue in #13196 is reportedly fixed.