### PR TITLE
refactor(io): deprecate `types.d.ts`

### DIFF
--- a/io/_test_common.ts
+++ b/io/_test_common.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import type { Reader } from "./types.d.ts";
-
 export const MIN_READ_BUFFER_SIZE = 16;
 export const bufsizes: number[] = [
   0,
@@ -16,7 +14,7 @@ export const bufsizes: number[] = [
   4096,
 ];
 
-export class BinaryReader implements Reader {
+export class BinaryReader implements Deno.Reader {
   index = 0;
 
   constructor(private bytes: Uint8Array = new Uint8Array(0)) {}

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -2,7 +2,6 @@
 
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";
-import type { Reader } from "./types.d.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 const MIN_BUF_SIZE = 16;
@@ -31,9 +30,9 @@ export interface ReadLineResult {
   more: boolean;
 }
 
-export class BufReader implements Reader {
+export class BufReader implements Deno.Reader {
   #buf!: Uint8Array;
-  #rd!: Reader; // Reader provided by caller.
+  #rd!: Deno.Reader; // Reader provided by caller.
   #r = 0; // buf read position.
   #w = 0; // buf write position.
   #eof = false;
@@ -41,11 +40,11 @@ export class BufReader implements Reader {
   // private lastCharSize: number;
 
   /** return new BufReader unless r is BufReader */
-  static create(r: Reader, size: number = DEFAULT_BUF_SIZE): BufReader {
+  static create(r: Deno.Reader, size: number = DEFAULT_BUF_SIZE): BufReader {
     return r instanceof BufReader ? r : new BufReader(r, size);
   }
 
-  constructor(rd: Reader, size: number = DEFAULT_BUF_SIZE) {
+  constructor(rd: Deno.Reader, size: number = DEFAULT_BUF_SIZE) {
     if (size < MIN_BUF_SIZE) {
       size = MIN_BUF_SIZE;
     }
@@ -96,11 +95,11 @@ export class BufReader implements Reader {
   /** Discards any buffered data, resets all state, and switches
    * the buffered reader to read from r.
    */
-  reset(r: Reader) {
+  reset(r: Deno.Reader) {
     this.#reset(this.#buf, r);
   }
 
-  #reset = (buf: Uint8Array, rd: Reader) => {
+  #reset = (buf: Uint8Array, rd: Deno.Reader) => {
     this.#buf = buf;
     this.#rd = rd;
     this.#eof = false;

--- a/io/buf_reader_test.ts
+++ b/io/buf_reader_test.ts
@@ -12,14 +12,13 @@ import { BufferFullError, BufReader, PartialReadError } from "./buf_reader.ts";
 import { StringReader } from "./string_reader.ts";
 import { bufsizes, MIN_READ_BUFFER_SIZE } from "./_test_common.ts";
 import { Buffer } from "./buffer.ts";
-import type { Reader } from "./types.d.ts";
 import { copy } from "../bytes/copy.ts";
 
 /** OneByteReader returns a Reader that implements
  * each non-empty Read by reading one byte from r.
  */
-class OneByteReader implements Reader {
-  constructor(readonly r: Reader) {}
+class OneByteReader implements Deno.Reader {
+  constructor(readonly r: Deno.Reader) {}
 
   read(p: Uint8Array): Promise<number | null> {
     if (p.byteLength === 0) {
@@ -35,8 +34,8 @@ class OneByteReader implements Reader {
 /** HalfReader returns a Reader that implements Read
  * by reading half as many requested bytes from r.
  */
-class HalfReader implements Reader {
-  constructor(readonly r: Reader) {}
+class HalfReader implements Deno.Reader {
+  constructor(readonly r: Deno.Reader) {}
 
   read(p: Uint8Array): Promise<number | null> {
     if (!(p instanceof Uint8Array)) {

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { copy } from "../bytes/copy.ts";
-import type { Writer, WriterSync } from "./types.d.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 
@@ -39,15 +38,18 @@ abstract class AbstractBufBase {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.Writer.
  */
-export class BufWriter extends AbstractBufBase implements Writer {
-  #writer: Writer;
+export class BufWriter extends AbstractBufBase implements Deno.Writer {
+  #writer: Deno.Writer;
 
   /** return new BufWriter unless writer is BufWriter */
-  static create(writer: Writer, size: number = DEFAULT_BUF_SIZE): BufWriter {
+  static create(
+    writer: Deno.Writer,
+    size: number = DEFAULT_BUF_SIZE,
+  ): BufWriter {
     return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
   }
 
-  constructor(writer: Writer, size: number = DEFAULT_BUF_SIZE) {
+  constructor(writer: Deno.Writer, size: number = DEFAULT_BUF_SIZE) {
     super(new Uint8Array(size <= 0 ? DEFAULT_BUF_SIZE : size));
     this.#writer = writer;
   }
@@ -55,7 +57,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
   /** Discards any unflushed buffered data, clears any error, and
    * resets buffer to write its output to w.
    */
-  reset(w: Writer) {
+  reset(w: Deno.Writer) {
     this.err = null;
     this.usedBufferBytes = 0;
     this.#writer = w;
@@ -131,12 +133,12 @@ export class BufWriter extends AbstractBufBase implements Writer {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.WriterSync.
  */
-export class BufWriterSync extends AbstractBufBase implements WriterSync {
-  #writer: WriterSync;
+export class BufWriterSync extends AbstractBufBase implements Deno.WriterSync {
+  #writer: Deno.WriterSync;
 
   /** return new BufWriterSync unless writer is BufWriterSync */
   static create(
-    writer: WriterSync,
+    writer: Deno.WriterSync,
     size: number = DEFAULT_BUF_SIZE,
   ): BufWriterSync {
     return writer instanceof BufWriterSync
@@ -144,7 +146,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
       : new BufWriterSync(writer, size);
   }
 
-  constructor(writer: WriterSync, size: number = DEFAULT_BUF_SIZE) {
+  constructor(writer: Deno.WriterSync, size: number = DEFAULT_BUF_SIZE) {
     super(new Uint8Array(size <= 0 ? DEFAULT_BUF_SIZE : size));
     this.#writer = writer;
   }
@@ -152,7 +154,7 @@ export class BufWriterSync extends AbstractBufBase implements WriterSync {
   /** Discards any unflushed buffered data, clears any error, and
    * resets buffer to write its output to w.
    */
-  reset(w: WriterSync) {
+  reset(w: Deno.WriterSync) {
     this.err = null;
     this.usedBufferBytes = 0;
     this.#writer = w;

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";
-import type { Reader, ReaderSync } from "./types.d.ts";
 import {
   BufferFullError as _BufferFullError,
   BufReader as _BufReader,
@@ -203,7 +202,7 @@ export class Buffer {
    *
    * Based on Go Lang's
    * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
-  async readFrom(r: Reader): Promise<number> {
+  async readFrom(r: Deno.Reader): Promise<number> {
     let n = 0;
     const tmp = new Uint8Array(MIN_READ);
     while (true) {
@@ -233,7 +232,7 @@ export class Buffer {
    *
    * Based on Go Lang's
    * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
-  readFromSync(r: ReaderSync): number {
+  readFromSync(r: Deno.ReaderSync): number {
     let n = 0;
     const tmp = new Uint8Array(MIN_READ);
     while (true) {

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { assert } from "../_util/asserts.ts";
-import type { Reader, Writer } from "./types.d.ts";
 
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 
@@ -12,8 +11,8 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param size Read size
  */
 export async function copyN(
-  r: Reader,
-  dest: Writer,
+  r: Deno.Reader,
+  dest: Deno.Writer,
   size: number,
 ): Promise<number> {
   let bytesRead = 0;

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { BytesList } from "../bytes/bytes_list.ts";
-import type { Reader } from "./types.d.ts";
 
 /** Generate longest proper prefix which is also suffix array. */
 function createLPS(pat: Uint8Array): Uint8Array {
@@ -26,7 +25,7 @@ function createLPS(pat: Uint8Array): Uint8Array {
 
 /** Read delimited bytes from a Reader. */
 export async function* readDelim(
-  reader: Reader,
+  reader: Deno.Reader,
   delim: Uint8Array,
 ): AsyncIterableIterator<Uint8Array> {
   // Avoid unicode problems

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { type Reader } from "./types.d.ts";
 import { BufReader } from "./buf_reader.ts";
 import { concat } from "../bytes/concat.ts";
 
@@ -21,7 +20,7 @@ import { concat } from "../bytes/concat.ts";
  * ```
  */
 export async function* readLines(
-  reader: Reader,
+  reader: Deno.Reader,
   decoderOpts?: {
     encoding?: string;
     fatal?: boolean;

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { type Reader } from "./types.d.ts";
 import { readDelim } from "./read_delim.ts";
 
 /**
@@ -20,7 +19,7 @@ import { readDelim } from "./read_delim.ts";
  * ```
  */
 export async function* readStringDelim(
-  reader: Reader,
+  reader: Deno.Reader,
   delim: string,
   decoderOpts?: {
     encoding?: string;

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -1,8 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Writer, WriterSync } from "./types.d.ts";
-
 const decoder = new TextDecoder();
 
 /**
@@ -35,7 +33,7 @@ const decoder = new TextDecoder();
  * base0123456789
  * ```
  */
-export class StringWriter implements Writer, WriterSync {
+export class StringWriter implements Deno.Writer, Deno.WriterSync {
   #chunks: Uint8Array[] = [];
   #byteLength = 0;
   #cache: string | undefined;

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
 
 const decoder = new TextDecoder();
 

--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+/** @deprecated (will be removed after 0.170.0) Use `Deno.Reader` instead. */
 export interface Reader {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
    * bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -26,6 +27,7 @@ export interface Reader {
   read(p: Uint8Array): Promise<number | null>;
 }
 
+/** @deprecated (will be removed after 0.170.0) Use `Deno.ReaderSync` instead. */
 export interface ReaderSync {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
    * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -51,6 +53,7 @@ export interface ReaderSync {
   readSync(p: Uint8Array): number | null;
 }
 
+/** @deprecated (will be removed after 0.170.0) Use `Deno.Writer` instead. */
 export interface Writer {
   /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
    * resolves to the number of bytes written from `p` (`0` <= `n` <=
@@ -64,6 +67,7 @@ export interface Writer {
   write(p: Uint8Array): Promise<number>;
 }
 
+/** @deprecated (will be removed after 0.170.0) Use `Deno.WriterSync` instead. */
 export interface WriterSync {
   /** Writes `p.byteLength` bytes from `p` to the underlying data
    * stream. It returns the number of bytes written from `p` (`0` <= `n`
@@ -77,6 +81,7 @@ export interface WriterSync {
   writeSync(p: Uint8Array): number;
 }
 
+/** @deprecated (will be removed after 0.170.0) Use `Deno.Closer` instead. */
 export interface Closer {
   close(): void;
 }

--- a/io/writers.ts
+++ b/io/writers.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
 
 import { StringWriter as _StringWriter } from "./string_writer.ts";
 


### PR DESCRIPTION
`Reader`, `ReaderSync`, `Writer` and `WriterSync` interfaces are now supported in Deploy.

FYI `types.d.ts` was added in #912, in May 2021. 