### PR TITLE
fix(node/http): request with headers

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -96,6 +96,7 @@ export interface RequestOptions {
   href?: string;
 }
 
+// TODO: Implement ClientRequest methods (e.g. setHeader())
 /** ClientRequest represents the http(s) request from the client */
 class ClientRequest extends NodeWritable {
   defaultProtocol = "http:";
@@ -131,7 +132,12 @@ class ClientRequest extends NodeWritable {
     }
 
     const client = await this._createCustomClient();
-    const opts = { body: this.body, method: this.opts.method, client };
+    const opts = {
+      body: this.body,
+      method: this.opts.method,
+      client,
+      headers: this.opts.headers,
+    };
     const mayResponse = fetch(this._createUrlStrFromOptions(this.opts), opts)
       .catch((e) => {
         if (e.message.includes("connection closed before message completed")) {

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -151,6 +151,35 @@ Deno.test("[node/http] request default protocol", async () => {
   await promise;
 });
 
+Deno.test("[node/http] request with headers", async () => {
+  const promise = deferred<void>();
+  const server = http.createServer((req, res) => {
+    assertEquals(req.headers["x-foo"], "bar");
+    res.end("ok");
+  });
+  server.listen(() => {
+    const req = http.request(
+      {
+        host: "localhost",
+        port: server.address().port,
+        headers: { "x-foo": "bar" },
+      },
+      (res) => {
+        res.on("data", () => {});
+        res.on("end", () => {
+          server.close();
+        });
+        assertEquals(res.statusCode, 200);
+      },
+    );
+    req.end();
+  });
+  server.on("close", () => {
+    promise.resolve();
+  });
+  await promise;
+});
+
 Deno.test("[node/http] non-string buffer response", async () => {
   const promise = deferred<void>();
   const server = http.createServer((_, res) => {


### PR DESCRIPTION
This PR makes `http.request()` with the `headers` option actually send the headers.