### PR TITLE
chore: drop Deno.getGid() and Deno.getUid()

### DIFF
--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -29,7 +29,7 @@ export function access(
     }
     const m = +mode || 0;
     let fileMode = +info.mode || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.uid?.()) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;
@@ -83,7 +83,7 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
-    if (Deno.build.os !== "windows" && info.uid === Deno.uid?.()) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;

--- a/node/_fs/_fs_access.ts
+++ b/node/_fs/_fs_access.ts
@@ -29,12 +29,7 @@ export function access(
     }
     const m = +mode || 0;
     let fileMode = +info.mode || 0;
-    if (
-      Deno.build.os !== "windows" &&
-      // TODO(cjihrig):
-      // @ts-ignore Deno.getUid() is being renamed.
-      info.uid === (Deno.uid?.() ?? Deno.getUid?.())
-    ) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid?.()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;
@@ -88,12 +83,7 @@ export function accessSync(path: string | Buffer | URL, mode?: number) {
     }
     const m = +mode! || 0;
     let fileMode = +info.mode! || 0;
-    if (
-      Deno.build.os !== "windows" &&
-      // TODO(cjihrig):
-      // @ts-ignore Deno.getUid() is being renamed.
-      info.uid === (Deno.uid?.() ?? Deno.getUid?.())
-    ) {
+    if (Deno.build.os !== "windows" && info.uid === Deno.uid?.()) {
       // If the user is the owner of the file, then use the owner bits of
       // the file permission
       fileMode >>= 6;

--- a/node/process.ts
+++ b/node/process.ts
@@ -566,12 +566,12 @@ class Process extends EventEmitter {
 
   /** This method is removed on Windows */
   getgid?(): number {
-    return Deno.gid?.()!;
+    return Deno.gid()!;
   }
 
   /** This method is removed on Windows */
   getuid?(): number {
-    return Deno.uid?.()!;
+    return Deno.uid()!;
   }
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode

--- a/node/process.ts
+++ b/node/process.ts
@@ -566,16 +566,12 @@ class Process extends EventEmitter {
 
   /** This method is removed on Windows */
   getgid?(): number {
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getGid() is being renamed.
-    return Deno.gid?.()! ?? Deno.getGid?.()!;
+    return Deno.gid?.()!;
   }
 
   /** This method is removed on Windows */
   getuid?(): number {
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
-    return Deno.uid?.()! ?? Deno.getUid?.()!;
+    return Deno.uid?.()!;
   }
 
   // TODO(kt3k): Implement this when we added -e option to node compat mode

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -525,7 +525,7 @@ Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getgid, undefined);
   } else {
-    assertEquals(process.getgid?.(), Deno.gid?.());
+    assertEquals(process.getgid?.(), Deno.gid());
   }
 });
 
@@ -533,7 +533,7 @@ Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getuid, undefined);
   } else {
-    assertEquals(process.getuid?.(), Deno.uid?.());
+    assertEquals(process.getuid?.(), Deno.uid());
   }
 });
 

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -525,9 +525,7 @@ Deno.test("process.getgid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getgid, undefined);
   } else {
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getGid() is being renamed.
-    assertEquals(process.getgid?.(), Deno.gid?.() ?? Deno.getGid?.());
+    assertEquals(process.getgid?.(), Deno.gid?.());
   }
 });
 
@@ -535,9 +533,7 @@ Deno.test("process.getuid", () => {
   if (Deno.build.os === "windows") {
     assertEquals(process.getuid, undefined);
   } else {
-    // TODO(cjihrig):
-    // @ts-ignore Deno.getUid() is being renamed.
-    assertEquals(process.getuid?.(), Deno.uid?.() ?? Deno.getUid?.());
+    assertEquals(process.getuid?.(), Deno.uid?.());
   }
 });
 


### PR DESCRIPTION
The API rename has been completed in the CLI repo.