### PR TITLE
fix(node): do not buffer first chunk

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -285,7 +285,6 @@ export class ServerResponse extends NodeWritable {
   // used by `npm:on-finished`
   finished = false;
   headersSent = false;
-  #firstChunk: Chunk | null = null;
   // Used if --unstable flag IS NOT present
   #reqEvent?: Deno.RequestEvent;
   // Used if --unstable flag IS present

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -5,6 +5,7 @@ import http, { type RequestOptions } from "./http.ts";
 import { ERR_SERVER_NOT_RUNNING } from "./internal/errors.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { deferred } from "../async/deferred.ts";
+import { deadline } from "../async/deadline.ts";
 import { gzip } from "./zlib.ts";
 import { Buffer } from "./buffer.ts";
 import { serve } from "../http/server.ts";
@@ -198,6 +199,34 @@ Deno.test("[node/http] non-string buffer response", async () => {
     try {
       const text = await res.text();
       assertEquals(text, "a".repeat(100));
+    } catch (e) {
+      server.emit("error", e);
+    } finally {
+      server.close();
+    }
+  });
+  server.on("close", () => {
+    promise.resolve();
+  });
+  await promise;
+});
+
+Deno.test("[node/http] server response - first chunk is not buffered", async () => {
+  const promise = deferred<void>();
+  const server = http.createServer((_, res) => {
+    res.write("A");
+  });
+  server.listen(async () => {
+    try {
+      const res = await deadline(
+        fetch(`http://localhost:${server.address().port}`),
+        100,
+      );
+      const reader = res.body?.getReader();
+      const dataA = await deadline(reader?.read()!, 100);
+      // Can read the first chunk even if the response not finished
+      assertEquals(new TextDecoder().decode(dataA!.value), "A");
+      reader?.cancel();
     } catch (e) {
       server.emit("error", e);
     } finally {

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -220,10 +220,10 @@ Deno.test("[node/http] server response - first chunk is not buffered", async () 
     try {
       const res = await deadline(
         fetch(`http://localhost:${server.address().port}`),
-        100,
+        500,
       );
       const reader = res.body?.getReader();
-      const dataA = await deadline(reader?.read()!, 100);
+      const dataA = await deadline(reader?.read()!, 500);
       // Can read the first chunk even if the response not finished
       assertEquals(new TextDecoder().decode(dataA!.value), "A");
       reader?.cancel();


### PR DESCRIPTION
This PR updates http ServerResponse class.

Currently the first chunk of server responses are buffered in the private field `#firstChunk` to add `content-type: text/plain;charset=UTF-8` automatically when the only chunk is string (only on non flash-backed implementation). This behavior is not tested anywhere and it seems only causing the issue (https://github.com/denoland/deno/issues/16929). This PR removes this buffering behavior, and now the server always responds the first chunk immediately.

closes https://github.com/denoland/deno/issues/16929

- [x] write tests