### PR TITLE
chore(uuid): cleanup unused internal functions

### DIFF
--- a/uuid/_common.ts
+++ b/uuid/_common.ts
@@ -37,29 +37,3 @@ export function uuidToBytes(uuid: string): number[] {
 
   return bytes;
 }
-
-/**
- * Converts a string to a byte array using the char code.
- * @param str Value that gets converted.
- */
-export function stringToBytes(str: string): number[] {
-  str = unescape(encodeURIComponent(str));
-  const bytes = Array.from<number>({ length: str.length });
-  for (let i = 0; i < str.length; i++) {
-    bytes[i] = str.charCodeAt(i);
-  }
-  return bytes;
-}
-
-/**
- * Creates a buffer for creating a SHA-1 hash.
- * @param content Buffer for SHA-1 hash.
- */
-export function createBuffer(content: number[]): ArrayBuffer {
-  const arrayBuffer = new ArrayBuffer(content.length);
-  const uint8Array = new Uint8Array(arrayBuffer);
-  for (let i = 0; i < content.length; i++) {
-    uint8Array[i] = content[i];
-  }
-  return arrayBuffer;
-}


### PR DESCRIPTION
This PR removes the internal utilities `stringToBytes` and `createBuffer`, which aren't used in the codebase.