### PR TITLE
test(http): fix test case of http2 stream error

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1173,14 +1173,10 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   });
   const resp1 = await fetch(url, { client });
   const resp2 = await fetch(url, { client });
-  const resp3 = await fetch(url, { client });
 
   const err = await assertRejects(async () => {
-    const data = await resp3.text();
-    // Note: the lone above should be throwing - but it's not right now due to
-    // a bug in ext/http. So for now we will add a check for the empty string
-    // (which is what we expect to be returned in case of this bug).
-    if (data === "") throw new Error("the stream errored!");
+    const resp3 = await fetch(url, { client });
+    const _data = await resp3.text();
   });
   assert(err);
   a.resolve();


### PR DESCRIPTION
This PR fixes the test case `Server should not close the http2 downstream connection when the response stream throws` in `http/server_test.ts` for canary

After the change https://github.com/denoland/deno/pull/17126, the 3rd fetch call throws immediately (Looks like it's more ideal behavior according to the comment in the test case)