### PR TITLE
chore: use renamed Deno.getUid() and Deno.getGid()

### DIFF
--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -33,7 +33,7 @@ export function access(
       Deno.build.os !== "windows" &&
     // TODO(cjihrig):
     // @ts-ignore Deno.getUid() is being renamed.
-      info.uid === (Deno.uid?.() && Deno.getUid?.())
+      info.uid === (Deno.uid?.() ?? Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
@@ -92,7 +92,7 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
       Deno.build.os !== "windows" &&
     // TODO(cjihrig):
     // @ts-ignore Deno.getUid() is being renamed.
-      info.uid === (Deno.uid?.() && Deno.getUid?.())
+      info.uid === (Deno.uid?.() ?? Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -29,10 +29,10 @@ export function access(
     }
     const m = +mode || 0;
     let fileMode = +info.mode || 0;
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
     if (
       Deno.build.os !== "windows" &&
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
       info.uid === (Deno.uid?.() && Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of
@@ -88,10 +88,10 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
     if (
       Deno.build.os !== "windows" &&
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
       info.uid === (Deno.uid?.() && Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -29,7 +29,12 @@ export function access(
     }
     const m = +mode || 0;
     let fileMode = +info.mode || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
+    if (
+      Deno.build.os !== "windows" &&
+      info.uid === (Deno.uid?.() && Deno.getUid?.())
+    ) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;
@@ -83,7 +88,12 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
+    if (
+      Deno.build.os !== "windows" &&
+      info.uid === (Deno.uid?.() && Deno.getUid?.())
+    ) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -31,8 +31,8 @@ export function access(
     let fileMode = +info.mode || 0;
     if (
       Deno.build.os !== "windows" &&
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
+      // TODO(cjihrig):
+      // @ts-ignore Deno.getUid() is being renamed.
       info.uid === (Deno.uid?.() ?? Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of
@@ -90,8 +90,8 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     let fileMode = +info.mode! || 0;
     if (
       Deno.build.os !== "windows" &&
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
+      // TODO(cjihrig):
+      // @ts-ignore Deno.getUid() is being renamed.
       info.uid === (Deno.uid?.() ?? Deno.getUid?.())
     ) {
       // If the user is the owner of the file, then use the owner bits of

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -29,7 +29,7 @@ export function access(
     }
     const m = +mode || 0;
     let fileMode = +info.mode || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.getUid()) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;
@@ -83,7 +83,7 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.getUid()) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;

--- a/node/process.ts
+++ b/node/process.ts
@@ -568,14 +568,14 @@ class Process extends EventEmitter {
   getgid?(): number {
     // TODO(cjihrig):
     // @ts-ignore Deno.getGid() is being renamed.
-    return Deno.gid?.()! && Deno.getGid?.()!;
+    return Deno.gid?.()! ?? Deno.getGid?.()!;
   }
 
   /** This method is removed on Windows */
   getuid?(): number {
     // TODO(cjihrig):
     // @ts-ignore Deno.getUid() is being renamed.
-    return Deno.uid?.()! && Deno.getUid?.()!;
+    return Deno.uid?.()! ?? Deno.getUid?.()!;
   }
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode

--- a/node/process.ts
+++ b/node/process.ts
@@ -566,12 +566,12 @@ class Process extends EventEmitter {
 
   /** This method is removed on Windows */
   getgid?(): number {
-    return Deno.getGid()!;
+    return Deno.gid()!;
   }
 
   /** This method is removed on Windows */
   getuid?(): number {
-    return Deno.getUid()!;
+    return Deno.uid()!;
   }
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode

--- a/node/process.ts
+++ b/node/process.ts
@@ -566,12 +566,16 @@ class Process extends EventEmitter {
 
   /** This method is removed on Windows */
   getgid?(): number {
-    return Deno.gid()!;
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getGid() is being renamed.
+    return Deno.gid?.()! && Deno.getGid?.()!;
   }
 
   /** This method is removed on Windows */
   getuid?(): number {
-    return Deno.uid()!;
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
+    return Deno.uid?.()! && Deno.getUid?.()!;
   }
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -527,7 +527,7 @@ Deno.test("process.getgid", () => {
   } else {
     // TODO(cjihrig):
     // @ts-ignore Deno.getGid() is being renamed.
-    assertEquals(process.getgid?.(), Deno.gid?.() && Deno.getGid?.());
+    assertEquals(process.getgid?.(), Deno.gid?.() ?? Deno.getGid?.());
   }
 });
 
@@ -537,7 +537,7 @@ Deno.test("process.getuid", () => {
   } else {
     // TODO(cjihrig):
     // @ts-ignore Deno.getUid() is being renamed.
-    assertEquals(process.getuid?.(), Deno.uid?.() && Deno.getUid?.());
+    assertEquals(process.getuid?.(), Deno.uid?.() ?? Deno.getUid?.());
   }
 });
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -525,7 +525,7 @@ Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getgid, undefined);
   } else {
-    assertEquals(process.getgid?.(), Deno.getGid());
+    assertEquals(process.getgid?.(), Deno.gid());
   }
 });
 
@@ -533,7 +533,7 @@ Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getuid, undefined);
   } else {
-    assertEquals(process.getuid?.(), Deno.getUid());
+    assertEquals(process.getuid?.(), Deno.uid());
   }
 });
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -525,7 +525,9 @@ Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getgid, undefined);
   } else {
-    assertEquals(process.getgid?.(), Deno.gid());
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getGid() is being renamed.
+    assertEquals(process.getgid?.(), Deno.gid?.() && Deno.getGid?.());
   }
 });
 
@@ -533,7 +535,9 @@ Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getuid, undefined);
   } else {
-    assertEquals(process.getuid?.(), Deno.uid());
+    // TODO(cjihrig):
+    // @ts-ignore Deno.getUid() is being renamed.
+    assertEquals(process.getuid?.(), Deno.uid?.() && Deno.getUid?.());
   }
 });
 


### PR DESCRIPTION
These are being renamed to `Deno.uid()` and `Deno.gid()` in core.

Depends on https://github.com/denoland/deno/pull/16432