### PR TITLE
fix(fs/expandGlob): globstar false does not take effect (#2571)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
 .vscode/settings.json
+.vim
 **/cov/
 /crypto/_wasm_crypto/target
 /encoding/varint/_wasm_varint/target

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -91,11 +91,15 @@ export async function* expandGlob(
     .map((s: string): RegExp => globToRegExp(s, globOptions));
   const shouldInclude = (path: string): boolean =>
     !excludePatterns.some((p: RegExp): boolean => !!path.match(p));
-  const { segments, isAbsolute: isGlobAbsolute, hasTrailingSep, winRoot } =
-    split(toPathString(glob));
+  const {
+    segments,
+    isAbsolute: isGlobAbsolute,
+    hasTrailingSep,
+    winRoot,
+  } = split(toPathString(glob));
 
   let fixedRoot = isGlobAbsolute
-    ? (winRoot != undefined ? winRoot : "/")
+    ? winRoot != undefined ? winRoot : "/"
     : absRoot;
   while (segments.length > 0 && !isGlob(segments[0])) {
     const seg = segments.shift();
@@ -127,7 +131,10 @@ export async function* expandGlob(
       }
       return;
     } else if (globSegment == "**") {
-      return yield* walk(walkInfo.path, { skip: excludePatterns });
+      return yield* walk(walkInfo.path, {
+        skip: excludePatterns,
+        maxDepth: globstar ? Infinity : 1,
+      });
     }
     const globPattern = globToRegExp(globSegment, globOptions);
     for await (
@@ -137,7 +144,8 @@ export async function* expandGlob(
       })
     ) {
       if (
-        walkEntry.path != walkInfo.path && walkEntry.name.match(globPattern)
+        walkEntry.path != walkInfo.path &&
+        walkEntry.name.match(globPattern)
       ) {
         yield walkEntry;
       }
@@ -149,13 +157,16 @@ export async function* expandGlob(
     // Advancing the list of current matches may introduce duplicates, so we
     // pass everything through this Map.
     const nextMatchMap: Map<string, WalkEntry> = new Map();
-    await Promise.all(currentMatches.map(async (currentMatch) => {
-      for await (const nextMatch of advanceMatch(currentMatch, segment)) {
-        nextMatchMap.set(nextMatch.path, nextMatch);
-      }
-    }));
+    await Promise.all(
+      currentMatches.map(async (currentMatch) => {
+        for await (const nextMatch of advanceMatch(currentMatch, segment)) {
+          nextMatchMap.set(nextMatch.path, nextMatch);
+        }
+      }),
+    );
     currentMatches = [...nextMatchMap.values()].sort(comparePath);
   }
+
   if (hasTrailingSep) {
     currentMatches = currentMatches.filter(
       (entry: WalkEntry): boolean => entry.isDirectory,
@@ -199,11 +210,15 @@ export function* expandGlobSync(
     .map((s: string): RegExp => globToRegExp(s, globOptions));
   const shouldInclude = (path: string): boolean =>
     !excludePatterns.some((p: RegExp): boolean => !!path.match(p));
-  const { segments, isAbsolute: isGlobAbsolute, hasTrailingSep, winRoot } =
-    split(toPathString(glob));
+  const {
+    segments,
+    isAbsolute: isGlobAbsolute,
+    hasTrailingSep,
+    winRoot,
+  } = split(toPathString(glob));
 
   let fixedRoot = isGlobAbsolute
-    ? (winRoot != undefined ? winRoot : "/")
+    ? winRoot != undefined ? winRoot : "/"
     : absRoot;
   while (segments.length > 0 && !isGlob(segments[0])) {
     const seg = segments.shift();
@@ -235,7 +250,10 @@ export function* expandGlobSync(
       }
       return;
     } else if (globSegment == "**") {
-      return yield* walkSync(walkInfo.path, { skip: excludePatterns });
+      return yield* walkSync(walkInfo.path, {
+        skip: excludePatterns,
+        maxDepth: globstar ? Infinity : 1,
+      });
     }
     const globPattern = globToRegExp(globSegment, globOptions);
     for (
@@ -245,7 +263,8 @@ export function* expandGlobSync(
       })
     ) {
       if (
-        walkEntry.path != walkInfo.path && walkEntry.name.match(globPattern)
+        walkEntry.path != walkInfo.path &&
+        walkEntry.name.match(globPattern)
       ) {
         yield walkEntry;
       }
@@ -264,6 +283,7 @@ export function* expandGlobSync(
     }
     currentMatches = [...nextMatchMap.values()].sort(comparePath);
   }
+
   if (hasTrailingSep) {
     currentMatches = currentMatches.filter(
       (entry: WalkEntry): boolean => entry.isDirectory,

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -19,7 +19,7 @@ import {
 
 async function expandGlobArray(
   globString: string,
-  options: ExpandGlobOptions
+  options: ExpandGlobOptions,
 ): Promise<string[]> {
   const paths: string[] = [];
   for await (const { path } of expandGlob(globString, options)) {
@@ -27,7 +27,7 @@ async function expandGlobArray(
   }
   paths.sort();
   const pathsSync = [...expandGlobSync(globString, options)].map(
-    ({ path }): string => path
+    ({ path }): string => path,
   );
   pathsSync.sort();
   assertEquals(paths, pathsSync);
@@ -36,7 +36,7 @@ async function expandGlobArray(
     assert(path.startsWith(root));
   }
   const relativePaths = paths.map(
-    (path: string): string => relative(root, path) || "."
+    (path: string): string => relative(root, path) || ".",
   );
   relativePaths.sort();
   return relativePaths;
@@ -100,7 +100,7 @@ Deno.test("expandGlobGlobstar", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["**", "abc"], options), options),
-    ["abc", join("subdir", "abc")]
+    ["abc", join("subdir", "abc")],
   );
 });
 
@@ -108,7 +108,7 @@ Deno.test("expandGlobGlobstarParent", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["subdir", "**", ".."], options), options),
-    ["."]
+    ["."],
   );
 });
 

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -19,7 +19,7 @@ import {
 
 async function expandGlobArray(
   globString: string,
-  options: ExpandGlobOptions,
+  options: ExpandGlobOptions
 ): Promise<string[]> {
   const paths: string[] = [];
   for await (const { path } of expandGlob(globString, options)) {
@@ -27,7 +27,7 @@ async function expandGlobArray(
   }
   paths.sort();
   const pathsSync = [...expandGlobSync(globString, options)].map(
-    ({ path }): string => path,
+    ({ path }): string => path
   );
   pathsSync.sort();
   assertEquals(paths, pathsSync);
@@ -36,7 +36,7 @@ async function expandGlobArray(
     assert(path.startsWith(root));
   }
   const relativePaths = paths.map(
-    (path: string): string => relative(root, path) || ".",
+    (path: string): string => relative(root, path) || "."
   );
   relativePaths.sort();
   return relativePaths;
@@ -100,7 +100,7 @@ Deno.test("expandGlobGlobstar", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["**", "abc"], options), options),
-    ["abc", join("subdir", "abc")],
+    ["abc", join("subdir", "abc")]
   );
 });
 
