### PR TITLE
chore: deprecate `std/textproto`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@
 
 # deno std
 _util/        @bartlomieju @kt3k
-_wasm_crypto/ @bartlomieju @kt3k
 archive/      @bartlomieju @kt3k
 async/        @bartlomieju @kt3k
 bytes/        @bartlomieju @kt3k
@@ -20,13 +19,11 @@ hash/         @bartlomieju @kt3k
 http/         @bartlomieju @kt3k
 io/           @bartlomieju @kt3k
 log/          @bartlomieju @kt3k
-mime/         @bartlomieju @kt3k
 node/         @bartlomieju @kt3k
 path/         @bartlomieju @kt3k
 permissions/  @bartlomieju @kt3k
 signal/       @bartlomieju @kt3k
 streams/      @bartlomieju @kt3k
 testing/      @bartlomieju @kt3k
-textproto/    @bartlomieju @kt3k
 uuid/         @bartlomieju @kt3k
 wasi/         @bartlomieju @kt3k

--- a/examples/chat/server_test.ts
+++ b/examples/chat/server_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../../testing/asserts.ts";
-import { TextProtoReader } from "../../textproto/mod.ts";
 import { BufReader } from "../../io/buffer.ts";
 import { delay } from "../../async/delay.ts";
 import { dirname, fromFileUrl, resolve } from "../../path/mod.ts";
@@ -24,9 +23,12 @@ async function startServer(): Promise<
   });
   try {
     assert(server.stdout != null);
-    const r = new TextProtoReader(new BufReader(server.stdout));
+    const r = new BufReader(server.stdout);
     const s = await r.readLine();
-    assert(s !== null && s.includes("chat server starting"));
+    assert(
+      s !== null &&
+        new TextDecoder().decode(s.line).includes("chat server starting"),
+    );
   } catch {
     server.stdout.close();
     server.close();

--- a/textproto/mod.ts
+++ b/textproto/mod.ts
@@ -3,12 +3,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/**
+/** **Deprecated**. Use `TextLineStream` from `std/steams` for line-by-line text reading instead.
+ *
  * A reader for dealing with low level text based protocols.
  *
  * Based on
  * [net/textproto](https://github.com/golang/go/tree/master/src/net/textproto).
  *
+ * @deprecated (will be removed after 0.159.0) Use `TextLineStream` from `std/steams` for line-by-line text reading instead.
  * @module
  */
 

--- a/textproto/mod.ts
+++ b/textproto/mod.ts
@@ -33,6 +33,9 @@ function str(buf: Uint8Array | null | undefined): string {
   return !buf ? "" : decoder.decode(buf);
 }
 
+/**
+ * @deprecated (will be removed after 0.159.0) Use `TextLineStream` from `std/steams` for line-by-line text reading instead.
+ */
 export class TextProtoReader {
   constructor(readonly r: BufReader) {}
 


### PR DESCRIPTION
This PR deprecates `std/textproto` in 0.159.0 for removal in 0.160.0 and closes #2609.

Concerns:
1. Is the recommended alternative in the deprecation description valid?
2. Is the deprecation timeframe reasonable?