### PR TITLE
fix(node): fix nextTick shim in deploy

### DIFF
--- a/node/_core.ts
+++ b/node/_core.ts
@@ -33,11 +33,7 @@ if (Deno?.core) {
         "Deno.core.hasTickScheduled() is not supported in this environment",
       );
     },
-    setNextTickCallback() {
-      throw new Error(
-        "Deno.core.setNextTickCallback() is not supported in this environment",
-      );
-    },
+    setNextTickCallback: undefined,
     setMacrotaskCallback() {
       throw new Error(
         "Deno.core.setNextTickCallback() is not supported in this environment",


### PR DESCRIPTION
`std/node` is now not possible to load in Deploy. It started from https://github.com/denoland/deno_std/pull/2965

`node/_next_tick.ts` branches based on the condition `typeof core.setNextTickCallback !== "undefined"`. So `setNextTickCallback` should be `undefined` in Deploy.

The fix is manually checked as the deployment https://node-fix-next-tick.deno.dev/