### PR TITLE
fix(node): handle inherited output in spawnSync()

### DIFF
--- a/node/child_process_test.ts
+++ b/node/child_process_test.ts
@@ -534,5 +534,5 @@ Deno.test({
 });
 
 Deno.test("[node/child_process execFileSync] 'inherit' stdout and stderr", () => {
-  execFileSync(process.execPath, ["--help"], { stdio: "inherit" });
+  execFileSync(Deno.execPath(), ["--help"], { stdio: "inherit" });
 });

--- a/node/child_process_test.ts
+++ b/node/child_process_test.ts
@@ -14,7 +14,7 @@ import * as path from "../path/mod.ts";
 import { Buffer } from "./buffer.ts";
 import { ERR_CHILD_PROCESS_STDIO_MAXBUFFER } from "./internal/errors.ts";
 
-const { spawn, execFile, ChildProcess } = CP;
+const { spawn, execFile, execFileSync, ChildProcess } = CP;
 
 function withTimeout<T>(timeoutInMS: number): Deferred<T> {
   const promise = deferred<T>();
@@ -531,4 +531,8 @@ Deno.test({
     await p;
     assertEquals(output, "foo\ntrue\ntrue\ntrue\n");
   },
+});
+
+Deno.test("[node/child_process execFileSync] 'inherit' stdout and stderr", () => {
+  execFileSync(process.execPath, ["--help"], { stdio: "inherit" });
 });


### PR DESCRIPTION
Deno.spawnSync() returns getters for stdout and stderr which throw when 'inherit' is used. This commit updates Node's spawnSync() to handle this case.

Fixes: https://github.com/denoland/deno_std/issues/2742