### PR TITLE
fix(http): remove unnecessary delay when closing server

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -371,20 +371,22 @@ export class Server {
           error instanceof Deno.errors.ConnectionReset ||
           error instanceof Deno.errors.NotConnected
         ) {
-          // Backoff after transient errors to allow time for the system to
-          // recover, and avoid blocking up the event loop with a continuously
-          // running loop.
-          if (!acceptBackoffDelay) {
-            acceptBackoffDelay = INITIAL_ACCEPT_BACKOFF_DELAY;
-          } else {
-            acceptBackoffDelay *= 2;
-          }
+          if (!this.#closed) {
+            // Backoff after transient errors to allow time for the system to
+            // recover, and avoid blocking up the event loop with a continuously
+            // running loop.
+            if (!acceptBackoffDelay) {
+              acceptBackoffDelay = INITIAL_ACCEPT_BACKOFF_DELAY;
+            } else {
+              acceptBackoffDelay *= 2;
+            }
 
-          if (acceptBackoffDelay >= MAX_ACCEPT_BACKOFF_DELAY) {
-            acceptBackoffDelay = MAX_ACCEPT_BACKOFF_DELAY;
-          }
+            if (acceptBackoffDelay >= MAX_ACCEPT_BACKOFF_DELAY) {
+              acceptBackoffDelay = MAX_ACCEPT_BACKOFF_DELAY;
+            }
 
-          await delay(acceptBackoffDelay);
+            await delay(acceptBackoffDelay);
+          }
 
           continue;
         }

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -991,6 +991,16 @@ Deno.test(
   },
 );
 
+Deno.test("Server should not leak async ops when closed", () => {
+  const hostname = "127.0.0.1";
+  const port = 4505;
+  const handler = () => new Response();
+  const server = new Server({ port, hostname, handler });
+  server.listenAndServe();
+  server.close();
+  // Otherwise, the test would fail with: AssertionError: Test case is leaking async ops.
+});
+
 Deno.test("Server should reject if the listener throws an unexpected error accepting a connection", async () => {
   const conn = createMockConn();
   const rejectionError = new Error("test-unexpected-error");


### PR DESCRIPTION
This conditionally removes the backoff delay when an error happens while accepting connections, if the server is already closed. This fixes the leaking async op encountered in the issue below, that can also be reproduced using the test case added in this PR.

closes https://github.com/denoland/deno_std/issues/2717