### PR TITLE
chore: upgrade to `deno_graph@0.34.0` for circular dependency check

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -3,7 +3,7 @@
 import { VERSION } from "../version.ts";
 import * as semver from "../semver/mod.ts";
 import * as colors from "../fmt/colors.ts";
-import { doc } from "https://deno.land/x/deno_doc/mod.ts";
+import { doc } from "https://deno.land/x/deno_doc@0.46.0/mod.ts";
 
 const EXTENSIONS = [".mjs", ".js", ".ts"];
 const EXCLUDED_PATHS = [


### PR DESCRIPTION
Also specifies a version for `deno_doc` in the deprecation check so avoid any compatibility issues in the future.