### PR TITLE
add image/jxl mime type

### DIFF
--- a/media_types/vendor/mime-db.v1.52.0.ts
+++ b/media_types/vendor/mime-db.v1.52.0.ts
@@ -7152,6 +7152,9 @@ export default {
     "compressible": false,
     "extensions": ["jpx", "jpf"]
   },
+  "image/jxl": {
+    "extensions": ["jxl"]
+  },
   "image/jxr": {
     "source": "iana",
     "extensions": ["jxr"]


### PR DESCRIPTION
[JPEG XL](https://jpeg.org/jpegxl/) is a new image format.
[Wikipedia](https://en.wikipedia.org/wiki/JPEG_XL), [jpegxl.info](https://jpegxl.info/), [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1539075) and [Palemoon](https://repo.palemoon.org/MoonchildProductions/UXP/commit/fb0c204f2b59485e796b93ce89f73af552b05c2b) say the mime type is image/jxl
It is even supported by at least one [browser](https://www.palemoon.org/releasenotes.shtml).

That's why I think the mime type db should be updated.