### PR TITLE
fix(node/string_decoder) proper buffer type casting and fix default logic

### DIFF
--- a/node/string_decoder.ts
+++ b/node/string_decoder.ts
@@ -202,7 +202,11 @@ function utf8Write(
   } else {
     i = 0;
   }
-  if (i < buf.length) return r ? r + this.text(normalizedBuffer, i) : this.text(normalizedBuffer, i);
+  if (i < buf.length) {
+    return r 
+      ? r + this.text(normalizedBuffer, i) 
+      : this.text(normalizedBuffer, i);
+  }
   return r || "";
 }
 

--- a/node/string_decoder.ts
+++ b/node/string_decoder.ts
@@ -203,8 +203,8 @@ function utf8Write(
     i = 0;
   }
   if (i < buf.length) {
-    return r 
-      ? r + this.text(normalizedBuffer, i) 
+    return r
+      ? r + this.text(normalizedBuffer, i)
       : this.text(normalizedBuffer, i);
   }
   return r || "";

--- a/node/string_decoder_test.ts
+++ b/node/string_decoder_test.ts
@@ -116,3 +116,64 @@ Deno.test({
     assertEquals(decoder.text(Buffer.from([0x41]), 2), "");
   },
 });
+
+Deno.test({
+  name:
+    "String decoder with utf8 would handle incomplete character correctly when append",
+  fn() {
+    let decoder;
+    const specialCharactersText = "不完全な文字のテスト";
+    const encodedBuffer = Buffer.from(specialCharactersText);
+
+    decoder = new StringDecoder("utf8");
+    let str = "";
+    str += decoder.write(encodedBuffer.slice(0, 4));
+    assertEquals(str, "不");
+    str += decoder.write(encodedBuffer.slice(4));
+    assertEquals(str, "不完全な文字のテスト");
+
+    decoder = new StringDecoder("utf8");
+    str = "";
+    str += decoder.write(encodedBuffer.slice(0, 4));
+    str += decoder.write(encodedBuffer.slice(5));
+    assertEquals(str, "不�全な文字のテスト");
+  },
+});
+
+Deno.test({
+  name: "String decoder would have default encoding option as utf8",
+  fn() {
+    let decoder;
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.write(Buffer.from("E1", "hex")), "");
+    assertEquals(decoder.end(), "\ufffd");
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.write(Buffer.from("E18B", "hex")), "");
+    assertEquals(decoder.end(), "\ufffd");
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.write(Buffer.from("\ufffd")), "\ufffd");
+    assertEquals(decoder.end(), "");
+
+    decoder = new StringDecoder();
+    assertEquals(
+      decoder.write(Buffer.from("\ufffd\ufffd\ufffd")),
+      "\ufffd\ufffd\ufffd",
+    );
+    assertEquals(decoder.end(), "");
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.write(Buffer.from("EFBFBDE2", "hex")), "\ufffd");
+    assertEquals(decoder.end(), "\ufffd");
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.write(Buffer.from("F1", "hex")), "");
+    assertEquals(decoder.write(Buffer.from("41F2", "hex")), "\ufffdA");
+    assertEquals(decoder.end(), "\ufffd");
+
+    decoder = new StringDecoder();
+    assertEquals(decoder.text(Buffer.from([0x41]), 2), "");
+  },
+});


### PR DESCRIPTION
Issues: https://github.com/denoland/deno_std/issues/2859
I found out there are 4 problems when checking on this:
1) decoder needs `Buffer` while what received was `TypedArray`. Even though those two are similar, there are some fundamental difference between the pair. Most notably the `copy` method and how the `Buffer View` works.
2) With the current code in the issue, if you add specific encoding `utf8` it would also not work
3) The current `string_decoder` has different encoding normalisation logic from `node` code. Can reference here - https://github.com/nodejs/string_decoder .By default, if not specified, all encoding should be `utf8`, `GenericDecoder` is for unrecognised `encoding` only. 
 4) Current `deno` `string_decoder` is using old `string_decoder` logic from nodes, the current `node` has converted the function to handle in `C`. 

So in this PR, I use the existing function `normalizeEncoding` to follow `node` defaulting logic. And add a `TypedArray` check before start writing `Buffer`. If it's `TypeArray`, we would cast it properly to `Buffer`