### PR TITLE
docs: Using absolute paths in jsdoc import statements

### DIFF
--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -23,7 +23,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * aborted.
  *
  * ```
- * import { debounce } from "./debounce.ts";
+ * import { debounce } from "https://deno.land/std@$STD_VERSION/async/debounce.ts";
  *
  * const log = debounce(
  *   (event: Deno.FsEvent) =>

--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -17,7 +17,7 @@ export interface Deferred<T> extends Promise<T> {
  * placed as methods on the promise object itself. It allows you to do:
  *
  * ```ts
- *     import { deferred } from "./deferred.ts";
+ *     import { deferred } from "https://deno.land/std@$STD_VERSION/async/deferred.ts";
  *
  *     const p = deferred<number>();
  *     // ...

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -52,7 +52,7 @@ class Queue<T> {
  * Example:
  *
  * ```ts
- *     import { tee } from "./tee.ts";
+ *     import { tee } from "https://deno.land/std@$STD_VERSION/async/tee.ts";
  *
  *     const gen = async function* gen() {
  *       yield 1;

--- a/bytes/mod.ts
+++ b/bytes/mod.ts
@@ -17,7 +17,7 @@
  * The complexity of this function is O(source.lenth * needle.length).
  *
  * ```ts
- * import { indexOfNeedle } from "./mod.ts";
+ * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(indexOfNeedle(source, needle)); // 1
@@ -64,7 +64,7 @@ export function indexOfNeedle(
  * The complexity of this function is O(source.lenth * needle.length).
  *
  * ```ts
- * import { lastIndexOfNeedle } from "./mod.ts";
+ * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(lastIndexOfNeedle(source, needle)); // 5
@@ -108,7 +108,7 @@ export function lastIndexOfNeedle(
  * The complexity of this function is O(prefix.length).
  *
  * ```ts
- * import { startsWith } from "./mod.ts";
+ * import { startsWith } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const prefix = new Uint8Array([0, 1, 2]);
  * console.log(startsWith(source, prefix)); // true
@@ -127,7 +127,7 @@ export function startsWith(source: Uint8Array, prefix: Uint8Array): boolean {
  * The complexity of this function is O(suffix.length).
  *
  * ```ts
- * import { endsWith } from "./mod.ts";
+ * import { endsWith } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const suffix = new Uint8Array([1, 2, 3]);
  * console.log(endsWith(source, suffix)); // true
@@ -150,7 +150,7 @@ export function endsWith(source: Uint8Array, suffix: Uint8Array): boolean {
  * If `count` is negative, a `RangeError` is thrown.
  *
  * ```ts
- * import { repeat } from "./mod.ts";
+ * import { repeat } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2]);
  * console.log(repeat(source, 3)); // [0, 1, 2, 0, 1, 2, 0, 1, 2]
  * console.log(repeat(source, 0)); // []
@@ -188,7 +188,7 @@ export function repeat(source: Uint8Array, count: number): Uint8Array {
 /** Concatenate the given arrays into a new Uint8Array.
  *
  * ```ts
- * import { concat } from "./mod.ts";
+ * import { concat } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);
  * console.log(concat(a, b)); // [0, 1, 2, 3, 4, 5]
@@ -217,7 +217,7 @@ export function concat(...buf: Uint8Array[]): Uint8Array {
  * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
- * import { includesNeedle } from "./mod.ts";
+ * import { includesNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(includesNeedle(source, needle)); // true
@@ -243,7 +243,7 @@ export function includesNeedle(
  * the array.
  *
  * ```ts
- * import { copy } from "./mod.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const src = new Uint8Array([9, 8, 7]);
  * const dst = new Uint8Array([0, 1, 2, 3, 4, 5]);
  * console.log(copy(src, dst)); // 3
@@ -251,7 +251,7 @@ export function includesNeedle(
  * ```
  *
  * ```ts
- * import { copy } from "./mod.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
  * const src = new Uint8Array([1, 1, 1, 1]);
  * const dst = new Uint8Array([0, 0, 0, 0]);
  * console.log(copy(src, dst, 1)); // 3

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -167,7 +167,7 @@ export type DifferenceOptions = {
  * example :
  *
  * ```typescript
- * import * as datetime from "./mod.ts";
+ * import * as datetime from "https://deno.land/std@$STD_VERSION/datetime/mod.ts";
  *
  * datetime.difference(new Date("2020/1/1"),new Date("2020/2/2"),{ units : ["days","months"] })
  * ```

--- a/encoding/varint/mod.ts
+++ b/encoding/varint/mod.ts
@@ -14,7 +14,7 @@ const U64MAX = 18_446_744_073_709_551_615n;
 /**
  * Encodes the given `number` into `Uint8Array` with LEB128. The number needs to be in the range of `0` and `0xffffffff`.
  * ```ts
- * import { encodeU32 } from "./mod.ts";
+ * import { encodeU32 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
  *
  * const encodedValue = encodeU32(42);
  * // Do something with the encoded value
@@ -35,7 +35,7 @@ export function encodeU32(val: number): Uint8Array {
 /**
  * Encodes the given `BigInt` into `Uint8Array` with LEB128. The number needs to be in the range of `0` and `0xffffffffffffffff`.
  * ```ts
- * import { encodeU64 } from "./mod.ts";
+ * import { encodeU64 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
  *
  * const encodedValue = encodeU64(42n);
  * // Do something with the encoded value
@@ -55,7 +55,7 @@ export function encodeU64(val: bigint): Uint8Array {
 /**
  * Decodes the given `Uint8Array` into a `number` with LEB128.
  * ```ts
- * import { decodeU32 } from "./mod.ts";
+ * import { decodeU32 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
  * const bytes = Uint8Array.from([221, 199, 1]);
  * const decodedValue = decodeU32(bytes);
  *
@@ -76,7 +76,7 @@ export function decodeU32(val: Uint8Array): number {
 /**
  * Decodes the given `Uint8Array` into a `BigInt` with LEB128.
  * ```ts
- * import { decodeU64 } from "./mod.ts";
+ * import { decodeU64 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
  * const bytes = Uint8Array.from([221, 199, 1]);
  * const decodedValue = decodeU64(bytes);
  *

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -234,7 +234,7 @@ export interface ParseOptions<
    *
    * ```ts
    * // $ deno run example.ts -- a arg1
-   * import { parse } from "./mod.ts";
+   * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
    * console.dir(parse(Deno.args, { "--": false }));
    * // output: { _: [ "a", "arg1" ] }
    * console.dir(parse(Deno.args, { "--": true }));
@@ -332,12 +332,12 @@ function hasKey(obj: NestedMapping, keys: string[]): boolean {
  * available in the `_` property of the returned object.
  *
  * ```ts
- * import { parse } from "./mod.ts";
+ * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
  * const parsedArgs = parse(Deno.args);
  * ```
  *
  * ```ts
- * import { parse } from "./mod.ts";
+ * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
  * const parsedArgs = parse(["--foo", "--bar=baz", "./quux.txt"]);
  * // parsedArgs: { foo: true, bar: "baz", _: ["./quux.txt"] }
  * ```

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -448,7 +448,7 @@ export function bgRgb8(str: string, color: number): string {
  * To produce the color magenta:
  *
  * ```ts
- *      import { rgb24 } from "./colors.ts";
+ *      import { rgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *      rgb24("foo", 0xff00ff);
  *      rgb24("foo", {r: 255, g: 0, b: 255});
  * ```
@@ -488,7 +488,7 @@ export function rgb24(str: string, color: number | Rgb): string {
  * To produce the color magenta:
  *
  * ```ts
- *      import { bgRgb24 } from "./colors.ts";
+ *      import { bgRgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *      bgRgb24("foo", 0xff00ff);
  *      bgRgb24("foo", {r: 255, g: 0, b: 255});
  * ```

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -66,7 +66,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  *
  * Example:
  * ```ts
- *      import { expandGlob } from "./expand_glob.ts";
+ *      import { expandGlob } from "https://deno.land/std@$STD_VERSION/fs/expand_glob.ts";
  *      for await (const file of expandGlob("**\/*.ts")) {
  *        console.log(file);
  *      }
@@ -174,7 +174,7 @@ export async function* expandGlob(
  * Example:
  *
  * ```ts
- *      import { expandGlobSync } from "./expand_glob.ts";
+ *      import { expandGlobSync } from "https://deno.land/std@$STD_VERSION/fs/expand_glob.ts";
  *      for (const file of expandGlobSync("**\/*.ts")) {
  *        console.log(file);
  *      }

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -67,8 +67,8 @@ export type { WalkEntry };
  * - skip?: RegExp[];
  *
  * ```ts
- *       import { walk } from "./walk.ts";
- *       import { assert } from "../testing/asserts.ts";
+ *       import { walk } from "https://deno.land/std@$STD_VERSION/fs/walk.ts";
+ *       import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  *       for await (const entry of walk(".")) {
  *         console.log(entry.path);

--- a/io/files.ts
+++ b/io/files.ts
@@ -19,8 +19,8 @@ export interface ByteRange {
  * range.
  *
  * ```ts
- * import { assertEquals } from "../testing/asserts.ts";
- * import { readRange } from "./files.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+ * import { readRange } from "https://deno.land/std@$STD_VERSION/io/files.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = await Deno.open("example.txt", { read: true });
@@ -57,8 +57,8 @@ export async function readRange(
  * within that range.
  *
  * ```ts
- * import { assertEquals } from "../testing/asserts.ts";
- * import { readRangeSync } from "./files.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+ * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/files.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = Deno.openSync("example.txt", { read: true });

--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -20,7 +20,7 @@ export interface Reader {
    *
    * Implementations should not retain a reference to `p`.
    *
-   * Use iterateReader() from https://deno.land/std/streams/conversion.ts to turn a Reader into an
+   * Use iterateReader() from https://deno.land/std@$STD_VERSION/streams/conversion.ts to turn a Reader into an
    * AsyncIterator.
    */
   read(p: Uint8Array): Promise<number | null>;
@@ -45,7 +45,7 @@ export interface ReaderSync {
    *
    * Implementations should not retain a reference to `p`.
    *
-   * Use iterateReaderSync() from https://deno.land/std/streams/conversion.ts to turn a ReaderSync
+   * Use iterateReaderSync() from https://deno.land/std@$STD_VERSION/streams/conversion.ts to turn a ReaderSync
    * into an Iterator.
    */
   readSync(p: Uint8Array): number | null;

--- a/node/module.ts
+++ b/node/module.ts
@@ -665,7 +665,7 @@ class Module {
    * Also injects available Node.js builtin module polyfills.
    *
    * ```ts
-   *     import { createRequire } from "./module.ts";
+   *     import { createRequire } from "https://deno.land/std@$STD_VERSION/node/module.ts";
    *     const require = createRequire(import.meta.url);
    *     const fs = require("fs");
    *     const leftPad = require("left-pad");

--- a/node/path/posix.ts
+++ b/node/path/posix.ts
@@ -478,7 +478,7 @@ export function parse(path: string): ParsedPath {
  * Converts a file URL to a path string.
  *
  * ```ts
- *      import { fromFileUrl } from "./posix.ts";
+ *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/node/path/posix.ts";
  *      fromFileUrl("file:///home/foo"); // "/home/foo"
  * ```
  * @param url of a file URL
@@ -497,7 +497,7 @@ export function fromFileUrl(url: string | URL): string {
  * Converts a path string to a file URL.
  *
  * ```ts
- *      import { toFileUrl } from "./posix.ts";
+ *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/node/path/posix.ts";
  *      toFileUrl("/home/foo"); // new URL("file:///home/foo")
  * ```
  * @param path to convert to file URL

--- a/node/path/win32.ts
+++ b/node/path/win32.ts
@@ -952,7 +952,7 @@ export function parse(path: string): ParsedPath {
  * Converts a file URL to a path string.
  *
  * ```ts
- *      import { fromFileUrl } from "./win32.ts";
+ *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/node/path/win32.ts";
  *      fromFileUrl("file:///home/foo"); // "\\home\\foo"
  *      fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"
  *      fromFileUrl("file://localhost/home/foo"); // "\\\\localhost\\home\\foo"
@@ -980,7 +980,7 @@ export function fromFileUrl(url: string | URL): string {
  * Converts a path string to a file URL.
  *
  * ```ts
- *      import { toFileUrl } from "./win32.ts";
+ *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/node/path/win32.ts";
  *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
  *      toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")
  *      toFileUrl("\\\\127.0.0.1\\home\\foo"); // new URL("file://127.0.0.1/home/foo")

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -481,7 +481,7 @@ export function parse(path: string): ParsedPath {
  * Converts a file URL to a path string.
  *
  * ```ts
- *      import { fromFileUrl } from "./posix.ts";
+ *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
  *      fromFileUrl("file:///home/foo"); // "/home/foo"
  * ```
  * @param url of a file URL
@@ -500,7 +500,7 @@ export function fromFileUrl(url: string | URL): string {
  * Converts a path string to a file URL.
  *
  * ```ts
- *      import { toFileUrl } from "./posix.ts";
+ *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
  *      toFileUrl("/home/foo"); // new URL("file:///home/foo")
  * ```
  * @param path to convert to file URL

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -955,7 +955,7 @@ export function parse(path: string): ParsedPath {
  * Converts a file URL to a path string.
  *
  * ```ts
- *      import { fromFileUrl } from "./win32.ts";
+ *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
  *      fromFileUrl("file:///home/foo"); // "\\home\\foo"
  *      fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"
  *      fromFileUrl("file://localhost/home/foo"); // "\\\\localhost\\home\\foo"
@@ -983,7 +983,7 @@ export function fromFileUrl(url: string | URL): string {
  * Converts a path string to a file URL.
  *
  * ```ts
- *      import { toFileUrl } from "./win32.ts";
+ *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
  *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
  *      toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")
  *      toFileUrl("\\\\127.0.0.1\\home\\foo"); // new URL("file://127.0.0.1/home/foo")

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -34,7 +34,7 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
  * the permissions that are granted.
  *
  * ```ts
- *      import { grant } from "./mod.ts";
+ *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      const perms = await grant({ name: "net" }, { name: "read" });
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
@@ -52,7 +52,7 @@ export async function grant(
  * the permissions that are granted.
  *
  * ```ts
- *      import { grant } from "./mod.ts";
+ *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      const perms = await grant([{ name: "net" }, { name: "read" }]);
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
@@ -89,7 +89,7 @@ export async function grant(
 /** Attempts to grant a set of permissions or rejects.
  *
  * ```ts
- *      import { grantOrThrow } from "./mod.ts";
+ *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      await grantOrThrow({ name: "env" }, { name: "net" });
  * ```
  *
@@ -103,7 +103,7 @@ export async function grantOrThrow(
 /** Attempts to grant a set of permissions or rejects.
  *
  * ```ts
- *      import { grantOrThrow } from "./mod.ts";
+ *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      await grantOrThrow([{ name: "env" }, { name: "net" }]);
  * ```
  *

--- a/signal/README.md
+++ b/signal/README.md
@@ -12,7 +12,7 @@ Generates an AsyncIterable which can be awaited on for one or more signals.
 `dispose()` can be called when you are finished waiting on the events.
 
 ```typescript
-import { signal } from "https://deno.land/std/signal/mod.ts";
+import { signal } from "https://deno.land/std@$STD_VERSION/signal/mod.ts";
 const sig = signal("SIGUSR1", "SIGINT");
 setTimeout(() => {}, 5000); // Prevents exiting immediately.
 

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -17,7 +17,7 @@ export type Disposable = { dispose: () => void };
  * Example:
  *
  * ```ts
- *       import { signal } from "./mod.ts";
+ *       import { signal } from "https://deno.land/std@$STD_VERSION/signal/mod.ts";
  *
  *       const sig = signal("SIGUSR1", "SIGINT");
  *       setTimeout(() => {}, 5000); // Prevents exiting immediately

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -175,7 +175,7 @@ export class Buffer {
  * an error will be thrown.
  *
  * ```ts
- * import { LimitedBytesTransformStream } from "./buffer.ts";
+ * import { LimitedBytesTransformStream } from "https://deno.land/std@$STD_VERSION/streams/buffer.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!
  *   .pipeThrough(new LimitedBytesTransformStream(512 * 1024));
@@ -208,7 +208,7 @@ export class LimitedBytesTransformStream
  * an error will be thrown.
  *
  * ```ts
- * import { LimitedTransformStream } from "./buffer.ts";
+ * import { LimitedTransformStream } from "https://deno.land/std@$STD_VERSION/streams/buffer.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!.pipeThrough(new LimitedTransformStream(50));
  * ```

--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -14,7 +14,7 @@ function isCloser(value: unknown): value is Deno.Closer {
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
  * ```ts
- *      import { readerFromIterable, copy } from "./conversion.ts";
+ *      import { readerFromIterable, copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  *      const file = await Deno.open("metrics.txt", { write: true });
  *      const reader = readerFromIterable((async function* () {
@@ -138,7 +138,7 @@ export function writableStreamFromWriter(
 /** Create a `ReadableStream` from any kind of iterable.
  *
  * ```ts
- *      import { readableStreamFromIterable } from "./conversion.ts";
+ *      import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  *      const r1 = readableStreamFromIterable(["foo, bar, baz"]);
  *      const r2 = readableStreamFromIterable(async function* () {
@@ -157,7 +157,7 @@ export function writableStreamFromWriter(
  * `readableStream.cancel()`. This is the case for the second input type above:
  *
  * ```ts
- * import { readableStreamFromIterable } from "./conversion.ts";
+ * import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * const r3 = readableStreamFromIterable(async function* () {
  *   try {
@@ -200,7 +200,7 @@ export function readableStreamFromIterable<T>(
  * Convert the generator function into a TransformStream.
  *
  * ```ts
- * import { readableStreamFromIterable, toTransformStream } from "./conversion.ts";
+ * import { readableStreamFromIterable, toTransformStream } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * const readable = readableStreamFromIterable([0, 1, 2])
  *   .pipeThrough(toTransformStream(async function* (src) {
@@ -293,7 +293,7 @@ export interface ReadableStreamFromReaderOptions {
  * An example converting a `Deno.FsFile` into a readable stream:
  *
  * ```ts
- * import { readableStreamFromReader } from "./mod.ts";
+ * import { readableStreamFromReader } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
  *
  * const file = await Deno.open("./file.txt", { read: true });
  * const fileStream = readableStreamFromReader(file);
@@ -341,8 +341,8 @@ export function readableStreamFromReader(
  * Uint8Array`.
  *
  * ```ts
- * import { Buffer } from "../io/buffer.ts";
- * import { readAll } from "./conversion.ts";
+ * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
+ * import { readAll } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * // Example from stdin
  * const stdinContent = await readAll(Deno.stdin);
@@ -369,8 +369,8 @@ export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
  * as `Uint8Array`.
  *
  * ```ts
- * import { Buffer } from "../io/buffer.ts";
- * import { readAllSync } from "./conversion.ts";
+ * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
+ * import { readAllSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * // Example from stdin
  * const stdinContent = readAllSync(Deno.stdin);
@@ -396,8 +396,8 @@ export function readAllSync(r: Deno.ReaderSync): Uint8Array {
 /** Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
  * ```ts
- * import { Buffer } from "../io/buffer.ts";
- * import { writeAll } from "./conversion.ts";
+ * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
+ * import { writeAll } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");
@@ -427,8 +427,8 @@ export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
  * writer (`w`).
  *
  * ```ts
- * import { Buffer } from "../io/buffer.ts";
- * import { writeAllSync } from "./conversion.ts";
+ * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
+ * import { writeAllSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");
@@ -457,7 +457,7 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array) {
 /** Turns a Reader, `r`, into an async iterator.
  *
  * ```ts
- * import { iterateReader } from "./conversion.ts";
+ * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * for await (const chunk of iterateReader(f)) {
@@ -470,7 +470,7 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array) {
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iterateReader } from "./conversion.ts";
+ * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * const it = iterateReader(f, {
@@ -508,7 +508,7 @@ export async function* iterateReader(
 /** Turns a ReaderSync, `r`, into an iterator.
  *
  * ```ts
- * import { iterateReaderSync } from "./conversion.ts";
+ * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * let f = Deno.openSync("/etc/passwd");
  * for (const chunk of iterateReaderSync(f)) {
@@ -521,7 +521,7 @@ export async function* iterateReader(
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iterateReaderSync } from "./conversion.ts";
+ * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 
  * let f = await Deno.open("/etc/passwd");
  * const iter = iterateReaderSync(f, {
@@ -561,7 +561,7 @@ export function* iterateReaderSync(
  * the first error encountered while copying.
  *
  * ```ts
- * import { copy } from "./conversion.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
  * const source = await Deno.open("my_file.txt");
  * const bytesCopied1 = await copy(source, Deno.stdout);

--- a/streams/delimiter.ts
+++ b/streams/delimiter.ts
@@ -12,7 +12,7 @@ interface TextLineStreamOptions {
  * be it `\n` or `\r\n`. `\r` can be enabled via the `allowCR` option.
  *
  * ```ts
- * import { TextLineStream } from "./delimiter.ts";
+ * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");
  * const lines = res.body!
  *   .pipeThrough(new TextDecoderStream())
@@ -70,7 +70,7 @@ export class TextLineStream extends TransformStream<string, string> {
 /** Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
  * ```ts
- * import { DelimiterStream } from "./delimiter.ts";
+ * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!
  *   .pipeThrough(new DelimiterStream(new TextEncoder().encode("foo")))
@@ -136,7 +136,7 @@ export class DelimiterStream extends TransformStream<Uint8Array, Uint8Array> {
 /** Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
  * ```ts
- * import { TextDelimiterStream } from "./delimiter.ts";
+ * import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!
  *   .pipeThrough(new TextDecoderStream())

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -155,7 +155,7 @@ export function assertFalse(expr: unknown, msg = ""): asserts expr is Falsy {
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
  * ```ts
- * import { assertEquals } from "./asserts.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertEquals<number>(1, 2)
  * ```
@@ -191,7 +191,7 @@ export function assertEquals<T>(actual: T, expected: T, msg?: string) {
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
  * ```ts
- * import { assertNotEquals } from "./asserts.ts";
+ * import { assertNotEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertNotEquals<number>(1, 2)
  * ```
@@ -223,7 +223,7 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
  * not then throw.
  *
  * ```ts
- * import { assertStrictEquals } from "./asserts.ts";
+ * import { assertStrictEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertStrictEquals(1, 2)
  * ```
@@ -277,7 +277,7 @@ export function assertStrictEquals<T>(
  * If the values are strictly equal then throw.
  *
  * ```ts
- * import { assertNotStrictEquals } from "./asserts.ts";
+ * import { assertNotStrictEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertNotStrictEquals(1, 1)
  * ```
@@ -303,7 +303,7 @@ export function assertNotStrictEquals<T>(
  * If the values are not almost equal then throw.
  *
  * ```ts
- * import { assertAlmostEquals, assertThrows } from "./asserts.ts";
+ * import { assertAlmostEquals, assertThrows } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertAlmostEquals(0.1, 0.2);
  *
@@ -429,7 +429,7 @@ export function assertStringIncludes(
  * For example:
  *
  * ```ts
- * import { assertArrayIncludes } from "./asserts.ts";
+ * import { assertArrayIncludes } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertArrayIncludes<number>([1, 2], [2])
  * ```

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -356,7 +356,7 @@ class AssertSnapshotContext {
  * Type parameter can be specified to ensure values under comparison have the same type.
  * For example:
  * ```ts
- * import { assertSnapshot } from "./snapshot.ts";
+ * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
  *
  * Deno.test("snapshot", async (test) => {
  *  await assertSnapshot<number>(test, 2);

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -26,7 +26,7 @@ export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
  * Check if the passed UUID is the nil UUID.
  *
  * ```js
- * import { isNil } from "./mod.ts";
+ * import { isNil } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts";
  *
  * isNil("00000000-0000-0000-0000-000000000000") // true
  * isNil(crypto.randomUUID()) // false
@@ -40,7 +40,7 @@ export function isNil(id: string): boolean {
  * Test a string to see if it is a valid UUID.
  *
  * ```js
- * import { validate } from "./mod.ts"
+ * import { validate } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
  *
  * validate("not a UUID") // false
  * validate("6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b") // true
@@ -57,7 +57,7 @@ export function validate(uuid: string): boolean {
  * Detect RFC version of a UUID.
  *
  * ```js
- * import { version } from "./mod.ts"
+ * import { version } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
  *
  * version("d9428888-122b-11e1-b85c-61cd3cbb3210") // 1
  * version("109156be-c4fb-41ea-b1b4-efe1671c5836") // 4

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -8,8 +8,8 @@ const UUID_RE =
  * Validate that the passed UUID is an RFC4122 v4 UUID.
  *
  * ```ts
- * import { validate } from "./v4.ts";
- * import { generate as generateV1 } from "./v1.ts";
+ * import { validate } from "https://deno.land/std@$STD_VERSION/uuid/v4.ts";
+ * import { generate as generateV1 } from "https://deno.land/std@$STD_VERSION/uuid/v1.ts";
  *
  * validate(crypto.randomUUID()); // true
  * validate(generateV1() as string); // false

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -12,7 +12,7 @@ const UUID_RE =
  * Validate that the passed UUID is an RFC4122 v5 UUID.
  *
  * ```ts
- * import { generate as generateV5, validate } from "./v5.ts";
+ * import { generate as generateV5, validate } from "https://deno.land/std@$STD_VERSION/uuid/v5.ts";
  *
  * validate(await generateV5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", new Uint8Array())); // true
  * validate(crypto.randomUUID()); // false
@@ -27,7 +27,7 @@ export function validate(id: string): boolean {
  * Generate a RFC4122 v5 UUID (SHA-1 namespace).
  *
  * ```js
- * import { generate } from "./v5.ts";
+ * import { generate } from "https://deno.land/std@$STD_VERSION/uuid/v5.ts";
  *
  * const NAMESPACE_URL = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
  *


### PR DESCRIPTION
Some documentation uses relative paths in import statements. It's nice to have this as an absolute path so people can copy and paste.

example: https://deno.land/std@0.159.0/streams/mod.ts?s=readAll

![image](https://user-images.githubusercontent.com/40050810/194756823-609e69cd-c7c9-416f-a35c-d722ce6aee23.png)
