### PR TITLE
chore: Avoid using rid-based filesystem functions

### DIFF
--- a/_util/download_file.ts
+++ b/_util/download_file.ts
@@ -20,8 +20,5 @@ export async function downloadFile(url: string, fileUrl: URL) {
 
   await ensureFile(fromFileUrl(fileUrl));
   const file = await Deno.open(fileUrl, { truncate: true, write: true });
-  for await (const chunk of response.body) {
-    Deno.writeSync(file.rid, chunk);
-  }
-  file.close();
+  await response.body.pipeTo(file.writable);
 }

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -137,9 +137,9 @@ class FileReader implements Reader {
     if (!this.#file) {
       this.#file = await Deno.open(this.filePath, { read: true });
     }
-    const res = await Deno.read(this.#file.rid, p);
+    const res = await this.#file.read(p);
     if (res === null) {
-      Deno.close(this.#file.rid);
+      this.#file.close();
       this.#file = undefined;
     }
     return res;

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -150,7 +150,7 @@ async function fetchExactPath(
     });
   } finally {
     if (conn) {
-      Deno.close(conn.rid);
+      conn.close();
     }
   }
 }

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -941,7 +941,7 @@ Deno.test("readLinesWithEncodingISO-8859-15", async function () {
     lines_.push(l);
   }
 
-  Deno.close(file_.rid);
+  file_.close();
 
   assertEquals(lines_.length, 12);
   assertEquals(lines_, [

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -227,7 +227,7 @@ export class RotatingFileHandler extends FileHandler {
 
   rotateLogFiles() {
     this._buf.flush();
-    Deno.close(this._file!.rid);
+    this._file!.close();
 
     for (let i = this.#maxBackupCount - 1; i >= 0; i--) {
       const source = this._filename + (i === 0 ? "" : "." + i);

--- a/node/_tools/setup.ts
+++ b/node/_tools/setup.ts
@@ -110,7 +110,7 @@ async function decompressTests(archivePath: string) {
   );
 
   const buffer = new Buffer(gunzip(await readAll(compressedFile)));
-  Deno.close(compressedFile.rid);
+  compressedFile.close();
 
   const tar = new Untar(buffer);
   const outFolder = dirname(fromFileUrl(new URL(archivePath, import.meta.url)));

--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -350,7 +350,7 @@ export function readableStreamFromReader(
  * // Example from file
  * const file = await Deno.open("my_file.txt", {read: true});
  * const myFileContent = await readAll(file);
- * Deno.close(file.rid);
+ * file.close();
  *
  * // Example from buffer
  * const myData = new Uint8Array(100);
@@ -378,7 +378,7 @@ export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
  * // Example from file
  * const file = Deno.openSync("my_file.txt", {read: true});
  * const myFileContent = readAllSync(file);
- * Deno.close(file.rid);
+ * file.close();
  *
  * // Example from buffer
  * const myData = new Uint8Array(100);
@@ -407,7 +407,7 @@ export function readAllSync(r: Deno.ReaderSync): Uint8Array {
  * contentBytes = new TextEncoder().encode("Hello World");
  * const file = await Deno.open('test.file', {write: true});
  * await writeAll(file, contentBytes);
- * Deno.close(file.rid);
+ * file.close();
  *
  * // Example writing to buffer
  * contentBytes = new TextEncoder().encode("Hello World");
@@ -438,7 +438,7 @@ export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
  * contentBytes = new TextEncoder().encode("Hello World");
  * const file = Deno.openSync('test.file', {write: true});
  * writeAllSync(file, contentBytes);
- * Deno.close(file.rid);
+ * file.close();
  *
  * // Example writing to buffer
  * contentBytes = new TextEncoder().encode("Hello World");


### PR DESCRIPTION
I think Deno CLI is trying to move away from using rid based filesystem functions. (https://github.com/denoland/deno/issues/12107, https://github.com/denoland/deno/issues/15796#issue-1364389627, https://github.com/denoland/deno/pull/15933#issuecomment-1250044922)
This PR removes the use of rid based functions from the standard library and replaces them with:

- `Deno.read(file.rid, buf)` -> `file.read(buf)`
- `Deno.write(file.rid, buf)` -> `file.write(buf)`
- `Deno.close(file.rid)` -> `file.close()`

(However, I didn't change `node` and `wasi` because they still seem to need rid-based functions.)

This is just a source code cleanup and does not change existing behavior.