### PR TITLE
fix(node/child_process): mock childProcess.disconnect method

### DIFF
--- a/node/child_process_test.ts
+++ b/node/child_process_test.ts
@@ -59,6 +59,24 @@ Deno.test("[node/child_process spawn] The 'exit' event is emitted with an exit c
   }
 });
 
+Deno.test("[node/child_process disconnect] the method exists", async () => {
+  const promise = withTimeout(1000);
+  const childProcess = spawn(Deno.execPath(), ["--help"], {
+    env: { NO_COLOR: "true" },
+  });
+  try {
+    childProcess.disconnect();
+    childProcess.on("exit", () => {
+      promise.resolve();
+    });
+    await promise;
+  } finally {
+    childProcess.kill();
+    childProcess.stdout?.destroy();
+    childProcess.stderr?.destroy();
+  }
+});
+
 Deno.test({
   name: "[node/child_process spawn] Verify that stdin and stdout work",
   fn: async () => {

--- a/node/internal/child_process.ts
+++ b/node/internal/child_process.ts
@@ -5,7 +5,7 @@
 import { assert } from "../../_util/assert.ts";
 import { EventEmitter } from "../events.ts";
 import { os } from "../internal_binding/constants.ts";
-import { notImplemented } from "../_utils.ts";
+import { notImplemented, warnNotImplemented } from "../_utils.ts";
 import { Readable, Stream, Writable } from "../stream.ts";
 import { deferred } from "../../async/deferred.ts";
 import { isWindows } from "../../_util/os.ts";
@@ -261,6 +261,10 @@ export class ChildProcess extends EventEmitter {
 
   unref() {
     this.#process.unref();
+  }
+
+  disconnect() {
+    warnNotImplemented("ChildProcess.prototype.disconnect");
   }
 
   async #_waitForChildStreamsToClose() {


### PR DESCRIPTION
This PR mocks `ChildProcess.prototype.disconnect` method.

Resolves https://github.com/denoland/deno/issues/16256