### PR TITLE
fix(node/process): do not error assigning `false` to `process.env[VAR_NAME]`

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -81,7 +81,7 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
     },
     set(_target, prop, value) {
       Deno.env.set(String(prop), String(value));
-      return value;
+      return true; // success
     },
     has: (_target, prop) => typeof denoEnvGet(String(prop)) === "string",
   });

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -276,6 +276,12 @@ Deno.test({
 
     assertEquals(process.env.toString(), "[object Object]");
     assertEquals(process.env.toLocaleString(), "[object Object]");
+
+    // should not error when assigning false to an env var
+    process.env.HELLO = false as unknown as string;
+    assertEquals(process.env.HELLO, "false");
+    process.env.HELLO = "WORLD";
+    assertEquals(process.env.HELLO, "WORLD");
   },
 });
 


### PR DESCRIPTION
Should return `true` for success. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set#return_value