### PR TITLE
docs(streams): remove obsolete note

### DIFF
--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -481,11 +481,6 @@ export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array) {
  * }
  * f.close();
  * ```
- *
- * Iterator uses an internal buffer of fixed size for efficiency; it returns
- * a view on that buffer on each iteration. It is therefore caller's
- * responsibility to copy contents of the buffer if needed; otherwise the
- * next iteration will overwrite contents of previously returned chunk.
  */
 export async function* iterateReader(
   r: Deno.Reader,


### PR DESCRIPTION
This PR removes the note in the docs of `iterateReader`, which is no longer meaningful.

ref: https://github.com/denoland/deno_std/pull/2735