### PR TITLE
fix: wording for cookie value validation error

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -134,7 +134,7 @@ function validateValue(name: string, value: string | null) {
       c == String.fromCharCode(0x5c) || c == String.fromCharCode(0x7f)
     ) {
       throw new Error(
-        "RFC2616 cookie '" + name + "' cannot have '" + c + "' as value",
+        "RFC2616 cookie '" + name + "' cannot contain character '" + c + "'",
       );
     }
     if (c > String.fromCharCode(0x80)) {

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -101,6 +101,13 @@ Deno.test({
         "RFC2616 cookie 'Space'",
       );
     });
+
+    assertThrows(() => {
+      setCookie(headers, {
+        name: "location",
+        value: "United Kingdom"
+      })
+    }, Error, "RFC2616 cookie 'location' cannot contain character ' '")
   },
 });
 

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -102,12 +102,16 @@ Deno.test({
       );
     });
 
-    assertThrows(() => {
-      setCookie(headers, {
-        name: "location",
-        value: "United Kingdom"
-      })
-    }, Error, "RFC2616 cookie 'location' cannot contain character ' '")
+    assertThrows(
+      () => {
+        setCookie(headers, {
+          name: "location",
+          value: "United Kingdom",
+        });
+      },
+      Error,
+      "RFC2616 cookie 'location' cannot contain character ' '",
+    );
   },
 });
 


### PR DESCRIPTION
Before, when setting a cookie with a value that contained a space (like `United Kingdom`), the error message implied that the value was `" "`. This can be confusing, because what it really means is that the value *contained* `" "`! This PR updates that error message, so it's more descriptive of the error.