### PR TITLE
fix(streams): don't use shared buffer for iterateReader outputs

### DIFF
--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -494,8 +494,8 @@ export async function* iterateReader(
   },
 ): AsyncIterableIterator<Uint8Array> {
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
-  const b = new Uint8Array(bufSize);
   while (true) {
+    const b = new Uint8Array(bufSize);
     const result = await r.read(b);
     if (result === null) {
       break;
@@ -545,8 +545,8 @@ export function* iterateReaderSync(
   },
 ): IterableIterator<Uint8Array> {
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
-  const b = new Uint8Array(bufSize);
   while (true) {
+    const b = new Uint8Array(bufSize);
     const result = r.readSync(b);
     if (result === null) {
       break;


### PR DESCRIPTION
`iterateReader` and `iterateReaderSync` use shared underlying buffer for its outputs. This causes the issue when the consumer of iterable is slow at handling these bytes. (Especially when used in `fetch` body, the request body can be corrupted in real world use cases. See https://github.com/denoland/deno/issues/14437 for details.)

closes https://github.com/denoland/deno/issues/14437