### PR TITLE
feat(node): add util.types.isProxy

### DIFF
--- a/node/_core.ts
+++ b/node/_core.ts
@@ -3,6 +3,8 @@
 // This module provides an interface to `Deno.core`. For environments
 // that don't have access to `Deno.core` some APIs are polyfilled, while
 // some are unavailble and throw on call.
+// Note: deno_std shouldn't use Deno.core namespace. We should minimize these
+// usages.
 
 // deno-lint-ignore no-explicit-any
 export let core: any;
@@ -29,6 +31,9 @@ if (Deno?.core) {
       return new TextDecoder().decode(chunk);
     },
     eventLoopHasMoreWork(): boolean {
+      return false;
+    },
+    isProxy(): boolean {
       return false;
     },
     ops: {

--- a/node/_tools/test/parallel/test-util-types.js
+++ b/node/_tools/test/parallel/test-util-types.js
@@ -58,7 +58,7 @@ for (const [ value, _method ] of [
   //                         { value: 'foo' }) ],
   [ new DataView(new ArrayBuffer()) ],
   [ new SharedArrayBuffer() ],
-  // [ new Proxy({}, {}), 'isProxy' ],
+  [ new Proxy({}, {}), 'isProxy' ],
 ]) {
   const method = _method || `is${value.constructor.name}`;
   assert(method in types, `Missing ${method} for ${inspect(value)}`);

--- a/node/internal/util/types.ts
+++ b/node/internal/util/types.ts
@@ -106,7 +106,7 @@ export const {
   isArrayBuffer,
   isDataView,
   isSharedArrayBuffer,
-  // isProxy,
+  isProxy,
   isModuleNamespaceObject,
   isAnyArrayBuffer,
   isBoxedPrimitive,

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -21,6 +21,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { core } from "../_core.ts";
+
 const _toString = Object.prototype.toString;
 
 const _isObjectLike = (value: unknown): boolean =>
@@ -114,6 +116,10 @@ export function isBigIntObject(value: unknown): boolean {
 
 export function isPromise(value: unknown): boolean {
   return _isObjectLike(value) && _toString.call(value) === "[object Promise]";
+}
+
+export function isProxy(value: unknown): boolean {
+  return core.isProxy(value);
 }
 
 export function isRegExp(value: unknown): boolean {


### PR DESCRIPTION
This PR adds `util.types.isProxy`. Currently this depends on `Deno.core` namespace, but the dependency should be removed when https://github.com/denoland/deno/pull/16872 landed

Note: util.types.isProxy is used in undici https://github.com/nodejs/undici/blob/232905f476913da9c73df03bac41a0a96d48b128/lib/fetch/webidl.js#L262

ref https://github.com/denoland/deno/issues/16710 https://github.com/denoland/deno/issues/15427#issuecomment-1329945670