### PR TITLE
(fmt/bytes): rename prettyBytes

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -247,24 +247,24 @@ Note: This module was ported from
 ## Usage
 
 ```ts
-import { prettyBytes } from "https://deno.land/std@$STD_VERSION/fmt/bytes.ts";
+import { format } from "https://deno.land/std@$STD_VERSION/fmt/bytes.ts";
 
-prettyBytes(1337);
+format(1337);
 //=> '1.34 kB'
 
-prettyBytes(100);
+format(100);
 //=> '100 B'
 
 // Display with units of bits
-prettyBytes(1337, { bits: true });
+format(1337, { bits: true });
 //=> '1.34 kbit'
 
 // Display file size differences
-prettyBytes(42, { signed: true });
+format(42, { signed: true });
 //=> '+42 B'
 
 // Localized output using German locale
-prettyBytes(1337, { locale: "de" });
+format(1337, { locale: "de" });
 //=> '1,34 kB'
 ```
 

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -17,7 +17,7 @@ type LocaleOptions = {
 };
 
 /**
- * @depreacted (will be reomved after 0.170.0) use `FormatOptions` instead
+ * @depreacted (will be removed after 0.170.0) use `FormatOptions` instead
  */
 export interface PrettyBytesOptions {
   /** Uses bits representation. Default is false. */
@@ -52,7 +52,7 @@ export interface FormatOptions {
 }
 
 /**
- * @depreacted (will be reomved after 0.170.0) use `FormatOptions` instead
+ * @depreacted (will be removed after 0.170.0) use `FormatOptions` instead
  */
 export function pretty(num: number, options: FormatOptions = {}) {
   return format(num, options);

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -52,9 +52,9 @@ export interface FormatOptions {
 }
 
 /**
- * @depreacted (will be removed after 0.170.0) use `FormatOptions` instead
+ * @depreacted (will be removed after 0.170.0) use `format` instead
  */
-export function pretty(num: number, options: FormatOptions = {}) {
+export function prettyBytes(num: number, options: FormatOptions = {}) {
   return format(num, options);
 }
 

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -17,7 +17,7 @@ type LocaleOptions = {
 };
 
 /**
- * The options for pretty printing the byte numbers.
+ * @depreacted (will be reomved after 0.170.0) use `FormatOptions` instead
  */
 export interface PrettyBytesOptions {
   /** Uses bits representation. Default is false. */
@@ -33,6 +33,30 @@ export interface PrettyBytesOptions {
   /** The maximum number of fraction digits to display. If neither minimumFractionDigits or maximumFractionDigits are set, the default behavior is to round to 3 significant digits. */
   maximumFractionDigits?: number;
 }
+/**
+ * The options for pretty printing the byte numbers.
+ */
+export interface FormatOptions {
+  /** Uses bits representation. Default is false. */
+  bits?: boolean;
+  /** Uses binary bytes (e.g. kibibyte). Default is false. */
+  binary?: boolean;
+  /** Include plus sign for positive numbers. */
+  signed?: boolean;
+  /** Uses localized number formatting. If it is set to true, uses default locale on the system. If it's set to string, uses that locale. The given string should be BCP 47 language tag (ref: https://en.wikipedia.org/wiki/IETF_language_tag). You can also give the list of language tags. */
+  locale?: boolean | string | string[];
+  /** The minimum number of fraction digits to display. If neither minimumFractionDigits or maximumFractionDigits are set, the default behavior is to round to 3 significant digits. */
+  minimumFractionDigits?: number;
+  /** The maximum number of fraction digits to display. If neither minimumFractionDigits or maximumFractionDigits are set, the default behavior is to round to 3 significant digits. */
+  maximumFractionDigits?: number;
+}
+
+/**
+ * @depreacted (will be reomved after 0.170.0) use `FormatOptions` instead
+ */
+export function pretty(num: number, options: FormatOptions = {}) {
+  return format(num, options);
+}
 
 /**
  * Convert bytes to a human readable string: 1337 → 1.34 kB
@@ -40,9 +64,9 @@ export interface PrettyBytesOptions {
  * @param num The number to format
  * @param options The options
  */
-export function prettyBytes(
+export function format(
   num: number,
-  options: PrettyBytesOptions = {},
+  options: FormatOptions = {},
 ): string {
   if (!Number.isFinite(num)) {
     throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
@@ -92,7 +116,7 @@ export function prettyBytes(
 }
 
 function getLocaleOptions(
-  { maximumFractionDigits, minimumFractionDigits }: PrettyBytesOptions,
+  { maximumFractionDigits, minimumFractionDigits }: FormatOptions,
 ): LocaleOptions | undefined {
   if (maximumFractionDigits || minimumFractionDigits) {
     return {

--- a/fmt/bytes_test.ts
+++ b/fmt/bytes_test.ts
@@ -2,160 +2,160 @@
 // Copyright 2014-2021 Sindre Sorhus. All rights reserved. MIT license.
 // Copyright 2021 Yoshiya Hinosawa. All rights reserved. MIT license.
 
-import { prettyBytes } from "./bytes.ts";
+import { format } from "./bytes.ts";
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
 
 Deno.test("throws on invalid input", () => {
   // deno-lint-ignore no-explicit-any
-  assertThrows(() => prettyBytes("" as any));
+  assertThrows(() => format("" as any));
   // deno-lint-ignore no-explicit-any
-  assertThrows(() => prettyBytes("1" as any));
-  assertThrows(() => prettyBytes(NaN));
+  assertThrows(() => format("1" as any));
+  assertThrows(() => format(NaN));
   // deno-lint-ignore no-explicit-any
-  assertThrows(() => prettyBytes(true as any));
-  assertThrows(() => prettyBytes(Infinity));
-  assertThrows(() => prettyBytes(-Infinity));
+  assertThrows(() => format(true as any));
+  assertThrows(() => format(Infinity));
+  assertThrows(() => format(-Infinity));
   // deno-lint-ignore no-explicit-any
-  assertThrows(() => prettyBytes(null as any));
+  assertThrows(() => format(null as any));
 });
 
 Deno.test("converts bytes to human readable strings", () => {
-  assertEquals(prettyBytes(0), "0 B");
-  assertEquals(prettyBytes(0.4), "0.4 B");
-  assertEquals(prettyBytes(0.7), "0.7 B");
-  assertEquals(prettyBytes(10), "10 B");
-  assertEquals(prettyBytes(10.1), "10.1 B");
-  assertEquals(prettyBytes(999), "999 B");
-  assertEquals(prettyBytes(1001), "1 kB");
-  assertEquals(prettyBytes(1001), "1 kB");
-  assertEquals(prettyBytes(1e16), "10 PB");
-  assertEquals(prettyBytes(1e30), "1000000 YB");
+  assertEquals(format(0), "0 B");
+  assertEquals(format(0.4), "0.4 B");
+  assertEquals(format(0.7), "0.7 B");
+  assertEquals(format(10), "10 B");
+  assertEquals(format(10.1), "10.1 B");
+  assertEquals(format(999), "999 B");
+  assertEquals(format(1001), "1 kB");
+  assertEquals(format(1001), "1 kB");
+  assertEquals(format(1e16), "10 PB");
+  assertEquals(format(1e30), "1000000 YB");
 });
 
 Deno.test("supports negative number", () => {
-  assertEquals(prettyBytes(-0.4), "-0.4 B");
-  assertEquals(prettyBytes(-0.7), "-0.7 B");
-  assertEquals(prettyBytes(-10.1), "-10.1 B");
-  assertEquals(prettyBytes(-999), "-999 B");
-  assertEquals(prettyBytes(-1001), "-1 kB");
+  assertEquals(format(-0.4), "-0.4 B");
+  assertEquals(format(-0.7), "-0.7 B");
+  assertEquals(format(-10.1), "-10.1 B");
+  assertEquals(format(-999), "-999 B");
+  assertEquals(format(-1001), "-1 kB");
 });
 
 Deno.test("locale option", () => {
-  assertEquals(prettyBytes(-0.4, { locale: "de" }), "-0,4 B");
-  assertEquals(prettyBytes(0.4, { locale: "de" }), "0,4 B");
-  assertEquals(prettyBytes(1001, { locale: "de" }), "1 kB");
-  assertEquals(prettyBytes(10.1, { locale: "de" }), "10,1 B");
-  assertEquals(prettyBytes(1e30, { locale: "de" }), "1.000.000 YB");
+  assertEquals(format(-0.4, { locale: "de" }), "-0,4 B");
+  assertEquals(format(0.4, { locale: "de" }), "0,4 B");
+  assertEquals(format(1001, { locale: "de" }), "1 kB");
+  assertEquals(format(10.1, { locale: "de" }), "10,1 B");
+  assertEquals(format(1e30, { locale: "de" }), "1.000.000 YB");
 
-  assertEquals(prettyBytes(-0.4, { locale: "en" }), "-0.4 B");
-  assertEquals(prettyBytes(0.4, { locale: "en" }), "0.4 B");
-  assertEquals(prettyBytes(1001, { locale: "en" }), "1 kB");
-  assertEquals(prettyBytes(10.1, { locale: "en" }), "10.1 B");
-  assertEquals(prettyBytes(1e30, { locale: "en" }), "1,000,000 YB");
+  assertEquals(format(-0.4, { locale: "en" }), "-0.4 B");
+  assertEquals(format(0.4, { locale: "en" }), "0.4 B");
+  assertEquals(format(1001, { locale: "en" }), "1 kB");
+  assertEquals(format(10.1, { locale: "en" }), "10.1 B");
+  assertEquals(format(1e30, { locale: "en" }), "1,000,000 YB");
 
   assertEquals(
-    prettyBytes(-0.4, { locale: ["unknown", "de", "en"] }),
+    format(-0.4, { locale: ["unknown", "de", "en"] }),
     "-0,4 B",
   );
-  assertEquals(prettyBytes(0.4, { locale: ["unknown", "de", "en"] }), "0,4 B");
-  assertEquals(prettyBytes(1001, { locale: ["unknown", "de", "en"] }), "1 kB");
+  assertEquals(format(0.4, { locale: ["unknown", "de", "en"] }), "0,4 B");
+  assertEquals(format(1001, { locale: ["unknown", "de", "en"] }), "1 kB");
   assertEquals(
-    prettyBytes(10.1, { locale: ["unknown", "de", "en"] }),
+    format(10.1, { locale: ["unknown", "de", "en"] }),
     "10,1 B",
   );
   assertEquals(
-    prettyBytes(1e30, { locale: ["unknown", "de", "en"] }),
+    format(1e30, { locale: ["unknown", "de", "en"] }),
     "1.000.000 YB",
   );
 
-  assertEquals(prettyBytes(-0.4, { locale: true }), "-0.4 B");
-  assertEquals(prettyBytes(0.4, { locale: true }), "0.4 B");
-  assertEquals(prettyBytes(1001, { locale: true }), "1 kB");
-  assertEquals(prettyBytes(10.1, { locale: true }), "10.1 B");
-  assertEquals(prettyBytes(1e30, { locale: true }), "1,000,000 YB");
+  assertEquals(format(-0.4, { locale: true }), "-0.4 B");
+  assertEquals(format(0.4, { locale: true }), "0.4 B");
+  assertEquals(format(1001, { locale: true }), "1 kB");
+  assertEquals(format(10.1, { locale: true }), "10.1 B");
+  assertEquals(format(1e30, { locale: true }), "1,000,000 YB");
 
-  assertEquals(prettyBytes(-0.4, { locale: false }), "-0.4 B");
-  assertEquals(prettyBytes(0.4, { locale: false }), "0.4 B");
-  assertEquals(prettyBytes(1001, { locale: false }), "1 kB");
-  assertEquals(prettyBytes(10.1, { locale: false }), "10.1 B");
-  assertEquals(prettyBytes(1e30, { locale: false }), "1000000 YB");
+  assertEquals(format(-0.4, { locale: false }), "-0.4 B");
+  assertEquals(format(0.4, { locale: false }), "0.4 B");
+  assertEquals(format(1001, { locale: false }), "1 kB");
+  assertEquals(format(10.1, { locale: false }), "10.1 B");
+  assertEquals(format(1e30, { locale: false }), "1000000 YB");
 
-  assertEquals(prettyBytes(-0.4, { locale: undefined }), "-0.4 B");
-  assertEquals(prettyBytes(0.4, { locale: undefined }), "0.4 B");
-  assertEquals(prettyBytes(1001, { locale: undefined }), "1 kB");
-  assertEquals(prettyBytes(10.1, { locale: undefined }), "10.1 B");
-  assertEquals(prettyBytes(1e30, { locale: undefined }), "1000000 YB");
+  assertEquals(format(-0.4, { locale: undefined }), "-0.4 B");
+  assertEquals(format(0.4, { locale: undefined }), "0.4 B");
+  assertEquals(format(1001, { locale: undefined }), "1 kB");
+  assertEquals(format(10.1, { locale: undefined }), "10.1 B");
+  assertEquals(format(1e30, { locale: undefined }), "1000000 YB");
 });
 
 Deno.test("signed option", () => {
-  assertEquals(prettyBytes(42, { signed: true }), "+42 B");
-  assertEquals(prettyBytes(-13, { signed: true }), "-13 B");
-  assertEquals(prettyBytes(0, { signed: true }), " 0 B");
+  assertEquals(format(42, { signed: true }), "+42 B");
+  assertEquals(format(-13, { signed: true }), "-13 B");
+  assertEquals(format(0, { signed: true }), " 0 B");
 });
 
 Deno.test("bits option", () => {
-  assertEquals(prettyBytes(0, { bits: true }), "0 b");
-  assertEquals(prettyBytes(0.4, { bits: true }), "0.4 b");
-  assertEquals(prettyBytes(0.7, { bits: true }), "0.7 b");
-  assertEquals(prettyBytes(10, { bits: true }), "10 b");
-  assertEquals(prettyBytes(10.1, { bits: true }), "10.1 b");
-  assertEquals(prettyBytes(999, { bits: true }), "999 b");
-  assertEquals(prettyBytes(1001, { bits: true }), "1 kbit");
-  assertEquals(prettyBytes(1001, { bits: true }), "1 kbit");
-  assertEquals(prettyBytes(1e16, { bits: true }), "10 Pbit");
-  assertEquals(prettyBytes(1e30, { bits: true }), "1000000 Ybit");
+  assertEquals(format(0, { bits: true }), "0 b");
+  assertEquals(format(0.4, { bits: true }), "0.4 b");
+  assertEquals(format(0.7, { bits: true }), "0.7 b");
+  assertEquals(format(10, { bits: true }), "10 b");
+  assertEquals(format(10.1, { bits: true }), "10.1 b");
+  assertEquals(format(999, { bits: true }), "999 b");
+  assertEquals(format(1001, { bits: true }), "1 kbit");
+  assertEquals(format(1001, { bits: true }), "1 kbit");
+  assertEquals(format(1e16, { bits: true }), "10 Pbit");
+  assertEquals(format(1e30, { bits: true }), "1000000 Ybit");
 });
 
 Deno.test("binary option", () => {
-  assertEquals(prettyBytes(0, { binary: true }), "0 B");
-  assertEquals(prettyBytes(4, { binary: true }), "4 B");
-  assertEquals(prettyBytes(10, { binary: true }), "10 B");
-  assertEquals(prettyBytes(10.1, { binary: true }), "10.1 B");
-  assertEquals(prettyBytes(999, { binary: true }), "999 B");
-  assertEquals(prettyBytes(1025, { binary: true }), "1 kiB");
-  assertEquals(prettyBytes(1001, { binary: true }), "1000 B");
-  assertEquals(prettyBytes(1e16, { binary: true }), "8.88 PiB");
-  assertEquals(prettyBytes(1e30, { binary: true }), "827000 YiB");
+  assertEquals(format(0, { binary: true }), "0 B");
+  assertEquals(format(4, { binary: true }), "4 B");
+  assertEquals(format(10, { binary: true }), "10 B");
+  assertEquals(format(10.1, { binary: true }), "10.1 B");
+  assertEquals(format(999, { binary: true }), "999 B");
+  assertEquals(format(1025, { binary: true }), "1 kiB");
+  assertEquals(format(1001, { binary: true }), "1000 B");
+  assertEquals(format(1e16, { binary: true }), "8.88 PiB");
+  assertEquals(format(1e30, { binary: true }), "827000 YiB");
 });
 
 Deno.test("bits and binary option", () => {
-  assertEquals(prettyBytes(0, { bits: true, binary: true }), "0 b");
-  assertEquals(prettyBytes(4, { bits: true, binary: true }), "4 b");
-  assertEquals(prettyBytes(10, { bits: true, binary: true }), "10 b");
-  assertEquals(prettyBytes(999, { bits: true, binary: true }), "999 b");
-  assertEquals(prettyBytes(1025, { bits: true, binary: true }), "1 kibit");
-  assertEquals(prettyBytes(1e6, { bits: true, binary: true }), "977 kibit");
+  assertEquals(format(0, { bits: true, binary: true }), "0 b");
+  assertEquals(format(4, { bits: true, binary: true }), "4 b");
+  assertEquals(format(10, { bits: true, binary: true }), "10 b");
+  assertEquals(format(999, { bits: true, binary: true }), "999 b");
+  assertEquals(format(1025, { bits: true, binary: true }), "1 kibit");
+  assertEquals(format(1e6, { bits: true, binary: true }), "977 kibit");
 });
 
 Deno.test("fractional digits options", () => {
-  assertEquals(prettyBytes(1900, { maximumFractionDigits: 1 }), "1.9 kB");
-  assertEquals(prettyBytes(1900, { minimumFractionDigits: 3 }), "1.900 kB");
-  assertEquals(prettyBytes(1911, { maximumFractionDigits: 1 }), "1.9 kB");
-  assertEquals(prettyBytes(1111, { maximumFractionDigits: 2 }), "1.11 kB");
-  assertEquals(prettyBytes(1019, { maximumFractionDigits: 3 }), "1.019 kB");
-  assertEquals(prettyBytes(1001, { maximumFractionDigits: 3 }), "1.001 kB");
+  assertEquals(format(1900, { maximumFractionDigits: 1 }), "1.9 kB");
+  assertEquals(format(1900, { minimumFractionDigits: 3 }), "1.900 kB");
+  assertEquals(format(1911, { maximumFractionDigits: 1 }), "1.9 kB");
+  assertEquals(format(1111, { maximumFractionDigits: 2 }), "1.11 kB");
+  assertEquals(format(1019, { maximumFractionDigits: 3 }), "1.019 kB");
+  assertEquals(format(1001, { maximumFractionDigits: 3 }), "1.001 kB");
   assertEquals(
-    prettyBytes(1000, { minimumFractionDigits: 1, maximumFractionDigits: 3 }),
+    format(1000, { minimumFractionDigits: 1, maximumFractionDigits: 3 }),
     "1.0 kB",
   );
   assertEquals(
-    prettyBytes(3942, { minimumFractionDigits: 1, maximumFractionDigits: 2 }),
+    format(3942, { minimumFractionDigits: 1, maximumFractionDigits: 2 }),
     "3.94 kB",
   );
   assertEquals(
-    prettyBytes(4001, { maximumFractionDigits: 3, binary: true }),
+    format(4001, { maximumFractionDigits: 3, binary: true }),
     "3.907 kiB",
   );
   assertEquals(
-    prettyBytes(18717, { maximumFractionDigits: 2, binary: true }),
+    format(18717, { maximumFractionDigits: 2, binary: true }),
     "18.28 kiB",
   );
   assertEquals(
-    prettyBytes(18717, { maximumFractionDigits: 4, binary: true }),
+    format(18717, { maximumFractionDigits: 4, binary: true }),
     "18.2783 kiB",
   );
   assertEquals(
-    prettyBytes(32768, {
+    format(32768, {
       minimumFractionDigits: 2,
       maximumFractionDigits: 3,
       binary: true,
@@ -163,7 +163,7 @@ Deno.test("fractional digits options", () => {
     "32.00 kiB",
   );
   assertEquals(
-    prettyBytes(65536, {
+    format(65536, {
       minimumFractionDigits: 1,
       maximumFractionDigits: 3,
       binary: true,


### PR DESCRIPTION
- rename `prettyBytes` to `format`
- deprecate `prettyBytes`
- rename `PrettyBytesOptions` to `FormatOptions`
- deprecate `PrettyBytesOptions`