### PR TITLE
test(node): ignore Node API test on aarch64 darwin

### DIFF
--- a/node/module_test.ts
+++ b/node/module_test.ts
@@ -232,7 +232,9 @@ Deno.test("createRequire with http(s):// URL  throws with correct error message"
   );
 });
 
-Deno.test("require Node-API module", () => {
+Deno.test("require Node-API module", {
+  ignore: Deno.build.arch === "aarch64" && Deno.build.os === "darwin",
+}, () => {
   const require = createRequire(import.meta.url);
   if (Deno.build.os === "windows") {
     // TODO(kt3k): Add lib binary for windows from 1_hello_world example of


### PR DESCRIPTION
closes #2856 