### PR TITLE
chore: add ts-ignores for Deno.consoleSize() API

### DIFF
--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -26,6 +26,8 @@ import { stripColor as removeColors } from "../fmt/colors.ts";
 
 function getConsoleWidth(): number {
   try {
+    // TODO(bartlomieju):
+    // @ts-ignore Deno.consoleSize is getting stabilized and its signature changes
     return Deno.consoleSize(Deno.stderr.rid).columns;
   } catch {
     return 80;


### PR DESCRIPTION
I didn't save one of the files 🤦 