### PR TITLE
feat(http/file_server): add `showIndex` option to serveDir

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1047,6 +1047,35 @@ Deno.test(
 );
 
 Deno.test(
+  "serveDir serves index.html when showIndex is true",
+  async () => {
+    const url = "http://localhost:4507/http/testdata/subdir-with-index/";
+    const expectedText = "This is subdir-with-index/index.html";
+    {
+      const res = await serveDir(new Request(url), { showIndex: true });
+      assertEquals(res.status, 200);
+      assertStringIncludes(await res.text(), expectedText);
+    }
+
+    {
+      // showIndex is true by default
+      const res = await serveDir(new Request(url));
+      assertEquals(res.status, 200);
+      assertStringIncludes(await res.text(), expectedText);
+    }
+  },
+);
+
+Deno.test(
+  "serveDir doesn't serve index.html when showIndex is false",
+  async () => {
+    const url = "http://localhost:4507/http/testdata/subdir-with-index/";
+    const res = await serveDir(new Request(url), { showIndex: false });
+    assertEquals(res.status, 404);
+  },
+);
+
+Deno.test(
   "file_server returns 304 for requests with if-none-match set with the etag but with W/ prefixed etag in request headers.",
   async () => {
     await startFileServer();

--- a/http/testdata/subdir-with-index/index.html
+++ b/http/testdata/subdir-with-index/index.html
@@ -1,0 +1,1 @@
+This is subdir-with-index/index.html


### PR DESCRIPTION
This PR adds option to `serveDir` which controls whether it serves `index.html` as index of dir or not. Default is true.

closes #2709 