### PR TITLE
chore(streams): memory optimizations by avoiding large buffer allocation in a loop

### DIFF
--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -494,14 +494,14 @@ export async function* iterateReader(
   },
 ): AsyncIterableIterator<Uint8Array> {
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
+  const b = new Uint8Array(bufSize);
   while (true) {
-    const b = new Uint8Array(bufSize);
     const result = await r.read(b);
     if (result === null) {
       break;
     }
 
-    yield b.subarray(0, result);
+    yield b.slice(0, result);
   }
 }
 
@@ -545,14 +545,14 @@ export function* iterateReaderSync(
   },
 ): IterableIterator<Uint8Array> {
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
+  const b = new Uint8Array(bufSize);
   while (true) {
-    const b = new Uint8Array(bufSize);
     const result = r.readSync(b);
     if (result === null) {
       break;
     }
 
-    yield b.subarray(0, result);
+    yield b.slice(0, result);
   }
 }
 


### PR DESCRIPTION
Amending https://github.com/denoland/deno_std/pull/2735

I read the awesome blog entry[^blog] by @kt3k, which describes how he found the difficult bug, and I recognized that his patch could be slightly better in memory allocation.

This PR uses `Uint8Array.prototype.slice()`, which returns a new Uint8Array with a new underlying ArrayBuffer.

Consider `bufSize: 1024 * 1024 * 1024 /* 1MiB */`. In the current code, `new Uint8Array(bufSize)` allocates 1MiB buffer, and initializes it with zero for each loop block. Instead, with this patch, a large buffer will be allocated before the loop, and `.slice` creates a Uint8Array with an underlying ArrayBuffer that allocates only the required size. It might not be a problem when `bufSize` is small but could consume unnecessary memory when `bufSize` is large[^deno_reader]. 

[^blog]: https://qiita.com/kt3k/items/77e715a790d84cd73878 (ja)
[^deno_reader]: https://deno.land/api@v1.26.0?s=Deno.Reader#method_read_0 "If some data is available but not p.byteLength bytes, read() conventionally resolves to what is available **instead of waiting for more**."