### PR TITLE
fix: allow creating http.IncomingRequest without url being set

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -419,7 +419,7 @@ export class IncomingMessageForServer extends NodeReadable {
     });
     // TODO: consider more robust path extraction, e.g:
     // url: (new URL(request.url).pathname),
-    this.url = req.url.slice(req.url.indexOf("/", 8));
+    this.url = req.url?.slice(req.url.indexOf("/", 8));
     this.method = req.method;
     this.#req = req;
   }

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -181,13 +181,16 @@ Deno.test("[node/http] non-string buffer response", async () => {
 });
 
 Deno.test("[node/http] http.IncomingMessage can be created without url", async () => {
-  const message = new http.IncomingMessage({
-    encrypted: true,
-    readable: false,
-    remoteAddress: "foo",
-    address: () => ({ port: 443 }),
-    end: Function.prototype,
-    destroy: Function.prototype,
-  });
+  const message = new http.IncomingMessage(
+    // adapted from https://github.com/dougmoscrop/serverless-http/blob/80bfb3e940057d694874a8b0bc12ad96d2abe7ab/lib/request.js#L7
+    {
+      encrypted: true,
+      readable: false,
+      remoteAddress: "foo",
+      address: () => ({ port: 443 }),
+      end: Function.prototype,
+      destroy: Function.prototype,
+    } as any,
+  );
   message.url = "https://example.com";
 });

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -187,7 +187,7 @@ Deno.test("[node/http] http.IncomingMessage can be created without url", async (
     remoteAddress: "foo",
     address: () => ({ port: 443 }),
     end: Function.prototype,
-    destroy: Function.prototype
-  })
-  message.url = "https://example.com"
+    destroy: Function.prototype,
+  });
+  message.url = "https://example.com";
 });

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -184,13 +184,14 @@ Deno.test("[node/http] http.IncomingMessage can be created without url", async (
   const message = new http.IncomingMessage(
     // adapted from https://github.com/dougmoscrop/serverless-http/blob/80bfb3e940057d694874a8b0bc12ad96d2abe7ab/lib/request.js#L7
     {
+      // @ts-expect-error
       encrypted: true,
       readable: false,
       remoteAddress: "foo",
       address: () => ({ port: 443 }),
       end: Function.prototype,
       destroy: Function.prototype,
-    } as any,
+    },
   );
   message.url = "https://example.com";
 });

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -180,11 +180,11 @@ Deno.test("[node/http] non-string buffer response", async () => {
   await promise;
 });
 
-Deno.test("[node/http] http.IncomingMessage can be created without url", async () => {
+Deno.test("[node/http] http.IncomingMessage can be created without url", () => {
   const message = new http.IncomingMessage(
     // adapted from https://github.com/dougmoscrop/serverless-http/blob/80bfb3e940057d694874a8b0bc12ad96d2abe7ab/lib/request.js#L7
     {
-      // @ts-expect-error
+      // @ts-expect-error - non-request properties will also be passed in, e.g. by serverless-http
       encrypted: true,
       readable: false,
       remoteAddress: "foo",

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -179,3 +179,15 @@ Deno.test("[node/http] non-string buffer response", async () => {
   });
   await promise;
 });
+
+Deno.test("[node/http] http.IncomingMessage can be created without url", async () => {
+  const message = new http.IncomingMessage({
+    encrypted: true,
+    readable: false,
+    remoteAddress: "foo",
+    address: () => ({ port: 443 }),
+    end: Function.prototype,
+    destroy: Function.prototype
+  })
+  message.url = "https://example.com"
+});


### PR DESCRIPTION
Congrats on launching the NPM compatibility, this is huge!
I'm trying to get an express app running on Netlify Edge Functions, and using https://github.com/dougmoscrop/serverless-http to do so. That library is [creating a `http.IncomingMessage`](https://github.com/dougmoscrop/serverless-http/blob/80bfb3e940057d694874a8b0bc12ad96d2abe7ab/lib/request.js#LL7) without `url` being specified, and sets it [in a second step](https://github.com/dougmoscrop/serverless-http/blob/80bfb3e940057d694874a8b0bc12ad96d2abe7ab/lib/request.js#LL29) (reproduced in the test).

That currently results in an uncaught exception with Deno's polyfill. This PR fixes that.