### PR TITLE
test(node): update domain names in dns test

### DIFF
--- a/node/_tools/test/common/internet.js
+++ b/node/_tools/test/common/internet.js
@@ -32,7 +32,10 @@ const addresses = {
   // record not found. Use this to guarantee record not found.
   NOT_FOUND: 'come.on.fhqwhgads.test',
   // A host with SRV records registered
-  SRV_HOST: '_jabber._tcp.google.com',
+  // TODO(kt3k): Temporarily use _caldav._tcp.google.com instead of
+  // _jabber._tcp.google.com, which currently doesn't respond
+  // SRV_HOST: '_jabber._tcp.google.com',
+  SRV_HOST: '_caldav._tcp.google.com',
   // A host with PTR records registered
   PTR_HOST: '8.8.8.8.in-addr.arpa',
   // A host with NAPTR records registered

--- a/node/_tools/test/internet/test-dns-any.js
+++ b/node/_tools/test/internet/test-dns-any.js
@@ -152,10 +152,17 @@ TEST(async function test_google_for_cname_and_srv(done) {
     assert.ok(types.SRV);
   }
 
-  validateResult(await dnsPromises.resolve('_jabber._tcp.google.com', 'ANY'));
+  // TODO(kt3k): Temporarily use _caldav._tcp.google.com instead of
+  // _jabber._tcp.google.com, which currently doesn't respond
+  // validateResult(await dnsPromises.resolve('_jabber._tcp.google.com', 'ANY'));
+  validateResult(await dnsPromises.resolve('_caldav._tcp.google.com', 'ANY'));
 
+
+  // TODO(kt3k): Temporarily use _caldav._tcp.google.com instead of
+  // _jabber._tcp.google.com, which currently doesn't respond
   const req = dns.resolve(
-    '_jabber._tcp.google.com',
+    // '_jabber._tcp.google.com',
+    '_caldav._tcp.google.com',
     'ANY',
     common.mustSucceed((ret) => {
       validateResult(ret);


### PR DESCRIPTION
This PR updates the domain name `_jabber._tcp.google.com` to `_caldav._tcp.google.com` in test-dns-any.js (in node compat testing). `_jabber._tcp.google.com` seems to have stopped working recently. `_caldav._tcp.google.com` seems still working.