### PR TITLE
ci: check deploy compatibility in PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,23 +1,15 @@
 name: deploy-compat
 on:
   push:
-    branches: [main]
+    branches: main
+  pull_request:
+    branches: main
 jobs:
   deploy-compat:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Deploy to Deno Deploy
-        uses: denoland/deployctl@v1
-        id: deploy
-        with:
-          project: std-deploy-compat-test
-          entrypoint: _tools/deploy.ts
-
       - name: Check deployment
-        run: curl --fail ${{ steps.deploy.outputs.url }}
+        run: deno run --allow-net _tools/check_deploy.ts ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}

--- a/_tools/check_deploy.ts
+++ b/_tools/check_deploy.ts
@@ -1,0 +1,26 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { retry } from "../async/retry.ts";
+
+const projectName = "std-deploy-compat-test";
+const branch = Deno.args[0];
+
+if (!branch) {
+  console.log("Usage: deno run deploy-check.ts <branch-name>");
+  Deno.exit(1);
+}
+
+const deployName = branch === "main"
+  ? projectName
+  : `${projectName}--${branch.replace(/\//g, "-")}`;
+
+await retry(async () => {
+  const deployUrl = `https://${deployName}.deno.dev`;
+  console.log(`Checking ${deployUrl}`);
+  const resp = await fetch(deployUrl);
+  await resp.text();
+  if (resp.status !== 200) {
+    console.log(`${deployUrl} is unavailable`);
+    throw new Error("failed");
+  }
+  console.log(`${deployUrl} is available`);
+});


### PR DESCRIPTION
This PR checks the compatibility of `std/node` with Deno Deploy in each PR.

Currently deploy compatibility is only check in `push` event of main branch. So we don't know if a PR breaks the deploy compat before landing it, and it caused an error like https://github.com/denoland/deno_std/pull/2965. This PR prevents it