### PR TITLE
fix(node): revert using `Buffer.from` in setup

### DIFF
--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -109,7 +109,7 @@ async function decompressTests(archivePath: string) {
     { read: true },
   );
 
-  const buffer = Buffer.from(gunzip(await readAll(compressedFile)));
+  const buffer = new Buffer(gunzip(await readAll(compressedFile)));
   Deno.close(compressedFile.rid);
 
   const tar = new Untar(buffer);


### PR DESCRIPTION
Running `deno task node:setup` fails because `Buffer.from` was not a function. `Buffer` import was coming from the non-Node part of this library.