### PR TITLE
docs(flags): fix broken link to minimist

### DIFF
--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 /**
  * Command line arguments parser based on
- * [minimist](https://github.com/substack/minimist).
+ * [minimist](https://github.com/minimistjs/minimist).
  *
  * This module is browser compatible.
  *


### PR DESCRIPTION
I noticed a broken link in the flags docs 🙂