### PR TITLE
Reorder steps to view documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ guaranteed for them.
 To browse documentation for modules:
 
 - Go to https://deno.land/std/.
-- Navigate to any module of interest.
 - Click "View Documentation".
+- Navigate to any module of interest.
 
 ## Contributing
 


### PR DESCRIPTION
One needs to first click in "View Documentation" before we can choose a module whose docs to view.