### PR TITLE
refactor(node): create _test_utils.ts

### DIFF
--- a/node/_fs/_fs_appendFile_test.ts
+++ b/node/_fs/_fs_appendFile_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, assertThrows, fail } from "../../testing/asserts.ts";
 import { appendFile, appendFileSync } from "./_fs_appendFile.ts";
 import { fromFileUrl } from "../path.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 
 const decoder = new TextDecoder("utf-8");
 

--- a/node/_fs/_fs_chmod_test.ts
+++ b/node/_fs/_fs_chmod_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assert, fail } from "../../testing/asserts.ts";
 import { isWindows } from "../../_util/os.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chmod, chmodSync } from "./_fs_chmod.ts";
 
 Deno.test({

--- a/node/_fs/_fs_chown_test.ts
+++ b/node/_fs/_fs_chown_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, fail } from "../../testing/asserts.ts";
 import { isWindows } from "../../_util/os.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chown, chownSync } from "./_fs_chown.ts";
 
 // chown is difficult to test.  Best we can do is set the existing user id/group

--- a/node/_fs/_fs_close_test.ts
+++ b/node/_fs/_fs_close_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assert, assertThrows, fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { close, closeSync } from "./_fs_close.ts";
 
 Deno.test({

--- a/node/_fs/_fs_copy_test.ts
+++ b/node/_fs/_fs_copy_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../path/mod.ts";
 import { assert } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { copyFile, copyFileSync } from "./_fs_copy.ts";
 import { existsSync } from "./_fs_exists.ts";
 

--- a/node/_fs/_fs_dir_test.ts
+++ b/node/_fs/_fs_dir_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import Dir from "./_fs_dir.ts";
 import type Dirent from "./_fs_dirent.ts";
 

--- a/node/_fs/_fs_link_test.ts
+++ b/node/_fs/_fs_link_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../path/mod.ts";
 import { assert, assertEquals, fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { link, linkSync } from "./_fs_link.ts";
 
 Deno.test({

--- a/node/_fs/_fs_lstat_test.ts
+++ b/node/_fs/_fs_lstat_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { lstat, lstatSync } from "./_fs_lstat.ts";
 import { fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { assertStats, assertStatsBigInt } from "./_fs_stat_test.ts";
 import type { BigIntStats, Stats } from "./_fs_stat.ts";
 

--- a/node/_fs/_fs_mkdir_test.ts
+++ b/node/_fs/_fs_mkdir_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../path/mod.ts";
 import { assert } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { mkdir, mkdirSync } from "./_fs_mkdir.ts";
 import { existsSync } from "./_fs_exists.ts";
 

--- a/node/_fs/_fs_open_test.ts
+++ b/node/_fs/_fs_open_test.ts
@@ -15,7 +15,7 @@ import {
   assertThrows,
   fail,
 } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { open, openSync } from "./_fs_open.ts";
 import { join, parse } from "../../path/mod.ts";
 import { existsSync } from "../../fs/exists.ts";

--- a/node/_fs/_fs_opendir_test.ts
+++ b/node/_fs/_fs_opendir_test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../testing/asserts.ts";
 import { opendir, opendirSync } from "./_fs_opendir.ts";
 import { Buffer } from "../buffer.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 
 Deno.test("[node/fs] opendir()", async (t) => {
   const path = await Deno.makeTempDir();

--- a/node/_fs/_fs_readFile_test.ts
+++ b/node/_fs/_fs_readFile_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readFile, readFileSync } from "./_fs_readFile.ts";
 import * as path from "../../path/mod.ts";
 import { assert, assertEquals } from "../../testing/asserts.ts";

--- a/node/_fs/_fs_readdir_test.ts
+++ b/node/_fs/_fs_readdir_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertNotEquals, fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readdir, readdirSync } from "./_fs_readdir.ts";
 import { join } from "../../path/mod.ts";
 

--- a/node/_fs/_fs_readlink_test.ts
+++ b/node/_fs/_fs_readlink_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readlink, readlinkSync } from "./_fs_readlink.ts";
 import { assert, assertEquals } from "../../testing/asserts.ts";
 import * as path from "../path.ts";

--- a/node/_fs/_fs_realpath_test.ts
+++ b/node/_fs/_fs_realpath_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../path/mod.ts";
 import { assertEquals } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { realpath, realpathSync } from "./_fs_realpath.ts";
 
 Deno.test("realpath", async function () {

--- a/node/_fs/_fs_rename_test.ts
+++ b/node/_fs/_fs_rename_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, fail } from "../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { rename, renameSync } from "./_fs_rename.ts";
 import { existsSync } from "../../fs/exists.ts";
 import { join, parse } from "../../path/mod.ts";

--- a/node/_fs/_fs_rmdir_test.ts
+++ b/node/_fs/_fs_rmdir_test.ts
@@ -4,7 +4,7 @@ import { rmdir, rmdirSync } from "./_fs_rmdir.ts";
 import { closeSync } from "./_fs_close.ts";
 import { existsSync } from "../../fs/exists.ts";
 import { join } from "../../path/mod.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { isWindows } from "../../_util/os.ts";
 
 Deno.test({

--- a/node/_fs/_fs_stat_test.ts
+++ b/node/_fs/_fs_stat_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { BigIntStats, stat, Stats, statSync } from "./_fs_stat.ts";
 import { assertEquals, fail } from "../../testing/asserts.ts";
 

--- a/node/_fs/_fs_unlink_test.ts
+++ b/node/_fs/_fs_unlink_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, fail } from "../../testing/asserts.ts";
 import { existsSync } from "../../fs/exists.ts";
-import { assertCallbackErrorUncaught } from "../_utils.ts";
+import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { unlink, unlinkSync } from "./_fs_unlink.ts";
 
 Deno.test({

--- a/node/_test_utils.ts
+++ b/node/_test_utils.ts
@@ -1,0 +1,44 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import { readAll } from "../streams/conversion.ts";
+import { assert, assertStringIncludes } from "../testing/asserts.ts";
+
+/** Asserts that an error thrown in a callback will not be wrongly caught. */
+export async function assertCallbackErrorUncaught(
+  { prelude, invocation, cleanup }: {
+    /** Any code which needs to run before the actual invocation (notably, any import statements). */
+    prelude?: string;
+    /**
+     * The start of the invocation of the function, e.g. `open("foo.txt", `.
+     * The callback will be added after it.
+     */
+    invocation: string;
+    /** Called after the subprocess is finished but before running the assertions, e.g. to clean up created files. */
+    cleanup?: () => Promise<void> | void;
+  },
+) {
+  // Since the error has to be uncaught, and that will kill the Deno process,
+  // the only way to test this is to spawn a subprocess.
+  const p = Deno.run({
+    cmd: [
+      Deno.execPath(),
+      "eval",
+      "--unstable",
+      `${prelude ?? ""}
+  
+        ${invocation}(err) => {
+          // If the bug is present and the callback is called again with an error,
+          // don't throw another error, so if the subprocess fails we know it had the correct behaviour.
+          if (!err) throw new Error("success");
+        });`,
+    ],
+    stderr: "piped",
+  });
+  const status = await p.status();
+  const stderr = new TextDecoder().decode(await readAll(p.stderr));
+  p.close();
+  p.stderr.close();
+  await cleanup?.();
+  assert(!status.success);
+  assertStringIncludes(stderr, "Error: success");
+}

--- a/node/_utils.ts
+++ b/node/_utils.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-// import { deferred } from "../async/mod.ts";
-import { assert } from "../_util/asserts.ts";
-import { readAll } from "../streams/conversion.ts";
+
 import { errorMap } from "./internal_binding/uv.ts";
 import { codes } from "./internal/error_codes.ts";
 
@@ -175,47 +173,6 @@ export function once<T = undefined>(
     called = true;
     callback.apply(this, args);
   };
-}
-
-/** Asserts that an error thrown in a callback will not be wrongly caught. */
-export async function assertCallbackErrorUncaught(
-  { prelude, invocation, cleanup }: {
-    /** Any code which needs to run before the actual invocation (notably, any import statements). */
-    prelude?: string;
-    /**
-     * The start of the invocation of the function, e.g. `open("foo.txt", `.
-     * The callback will be added after it.
-     */
-    invocation: string;
-    /** Called after the subprocess is finished but before running the assertions, e.g. to clean up created files. */
-    cleanup?: () => Promise<void> | void;
-  },
-) {
-  // Since the error has to be uncaught, and that will kill the Deno process,
-  // the only way to test this is to spawn a subprocess.
-  const p = Deno.run({
-    cmd: [
-      Deno.execPath(),
-      "eval",
-      "--no-check", // Running TSC for every one of these tests would take way too long
-      "--unstable",
-      `${prelude ?? ""}
-
-      ${invocation}(err) => {
-        // If the bug is present and the callback is called again with an error,
-        // don't throw another error, so if the subprocess fails we know it had the correct behaviour.
-        if (!err) throw new Error("success");
-      });`,
-    ],
-    stderr: "piped",
-  });
-  const status = await p.status();
-  const stderr = new TextDecoder().decode(await readAll(p.stderr));
-  p.close();
-  p.stderr.close();
-  await cleanup?.();
-  assert(!status.success);
-  assert(stderr.includes("Error: success"));
 }
 
 export function makeMethodsEnumerable(klass: { new (): unknown }) {

--- a/node/internal/crypto/_randomBytes_test.ts
+++ b/node/internal/crypto/_randomBytes_test.ts
@@ -5,7 +5,7 @@ import {
   assertRejects,
   assertThrows,
 } from "../../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../../_utils.ts";
+import { assertCallbackErrorUncaught } from "../../_test_utils.ts";
 import randomBytes, { MAX_RANDOM_VALUES, MAX_SIZE } from "./_randomBytes.ts";
 
 Deno.test("randomBytes sync works correctly", function () {

--- a/node/internal/crypto/pbkdf2_test.ts
+++ b/node/internal/crypto/pbkdf2_test.ts
@@ -5,7 +5,7 @@ import {
   pbkdf2Sync,
 } from "./pbkdf2.ts";
 import { assert, assertEquals } from "../../../testing/asserts.ts";
-import { assertCallbackErrorUncaught } from "../../_utils.ts";
+import { assertCallbackErrorUncaught } from "../../_test_utils.ts";
 
 type Pbkdf2Fixture = {
   key: string | Float64Array | Int32Array | Uint8Array;


### PR DESCRIPTION
This PR creates `node/_test_utils.ts` and moves `assertCallbackErrorUncaught` from `node/_utils.ts` to there.

`assertCallbackErrorUncaught` is a testing utility, and it shouldn't be in the dependencies of non-test code.