### PR TITLE
chore: correct JSDoc example blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,35 @@ All internal non-test code, that is files that do not have `test` or `bench` in
 the name, must use the assertion functions within `_utils/asserts.ts` and not
 `testing/asserts.ts`. This is to create a separation of concerns between
 internal and testing assertions.
+
+### Examples
+
+Always prefix JSDoc example blocks with the `@example` tag and specify the
+correct language next to the backticks before the fenced code block.
+
+Bad:
+
+````
+/**
+ * ```
+ * foo();
+ * ```
+ */
+function foo() {
+  ...
+}
+````
+
+Good:
+
+````
+/**
+ * @example
+ * ```ts
+ * foo();
+ * ```
+ */
+function foo() {
+  ...
+}
+````

--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -3,6 +3,7 @@
 
 /** Concatenate the given arrays into a new Uint8Array.
  *
+ * @example
  * ```ts
  * import { concat } from "https://deno.land/std@$STD_VERSION/bytes/concat.ts";
  * const a = new Uint8Array([0, 1, 2]);

--- a/bytes/copy.ts
+++ b/bytes/copy.ts
@@ -11,6 +11,7 @@
  * that given index in the `dst` array. The offset defaults to the beginning of
  * the array.
  *
+ * @example
  * ```ts
  * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
  * const src = new Uint8Array([9, 8, 7]);
@@ -19,6 +20,7 @@
  * console.log(dst); // [9, 8, 7, 3, 4, 5]
  * ```
  *
+ * @example
  * ```ts
  * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
  * const src = new Uint8Array([1, 1, 1, 1]);

--- a/bytes/ends_with.ts
+++ b/bytes/ends_with.ts
@@ -6,6 +6,7 @@
  *
  * The complexity of this function is O(suffix.length).
  *
+ * @example
  * ```ts
  * import { endsWith } from "https://deno.land/std@$STD_VERSION/bytes/ends_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);

--- a/bytes/includes_needle.ts
+++ b/bytes/includes_needle.ts
@@ -10,6 +10,7 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  *
  * The complexity of this function is O(source.length * needle.length).
  *
+ * @example
  * ```ts
  * import { includesNeedle } from "https://deno.land/std@$STD_VERSION/bytes/includes_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -9,6 +9,7 @@
  *
  * The complexity of this function is O(source.lenth * needle.length).
  *
+ * @example
  * ```ts
  * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -9,6 +9,7 @@
  *
  * The complexity of this function is O(source.lenth * needle.length).
  *
+ * @example
  * ```ts
  * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/last_index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -7,6 +7,7 @@ import { copy } from "./copy.ts";
  *
  * If `count` is negative, a `RangeError` is thrown.
  *
+ * @example
  * ```ts
  * import { repeat } from "https://deno.land/std@$STD_VERSION/bytes/repeat.ts";
  * const source = new Uint8Array([0, 1, 2]);

--- a/bytes/starts_with.ts
+++ b/bytes/starts_with.ts
@@ -6,6 +6,7 @@
  *
  * The complexity of this function is O(prefix.length).
  *
+ * @example
  * ```ts
  * import { startsWith } from "https://deno.land/std@$STD_VERSION/bytes/starts_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -15,6 +15,7 @@
  * {@linkcode groupBy} import the module using the snake cased version of the
  * module:
  *
+ * @example
  * ```ts
  * import { groupBy } from "https://deno.land/std@$STD_VERSION/collections/group_by.ts";
  * ```

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -6,6 +6,7 @@
  * returned array holding all first tuple elements and the second one holding
  * all the second elements.
  *
+ * @example
  * ```ts
  * import { unzip } from "https://deno.land/std@$STD_VERSION/collections/unzip.ts";
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";

--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -25,6 +25,7 @@
  *
  * WebCrypto
  *
+ * @example
  * ```ts
  * // https://deno.land/std/crypto/mod.ts
  * const webCryptoDigestAlgorithms = [
@@ -38,6 +39,7 @@
  *
  * Wasm/Rust
  *
+ * @example
  * ```ts
  * // https://deno.land/std/_wasm_crypto/mod.ts
  * export const digestAlgorithms = [
@@ -81,6 +83,7 @@
  * [w3c/webcrypto#270](https://github.com/w3c/webcrypto/issues/270)), but until
  * that time, `timingSafeEqual()` is provided:
  *
+ * @example
  * ```ts
  * import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
  * import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
@@ -105,6 +108,7 @@
  * In addition to the method being part of the `crypto.subtle` interface, it is
  * also loadable directly:
  *
+ * @example
  * ```ts
  * import { timingSafeEqual } from "https://deno.land/std@$STD_VERSION/crypto/timing_safe_equal.ts";
  * import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
@@ -148,6 +152,7 @@
  *
  * @example Convert hash to a string
  *
+ * @example
  * ```ts
  * import {
  *   crypto,

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -11,6 +11,7 @@
  *
  * Then import the configuration using the `config` function.
  *
+ * @example
  * ```ts
  * // app.ts
  * import { config } from "https://deno.land/std@$STD_VERSION/dotenv/mod.ts";
@@ -35,6 +36,7 @@
  * GREETING=hello world
  * ```
  *
+ * @example
  * ```ts
  * // app.ts
  * import "https://deno.land/std@$STD_VERSION/dotenv/load.ts";

--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -66,6 +66,7 @@ export type ColumnDetails = {
  * the top level, `Column` can simply be a property accessor, which is either a
  * `string` (if it's a plain object) or a `number` (if it's an array).
  *
+ * @example
  * ```ts
  * const columns = [
  *   "name",
@@ -232,6 +233,7 @@ export type StringifyOptions = {
  *
  * `DataItem: Record<string, unknown> | unknown[]`
  *
+ * @example
  * ```ts
  * const data = [
  *   {

--- a/encoding/front_matter/mod.ts
+++ b/encoding/front_matter/mod.ts
@@ -36,6 +36,7 @@
  *
  * example.ts
  *
+ * @example
  * ```ts
  * import {
  *   extract,
@@ -69,6 +70,7 @@
  *
  * ### Advanced usage
  *
+ * @example
  * ```ts
  * import {
  *   createExtractor,
@@ -243,6 +245,7 @@ function _extract<T>(
  * @param formats A descriptor containing Format-parser pairs to use for each format.
  * @returns A function that extracts front matter from a string with the given parsers.
  *
+ * @example
  * ```ts
  * import { createExtractor, Format, Parser } from "https://deno.land/std@$STD_VERSION/encoding/front_matter/mod.ts";
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
@@ -305,6 +308,7 @@ export function createExtractor(
  * @param str String to test.
  * @param formats A list of formats to test for. Defaults to all supported formats.
  *
+ * @example
  * ```ts
  * import { test, Format } from "https://deno.land/std@$STD_VERSION/encoding/front_matter/mod.ts";
  * import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
@@ -341,6 +345,7 @@ export function test(str: string, formats?: Format[]): boolean {
  * @param str String to recognize.
  * @param formats A list of formats to recognize. Defaults to all supported formats.
  *
+ * @example
  * ```ts
  * import { recognize, Format } from "https://deno.land/std@$STD_VERSION/encoding/front_matter/mod.ts";
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";

--- a/encoding/jsonc.ts
+++ b/encoding/jsonc.ts
@@ -25,6 +25,7 @@ export interface ParseOptions {
  *
  * @example
  *
+ * @example
  * ```ts
  * import * as JSONC from "https://deno.land/std@$STD_VERSION/encoding/jsonc.ts";
  *

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -478,6 +478,7 @@ export function bgRgb8(str: string, color: number): string {
  *
  * To produce the color magenta:
  *
+ * @example
  * ```ts
  *      import { rgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *      rgb24("foo", 0xff00ff);
@@ -518,6 +519,7 @@ export function rgb24(str: string, color: number | Rgb): string {
  *
  * To produce the color magenta:
  *
+ * @example
  * ```ts
  *      import { bgRgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *      bgRgb24("foo", 0xff00ff);

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -3,6 +3,7 @@
 /**
  * Format milliseconds to time duration.
  *
+ * @example
  * ```ts
  * import { format } from "https://deno.land/std@$STD_VERSION/fmt/duration.ts";
  *

--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -6,6 +6,7 @@
  * To access the keys in a request and have any set keys available for creating
  * a response:
  *
+ * @example
  * ```ts
  * import {
  *   CookieMap,
@@ -33,6 +34,7 @@
  * difference is that the methods operate async in order to be able to support
  * async signing and validation of cookies:
  *
+ * @example
  * ```ts
  * import {
  *   SecureCookieMap,
@@ -63,6 +65,7 @@
  * response at construction of the cookies object, they can be passed and any
  * set cookies will be added directly to those headers:
  *
+ * @example
  * ```ts
  * import { CookieMap } from "https://deno.land/std@$STD_VERSION/http/cookie_map.ts";
  *

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -436,6 +436,7 @@ export interface ServeDirOptions {
 /**
  * Serves the files under the given directory root (opts.fsRoot).
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
@@ -454,6 +455,7 @@ export interface ServeDirOptions {
  *
  * Optionally you can pass `urlRoot` option. If it's specified that part is stripped from the beginning of the requested pathname.
  *
+ * @example
  * ```ts
  * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
  *

--- a/http/http_status.ts
+++ b/http/http_status.ts
@@ -17,6 +17,7 @@
  * console.log(STATUS_TEXT[Status.NotFound]); //=> "Not Found"
  * ```
  *
+ * @example
  * ```ts
  * import { isErrorStatus } from "https://deno.land/std@$STD_VERSION/http/http_status.ts";
  *

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -8,6 +8,7 @@
  * Server APIs utilizing Deno's
  * [HTTP server APIs](https://deno.land/manual/runtime/http_server_apis#http-server-apis).
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *

--- a/http/server.ts
+++ b/http/server.ts
@@ -499,6 +499,7 @@ export interface ServeInit extends Partial<Deno.ListenOptions> {
  * Constructs a server, accepts incoming connections on the given listener, and
  * handles requests on these connections with the given handler.
  *
+ * @example
  * ```ts
  * import { serveListener } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *
@@ -547,6 +548,7 @@ function hostnameForDisplay(hostname: string) {
  *
  * The below example serves with the port 8000.
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * serve((_req) => new Response("Hello, world"));
@@ -555,6 +557,7 @@ function hostnameForDisplay(hostname: string) {
  * You can change the listening address by the `hostname` and `port` options.
  * The below example serves with the port 3000.
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * serve((_req) => new Response("Hello, world"), { port: 3000 });
@@ -564,6 +567,7 @@ function hostnameForDisplay(hostname: string) {
  * on start-up by default. If you like to change this message, you can specify
  * `onListen` option to override it.
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * serve((_req) => new Response("Hello, world"), {
@@ -576,6 +580,7 @@ function hostnameForDisplay(hostname: string) {
  *
  * You can also specify `undefined` or `null` to stop the logging behavior.
  *
+ * @example
  * ```ts
  * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * serve((_req) => new Response("Hello, world"), { onListen: undefined });
@@ -637,6 +642,7 @@ export interface ServeTlsInit extends ServeInit {
  *
  * The below example serves with the default port 8443.
  *
+ * @example
  * ```ts
  * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  *
@@ -655,6 +661,7 @@ export interface ServeTlsInit extends ServeInit {
  * on start-up by default. If you like to change this message, you can specify
  * `onListen` option to override it.
  *
+ * @example
  * ```ts
  * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * const certFile = "/path/to/certFile.crt";
@@ -671,6 +678,7 @@ export interface ServeTlsInit extends ServeInit {
  *
  * You can also specify `undefined` or `null` to stop the logging behavior.
  *
+ * @example
  * ```ts
  * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
  * const certFile = "/path/to/certFile.crt";

--- a/io/files.ts
+++ b/io/files.ts
@@ -21,6 +21,7 @@ export interface ByteRange {
  * seekable.  The range start and end are inclusive of the bytes within that
  * range.
  *
+ * @example
  * ```ts
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  * import { readRange } from "https://deno.land/std@$STD_VERSION/io/files.ts";
@@ -40,6 +41,7 @@ export const readRange = _readRange;
  * readable and seekable.  The range start and end are inclusive of the bytes
  * within that range.
  *
+ * @example
  * ```ts
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/files.ts";

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -18,6 +18,7 @@ export interface ByteRange {
  * seekable.  The range start and end are inclusive of the bytes within that
  * range.
  *
+ * @example
  * ```ts
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  * import { readRange } from "https://deno.land/std@$STD_VERSION/io/read_range.ts";
@@ -56,6 +57,7 @@ export async function readRange(
  * readable and seekable.  The range start and end are inclusive of the bytes
  * within that range.
  *
+ * @example
  * ```ts
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/read_range.ts";

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -40,6 +40,7 @@
  * The authors of public modules can let the users display the internal logs of the
  * module by using a custom logger:
  *
+ * @example
  * ```ts
  * import { getLogger } from "https://deno.land/std@$STD_VERSION/log/mod.ts";
  *
@@ -60,6 +61,7 @@
  *
  * The user of the module can then display the internal logs with:
  *
+ * @example
  * ```ts, ignore
  * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
  * import { sum } from "<the-awesome-module>/mod.ts";
@@ -83,6 +85,7 @@
  * Please note that, due to the order of initialization of the loggers, the
  * following won't work:
  *
+ * @example
  * ```ts
  * import { getLogger } from "https://deno.land/std@$STD_VERSION/log/mod.ts";
  *

--- a/path/common.ts
+++ b/path/common.ts
@@ -6,6 +6,7 @@ import { SEP } from "./separator.ts";
 /** Determines the common path from a set of paths, using an optional separator,
  * which defaults to the OS default separator.
  *
+ * @example
  * ```ts
  *       import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
  *       const p = common([

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -482,6 +482,7 @@ export function parse(path: string): ParsedPath {
 /**
  * Converts a file URL to a path string.
  *
+ * @example
  * ```ts
  *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
  *      fromFileUrl("file:///home/foo"); // "/home/foo"
@@ -501,6 +502,7 @@ export function fromFileUrl(url: string | URL): string {
 /**
  * Converts a path string to a file URL.
  *
+ * @example
  * ```ts
  *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
  *      toFileUrl("/home/foo"); // new URL("file:///home/foo")

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -954,6 +954,7 @@ export function parse(path: string): ParsedPath {
 /**
  * Converts a file URL to a path string.
  *
+ * @example
  * ```ts
  *      import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
  *      fromFileUrl("file:///home/foo"); // "\\home\\foo"
@@ -982,6 +983,7 @@ export function fromFileUrl(url: string | URL): string {
 /**
  * Converts a path string to a file URL.
  *
+ * @example
  * ```ts
  *      import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
  *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -33,6 +33,7 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
 /** Attempts to grant a set of permissions, resolving with the descriptors of
  * the permissions that are granted.
  *
+ * @example
  * ```ts
  *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      const perms = await grant({ name: "net" }, { name: "read" });
@@ -51,6 +52,7 @@ export async function grant(
 /** Attempts to grant a set of permissions, resolving with the descriptors of
  * the permissions that are granted.
  *
+ * @example
  * ```ts
  *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      const perms = await grant([{ name: "net" }, { name: "read" }]);
@@ -88,6 +90,7 @@ export async function grant(
 
 /** Attempts to grant a set of permissions or rejects.
  *
+ * @example
  * ```ts
  *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      await grantOrThrow({ name: "env" }, { name: "net" });
@@ -102,6 +105,7 @@ export async function grantOrThrow(
 ): Promise<void>;
 /** Attempts to grant a set of permissions or rejects.
  *
+ * @example
  * ```ts
  *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
  *      await grantOrThrow([{ name: "env" }, { name: "net" }]);

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -16,6 +16,7 @@ export type Disposable = { dispose: () => void };
  *
  * Example:
  *
+ * @example
  * ```ts
  * import { signal } from "https://deno.land/std@$STD_VERSION/signal/mod.ts";
  *

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -179,6 +179,7 @@ export class Buffer {
  * if options.error is set, then instead of terminating the stream,
  * an error will be thrown.
  *
+ * @example
  * ```ts
  * import { LimitedBytesTransformStream } from "https://deno.land/std@$STD_VERSION/streams/buffer.ts";
  * const res = await fetch("https://example.com");
@@ -196,6 +197,7 @@ export const LimitedBytesTransformStream = _LimitedBytesTransformStream;
  * if options.error is set, then instead of terminating the stream,
  * an error will be thrown.
  *
+ * @example
  * ```ts
  * import { LimitedTransformStream } from "https://deno.land/std@$STD_VERSION/streams/buffer.ts";
  * const res = await fetch("https://example.com");

--- a/streams/conversion.ts
+++ b/streams/conversion.ts
@@ -29,6 +29,7 @@ import { writableStreamFromWriter as _writableStreamFromWriter } from "./writabl
  *
  * Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
+ * @example
  * ```ts
  *      import { readerFromIterable, copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -113,6 +114,7 @@ export const writableStreamFromWriter = _writableStreamFromWriter;
  *
  * reate a `ReadableStream` from any kind of iterable.
  *
+ * @example
  * ```ts
  *      import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -132,6 +134,7 @@ export const writableStreamFromWriter = _writableStreamFromWriter;
  * to have a `.throw()` method on it, that will be called upon
  * `readableStream.cancel()`. This is the case for the second input type above:
  *
+ * @example
  * ```ts
  * import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -154,6 +157,7 @@ export const readableStreamFromIterable = _readableStreamFromIterable;
  *
  * Convert the generator function into a TransformStream.
  *
+ * @example
  * ```ts
  * import { readableStreamFromIterable, toTransformStream } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -204,6 +208,7 @@ export interface ReadableStreamFromReaderOptions {
  *
  * An example converting a `Deno.FsFile` into a readable stream:
  *
+ * @example
  * ```ts
  * import { readableStreamFromReader } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
  *
@@ -219,6 +224,7 @@ export const readableStreamFromReader = _readableStreamFromReader;
  * Read Reader `r` until EOF (`null`) and resolve to the content as
  * Uint8Array`.
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { readAll } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
@@ -246,6 +252,7 @@ export const readAll = _readAll;
  * Synchronously reads Reader `r` until EOF (`null`) and returns the content
  * as `Uint8Array`.
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { readAllSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
@@ -272,6 +279,7 @@ export const readAllSync = _readAllSync;
  *
  * Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { writeAll } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
@@ -301,6 +309,7 @@ export const writeAll = _writeAll;
  * Synchronously write all the content of the array buffer (`arr`) to the
  * writer (`w`).
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { writeAllSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
@@ -329,6 +338,7 @@ export const writeAllSync = _writeAllSync;
  *
  * Turns a Reader, `r`, into an async iterator.
  *
+ * @example
  * ```ts
  * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -342,6 +352,7 @@ export const writeAllSync = _writeAllSync;
  * Second argument can be used to tune size of a buffer.
  * Default size of the buffer is 32kB.
  *
+ * @example
  * ```ts
  * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -362,6 +373,7 @@ export const iterateReader = _iterateReader;
  *
  * Turns a ReaderSync, `r`, into an iterator.
  *
+ * @example
  * ```ts
  * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -375,6 +387,7 @@ export const iterateReader = _iterateReader;
  * Second argument can be used to tune size of a buffer.
  * Default size of the buffer is 32kB.
  *
+ * @example
  * ```ts
  * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 
@@ -402,6 +415,7 @@ export const iterateReaderSync = _iterateReaderSync;
  * an error occurs. It resolves to the number of bytes copied or rejects with
  * the first error encountered while copying.
  *
+ * @example
  * ```ts
  * import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *

--- a/streams/copy.ts
+++ b/streams/copy.ts
@@ -6,6 +6,7 @@ import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
  * an error occurs. It resolves to the number of bytes copied or rejects with
  * the first error encountered while copying.
  *
+ * @example
  * ```ts
  * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
  *

--- a/streams/delimiter.ts
+++ b/streams/delimiter.ts
@@ -11,6 +11,7 @@ import { TextDelimiterStream as _TextDelimiterStream } from "./text_delimiter_st
  * Transform a stream into a stream where each chunk is divided by a newline,
  * be it `\n` or `\r\n`. `\r` can be enabled via the `allowCR` option.
  *
+ * @example
  * ```ts
  * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");
@@ -26,6 +27,7 @@ export const TextLineStream = _TextLineStream;
  *
  * Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
+ * @example
  * ```ts
  * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");
@@ -41,6 +43,7 @@ export const DelimiterStream = _DelimiterStream;
  *
  * Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
+ * @example
  * ```ts
  * import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter.ts";
  * const res = await fetch("https://example.com");

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -5,6 +5,7 @@ import { createLPS } from "./_common.ts";
 
 /** Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
+ * @example
  * ```ts
  * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
  * const res = await fetch("https://example.com");

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -4,6 +4,7 @@ import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
 
 /** Turns a Reader, `r`, into an async iterator.
  *
+ * @example
  * ```ts
  * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
  *
@@ -17,6 +18,7 @@ import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
  * Second argument can be used to tune size of a buffer.
  * Default size of the buffer is 32kB.
  *
+ * @example
  * ```ts
  * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
  *
@@ -50,6 +52,7 @@ export async function* iterateReader(
 
 /** Turns a ReaderSync, `r`, into an iterator.
  *
+ * @example
  * ```ts
  * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
  *
@@ -63,6 +66,7 @@ export async function* iterateReader(
  * Second argument can be used to tune size of a buffer.
  * Default size of the buffer is 32kB.
  *
+ * @example
  * ```ts
  * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
 

--- a/streams/limited_bytes_transform_stream.ts
+++ b/streams/limited_bytes_transform_stream.ts
@@ -7,6 +7,7 @@
  * if options.error is set, then instead of terminating the stream,
  * an error will be thrown.
  *
+ * @example
  * ```ts
  * import { LimitedBytesTransformStream } from "https://deno.land/std@$STD_VERSION/streams/limited_bytes_transform_stream.ts";
  * const res = await fetch("https://example.com");

--- a/streams/limited_transform_stream.ts
+++ b/streams/limited_transform_stream.ts
@@ -5,6 +5,7 @@
  * if options.error is set, then instead of terminating the stream,
  * an error will be thrown.
  *
+ * @example
  * ```ts
  * import { LimitedTransformStream } from "https://deno.land/std@$STD_VERSION/streams/limited_transform_stream.ts";
  * const res = await fetch("https://example.com");

--- a/streams/read_all.ts
+++ b/streams/read_all.ts
@@ -5,6 +5,7 @@ import { Buffer } from "../io/buffer.ts";
 /** Read Reader `r` until EOF (`null`) and resolve to the content as
  * Uint8Array`.
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { readAll } from "https://deno.land/std@$STD_VERSION/streams/read_all.ts";
@@ -33,6 +34,7 @@ export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
 /** Synchronously reads Reader `r` until EOF (`null`) and returns the content
  * as `Uint8Array`.
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { readAllSync } from "https://deno.land/std@$STD_VERSION/streams/read_all.ts";

--- a/streams/readable_stream_from_iterable.ts
+++ b/streams/readable_stream_from_iterable.ts
@@ -2,6 +2,7 @@
 
 /** Create a `ReadableStream` from any kind of iterable.
  *
+ * @example
  * ```ts
  *      import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_iterable.ts";
  *
@@ -21,6 +22,7 @@
  * to have a `.throw()` method on it, that will be called upon
  * `readableStream.cancel()`. This is the case for the second input type above:
  *
+ * @example
  * ```ts
  * import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_iterable.ts";
  *

--- a/streams/readable_stream_from_reader.ts
+++ b/streams/readable_stream_from_reader.ts
@@ -33,6 +33,7 @@ export interface ReadableStreamFromReaderOptions {
  *
  * An example converting a `Deno.FsFile` into a readable stream:
  *
+ * @example
  * ```ts
  * import { readableStreamFromReader } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_reader.ts";
  *

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -5,6 +5,7 @@ import { writeAll } from "./write_all.ts";
 
 /** Create a `Deno.Reader` from an iterable of `Uint8Array`s.
  *
+ * @example
  * ```ts
  *      import { readerFromIterable } from "https://deno.land/std@$STD_VERSION/streams/reader_from_iterable.ts";
  *      import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";

--- a/streams/text_delimiter_stream.ts
+++ b/streams/text_delimiter_stream.ts
@@ -4,6 +4,7 @@ import { createLPS } from "./_common.ts";
 
 /** Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
+ * @example
  * ```ts
  * import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/text_delimiter_stream.ts";
  * const res = await fetch("https://example.com");

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -8,6 +8,7 @@ interface TextLineStreamOptions {
 /** Transform a stream into a stream where each chunk is divided by a newline,
  * be it `\n` or `\r\n`. `\r` can be enabled via the `allowCR` option.
  *
+ * @example
  * ```ts
  * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/text_line_stream.ts";
  * const res = await fetch("https://example.com");

--- a/streams/to_transform_stream.ts
+++ b/streams/to_transform_stream.ts
@@ -3,6 +3,7 @@
 /**
  * Convert the generator function into a TransformStream.
  *
+ * @example
  * ```ts
  * import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_iterable.ts";
  * import { toTransformStream } from "https://deno.land/std@$STD_VERSION/streams/to_transform_stream.ts";

--- a/streams/write_all.ts
+++ b/streams/write_all.ts
@@ -2,6 +2,7 @@
 
 /** Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { writeAll } from "https://deno.land/std@$STD_VERSION/streams/write_all.ts";
@@ -33,6 +34,7 @@ export async function writeAll(w: Deno.Writer, arr: Uint8Array) {
 /** Synchronously write all the content of the array buffer (`arr`) to the
  * writer (`w`).
  *
+ * @example
  * ```ts
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
  * import { writeAllSync } from "https://deno.land/std@$STD_VERSION/streams/write_all.ts";

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -295,6 +295,7 @@ export function assertStrictEquals<T>(
  * Make an assertion that `actual` and `expected` are not strictly equal.
  * If the values are strictly equal then throw.
  *
+ * @example
  * ```ts
  * import { assertNotStrictEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
@@ -668,6 +669,7 @@ export function assertThrows(
  *
  * @example
  *
+ * @example
  * ```ts
  * import { assertThrows } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -86,6 +86,7 @@
  * `describe` and `it` using nested test grouping, flat test grouping, or a mix of
  * both styles.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_test.ts
  * import {
@@ -131,6 +132,7 @@
  * the new test suite it creates. The hooks can be created within it or be added to
  * the options argument for describe.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_nested_test.ts
  * import {
@@ -193,6 +195,7 @@
  * callback. The gives you the ability to have test grouping without any extra
  * indentation in front of the grouped tests.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_flat_test.ts
  * import {
@@ -253,6 +256,7 @@
  * be useful if you'd like to create deep groupings without all the extra
  * indentation in front of each line.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_mixed_test.ts
  * import {

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -16,6 +16,7 @@
  * this with Spies, one is to have the `square` function take the `multiply`
  * multiply as a parameter.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/parameter_injection.ts
  * export function multiply(a: number, b: number): number {
@@ -34,6 +35,7 @@
  * a spy function around the `multiply` function and call
  * `square(multiplySpy, value)` in the testing code.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/parameter_injection_test.ts
  * import {
@@ -69,6 +71,7 @@
  * method and the `square` function calls `_internals.multiply` instead of
  * `multiply`.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/internals_injection.ts
  * export function multiply(a: number, b: number): number {
@@ -87,6 +90,7 @@
  * testing code to be able to spy on how the `square` function calls the `multiply`
  * function.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/internals_injection_test.ts
  * import {
@@ -153,6 +157,7 @@
  * through to the original `randomInt` function, we are going to replace
  * `randomInt` with a function that returns pre-defined values.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/random.ts
  * export function randomInt(lowerBound: number, upperBound: number): number {
@@ -170,6 +175,7 @@
  * easy. The `returnsNext` function takes an array of values we want it to return
  * on consecutive calls.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/random_test.ts
  * import {
@@ -219,6 +225,7 @@
  * starting from any point in time. Below is an example where we want to test that
  * the callback is called every second.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval.ts
  * export function secondInterval(cb: () => void): number {
@@ -232,6 +239,7 @@
  * until real time is restored. You can control how time ticks forward with the
  * `tick` method on the `FakeTime` instance.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval_test.ts
  * import {

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -21,8 +21,8 @@
  * ```
  *
  * @example
- * ```ts
- * // __snapshots__/example_test.ts.snap
+ * ```js
+ * // __snapshots__/example_test.js.snap
  * export const snapshot = {};
  *
  * snapshot[`isSnapshotMatch 1`] = `
@@ -130,8 +130,8 @@
  * ```
  *
  * @example
- * ```ts
- * // .snaps/example_test.ts.snap
+ * ```js
+ * // .snaps/example_test.js.snap
  * export const snapshot = {};
  *
  * snapshot[`isSnapshotMatch 1`] = `This green text has had it's colours stripped`;

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -6,6 +6,7 @@
  * to a reference snapshot, which is stored alongside the test file in the
  * `__snapshots__` directory.
  *
+ * @example
  * ```ts
  * // example_test.ts
  * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
@@ -19,7 +20,8 @@
  * });
  * ```
  *
- * ```js
+ * @example
+ * ```ts
  * // __snapshots__/example_test.ts.snap
  * export const snapshot = {};
  *
@@ -70,6 +72,7 @@
  *
  * The `assertSnapshot` function optionally accepts an options object.
  *
+ * @example
  * ```ts
  * // example_test.ts
  * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
@@ -87,6 +90,7 @@
  *
  * You can also configure default options for `assertSnapshot`.
  *
+ * @example
  * ```ts
  * // example_test.ts
  * import { createAssertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
@@ -104,6 +108,7 @@
  * It is possible to "extend" an `assertSnapshot` function which has been
  * configured with default options.
  *
+ * @example
  * ```ts
  * // example_test.ts
  * import { createAssertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
@@ -124,7 +129,8 @@
  * });
  * ```
  *
- * ```js
+ * @example
+ * ```ts
  * // .snaps/example_test.ts.snap
  * export const snapshot = {};
  *

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -218,6 +218,7 @@ let dueTree: RedBlackTree<DueNode>;
  * Overrides the real Date object and timer functions with fake ones that can be
  * controlled through the fake time instance.
  *
+ * @example
  * ```ts
  * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval_test.ts
  * import {

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -25,7 +25,8 @@ export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
 /**
  * Check if the passed UUID is the nil UUID.
  *
- * ```js
+ * @example
+ * ```ts
  * import { isNil } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts";
  *
  * isNil("00000000-0000-0000-0000-000000000000") // true
@@ -39,7 +40,8 @@ export function isNil(id: string): boolean {
 /**
  * Test a string to see if it is a valid UUID.
  *
- * ```js
+ * @example
+ * ```ts
  * import { validate } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
  *
  * validate("not a UUID") // false
@@ -56,7 +58,8 @@ export function validate(uuid: string): boolean {
 /**
  * Detect RFC version of a UUID.
  *
- * ```js
+ * @example
+ * ```ts
  * import { version } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
  *
  * version("d9428888-122b-11e1-b85c-61cd3cbb3210") // 1


### PR DESCRIPTION
This change corrects JSDoc example blocks and provides a short guide on how to do so in the contributing section.