### PR TITLE
refactor(http/file_server): simplify normalizeURL util

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -620,37 +620,7 @@ export async function serveDir(req: Request, opts: ServeDirOptions = {}) {
 }
 
 function normalizeURL(url: string): string {
-  let normalizedUrl = url;
-
-  try {
-    //allowed per https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html
-    const absoluteURI = new URL(normalizedUrl);
-    normalizedUrl = absoluteURI.pathname;
-  } catch (e) {
-    //wasn't an absoluteURI
-    if (!(e instanceof TypeError)) {
-      throw e;
-    }
-  }
-
-  try {
-    normalizedUrl = decodeURIComponent(normalizedUrl);
-  } catch (e) {
-    if (!(e instanceof URIError)) {
-      throw e;
-    }
-  }
-
-  if (normalizedUrl[0] !== "/") {
-    throw new URIError("The request URI is malformed.");
-  }
-
-  normalizedUrl = posix.normalize(normalizedUrl);
-  const startOfParams = normalizedUrl.indexOf("?");
-
-  return startOfParams > -1
-    ? normalizedUrl.slice(0, startOfParams)
-    : normalizedUrl;
+  return posix.normalize(decodeURIComponent(new URL(url).pathname));
 }
 
 function main() {

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -327,7 +327,7 @@ Deno.test("checkURIEncodedPathTraversal", async function () {
 Deno.test("serveWithUnorthodoxFilename", async function () {
   await startFileServer();
   try {
-    let res = await fetch("http://localhost:4507/testdata/%");
+    let res = await fetch("http://localhost:4507/testdata/%25");
     assert(res.headers.has("access-control-allow-origin"));
     assert(res.headers.has("access-control-allow-headers"));
     assertEquals(res.status, 200);


### PR DESCRIPTION
The most of normalizeURL validations/path processing now seem useless because the basic validations are already done in CLI layer. This PR updates and simplifies it.