### PR TITLE
chore(semver): rename inc and diff

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -37,9 +37,9 @@ const DEPRECATION_AFTER_FORMAT_REGEX =
 let shouldFail = false;
 
 // add three minor version to current version
-const DEFAULT_DEPRECATED_VERSION = semver.inc(
-  semver.inc(
-    semver.inc(
+const DEFAULT_DEPRECATED_VERSION = semver.increment(
+  semver.increment(
+    semver.increment(
       VERSION,
       "minor",
     )!,

--- a/semver/README.md
+++ b/semver/README.md
@@ -85,11 +85,11 @@ that do range matching.
 
 #### Prerelease Identifiers
 
-The method `.inc` takes an additional `identifier` string argument that will
-append the value of the string as a prerelease identifier:
+The method `.increment` takes an additional `identifier` string argument that
+will append the value of the string as a prerelease identifier:
 
 ```javascript
-semver.inc("1.2.3", "prerelease", "beta");
+semver.increment("1.2.3", "prerelease", "beta");
 // "1.2.4-beta.0"
 ```
 
@@ -229,7 +229,7 @@ Strict-mode Comparators and Ranges will be strict about the SemVer strings that
 they parse.
 
 - `valid(v)`: Return the parsed version, or null if it"s not valid.
-- `inc(v, release)`: Return the version incremented by the release type
+- `increment(v, release)`: Return the version incremented by the release type
   (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or
   `prerelease`), or null if it"s not valid
   - `premajor` in one call will bump the version up to the next major version
@@ -268,8 +268,8 @@ they parse.
 - `compareBuild(v1, v2)`: The same as `compare` but considers `build` when two
   versions are equal. Sorts in ascending order if passed to `Array.sort()`. `v2`
   is greater. Sorts in ascending order if passed to `Array.sort()`.
-- `diff(v1, v2)`: Returns difference between two versions by the release type
-  (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or
+- `difference(v1, v2)`: Returns difference between two versions by the release
+  type (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or
   `prerelease`), or null if the versions are the same.
 
 ### Comparators

--- a/semver/diff_test.ts
+++ b/semver/diff_test.ts
@@ -5,7 +5,7 @@ import * as semver from "./mod.ts";
 
 Deno.test("diff", function () {
   //  [version1, version2, result]
-  //  diff(version1, version2) -> result
+  //  difference(version1, version2) -> result
   const versions: [string, string, semver.ReleaseType | null][] = [
     ["1.2.3", "0.2.3", "major"],
     ["1.4.5", "0.2.3", "major"],
@@ -25,8 +25,8 @@ Deno.test("diff", function () {
     const version1 = v[0];
     const version2 = v[1];
     const wanted = v[2];
-    const found = semver.diff(version1, version2);
-    const cmd = "diff(" + version1 + ", " + version2 + ")";
+    const found = semver.difference(version1, version2);
+    const cmd = "difference(" + version1 + ", " + version2 + ")";
     assertEquals(found, wanted, cmd + " === " + wanted);
   });
 });

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -155,19 +155,19 @@ Deno.test("increment", function () {
     const wanted = v[2];
     const options = v[3];
     const id = v[4];
-    const found = semver.inc(pre, what, options, id);
+    const found = semver.increment(pre, what, options, id);
     const cmd = "inc(" + pre + ", " + what + ", " + id + ")";
     assertEquals(found, wanted, cmd + " === " + wanted);
 
     const parsed = semver.parse(pre, options);
     if (wanted && parsed) {
       //todo ?
-      parsed.inc(what, id);
+      parsed.increment(what, id);
       assertEquals(parsed.version, wanted, cmd + " object version updated");
       assertEquals(parsed.raw, wanted, cmd + " object raw field updated");
     } else if (parsed) {
       assertThrows(function () {
-        parsed.inc(what, id);
+        parsed.increment(what, id);
       });
     } else {
       assertEquals(parsed, null);

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -397,36 +397,36 @@ export class SemVer {
     return 1;
   }
 
-  inc(release: ReleaseType, identifier?: string): SemVer {
+  increment(release: ReleaseType, identifier?: string): SemVer {
     switch (release) {
       case "premajor":
         this.prerelease.length = 0;
         this.patch = 0;
         this.minor = 0;
         this.major++;
-        this.inc("pre", identifier);
+        this.increment("pre", identifier);
         break;
       case "preminor":
         this.prerelease.length = 0;
         this.patch = 0;
         this.minor++;
-        this.inc("pre", identifier);
+        this.increment("pre", identifier);
         break;
       case "prepatch":
         // If this is already a prerelease, it will bump to the next version
         // drop any prereleases that might already exist, since they are not
         // relevant at this point.
         this.prerelease.length = 0;
-        this.inc("patch", identifier);
-        this.inc("pre", identifier);
+        this.increment("patch", identifier);
+        this.increment("pre", identifier);
         break;
       // If the input is a non-prerelease version, this acts the same as
       // prepatch.
       case "prerelease":
         if (this.prerelease.length === 0) {
-          this.inc("patch", identifier);
+          this.increment("patch", identifier);
         }
-        this.inc("pre", identifier);
+        this.increment("pre", identifier);
         break;
 
       case "major":
@@ -514,7 +514,7 @@ export class SemVer {
 /**
  * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
  */
-export function inc(
+export function increment(
   version: string | SemVer,
   release: ReleaseType,
   options?: Options,
@@ -525,13 +525,13 @@ export function inc(
     options = undefined;
   }
   try {
-    return new SemVer(version, options).inc(release, identifier).version;
+    return new SemVer(version, options).increment(release, identifier).version;
   } catch {
     return null;
   }
 }
 
-export function diff(
+export function difference(
   version1: string | SemVer,
   version2: string | SemVer,
   options?: Options,

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -397,6 +397,13 @@ export class SemVer {
     return 1;
   }
 
+  /**
+   * @deprecated (will be removed after 0.165.0) use `increment` instead
+   */
+  inc(release: ReleaseType, identifier?: string): SemVer {
+    return this.increment(release, identifier);
+  }
+
   increment(release: ReleaseType, identifier?: string): SemVer {
     switch (release) {
       case "premajor":
@@ -512,6 +519,18 @@ export class SemVer {
 }
 
 /**
+ * @deprecated (will be removed after 0.165.0) use `increment` instead
+ */
+export function inc(
+  version: string | SemVer,
+  release: ReleaseType,
+  options?: Options,
+  identifier?: string,
+): string | null {
+  return increment(version, release, options, identifier);
+}
+
+/**
  * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
  */
 export function increment(
@@ -529,6 +548,17 @@ export function increment(
   } catch {
     return null;
   }
+}
+
+/**
+ * @deprecated (will be removed after 0.165.0) use `difference` instead
+ */
+export function diff(
+  version1: string | SemVer,
+  version2: string | SemVer,
+  options?: Options,
+): string | null {
+  return difference(version1, version2, options);
 }
 
 export function difference(

--- a/semver/tooLong_test.ts
+++ b/semver/tooLong_test.ts
@@ -10,7 +10,7 @@ Deno.test("versionIsTooLong", function () {
     new semver.SemVer(v);
   });
   assertEquals(semver.valid(v), null);
-  assertEquals(semver.inc(v, "patch"), null);
+  assertEquals(semver.increment(v, "patch"), null);
 });
 
 Deno.test("tooBig", function () {
@@ -19,7 +19,7 @@ Deno.test("tooBig", function () {
     new semver.SemVer(v);
   });
   assertEquals(semver.valid(v), null);
-  assertEquals(semver.inc(v, "patch"), null);
+  assertEquals(semver.increment(v, "patch"), null);
 });
 
 Deno.test("parsingNullDoesNotThrow", function () {


### PR DESCRIPTION
- rename abbreviations: `inc` to `increment` and `diff` to `difference`.
This is more in alignment to the js naming convention.