### PR TITLE
fix(dotenv): Empty string crashing parsing

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -55,9 +55,9 @@ export function parse(
       keysForExpandCheck.push(key);
     }
 
-    env[key] = notInterpolated
+    env[key] = typeof notInterpolated === "string"
       ? notInterpolated
-      : interpolated || interpolated === ""
+      : typeof interpolated === "string"
       ? expandCharacters(interpolated)
       : unquoted.trim();
   }

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -57,7 +57,7 @@ export function parse(
 
     env[key] = notInterpolated
       ? notInterpolated
-      : interpolated
+      : interpolated || interpolated === ""
       ? expandCharacters(interpolated)
       : unquoted.trim();
   }

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -47,6 +47,12 @@ Deno.test("parser", () => {
   );
 
   assertEquals(
+    config.EMPTY_QUOTED,
+    "",
+    "handles empty quotes",
+  );
+
+  assertEquals(
     config.MULTILINE,
     "hello\nworld",
     "new lines are expanded in double quotes",

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -47,9 +47,15 @@ Deno.test("parser", () => {
   );
 
   assertEquals(
-    config.EMPTY_QUOTED,
+    config.EMPTY_SINGLE,
     "",
-    "handles empty quotes",
+    "handles empty single quotes",
+  );
+
+  assertEquals(
+    config.EMPTY_DOUBLE,
+    "",
+    "handles empty double quotes",
   );
 
   assertEquals(

--- a/dotenv/testdata/.env.test
+++ b/dotenv/testdata/.env.test
@@ -5,6 +5,7 @@ AFTER_EMPTY=empty
 EMPTY_VALUE=
 QUOTED_SINGLE='single quoted'
 QUOTED_DOUBLE="double quoted"
+EMPTY_QUOTED=""
 
 MULTILINE="hello\nworld"
 JSON='{"foo": "bar"}'

--- a/dotenv/testdata/.env.test
+++ b/dotenv/testdata/.env.test
@@ -5,7 +5,8 @@ AFTER_EMPTY=empty
 EMPTY_VALUE=
 QUOTED_SINGLE='single quoted'
 QUOTED_DOUBLE="double quoted"
-EMPTY_QUOTED=""
+EMPTY_SINGLE=''
+EMPTY_DOUBLE=""
 
 MULTILINE="hello\nworld"
 JSON='{"foo": "bar"}'


### PR DESCRIPTION
Empty strings in .env files crashed the parsing of them. Looks like it was just a falsey value that was not tested for.

Simple reproc (.env):
```
A=""
```

Related: #2798