### PR TITLE
feat(node/crypto): add base64url encoding to hash.digest()

### DIFF
--- a/node/crypto_test.ts
+++ b/node/crypto_test.ts
@@ -44,7 +44,7 @@ Deno.test("[node/crypto.Hash] basic usage - base64 output", () => {
 });
 
 Deno.test("[node/crypto.Hash] basic usage - base64url output", () => {
-  const d = createHash("sha1").update("abc").update("def").digest("base64");
+  const d = createHash("sha1").update("abc").update("def").digest("base64url");
   assertEquals(d, "H4rBDyPFtbwRZ72oS4M-XAV6d9I");
 });
 

--- a/node/crypto_test.ts
+++ b/node/crypto_test.ts
@@ -38,6 +38,16 @@ Deno.test("[node/crypto.Hash] basic usage - hex output", () => {
   assertEquals(d, "1f8ac10f23c5b5bc1167bda84b833e5c057a77d2");
 });
 
+Deno.test("[node/crypto.Hash] basic usage - base64 output", () => {
+  const d = createHash("sha1").update("abc").update("def").digest("base64");
+  assertEquals(d, "H4rBDyPFtbwRZ72oS4M+XAV6d9I=");
+});
+
+Deno.test("[node/crypto.Hash] basic usage - base64url output", () => {
+  const d = createHash("sha1").update("abc").update("def").digest("base64");
+  assertEquals(d, "H4rBDyPFtbwRZ72oS4M-XAV6d9I");
+});
+
 Deno.test("[node/crypto.Hash] streaming usage", async () => {
   const source = Readable.from(["abc", "def"]);
   const hash = createHash("sha1");

--- a/node/internal/crypto/hash.ts
+++ b/node/internal/crypto/hash.ts
@@ -10,6 +10,7 @@ import { Buffer } from "../../buffer.ts";
 import { Transform } from "../../stream.ts";
 import { encode as encodeToHex } from "../../../encoding/hex.ts";
 import { encode as encodeToBase64 } from "../../../encoding/base64.ts";
+import { encode as encodeToBase64Url } from "../../../encoding/base64url.ts";
 import type { TransformOptions } from "../../_stream.d.ts";
 import { validateString } from "../validators.mjs";
 import { notImplemented } from "../../_utils.ts";
@@ -115,6 +116,8 @@ export class Hash extends Transform {
         return String.fromCharCode(...digest);
       case "base64":
         return encodeToBase64(digest);
+      case "base64url":
+        return encodeToBase64Url(digest);
       default:
         throw new Error(
           `The output encoding for hash digest is not implemented: ${encoding}`,

--- a/node/internal/crypto/hash.ts
+++ b/node/internal/crypto/hash.ts
@@ -101,7 +101,7 @@ export class Hash extends Transform {
    *
    * If encoding is provided a string will be returned; otherwise a Buffer is returned.
    *
-   * Supported encoding is currently 'hex', 'binary', 'base64'.
+   * Supported encodings are currently 'hex', 'binary', 'base64', 'base64url'.
    */
   digest(encoding?: string): Buffer | string {
     const digest = this.#context.digest(undefined);


### PR DESCRIPTION
This is supported in Node:
> - `'base64url'`: [base64url](https://tools.ietf.org/html/rfc4648#section-5) encoding as specified in [RFC 4648, Section 5](https://tools.ietf.org/html/rfc4648#section-5).
https://nodejs.org/dist/latest-v16.x/docs/api/buffer.html#buffers-and-character-encodings