### PR TITLE
chore(fs): document the deprecation of `exists` and `existsSync`

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -14,6 +14,14 @@ const EXCLUDED_PATHS = [
   "http/testdata",
 ];
 
+console.warn(
+  colors.yellow("Warning"),
+  `ignore ${
+    colors.green(`"fs/exists.ts"`)
+  } until issue is resolved: https://github.com/denoland/deno_std/issues/2594`,
+);
+EXCLUDED_PATHS.push("fs/exists.ts");
+
 const ROOT = new URL("../", import.meta.url).pathname.slice(0, -1);
 
 const FAIL_FAST = Deno.args.includes("--fail-fast");

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -14,14 +14,6 @@ const EXCLUDED_PATHS = [
   "http/testdata",
 ];
 
-console.warn(
-  colors.yellow("Warning"),
-  `ignore ${
-    colors.green(`"fs/exists.ts"`)
-  } until issue is resolved: https://github.com/denoland/deno_std/issues/2594`,
-);
-EXCLUDED_PATHS.push("fs/exists.ts");
-
 const ROOT = new URL("../", import.meta.url).pathname.slice(0, -1);
 
 const FAIL_FAST = Deno.args.includes("--fail-fast");

--- a/fs/README.md
+++ b/fs/README.md
@@ -108,7 +108,7 @@ existsSync("./foo.txt"); // returns a boolean
 ```
 
 **Note: do not use this function if performing a check before another operation
-on that file. Doing so may cause a race condition. Instead, perform the actual
+on that file. Doing so causes a race condition. Instead, perform the actual file
 operation directly.**
 
 Bad:

--- a/fs/README.md
+++ b/fs/README.md
@@ -95,7 +95,65 @@ format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
 
 ### exists
 
-This function is now deprecated.
+Test whether or not the given path exists by checking with the file system.
+
+```ts
+import {
+  exists,
+  existsSync,
+} from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+
+exists("./foo.txt"); // resolves a boolean
+existsSync("./foo.txt"); // returns a boolean
+```
+
+**Note: do not use this function if performing a check before another operation
+on that file. Doing so may cause a race condition. Instead, perform the actual
+operation directly.**
+
+Bad:
+
+```ts
+import {
+  exists,
+  existsSync,
+} from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+
+if (await exists("./foo.txt")) {
+  await Deno.remove("./foo.txt");
+}
+
+// OR
+
+if (existsSync("./foo.txt")) {
+  Deno.removeSync("./foo.txt");
+}
+```
+
+Good:
+
+```ts
+// Notice no use of exists or existsSync
+try {
+  await Deno.remove("./foo.txt");
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) {
+    throw error;
+  }
+  // Do nothing...
+}
+
+// OR
+
+try {
+  Deno.removeSync("./foo.txt");
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) {
+    throw error;
+  }
+  // Do nothing...
+}
+```
 
 ### move
 

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -1,35 +1,81 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 /**
- * Test whether or not the given path exists by checking with the file system
- * @deprecated (will be removed after 0.157.0) Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
+ * Test whether or not the given path exists by checking with the file system.
+ *
+ * Note: do not use this function if performing a check before another operation on that file. Doing so may cause a race condition. Instead, perform the actual operation directly.
+ *
+ * Bad:
+ * ```ts
+ * import { exists } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ *
+ * if (await exists("./foo.txt")) {
+ *   await Deno.remove("./foo.txt");
+ * }
+ * ```
+ *
+ * Good:
+ * ```ts
+ * // Notice no use of exists
+ * try {
+ *   await Deno.remove("./foo.txt");
+ * } catch (error) {
+ *   if (!(error instanceof Deno.errors.NotFound)) {
+ *     throw error;
+ *   }
+ *   // Do nothing...
+ * }
+ * ```
  * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
  */
-export async function exists(filePath: string): Promise<boolean> {
+export async function exists(filePath: string | URL): Promise<boolean> {
   try {
     await Deno.lstat(filePath);
     return true;
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
       return false;
     }
-
-    throw err;
+    throw error;
   }
 }
 
 /**
- * Test whether or not the given path exists by checking with the file system
- * @deprecated (will be removed after 0.157.0) Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
+ * Test whether or not the given path exists by checking with the file system.
+ *
+ * Note: do not use this function if performing a check before another operation on that file. Doing so may cause a race condition. Instead, perform the actual operation directly.
+ *
+ * Bad:
+ * ```ts
+ * import { existsSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ *
+ * if (existsSync("./foo.txt")) {
+ *   Deno.removeSync("./foo.txt");
+ * }
+ * ```
+ *
+ * Good:
+ * ```ts
+ * // Notice no use of existsSync
+ * try {
+ *   Deno.removeSync("./foo.txt");
+ * } catch (error) {
+ *   if (!(error instanceof Deno.errors.NotFound)) {
+ *     throw error;
+ *   }
+ *   // Do nothing...
+ * }
+ * ```
  * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
  */
-export function existsSync(filePath: string): boolean {
+export function existsSync(filePath: string | URL): boolean {
   try {
     Deno.lstatSync(filePath);
     return true;
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
       return false;
     }
-    throw err;
+    throw error;
   }
 }

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -3,7 +3,7 @@
 /**
  * Test whether or not the given path exists by checking with the file system.
  *
- * Note: do not use this function if performing a check before another operation on that file. Doing so may cause a race condition. Instead, perform the actual operation directly.
+ * Note: do not use this function if performing a check before another operation on that file. Doing so creates a race condition. Instead, perform the actual file operation directly.
  *
  * Bad:
  * ```ts
@@ -43,7 +43,7 @@ export async function exists(filePath: string | URL): Promise<boolean> {
 /**
  * Test whether or not the given path exists by checking with the file system.
  *
- * Note: do not use this function if performing a check before another operation on that file. Doing so may cause a race condition. Instead, perform the actual operation directly.
+ * Note: do not use this function if performing a check before another operation on that file. Doing so creates a race condition. Instead, perform the actual file operation directly.
  *
  * Bad:
  * ```ts

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -27,6 +27,7 @@
  * }
  * ```
  * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
+ * @deprecated (will be removed after 0.157.0) Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
  */
 export async function exists(filePath: string | URL): Promise<boolean> {
   try {
@@ -67,6 +68,7 @@ export async function exists(filePath: string | URL): Promise<boolean> {
  * }
  * ```
  * @see https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
+ * @deprecated (will be removed after 0.157.0) Checking the state of a file before using it causes a race condition. Perform the actual operation directly instead.
  */
 export function existsSync(filePath: string | URL): boolean {
   try {

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -189,8 +189,12 @@ export class RotatingFileHandler extends FileHandler {
       // Remove old backups too as it doesn't make sense to start with a clean
       // log file, but old backups
       for (let i = 1; i <= this.#maxBackupCount; i++) {
-        if (await exists(this._filename + "." + i)) {
+        try {
           await Deno.remove(this._filename + "." + i);
+        } catch (error) {
+          if (!(error instanceof Deno.errors.NotFound)) {
+            throw error;
+          }
         }
       }
     } else if (this._mode === "x") {


### PR DESCRIPTION
`exists` was deprecated because it causes a race condition when used before a file operation. However, it still has some legitimate uses cases, [even within `std`](https://github.com/denoland/deno_std/blob/1c2a47fe0fa1968e5a55fa340c910d525c2b657c/log/handlers.ts#L199-L204). The community has expressed more arguments here:
* #2594
* #2102

This PR:
1. Reverts the deprecation of `exists` and `existsSync`.
2. Advises against using `exists` before a file operation and clearly explains the reasoning.
3. Closes #2125.
4. Cleans up an illegitimate use of `exists` within the codebase.
5. Adds `URL` support for the argument.

A few legitimate use cases were also likely removed in #2546, as `Deno.lstat` is still used to check for the existence of files. It'd be a good idea to revisit these removals and consider re-adding the `exists`, but only where appropriate.