### PR TITLE
fix(node/child_process): add support of windowsVerbatimArguments option

### DIFF
--- a/node/_tools/config.json
+++ b/node/_tools/config.json
@@ -740,7 +740,6 @@
       "test-child-process-execfile.js",
       "test-child-process-execsync-maxbuf.js",
       "test-child-process-kill.js",
-      "test-child-process-spawnsync-args.js",
       "test-console-log-throw-primitive.js",
       "test-console-no-swallow-stack-overflow.js",
       "test-console-sync-write-error.js",


### PR DESCRIPTION
depends on denoland/deno#16319

This PR adds support of `windowsVerbatimArguments` option in child_process APIs.