### PR TITLE
fix(encoding): base58 encoding

### DIFF
--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -129,7 +129,7 @@ export function decode(b58: string): Uint8Array {
     length = i;
   });
 
-  const validOutput = output.filter((item) => item ?? false);
+  const validOutput = output.filter((item) => item !== undefined);
 
   if (ones > 0) {
     const onesResult = Array.from({ length: ones }).fill(0, 0, ones);

--- a/encoding/base58_test.ts
+++ b/encoding/base58_test.ts
@@ -14,6 +14,7 @@ const testSetString = [
   ["foobar", "t1Zv2yaZ"],
   ["Hello World!", "2NEpo7TZRRrLZSi2U"],
   [new Uint8Array([0, 0, 0, 40, 127, 180, 205]), "111233QC4"],
+  [new Uint8Array([10, 0, 10]), "4MpV"],
 ];
 
 const testSetBinary = testSetString.map(([data, b58]) => {


### PR DESCRIPTION
Fix base58 encoding logic

The following was filtering filter `0`s and `undefined`s because `0` is falsy in `.filter`
```
const validOutput = output.filter((item) => item ?? false);
```

