### PR TITLE
chore: allow to return the proper type without casting

### DIFF
--- a/encoding/_yaml/parse.ts
+++ b/encoding/_yaml/parse.ts
@@ -14,7 +14,7 @@ export type ParseOptions = LoaderStateOptions;
  * Returns a JavaScript object or throws `YAMLException` on error.
  * By default, does not support regexps, functions and undefined. This method is safe for untrusted data.
  */
-export function parse(content: string, options?: ParseOptions): unknown {
+export function parse(content: string, options?: ParseOptions): any {
   return load(content, options);
 }
 


### PR DESCRIPTION
Hey peeps, I have to keep manually casting things and force the compiler to cast to a given type, but even so I keep getting the following error:

> Deno: Type 'unknown' is not assignable to type 'SemanticConventionFile'.

```ts
const data: SemanticConventionFile  = parse(content)
```

Hopefully this will allow me to do 

```ts
const data = parse<SemanticConventionFile>(content)
```