### PR TITLE
chore: correct ignored files for checks, linting and formatting

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -12,6 +12,9 @@ const EXCLUDED_PATHS = [
   "dotenv/testdata",
   "fs/testdata",
   "http/testdata",
+  "crypto/_wasm_crypto/target",
+  "encoding/varint/_wasm_varint/target",
+  "hash/_wasm/target",
 ];
 
 console.warn(

--- a/_tools/check_licence.ts
+++ b/_tools/check_licence.ts
@@ -11,6 +11,8 @@ const EXCLUDED_PATHS = [
   "node/_module/node_modules",
   "node/_tools",
   "node/testdata",
+  "crypto/_wasm_crypto/target",
+  "encoding/varint/_wasm_varint/target",
 ];
 
 const ROOT = new URL("../", import.meta.url).pathname.slice(0, -1);

--- a/deno.json
+++ b/deno.json
@@ -8,8 +8,8 @@
     "files": {
       "exclude": [
         ".git",
-        "_wasm_crypto/target",
-        "_wasm_varint/target",
+        "crypto/_wasm_crypto/target",
+        "encoding/varint/_wasm_varint/target",
         "cov",
         "encoding/testdata/jsonc",
         "hash/_wasm/target",
@@ -25,8 +25,8 @@
     "files": {
       "exclude": [
         ".git",
-        "_wasm_crypto/target",
-        "_wasm_varint/target",
+        "crypto/_wasm_crypto/target",
+        "encoding/varint/_wasm_varint/target",
         "encoding/testdata/jsonc",
         "cov",
         "hash/_wasm/target",


### PR DESCRIPTION
This PR adds directories found in `.gitignore` to those lists of directories that should be ignored when performing:
1. License check
2. Deprecation check
3. Linting
4. Formatting

Note: `/hash/_wasm/target` in checks were ignored because it's looking as though `std/hash` will soon be removed anyway.