### PR TITLE
fix(node): debuglog callback should be optional

### DIFF
--- a/node/internal/util/debuglog.ts
+++ b/node/internal/util/debuglog.ts
@@ -63,7 +63,7 @@ function debuglogImpl(
 // be accessed.
 export function debuglog(
   set: string,
-  cb: (debug: (...args: unknown[]) => void) => void,
+  cb?: (debug: (...args: unknown[]) => void) => void,
 ) {
   function init() {
     set = set.toUpperCase();


### PR DESCRIPTION
`util.debuglog(section[, callback])`