### PR TITLE
chore: update Deno.Command usages

### DIFF
--- a/crypto/test.ts
+++ b/crypto/test.ts
@@ -179,6 +179,7 @@ Deno.test("[crypto/digest] Memory use should remain reasonable even with large i
     args: ["--quiet", "run", "--no-check", "-"],
     cwd: moduleDir,
     stdin: "piped",
+    stdout: "piped",
     stderr: "inherit",
   });
   const child = process.spawn();

--- a/examples/catj_test.ts
+++ b/examples/catj_test.ts
@@ -79,6 +79,7 @@ function catj(...files: string[]): Deno.ChildProcess {
     ],
     cwd: moduleDir,
     stdin: "piped",
+    stdout: "piped",
     env: { NO_COLOR: "true" },
   });
   return process.spawn();

--- a/examples/chat/server_test.ts
+++ b/examples/chat/server_test.ts
@@ -14,6 +14,7 @@ async function startServer(): Promise<Deno.ChildProcess> {
       "server.ts",
     ],
     cwd: moduleDir,
+    stdout: "piped",
     stderr: "null",
     stdin: "null",
   });

--- a/examples/echo_server_test.ts
+++ b/examples/echo_server_test.ts
@@ -18,6 +18,7 @@ Deno.test({
   const decoder = new TextDecoder();
   const process = new Deno.Command(Deno.execPath(), {
     args: ["run", "--quiet", "--allow-net", "echo_server.ts"],
+    stdout: "piped",
     stderr: "null",
     cwd: moduleDir,
   });

--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -50,6 +50,7 @@ Deno.test({
       ],
       cwd: moduleDir,
       stdin: "piped",
+      stdout: "piped",
     });
     const child = p.spawn();
     const writer = child.stdin.getWriter();

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -53,6 +53,7 @@ async function startFileServer({
       `${dotfiles ? "" : "--no-dotfiles"}`,
     ],
     cwd: moduleDir,
+    stdout: "piped",
     stderr: "null",
   });
   child = fileServer.spawn();

--- a/wasi/snapshot_preview1_test.ts
+++ b/wasi/snapshot_preview1_test.ts
@@ -97,6 +97,7 @@ for (const pathname of tests) {
             path.resolve(rootdir, pathname),
           ],
           stdin: "piped",
+          stdout: "piped",
         });
         const child = process.spawn();
 


### PR DESCRIPTION
This PR updates Deno.Command usages. The default of `stdout` and `stderr` is changed from `piped` to `inherit` https://github.com/denoland/deno/pull/17025