### PR TITLE
chore: upgrade rust to 1.64.0 for `crypto/wasm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,8 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         if: success() && steps.source.outputs.modified == 'true'
         with:
-          # This must match the version in _wasm_crypto/rust-toolchain.toml:
-          rust-version: 1.57.0
+          # This must match the version in crypto/_wasm_crypto/rust-toolchain.toml
+          rust-version: 1.64.0
           targets: wasm32-unknown-unknown
           components: rustfmt
 
@@ -203,9 +203,7 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         if: success() && steps.source.outputs.modified == 'true'
         with:
-          # This must match the versions in:
-          # 1. crypto/_wasm_crypto/rust-toolchain.toml
-          # 2. encoding/_wasm_varint/rust-toolchain.toml
+          # This must match the versions in encoding/_wasm_varint/rust-toolchain.toml
           rust-version: 1.64.0
           targets: wasm32-unknown-unknown
           components: rustfmt


### PR DESCRIPTION
This was missed in #2721.