### PR TITLE
feat(node/fs): add support for numeric flags in `fs.open()`

### DIFF
--- a/node/_fs/_fs_common.ts
+++ b/node/_fs/_fs_common.ts
@@ -1,4 +1,13 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import {
+  O_APPEND,
+  O_CREAT,
+  O_EXCL,
+  O_RDONLY,
+  O_RDWR,
+  O_TRUNC,
+  O_WRONLY,
+} from "./_fs_constants.ts";
 import { validateFunction } from "../internal/validators.mjs";
 import type { ErrnoException } from "../_global.d.ts";
 import {
@@ -85,87 +94,118 @@ export function checkEncoding(encoding: Encodings | null): Encodings | null {
   throw new Error(`The value "${encoding}" is invalid for option "encoding"`);
 }
 
-export function getOpenOptions(flag: string | undefined): Deno.OpenOptions {
+export function getOpenOptions(
+  flag: string | number | undefined,
+): Deno.OpenOptions {
   if (!flag) {
     return { create: true, append: true };
   }
 
-  let openOptions: Deno.OpenOptions;
-  switch (flag) {
-    case "a": {
-      // 'a': Open file for appending. The file is created if it does not exist.
-      openOptions = { create: true, append: true };
-      break;
+  let openOptions: Deno.OpenOptions = {};
+
+  if (typeof flag === "string") {
+    switch (flag) {
+      case "a": {
+        // 'a': Open file for appending. The file is created if it does not exist.
+        openOptions = { create: true, append: true };
+        break;
+      }
+      case "ax":
+      case "xa": {
+        // 'ax', 'xa': Like 'a' but fails if the path exists.
+        openOptions = { createNew: true, write: true, append: true };
+        break;
+      }
+      case "a+": {
+        // 'a+': Open file for reading and appending. The file is created if it does not exist.
+        openOptions = { read: true, create: true, append: true };
+        break;
+      }
+      case "ax+":
+      case "xa+": {
+        // 'ax+', 'xa+': Like 'a+' but fails if the path exists.
+        openOptions = { read: true, createNew: true, append: true };
+        break;
+      }
+      case "r": {
+        // 'r': Open file for reading. An exception occurs if the file does not exist.
+        openOptions = { read: true };
+        break;
+      }
+      case "r+": {
+        // 'r+': Open file for reading and writing. An exception occurs if the file does not exist.
+        openOptions = { read: true, write: true };
+        break;
+      }
+      case "w": {
+        // 'w': Open file for writing. The file is created (if it does not exist) or truncated (if it exists).
+        openOptions = { create: true, write: true, truncate: true };
+        break;
+      }
+      case "wx":
+      case "xw": {
+        // 'wx', 'xw': Like 'w' but fails if the path exists.
+        openOptions = { createNew: true, write: true };
+        break;
+      }
+      case "w+": {
+        // 'w+': Open file for reading and writing. The file is created (if it does not exist) or truncated (if it exists).
+        openOptions = { create: true, write: true, truncate: true, read: true };
+        break;
+      }
+      case "wx+":
+      case "xw+": {
+        // 'wx+', 'xw+': Like 'w+' but fails if the path exists.
+        openOptions = { createNew: true, write: true, read: true };
+        break;
+      }
+      case "as":
+      case "sa": {
+        // 'as', 'sa': Open file for appending in synchronous mode. The file is created if it does not exist.
+        openOptions = { create: true, append: true };
+        break;
+      }
+      case "as+":
+      case "sa+": {
+        // 'as+', 'sa+': Open file for reading and appending in synchronous mode. The file is created if it does not exist.
+        openOptions = { create: true, read: true, append: true };
+        break;
+      }
+      case "rs+":
+      case "sr+": {
+        // 'rs+', 'sr+': Open file for reading and writing in synchronous mode. Instructs the operating system to bypass the local file system cache.
+        openOptions = { create: true, read: true, write: true };
+        break;
+      }
+      default: {
+        throw new Error(`Unrecognized file system flag: ${flag}`);
+      }
     }
-    case "ax":
-    case "xa": {
-      // 'ax', 'xa': Like 'a' but fails if the path exists.
-      openOptions = { createNew: true, write: true, append: true };
-      break;
+  } else if (typeof flag === "number") {
+    if ((flag & O_APPEND) === O_APPEND) {
+      openOptions.append = true;
     }
-    case "a+": {
-      // 'a+': Open file for reading and appending. The file is created if it does not exist.
-      openOptions = { read: true, create: true, append: true };
-      break;
+    if ((flag & O_CREAT) === O_CREAT) {
+      openOptions.create = true;
+      openOptions.write = true;
     }
-    case "ax+":
-    case "xa+": {
-      // 'ax+', 'xa+': Like 'a+' but fails if the path exists.
-      openOptions = { read: true, createNew: true, append: true };
-      break;
+    if ((flag & O_EXCL) === O_EXCL) {
+      openOptions.createNew = true;
+      openOptions.read = true;
+      openOptions.write = true;
     }
-    case "r": {
-      // 'r': Open file for reading. An exception occurs if the file does not exist.
-      openOptions = { read: true };
-      break;
+    if ((flag & O_TRUNC) === O_TRUNC) {
+      openOptions.truncate = true;
     }
-    case "r+": {
-      // 'r+': Open file for reading and writing. An exception occurs if the file does not exist.
-      openOptions = { read: true, write: true };
-      break;
+    if ((flag & O_RDONLY) === O_RDONLY) {
+      openOptions.read = true;
     }
-    case "w": {
-      // 'w': Open file for writing. The file is created (if it does not exist) or truncated (if it exists).
-      openOptions = { create: true, write: true, truncate: true };
-      break;
+    if ((flag & O_WRONLY) === O_WRONLY) {
+      openOptions.write = true;
     }
-    case "wx":
-    case "xw": {
-      // 'wx', 'xw': Like 'w' but fails if the path exists.
-      openOptions = { createNew: true, write: true };
-      break;
-    }
-    case "w+": {
-      // 'w+': Open file for reading and writing. The file is created (if it does not exist) or truncated (if it exists).
-      openOptions = { create: true, write: true, truncate: true, read: true };
-      break;
-    }
-    case "wx+":
-    case "xw+": {
-      // 'wx+', 'xw+': Like 'w+' but fails if the path exists.
-      openOptions = { createNew: true, write: true, read: true };
-      break;
-    }
-    case "as":
-    case "sa": {
-      // 'as', 'sa': Open file for appending in synchronous mode. The file is created if it does not exist.
-      openOptions = { create: true, append: true };
-      break;
-    }
-    case "as+":
-    case "sa+": {
-      // 'as+', 'sa+': Open file for reading and appending in synchronous mode. The file is created if it does not exist.
-      openOptions = { create: true, read: true, append: true };
-      break;
-    }
-    case "rs+":
-    case "sr+": {
-      // 'rs+', 'sr+': Open file for reading and writing in synchronous mode. Instructs the operating system to bypass the local file system cache.
-      openOptions = { create: true, read: true, write: true };
-      break;
-    }
-    default: {
-      throw new Error(`Unrecognized file system flag: ${flag}`);
+    if ((flag & O_RDWR) === O_RDWR) {
+      openOptions.read = true;
+      openOptions.write = true;
     }
   }
 

--- a/node/_fs/_fs_open_test.ts
+++ b/node/_fs/_fs_open_test.ts
@@ -1,5 +1,15 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import {
+  O_APPEND,
+  O_CREAT,
+  O_EXCL,
+  O_RDONLY,
+  O_RDWR,
+  O_SYNC,
+  O_TRUNC,
+  O_WRONLY,
+} from "./_fs_constants.ts";
+import {
   assert,
   assertEquals,
   assertThrows,
@@ -43,7 +53,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'a'",
+  name: "open with string flag 'a'",
   fn() {
     const file = join(tempDir, "some_random_file");
     const fd = openSync(file, "a");
@@ -55,7 +65,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'ax'",
+  name: "open with string flag 'ax'",
   fn() {
     const file = Deno.makeTempFileSync();
     assertThrows(
@@ -70,7 +80,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'a+'",
+  name: "open with string flag 'a+'",
   fn() {
     const file = join(tempDir, "some_random_file2");
     const fd = openSync(file, "a+");
@@ -81,7 +91,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'ax+'",
+  name: "open with string flag 'ax+'",
   fn() {
     const file = Deno.makeTempFileSync();
     assertThrows(
@@ -96,7 +106,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'as'",
+  name: "open with string flag 'as'",
   fn() {
     const file = join(tempDir, "some_random_file10");
     const fd = openSync(file, "as");
@@ -107,7 +117,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'as+'",
+  name: "open with string flag 'as+'",
   fn() {
     const file = join(tempDir, "some_random_file10");
     const fd = openSync(file, "as+");
@@ -118,7 +128,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'r'",
+  name: "open with string flag 'r'",
   fn() {
     const file = join(tempDir, "some_random_file3");
     assertThrows(() => {
@@ -128,7 +138,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'r+'",
+  name: "open with string flag 'r+'",
   fn() {
     const file = join(tempDir, "some_random_file4");
     assertThrows(() => {
@@ -138,7 +148,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'w'",
+  name: "open with string flag 'w'",
   fn() {
     const file = Deno.makeTempFileSync();
     Deno.writeTextFileSync(file, "hi there");
@@ -156,7 +166,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'wx'",
+  name: "open with string flag 'wx'",
   fn() {
     const file = Deno.makeTempFileSync();
     Deno.writeTextFileSync(file, "hi there");
@@ -177,7 +187,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'w+'",
+  name: "open with string flag 'w+'",
   fn() {
     const file = Deno.makeTempFileSync();
     Deno.writeTextFileSync(file, "hi there");
@@ -195,12 +205,179 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with flag 'wx+'",
+  name: "open with string flag 'wx+'",
   fn() {
     const file = Deno.makeTempFileSync();
     assertThrows(
       () => {
         openSync(file, "wx+");
+      },
+      Error,
+      `EEXIST: file already exists, open '${file}'`,
+    );
+    Deno.removeSync(file);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY` ('a')",
+  fn() {
+    const file = join(tempDir, "some_random_file");
+    const fd = openSync(file, O_APPEND | O_CREAT | O_WRONLY);
+    assertEquals(typeof fd, "number");
+    assertEquals(existsSync(file), true);
+    assert(Deno.resources()[fd]);
+    closeSync(fd);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_EXCL` ('ax')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    assertThrows(
+      () => {
+        openSync(file, O_APPEND | O_CREAT | O_WRONLY | O_EXCL);
+      },
+      Error,
+      `EEXIST: file already exists, open '${file}'`,
+    );
+    Deno.removeSync(file);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_RDWR` ('a+')",
+  fn() {
+    const file = join(tempDir, "some_random_file2");
+    const fd = openSync(file, O_APPEND | O_CREAT | O_RDWR);
+    assertEquals(typeof fd, "number");
+    assertEquals(existsSync(file), true);
+    closeSync(fd);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_RDWR | O_EXCL` ('ax+')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    assertThrows(
+      () => {
+        openSync(file, O_APPEND | O_CREAT | O_RDWR | O_EXCL);
+      },
+      Error,
+      `EEXIST: file already exists, open '${file}'`,
+    );
+    Deno.removeSync(file);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_SYNC` ('as')",
+  fn() {
+    const file = join(tempDir, "some_random_file10");
+    const fd = openSync(file, O_APPEND | O_CREAT | O_WRONLY | O_SYNC);
+    assertEquals(existsSync(file), true);
+    assertEquals(typeof fd, "number");
+    closeSync(fd);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_APPEND | O_CREAT | O_RDWR | O_SYNC` ('as+')",
+  fn() {
+    const file = join(tempDir, "some_random_file10");
+    const fd = openSync(file, O_APPEND | O_CREAT | O_RDWR | O_SYNC);
+    assertEquals(existsSync(file), true);
+    assertEquals(typeof fd, "number");
+    closeSync(fd);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_RDONLY` ('r')",
+  fn() {
+    const file = join(tempDir, "some_random_file3");
+    assertThrows(() => {
+      openSync(file, O_RDONLY);
+    }, Error);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_RDWR` ('r+')",
+  fn() {
+    const file = join(tempDir, "some_random_file4");
+    assertThrows(() => {
+      openSync(file, O_RDWR);
+    }, Error);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_TRUNC | O_CREAT | O_WRONLY` ('w')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    Deno.writeTextFileSync(file, "hi there");
+    const fd = openSync(file, O_TRUNC | O_CREAT | O_WRONLY);
+    assertEquals(typeof fd, "number");
+    assertEquals(Deno.readTextFileSync(file), "");
+    closeSync(fd);
+
+    const file2 = join(tempDir, "some_random_file5");
+    const fd2 = openSync(file2, O_TRUNC | O_CREAT | O_WRONLY);
+    assertEquals(typeof fd2, "number");
+    assertEquals(existsSync(file2), true);
+    closeSync(fd2);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_TRUNC | O_CREAT | O_WRONLY | O_EXCL` ('wx')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    Deno.writeTextFileSync(file, "hi there");
+    const fd = openSync(file, "w");
+    assertEquals(typeof fd, "number");
+    assertEquals(Deno.readTextFileSync(file), "");
+    closeSync(fd);
+
+    const file2 = Deno.makeTempFileSync();
+    assertThrows(
+      () => {
+        openSync(file2, O_TRUNC | O_CREAT | O_WRONLY | O_EXCL);
+      },
+      Error,
+      `EEXIST: file already exists, open '${file2}'`,
+    );
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_TRUNC | O_CREAT | O_RDWR` ('w+')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    Deno.writeTextFileSync(file, "hi there");
+    const fd = openSync(file, O_TRUNC | O_CREAT | O_RDWR);
+    assertEquals(typeof fd, "number");
+    assertEquals(Deno.readTextFileSync(file), "");
+    closeSync(fd);
+
+    const file2 = join(tempDir, "some_random_file6");
+    const fd2 = openSync(file2, O_TRUNC | O_CREAT | O_RDWR);
+    assertEquals(typeof fd2, "number");
+    assertEquals(existsSync(file2), true);
+    closeSync(fd2);
+  },
+});
+
+Deno.test({
+  name: "open with numeric flag `O_TRUNC | O_CREAT | O_RDWR | O_EXCL` ('wx+')",
+  fn() {
+    const file = Deno.makeTempFileSync();
+    assertThrows(
+      () => {
+        openSync(file, O_TRUNC | O_CREAT | O_RDWR | O_EXCL);
       },
       Error,
       `EEXIST: file already exists, open '${file}'`,

--- a/node/_fs/_fs_open_test.ts
+++ b/node/_fs/_fs_open_test.ts
@@ -232,7 +232,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_EXCL` ('ax')",
+  name:
+    "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_EXCL` ('ax')",
   fn() {
     const file = Deno.makeTempFileSync();
     assertThrows(
@@ -273,7 +274,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_SYNC` ('as')",
+  name:
+    "open with numeric flag `O_APPEND | O_CREAT | O_WRONLY | O_SYNC` ('as')",
   fn() {
     const file = join(tempDir, "some_random_file10");
     const fd = openSync(file, O_APPEND | O_CREAT | O_WRONLY | O_SYNC);


### PR DESCRIPTION
Add support for [numeric flags](https://nodejs.org/api/fs.html#file-system-flags) for `fs.open()` and `fs.openSync()` and make argument handling a bit more aligned with [Node's implementation](https://github.com/nodejs/node/blob/main/lib/fs.js#L551).

Closes #2796: `npm:tmp` is failing because [it's using](https://github.com/raszi/node-tmp/blob/master/lib/tmp.js#L30) numeric flags for file opening which is not yet supported by our polyfill.