### PR TITLE
chore(_tools): disable some tests of doc import check tool

### DIFF
--- a/_tools/check_doc_imports_test.ts
+++ b/_tools/check_doc_imports_test.ts
@@ -28,6 +28,10 @@ Deno.test("doc import checker process should exit with code 1 and print warnings
   );
 
   assertEquals(code, 1);
+  // TODO(kt3k): Temporarily skips the assertion of the warning messages on linux.
+  if (Deno.build.os === "linux") {
+    return;
+  }
   assertEquals(
     new TextDecoder().decode(stdout),
     new TextDecoder().decode(expected),


### PR DESCRIPTION
Currently the last assertion of `_tools/check_doc_imports_test.ts` is ~~failing~~ flaky on main on ubuntu. This PR disables that assertion on ubuntu.