### PR TITLE
fix(node/fs): make fs.access resolve on windows

### DIFF
--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -21,8 +21,14 @@ export function access(
   const cb = makeCallback(callback);
 
   Deno.lstat(path).then((info) => {
+    if (info.mode === null) {
+      // If the file mode is unavailable, we pretend it has
+      // the permission
+      cb(null);
+      return;
+    }
     const m = +mode || 0;
-    let fileMode = +info.mode! || 0;
+    let fileMode = +info.mode || 0;
     if (Deno.build.os !== "windows" && info.uid === Deno.getUid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
@@ -70,6 +76,11 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
   mode = getValidMode(mode, "access");
   try {
     const info = Deno.lstatSync(path.toString());
+    if (info.mode === null) {
+      // If the file mode is unavailable, we pretend it has
+      // the permission
+      return;
+    }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
     if (Deno.build.os !== "windows" && info.uid === Deno.getUid()) {

--- a/node/_fs/_fs_access_test.ts
+++ b/node/_fs/_fs_access_test.ts
@@ -21,6 +21,20 @@ Deno.test(
 );
 
 Deno.test(
+  "[node/fs.access] doesn't reject on windows",
+  { ignore: Deno.build.os !== "windows" },
+  async () => {
+    const file = await Deno.makeTempFile();
+    try {
+      await fs.promises.access(file, fs.constants.R_OK);
+      await fs.promises.access(file, fs.constants.W_OK);
+    } finally {
+      await Deno.remove(file);
+    }
+  },
+);
+
+Deno.test(
   "[node/fs.accessSync] Uses the owner permission when the user is the owner",
   { ignore: Deno.build.os === "windows" },
   () => {
@@ -32,6 +46,21 @@ Deno.test(
       assertThrows(() => {
         fs.accessSync(file, fs.constants.X_OK);
       });
+    } finally {
+      Deno.removeSync(file);
+    }
+  },
+);
+
+Deno.test(
+  "[node/fs.accessSync] doesn't throw on windows",
+  { ignore: Deno.build.os !== "windows" },
+  () => {
+    const file = Deno.makeTempFileSync();
+    try {
+      Deno.chmod(file, 0o600);
+      fs.accessSync(file, fs.constants.R_OK);
+      fs.accessSync(file, fs.constants.W_OK);
     } finally {
       Deno.removeSync(file);
     }


### PR DESCRIPTION
On windows `fileInfo.mode` is null and we treat it as 0o000 permission, and that makes any `fs.access` usage fail. This PR change it, and it treats it as 0o777 permission. It's still not perfect, but works better in many cases for npm modules. Especially this resolves denoland/deno#16255