### PR TITLE
fix(node/util): reference error of 'process'

### DIFF
--- a/node/_http_outgoing.ts
+++ b/node/_http_outgoing.ts
@@ -5,7 +5,7 @@ import { getDefaultHighWaterMark } from "./internal/streams/state.mjs";
 import assert from "./internal/assert.mjs";
 import EE from "./events.ts";
 import { Stream } from "./stream.ts";
-import * as internalUtil from "./internal/util.mjs";
+import { deprecate } from "./util.ts";
 import type { Socket } from "./net.ts";
 import { kNeedDrain, kOutHeaders, utcDate } from "./internal/http.ts";
 import { Buffer } from "./buffer.ts";
@@ -141,7 +141,7 @@ Object.defineProperty(OutgoingMessage.prototype, "writableCorked", {
 });
 
 Object.defineProperty(OutgoingMessage.prototype, "_headers", {
-  get: internalUtil.deprecate(
+  get: deprecate(
     // deno-lint-ignore no-explicit-any
     function (this: any) {
       return this.getHeaders();
@@ -149,7 +149,7 @@ Object.defineProperty(OutgoingMessage.prototype, "_headers", {
     "OutgoingMessage.prototype._headers is deprecated",
     "DEP0066",
   ),
-  set: internalUtil.deprecate(
+  set: deprecate(
     // deno-lint-ignore no-explicit-any
     function (this: any, val: any) {
       if (val == null) {
@@ -180,7 +180,7 @@ Object.defineProperty(OutgoingMessage.prototype, "connection", {
 });
 
 Object.defineProperty(OutgoingMessage.prototype, "_headerNames", {
-  get: internalUtil.deprecate(
+  get: deprecate(
     // deno-lint-ignore no-explicit-any
     function (this: any) {
       const headers = this[kOutHeaders];
@@ -201,7 +201,7 @@ Object.defineProperty(OutgoingMessage.prototype, "_headerNames", {
     "OutgoingMessage.prototype._headerNames is deprecated",
     "DEP0066",
   ),
-  set: internalUtil.deprecate(
+  set: deprecate(
     // deno-lint-ignore no-explicit-any
     function (this: any, val: any) {
       if (typeof val === "object" && val !== null) {

--- a/node/internal/fs/streams.mjs
+++ b/node/internal/fs/streams.mjs
@@ -2,7 +2,8 @@
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
 import { ERR_INVALID_ARG_TYPE, ERR_OUT_OF_RANGE } from "../errors.ts";
-import { deprecate, kEmptyObject } from "../util.mjs";
+import { kEmptyObject } from "../util.mjs";
+import { deprecate } from "../../util.ts";
 import { validateFunction, validateInteger } from "../validators.mjs";
 import { errorOrDestroy } from "../streams/destroy.mjs";
 import { open as fsOpen } from "../../_fs/_fs_open.ts";

--- a/node/internal/fs/utils.mjs
+++ b/node/internal/fs/utils.mjs
@@ -18,7 +18,8 @@ import {
   isDate,
   isUint8Array,
 } from "../util/types.ts";
-import { deprecate, once } from "../util.mjs";
+import { once } from "../util.mjs";
+import { deprecate } from "../../util.ts";
 import { toPathIfFileURL } from "../url.ts";
 import {
   validateAbortSignal,

--- a/node/internal/util.mjs
+++ b/node/internal/util.mjs
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { validateFunction, validateString } from "./validators.mjs";
+import { validateFunction } from "./validators.mjs";
 import { normalizeEncoding, slowCases } from "./normalize_encoding.mjs";
 export { normalizeEncoding, slowCases };
 import { ObjectCreate, StringPrototypeToUpperCase } from "./primordials.mjs";
@@ -32,54 +32,6 @@ export function createDeferredPromise() {
   });
 
   return { promise, resolve, reject };
-}
-
-// Keep a list of deprecation codes that have been warned on so we only warn on
-// each one once.
-const codesWarned = new Set();
-
-// Mark that a method should not be used.
-// Returns a modified function which warns once by default.
-// If --no-deprecation is set, then it is a no-op.
-export function deprecate(fn, msg, code) {
-  // TODO(kt3k): Uncomment this
-  // if (process.noDeprecation === true) {
-  //  return fn;
-  // }
-
-  if (code !== undefined) {
-    validateString(code, "code");
-  }
-
-  let warned = false;
-  function deprecated(...args) {
-    if (!warned) {
-      warned = true;
-      if (code !== undefined) {
-        if (!codesWarned.has(code)) {
-          process.emitWarning(msg, "DeprecationWarning", code, deprecated);
-          codesWarned.add(code);
-        }
-      } else {
-        process.emitWarning(msg, "DeprecationWarning", deprecated);
-      }
-    }
-    if (new.target) {
-      return Reflect.construct(fn, args, new.target);
-    }
-    return Reflect.apply(fn, this, args);
-  }
-
-  // The wrapper will keep the same prototype as fn to maintain prototype chain
-  Object.setPrototypeOf(deprecated, fn);
-  if (fn.prototype) {
-    // Setting this (rather than using Object.setPrototype, as above) ensures
-    // that calling the unwrapped constructor gives an instanceof the wrapped
-    // constructor.
-    deprecated.prototype = fn.prototype;
-  }
-
-  return deprecated;
 }
 
 // In addition to being accessible through util.promisify.custom,
@@ -186,7 +138,6 @@ export default {
   kEnumerableProperty,
   normalizeEncoding,
   once,
-  deprecate,
   promisify,
   slowCases,
 };

--- a/node/process.ts
+++ b/node/process.ts
@@ -671,6 +671,9 @@ class Process extends EventEmitter {
   }
 
   features = { inspector: false };
+
+  // TODO(kt3k): Get the value from --no-deprecation flag.
+  noDeprecation = false;
 }
 
 if (Deno.build.os === "windows") {

--- a/node/util.ts
+++ b/node/util.ts
@@ -2,7 +2,6 @@
 import { promisify } from "./internal/util.mjs";
 import { callbackify } from "./_util/_util_callbackify.ts";
 import { debuglog } from "./internal/util/debuglog.ts";
-import { deprecate } from "./internal/util.mjs";
 import {
   format,
   formatWithOptions,
@@ -13,11 +12,12 @@ import { codes } from "./internal/error_codes.ts";
 import types from "./util/types.ts";
 import { Buffer } from "./buffer.ts";
 import { isDeepStrictEqual } from "./internal/util/comparisons.ts";
+import process from "./process.ts";
+import { validateString } from "./internal/validators.mjs";
 
 export {
   callbackify,
   debuglog,
-  deprecate,
   format,
   formatWithOptions,
   inspect,
@@ -200,6 +200,56 @@ function timestamp(): string {
 // deno-lint-ignore no-explicit-any
 export function log(...args: any[]) {
   console.log("%s - %s", timestamp(), format(...args));
+}
+
+// Keep a list of deprecation codes that have been warned on so we only warn on
+// each one once.
+const codesWarned = new Set();
+
+// Mark that a method should not be used.
+// Returns a modified function which warns once by default.
+// If --no-deprecation is set, then it is a no-op.
+// deno-lint-ignore no-explicit-any
+export function deprecate(fn: any, msg: string, code?: any) {
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  if (code !== undefined) {
+    validateString(code, "code");
+  }
+
+  let warned = false;
+  // deno-lint-ignore no-explicit-any
+  function deprecated(this: any, ...args: any[]) {
+    if (!warned) {
+      warned = true;
+      if (code !== undefined) {
+        if (!codesWarned.has(code)) {
+          process.emitWarning(msg, "DeprecationWarning", code, deprecated);
+          codesWarned.add(code);
+        }
+      } else {
+        // deno-lint-ignore no-explicit-any
+        process.emitWarning(msg, "DeprecationWarning", deprecated as any);
+      }
+    }
+    if (new.target) {
+      return Reflect.construct(fn, args, new.target);
+    }
+    return Reflect.apply(fn, this, args);
+  }
+
+  // The wrapper will keep the same prototype as fn to maintain prototype chain
+  Object.setPrototypeOf(deprecated, fn);
+  if (fn.prototype) {
+    // Setting this (rather than using Object.setPrototype, as above) ensures
+    // that calling the unwrapped constructor gives an instanceof the wrapped
+    // constructor.
+    deprecated.prototype = fn.prototype;
+  }
+
+  return deprecated;
 }
 
 export { getSystemErrorName, isDeepStrictEqual };

--- a/node/util_test.ts
+++ b/node/util_test.ts
@@ -249,3 +249,11 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "[util] deprecate() works",
+  fn() {
+    const fn = util.deprecate(() => {}, "foo");
+    fn();
+  }
+})

--- a/node/util_test.ts
+++ b/node/util_test.ts
@@ -255,5 +255,5 @@ Deno.test({
   fn() {
     const fn = util.deprecate(() => {}, "foo");
     fn();
-  }
-})
+  },
+});


### PR DESCRIPTION
Current implementation of `util.deprecate` depends on global `process` object and it doesn't work with `npm:` feature. (For example, `connect` from `npm:mongoose` doesn't work. See https://github.com/denoland/examples/pull/12 )

This PR fixes the above issue.

As a side effect of the fix, this PR moves the implementation of `deprecate` from `node/internal/utils.mjs` to `node/util.ts`. This was necessary for avoiding circular dependencies. (See also https://github.com/denoland/deno_std/pull/1697#discussion_r767247360