### PR TITLE
chore(examples): Converting Deno Streams to Web Streams

### DIFF
--- a/examples/cat.ts
+++ b/examples/cat.ts
@@ -5,10 +5,8 @@
  * @module
  */
 
-import { copy } from "../streams/conversion.ts";
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
-  await copy(file, Deno.stdout);
-  file.close();
+  await file.readable.pipeTo(Deno.stdout.writable);
 }

--- a/examples/cat.ts
+++ b/examples/cat.ts
@@ -8,5 +8,5 @@
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
-  await file.readable.pipeTo(Deno.stdout.writable);
+  await file.readable.pipeTo(Deno.stdout.writable, { preventClose: true });
 }

--- a/examples/curl.ts
+++ b/examples/curl.ts
@@ -8,9 +8,4 @@
 const url_ = Deno.args[0];
 const res = await fetch(url_);
 
-// TODO(ry) Re-enable streaming in this example.
-// Originally we did: await Deno.copy(res.body, Deno.stdout);
-// But maybe more JS-y would be: res.pipeTo(Deno.stdout);
-
-const body = new Uint8Array(await res.arrayBuffer());
-await Deno.stdout.write(body);
+await res.body!.pipeTo(Deno.stdout.writable);

--- a/examples/curl.ts
+++ b/examples/curl.ts
@@ -8,4 +8,4 @@
 const url_ = Deno.args[0];
 const res = await fetch(url_);
 
-await res.body!.pipeTo(Deno.stdout.writable);
+await res.body?.pipeTo(Deno.stdout.writable);

--- a/examples/xeval.ts
+++ b/examples/xeval.ts
@@ -33,7 +33,7 @@ OPTIONS:
 ARGS:
   <code>`;
 
-export type XevalFunc = (v: string) => unknown | Promise<unknown>;
+export type XevalFunc = (v: string) => Promise<unknown>;
 
 export interface XevalOptions {
   delimiter?: string;

--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -6,16 +6,25 @@ import { dirname, fromFileUrl } from "../path/mod.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 
+function createReadableStream(str: string) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(str));
+      controller.close();
+    },
+  });
+}
+
 Deno.test("xevalSuccess", async function () {
   const chunks: string[] = [];
-  await xeval(new StringReader("a\nb\nc"), ($): number => chunks.push($));
+  await xeval(createReadableStream("a\nb\nc"), ($): number => chunks.push($));
   assertEquals(chunks, ["a", "b", "c"]);
 });
 
 Deno.test("xevalDelimiter", async function () {
   const chunks: string[] = [];
   await xeval(
-    new StringReader("!MADMADAMADAM!"),
+    createReadableStream("!MADMADAMADAM!"),
     ($): number => chunks.push($),
     {
       delimiter: "MADAM",

--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -16,7 +16,10 @@ function createReadableStream(str: string) {
 
 Deno.test("xevalSuccess", async function () {
   const chunks: string[] = [];
-  await xeval(createReadableStream("a\nb\nc"), ($): number => chunks.push($));
+  await xeval(
+    createReadableStream("a\nb\nc"),
+    ($) => Promise.resolve(chunks.push($)),
+  );
   assertEquals(chunks, ["a", "b", "c"]);
 });
 
@@ -24,7 +27,7 @@ Deno.test("xevalDelimiter", async function () {
   const chunks: string[] = [];
   await xeval(
     createReadableStream("!MADMADAMADAM!"),
-    ($): number => chunks.push($),
+    ($) => Promise.resolve(chunks.push($)),
     {
       delimiter: "MADAM",
     },

--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { xeval } from "./xeval.ts";
-import { StringReader } from "../io/readers.ts";
 import { assertEquals, assertStringIncludes } from "../testing/asserts.ts";
 import { dirname, fromFileUrl } from "../path/mod.ts";
 


### PR DESCRIPTION
towards https://github.com/denoland/deno_std/issues/1986

Switch the Deno stream used in the `example/` directory to a web stream.
And resolve the todo comment below.

> // TODO(ry) Re-enable streaming in this example.
// Originally we did: await Deno.copy(res.body, Deno.stdout);
// But maybe more JS-y would be: res.pipeTo(Deno.stdout);
