### PR TITLE
fix(node/tls): set tlssocket._handle._parentWrap

### DIFF
--- a/node/_tls_wrap.ts
+++ b/node/_tls_wrap.ts
@@ -142,6 +142,11 @@ export class TLSSocket extends net.Socket {
       (handle as any).verifyError = function () {
         return null; // Never fails, rejectUnauthorized is always true in Deno.
       };
+      // Pretends `handle` is `tls_wrap.wrap(handle, ...)` to make some npm modules happy
+      // An example usage of `_parentWrap` in npm module:
+      // https://github.com/szmarczak/http2-wrapper/blob/51eeaf59ff9344fb192b092241bfda8506983620/source/utils/js-stream-socket.js#L6
+      handle._parent = handle;
+      handle._parentWrap = wrap;
 
       return handle;
     }

--- a/node/tls_test.ts
+++ b/node/tls_test.ts
@@ -98,8 +98,8 @@ Deno.test("tls.createServer creates a TLS server", async () => {
 Deno.test("tlssocket._handle._parentWrap is set", () => {
   // Note: This feature is used in popular 'http2-wrapper' module
   // https://github.com/szmarczak/http2-wrapper/blob/51eeaf59ff9344fb192b092241bfda8506983620/source/utils/js-stream-socket.js#L6
-  // deno-lint-ignore no-explicit-any
   const parentWrap =
+    // deno-lint-ignore no-explicit-any
     (new tls.TLSSocket(new stream.PassThrough(), {})._handle as any)!
       ._parentWrap;
   assertInstanceOf(parentWrap, stream.PassThrough);

--- a/node/tls_test.ts
+++ b/node/tls_test.ts
@@ -1,12 +1,13 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "../testing/asserts.ts";
+import { assertEquals, assertInstanceOf } from "../testing/asserts.ts";
 import { delay } from "../async/delay.ts";
 import { deferred } from "../async/deferred.ts";
 import { fromFileUrl, join } from "./path.ts";
 import { serveTls } from "../http/server.ts";
 import * as tls from "./tls.ts";
 import * as net from "./net.ts";
+import * as stream from "./stream.ts";
 
 const tlsTestdataDir = fromFileUrl(
   new URL("../http/testdata/tls", import.meta.url),
@@ -92,4 +93,14 @@ Deno.test("tls.createServer creates a TLS server", async () => {
     p.resolve();
   });
   await p;
+});
+
+Deno.test("tlssocket._handle._parentWrap is set", () => {
+  // Note: This feature is used in popular 'http2-wrapper' module
+  // https://github.com/szmarczak/http2-wrapper/blob/51eeaf59ff9344fb192b092241bfda8506983620/source/utils/js-stream-socket.js#L6
+  // deno-lint-ignore no-explicit-any
+  const parentWrap =
+    (new tls.TLSSocket(new stream.PassThrough(), {})._handle as any)!
+      ._parentWrap;
+  assertInstanceOf(parentWrap, stream.PassThrough);
 });


### PR DESCRIPTION
This PR improves the compatibility of TLSSocket.

An npm module `http2-wrapper` (which has 5M weekly downloads) has the following line to extract `JSStreamSocket` from the internal property of TLSSocket.

```js
const JSStreamSocket = (new tls.TLSSocket(new stream.PassThrough()))._handle._parentWrap.constructor;
```

This PR still doesn't fully support this hack (because we don't have `JSStreamSocket` implementation at all), but at least this enables the above line passing (and as a result `deno run -A --unstable npm:web-ext --version` works with this fix and #2749 )