### PR TITLE
fix(bytes): JSDoc examples match new structure

### DIFF
--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -4,7 +4,7 @@
 /** Concatenate the given arrays into a new Uint8Array.
  *
  * ```ts
- * import { concat } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { concat } from "https://deno.land/std@$STD_VERSION/bytes/concat.ts";
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);
  * console.log(concat(a, b)); // [0, 1, 2, 3, 4, 5]

--- a/bytes/copy.ts
+++ b/bytes/copy.ts
@@ -12,7 +12,7 @@
  * the array.
  *
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
  * const src = new Uint8Array([9, 8, 7]);
  * const dst = new Uint8Array([0, 1, 2, 3, 4, 5]);
  * console.log(copy(src, dst)); // 3
@@ -20,7 +20,7 @@
  * ```
  *
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
  * const src = new Uint8Array([1, 1, 1, 1]);
  * const dst = new Uint8Array([0, 0, 0, 0]);
  * console.log(copy(src, dst, 1)); // 3

--- a/bytes/ends_with.ts
+++ b/bytes/ends_with.ts
@@ -7,7 +7,7 @@
  * The complexity of this function is O(suffix.length).
  *
  * ```ts
- * import { endsWith } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { endsWith } from "https://deno.land/std@$STD_VERSION/bytes/ends_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const suffix = new Uint8Array([1, 2, 3]);
  * console.log(endsWith(source, suffix)); // true

--- a/bytes/includes_needle.ts
+++ b/bytes/includes_needle.ts
@@ -11,7 +11,7 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
- * import { includesNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { includesNeedle } from "https://deno.land/std@$STD_VERSION/bytes/includes_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(includesNeedle(source, needle)); // true

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -10,7 +10,7 @@
  * The complexity of this function is O(source.lenth * needle.length).
  *
  * ```ts
- * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(indexOfNeedle(source, needle)); // 1

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -10,7 +10,7 @@
  * The complexity of this function is O(source.lenth * needle.length).
  *
  * ```ts
- * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/last_index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(lastIndexOfNeedle(source, needle)); // 5

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -8,7 +8,7 @@ import { copy } from "./copy.ts";
  * If `count` is negative, a `RangeError` is thrown.
  *
  * ```ts
- * import { repeat } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { repeat } from "https://deno.land/std@$STD_VERSION/bytes/repeat.ts";
  * const source = new Uint8Array([0, 1, 2]);
  * console.log(repeat(source, 3)); // [0, 1, 2, 0, 1, 2, 0, 1, 2]
  * console.log(repeat(source, 0)); // []

--- a/bytes/starts_with.ts
+++ b/bytes/starts_with.ts
@@ -7,7 +7,7 @@
  * The complexity of this function is O(prefix.length).
  *
  * ```ts
- * import { startsWith } from "https://deno.land/std@$STD_VERSION/bytes/mod.ts";
+ * import { startsWith } from "https://deno.land/std@$STD_VERSION/bytes/starts_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const prefix = new Uint8Array([0, 1, 2]);
  * console.log(startsWith(source, prefix)); // true


### PR DESCRIPTION
I missed this in #2955.