### PR TITLE
chore(node): remove core.decode

### DIFF
--- a/node/_core.ts
+++ b/node/_core.ts
@@ -25,9 +25,6 @@ if (Deno?.core) {
     encode(chunk: string): Uint8Array {
       return new TextEncoder().encode(chunk);
     },
-    decode(chunk: Uint8Array): string {
-      return new TextDecoder().decode(chunk);
-    },
     eventLoopHasMoreWork(): boolean {
       return false;
     },


### PR DESCRIPTION
We dropped `core.decode` dependency in https://github.com/denoland/deno_std/pull/2897. This PR removes it as it's no longer used.