@@ -108,8 +108,20 @@ Deno.test("expandGlobGlobstarParent", async function () {
   const options = { ...EG_OPTIONS, globstar: true };
   assertEquals(
     await expandGlobArray(joinGlobs(["subdir", "**", ".."], options), options),
-    ["."],
+    ["."]
   );
+});
+
+Deno.test("expandGlobGlobstarFalseWithGlob", async function () {
+  const options = { ...EG_OPTIONS, globstar: false };
+  assertEquals(await expandGlobArray("**", options), [
+    ".",
+    "a[b]c",
+    "abc",
+    "abcdef",
+    "abcdefghi",
+    "subdir",
+  ]);
 });
 
 Deno.test("expandGlobIncludeDirs", async function () {
@@ -120,12 +132,7 @@ Deno.test("expandGlobIncludeDirs", async function () {
 Deno.test("expandGlobPermError", async function () {
   const exampleUrl = new URL("testdata/expand_wildcard.js", import.meta.url);
   const { code, success, stdout, stderr } = await Deno.spawn(Deno.execPath(), {
-    args: [
-      "run",
-      "--quiet",
-      "--unstable",
-      exampleUrl.toString(),
-    ],
+    args: ["run", "--quiet", "--unstable", exampleUrl.toString()],
   });
   const decoder = new TextDecoder();
   assert(!success);


### PR DESCRIPTION
This is in relation to #2571. When passing globstar false, and passing the glob segment `**`, globstar false isn't being respected.