### PR TITLE
feat(node): add os.version

### DIFF
--- a/node/_tools/test/parallel/test-os.js
+++ b/node/_tools/test/parallel/test-os.js
@@ -202,11 +202,9 @@ const home = os.homedir();
 is.string(home);
 assert.ok(home.includes(path.sep));
 
-/* TODO(kt3k): Enable this test
 const version = os.version();
 assert.strictEqual(typeof version, 'string');
 assert(version);
-*/
 
 if (common.isWindows && process.env.USERPROFILE) {
   assert.strictEqual(home, process.env.USERPROFILE);
@@ -260,8 +258,7 @@ assert.strictEqual(`${os.endianness}`, os.endianness());
 // assert.strictEqual(`${os.tmpdir}`, os.tmpdir());
 assert.strictEqual(`${os.arch}`, os.arch());
 assert.strictEqual(`${os.platform}`, os.platform());
-// TODO(kt3k): Enable this test
-// assert.strictEqual(`${os.version}`, os.version());
+assert.strictEqual(`${os.version}`, os.version());
 
 assert.strictEqual(+os.totalmem, os.totalmem());
 

--- a/node/os.ts
+++ b/node/os.ts
@@ -114,6 +114,8 @@ export function arch(): string {
 // deno-lint-ignore no-explicit-any
 (release as any)[Symbol.toPrimitive] = (): string => release();
 // deno-lint-ignore no-explicit-any
+(version as any)[Symbol.toPrimitive] = (): string => version();
+// deno-lint-ignore no-explicit-any
 (totalmem as any)[Symbol.toPrimitive] = (): number => totalmem();
 // deno-lint-ignore no-explicit-any
 (type as any)[Symbol.toPrimitive] = (): string => type();
@@ -234,6 +236,13 @@ export function release(): string {
   return Deno.osRelease();
 }
 
+/** Returns a string identifying the kernel version */
+export function version(): string {
+  // TODO(kt3k): Temporarily uses Deno.osRelease().
+  // Revisit this if this implementation is insufficient for any npm module
+  return Deno.osRelease();
+}
+
 /** Not yet implemented */
 export function setPriority(pid: number, priority?: number) {
   /* The node API has the 'pid' as the first parameter and as optional.
@@ -330,6 +339,7 @@ export default {
   type,
   uptime,
   userInfo,
+  version,
   constants,
   EOL,
   devNull,


### PR DESCRIPTION
This PR implements `os.version`. The returned value is not identical to Node.js version, but it's sufficient for passing `test-os.js` and enabling `deno run npm:next info` command.

related: https://github.com/denoland/deno/issues/16679