### PR TITLE
feat(tools): auto-update copyright headers

### DIFF
--- a/_tools/check_licence.ts
+++ b/_tools/check_licence.ts
@@ -16,8 +16,12 @@ const EXCLUDED_DIRS = [
 ];
 
 const ROOT = new URL("../", import.meta.url);
+const CHECK = Deno.args.includes("--check");
 const FIRST_YEAR = 2018;
 const CURRENT_YEAR = new Date().getFullYear();
+const RX_COPYRIGHT = new RegExp(
+  `// Copyright ([0-9]{4})-([0-9]{4}) the Deno authors\\. All rights reserved\\. MIT license\\.\n`,
+);
 const COPYRIGHT =
   `// Copyright ${FIRST_YEAR}-${CURRENT_YEAR} the Deno authors. All rights reserved. MIT license.`;
 
@@ -31,15 +35,30 @@ for await (
   })
 ) {
   const content = await Deno.readTextFile(path);
+  const match = content.match(RX_COPYRIGHT);
 
-  if (!content.includes(COPYRIGHT)) {
-    if (Deno.args.includes("--check")) {
-      console.error(`Missing/incorrect copyright header: ${path}`);
+  if (!match) {
+    if (CHECK) {
+      console.error(`Missing copyright header: ${path}`);
       failed = true;
     } else {
       const contentWithCopyright = COPYRIGHT + "\n" + content;
       await Deno.writeTextFile(path, contentWithCopyright);
-      console.log("Copyright headers automatically added to " + path);
+      console.log("Copyright header automatically added to " + path);
+    }
+  } else if (
+    parseInt(match[1]) !== FIRST_YEAR || parseInt(match[2]) !== CURRENT_YEAR
+  ) {
+    if (CHECK) {
+      console.error(`Incorrect copyright year: ${path}`);
+      failed = true;
+    } else {
+      const index = match.index ?? 0;
+      const contentWithoutCopyright = content.replace(match[0], "");
+      const contentWithCopyright = contentWithoutCopyright.substring(0, index) +
+        COPYRIGHT + "\n" + contentWithoutCopyright.substring(index);
+      await Deno.writeTextFile(path, contentWithCopyright);
+      console.log("Copyright header automatically updated in " + path);
     }
   }
 }

--- a/_tools/check_licence.ts
+++ b/_tools/check_licence.ts
@@ -12,7 +12,6 @@ const EXCLUDED_DIRS = [
   "node/testdata",
   "crypto/_wasm/target",
   "encoding/varint/_wasm/target",
-  "_tools/testdata",
 ];
 
 const ROOT = new URL("../", import.meta.url);


### PR DESCRIPTION
Current implementation of `deno task fmt:licence-headers` adds a secondary header if the year is not correct. This PR extends the tool to update the year instead if there is a header already. 

This will be handy to create a "happy new year 🥳" PR soon.

Related: #2981