### PR TITLE
chore(fs): enable timestamp tests with copy

### DIFF
--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -318,10 +318,8 @@ testCopySync(
 
     assert(destStatInfo.atime instanceof Date);
     assert(destStatInfo.mtime instanceof Date);
-    // TODO(bartlomieju): Activate test when https://github.com/denoland/deno/issues/2411
-    // is fixed
-    // assertEquals(destStatInfo.atime, srcStatInfo.atime);
-    // assertEquals(destStatInfo.mtime, srcStatInfo.mtime);
+    assertEquals(destStatInfo.atime, srcStatInfo.atime);
+    assertEquals(destStatInfo.mtime, srcStatInfo.mtime);
   },
 );
 


### PR DESCRIPTION
https://github.com/denoland/deno/issues/2411 was resolved two years ago. Creating this PR to see if we can enable this test. 

Edit: We can.