### PR TITLE
Revert "test(node/http): modify writable of ClientRequest (#2945)"

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -223,12 +223,6 @@ class ClientRequest extends NodeWritable {
   setTimeout() {
     console.log("not implemented: ClientRequest.setTimeout");
   }
-
-  // Note: Modify this to pass "parallel/test-http-outgoing-finish-writable.js"
-  // @ts-ignore Overrides property by getter.
-  override get writable(): boolean {
-    return !this.closed;
-  }
 }
 
 /** IncomingMessage for http(s) client */


### PR DESCRIPTION
This reverts commit 5f5413df9ae7bf27819f2a112250a00822e811bb.

This change was made in response to https://github.com/denoland/deno/pull/16616. However, that change was reverted in https://github.com/denoland/deno/pull/16839 due to it breaking Vite. Let's revert it here as well.