### PR TITLE
fix(http): prevent downstream connections from getting closed when the response stream throws an error

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,7 @@
     }
   },
   "tasks": {
-    "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=node/,_tools/testdata --unsafely-ignore-certificate-errors",
+    "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=node/,_tools/testdata",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | xargs deno cache --check --reload --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",

--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,7 @@
     }
   },
   "tasks": {
-    "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=node/,_tools/testdata",
+    "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=node/,_tools/testdata --unsafely-ignore-certificate-errors",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | xargs deno cache --check --reload --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",

--- a/http/server.ts
+++ b/http/server.ts
@@ -310,10 +310,11 @@ export class Server {
       // Send the response.
       await requestEvent.respondWith(response);
     } catch {
-      // `respondWith()` can throw for various reasons, including downstream but also upstream connection errors,
-      // as well as errors thrown during streaming of the response content.
-      // In order to avoid false negatives, we ignore the error here and let `serveHttp` close the connection on
-      // the following iteration if it is in fact a downstream connection error.
+      // `respondWith()` can throw for various reasons, including downstream and
+      // upstream connection errors, as well as errors thrown during streaming
+      // of the response content.  In order to avoid false negatives, we ignore
+      // the error here and let `serveHttp` close the connection on the
+      // following iteration if it is in fact a downstream connection error.
     }
   }
 

--- a/http/server.ts
+++ b/http/server.ts
@@ -287,12 +287,10 @@ export class Server {
    * Responds to an HTTP request.
    *
    * @param requestEvent The HTTP request to respond to.
-   * @param httpCon The HTTP connection to yield requests from.
    * @param connInfo Information about the underlying connection.
    */
   async #respond(
     requestEvent: Deno.RequestEvent,
-    httpConn: Deno.HttpConn,
     connInfo: ConnInfo,
   ) {
     let response: Response;
@@ -312,10 +310,10 @@ export class Server {
       // Send the response.
       await requestEvent.respondWith(response);
     } catch {
-      // respondWith() fails when the connection has already been closed, or there is some
-      // other error with responding on this connection that prompts us to
-      // close it and open a new connection.
-      return this.#closeHttpConn(httpConn);
+      // `respondWith()` can throw for various reasons, including downstream but also upstream connection errors,
+      // as well as errors thrown during streaming of the response content.
+      // In order to avoid false negatives, we ignore the error here and let `serveHttp` close the connection on
+      // the following iteration if it is in fact a downstream connection error.
     }
   }
 
@@ -344,7 +342,7 @@ export class Server {
 
       // Respond to the request. Note we do not await this async method to
       // allow the connection to handle multiple requests in the case of h2.
-      this.#respond(requestEvent, httpConn, connInfo);
+      this.#respond(requestEvent, connInfo);
     }
 
     this.#closeHttpConn(httpConn);

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1160,9 +1160,15 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   const server = new Server({ handler });
   const servePromise = server.serve(listener);
 
-  await (await fetch(url)).text();
-  await (await fetch(url)).text();
-  await (await fetch(url)).text();
+  const caCert = await Deno.readTextFile(
+    join(testdataDir, "tls/RootCA.pem"),
+  );
+  const client = Deno.createHttpClient({
+    caCerts: [caCert],
+  });
+  await (await fetch(url, { client })).text();
+  await (await fetch(url, { client })).text();
+  await (await fetch(url, { client })).text();
 
   const numConns = connections.size;
   assertEquals(
@@ -1172,6 +1178,7 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   );
   assertEquals(n, 3, "The handler should had been called three times");
 
+  client.close();
   server.close();
   await servePromise;
 });

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1134,9 +1134,12 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   const listenOptions = {
     hostname: "localhost",
     port: 4505,
+    certFile: join(testdataDir, "tls/localhost.crt"),
+    keyFile: join(testdataDir, "tls/localhost.key"),
+    alpnProtocols: ["h2", "http/1.1"],
   };
-  const listener = Deno.listen(listenOptions);
-  const url = `http://${listenOptions.hostname}:${listenOptions.port}/`;
+  const listener = Deno.listenTls(listenOptions);
+  const url = `https://${listenOptions.hostname}:${listenOptions.port}/`;
 
   let n = 0;
   const connections = new Set();

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1136,7 +1136,7 @@ Deno.test("Server should not close the http2 downstream connection when the resp
     port: 4505,
     certFile: join(testdataDir, "tls/localhost.crt"),
     keyFile: join(testdataDir, "tls/localhost.key"),
-    alpnProtocols: ["h2", "http/1.1"],
+    alpnProtocols: ["h2"],
   };
   const listener = Deno.listenTls(listenOptions);
   const url = `https://${listenOptions.hostname}:${listenOptions.port}/`;


### PR DESCRIPTION
Stream errors does not warrant closing the downstream connection. This PR prevents that.

I've added a non-regression test for the errors thrown within new `ReadableStream`s. I've tried to write one for fetch upstream streams but have failed. Any suggestion on how to write such test would be appreciated!