### PR TITLE
fix(node/process): Deno 1.26 replaced Deno.setRaw with Deno.stdin.setRaw

### DIFF
--- a/node/_process/streams.mjs
+++ b/node/_process/streams.mjs
@@ -137,7 +137,7 @@ Object.defineProperty(stdin, "isTTY", {
 });
 stdin._isRawMode = false;
 stdin.setRawMode = (enable) => {
-  Deno.setRaw?.(Deno.stdin?.rid, enable);
+  Deno.stdin.setRaw?.(enable);
   stdin._isRawMode = enable;
   return stdin;
 };

--- a/node/_process/streams.mjs
+++ b/node/_process/streams.mjs
@@ -137,7 +137,7 @@ Object.defineProperty(stdin, "isTTY", {
 });
 stdin._isRawMode = false;
 stdin.setRawMode = (enable) => {
-  Deno.stdin.setRaw?.(enable);
+  Deno.stdin?.setRaw?.(enable);
   stdin._isRawMode = enable;
   return stdin;
 };


### PR DESCRIPTION
I'm unsure if the old line should be kept to ensure compatibility with Deno < 1.26