### PR TITLE
feat(http/cookie): allow number type for expires param

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -12,7 +12,7 @@ export interface Cookie {
   /** Value of the cookie. */
   value: string;
   /** Expiration date of the cookie. */
-  expires?: Date;
+  expires?: Date | number;
   /** Max-Age of the Cookie. Max-Age must be an integer superior or equal to 0. */
   maxAge?: number;
   /** Specifies those hosts to which the cookie will be sent. */
@@ -79,7 +79,8 @@ function toString(cookie: Cookie): string {
     out.push(`Path=${cookie.path}`);
   }
   if (cookie.expires) {
-    const dateString = toIMF(cookie.expires);
+    const { expires } = cookie;
+    const dateString = toIMF(typeof expires === "number" ? new Date(expires) : expires);
     out.push(`Expires=${dateString}`);
   }
   if (cookie.unparsed) {

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -80,7 +80,9 @@ function toString(cookie: Cookie): string {
   }
   if (cookie.expires) {
     const { expires } = cookie;
-    const dateString = toIMF(typeof expires === "number" ? new Date(expires) : expires);
+    const dateString = toIMF(
+      typeof expires === "number" ? new Date(expires) : expires,
+    );
     out.push(`Expires=${dateString}`);
   }
   if (cookie.unparsed) {

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -334,6 +334,17 @@ Deno.test({
     );
 
     headers = new Headers();
+    setCookie(headers, {
+      name: "Space",
+      value: "Cat",
+      expires: Date.UTC(1983, 0, 7, 15, 32),
+    });
+    assertEquals(
+      headers.get("Set-Cookie"),
+      "Space=Cat; Expires=Fri, 07 Jan 1983 15:32:00 GMT",
+    );
+
+    headers = new Headers();
     setCookie(headers, { name: "__Secure-Kitty", value: "Meow" });
     assertEquals(headers.get("Set-Cookie"), "__Secure-Kitty=Meow; Secure");
 


### PR DESCRIPTION
This PR allows number type for expires param of setCookie API. This is better aligned to how [CookieStore](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore/set) API handles `expires` param.

closes #2928