### PR TITLE
fix(node/net): modify close event timing

### DIFF
--- a/node/net.ts
+++ b/node/net.ts
@@ -2414,10 +2414,14 @@ export class Server extends EventEmitter {
       return;
     }
 
+    // We use setTimeout instead of nextTick here to avoid EADDRINUSE error
+    // when the same port listened immediately after the 'close' event.
+    // ref: https://github.com/denoland/deno_std/issues/2788
     defaultTriggerAsyncIdScope(
       this[asyncIdSymbol],
-      nextTick,
+      setTimeout,
       _emitCloseNT,
+      0,
       this,
     );
   }

--- a/node/net_test.ts
+++ b/node/net_test.ts
@@ -3,6 +3,7 @@
 import * as net from "./net.ts";
 import { assertEquals } from "../testing/asserts.ts";
 import { deferred } from "../async/deferred.ts";
+import * as http from "./http.ts";
 
 Deno.test("[node/net] close event emits after error event", async () => {
   const socket = net.createConnection(27009, "doesnotexist");
@@ -21,4 +22,31 @@ Deno.test("[node/net] close event emits after error event", async () => {
 
   // `error` happens before `close`
   assertEquals(events, ["error", "close"]);
+});
+
+Deno.test("[node/net] the port is available immediately after close callback", async () => {
+  const p = deferred();
+
+  // This simulates what get-port@5.1.1 does.
+  const getAvailablePort = (port: number) =>
+    new Promise((resolve, reject) => {
+      const server = net.createServer();
+      server.on("error", reject);
+      server.listen({ port }, () => {
+        // deno-lint-ignore no-explicit-any
+        const { port } = server.address() as any;
+        server.close(() => {
+          resolve(port);
+        });
+      });
+    });
+
+  const port = await getAvailablePort(5555);
+
+  const httpServer = http.createServer();
+  httpServer.on("error", (e) => p.reject(e));
+  httpServer.listen(port, () => {
+    httpServer.close(() => p.resolve());
+  });
+  await p;
 });


### PR DESCRIPTION
This PR delays the timing of 'close' event when `.close()` is called on net.Server. With the current implementation, 'close' event is emitted a bit too early and the port is not available yet. That causes the module `get-port` failing to return 'available' port. This PR uses `setTimeout` instead of `nextTick` for calling `_emitCloseNT` and the timing is delayed, and that makes `get-port` working.

closes #2788

related https://github.com/denoland/deno/issues/16282