### PR TITLE
perf(encoding/yaml) Don't allocate buffers unnecessarily

### DIFF
--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -118,7 +118,7 @@ function representYamlBinary(object: Uint8Array): string {
 
 function isBinary(obj: Any): obj is Buffer {
   if (
-    typeof obj !== "object" || !obj || typeof obj.readFromSync === "function"
+    typeof obj !== "object" || !obj || typeof obj.readFromSync !== "function"
   ) {
     return false;
   }

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -117,7 +117,7 @@ function representYamlBinary(object: Uint8Array): string {
 }
 
 function isBinary(obj: Any): obj is Buffer {
-  if (typeof obj?.readFromSync !== "function") {
+  if (typeof obj?.readSync !== "function") {
     return false;
   }
   const buf = new Buffer();

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -117,7 +117,9 @@ function representYamlBinary(object: Uint8Array): string {
 }
 
 function isBinary(obj: Any): obj is Buffer {
-  if (typeof obj !== "object" || !obj || obj.readSync === undefined) {
+  if (
+    typeof obj !== "object" || !obj || typeof obj.readFromSync === "function"
+  ) {
     return false;
   }
   const buf = new Buffer();

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -117,8 +117,9 @@ function representYamlBinary(object: Uint8Array): string {
 }
 
 function isBinary(obj: Any): obj is Buffer {
-  if (typeof obj !== "object") return false;
-  if (obj.readSync === undefined) return false;
+  if (typeof obj !== "object" || !obj || obj.readSync === undefined) {
+    return false;
+  }
   const buf = new Buffer();
   try {
     if (0 > buf.readFromSync(obj as Buffer)) return true;

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -117,6 +117,8 @@ function representYamlBinary(object: Uint8Array): string {
 }
 
 function isBinary(obj: Any): obj is Buffer {
+  if (typeof obj !== "object") return false;
+  if (obj.readSync === undefined) return false;
   const buf = new Buffer();
   try {
     if (0 > buf.readFromSync(obj as Buffer)) return true;

--- a/encoding/_yaml/type/binary.ts
+++ b/encoding/_yaml/type/binary.ts
@@ -117,9 +117,7 @@ function representYamlBinary(object: Uint8Array): string {
 }
 
 function isBinary(obj: Any): obj is Buffer {
-  if (
-    typeof obj !== "object" || !obj || typeof obj.readFromSync !== "function"
-  ) {
+  if (typeof obj?.readFromSync !== "function") {
     return false;
   }
   const buf = new Buffer();


### PR DESCRIPTION
`isBinary` is called for every object that is encoded in yaml. Currently, it works by attempting to read from every object inside a generic `try {} catch {}` block, but that incurs allocation of a Buffer object and at least two Uint8Arrays in buf.readFromSync before the exception is thrown. In workloads that are heavy in yaml serialization this adds up. 

Over at https://quarto.org, the PR I'm submitting by itself improves our total running time by 10% by simply checking the types more conservatively ahead of attempting to read from the buffer.