### PR TITLE
chore: update node tests

### DIFF
--- a/node/_tools/TODO.md
+++ b/node/_tools/TODO.md
@@ -1,5 +1,7 @@
 # Remaining Node Tests
 
+NOTE: This file should not be manually edited. Please edit `config.json` and run `deno task node:setup` instead.
+
 Total: 2822
 
 - [abort/test-abort-backtrace.js](https://github.com/nodejs/node/tree/v18.12.0/test/abort/test-abort-backtrace.js)

--- a/node/_tools/TODO.md
+++ b/node/_tools/TODO.md
@@ -1,6 +1,6 @@
 # Remaining Node Tests
 
-Total: 2825
+Total: 2822
 
 - [abort/test-abort-backtrace.js](https://github.com/nodejs/node/tree/v18.12.0/test/abort/test-abort-backtrace.js)
 - [abort/test-abort-fatal-error.js](https://github.com/nodejs/node/tree/v18.12.0/test/abort/test-abort-fatal-error.js)
@@ -1717,7 +1717,6 @@ Total: 2825
 - [parallel/test-process-env.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-env.js)
 - [parallel/test-process-euid-egid.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-euid-egid.js)
 - [parallel/test-process-exception-capture-errors.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-exception-capture-errors.js)
-- [parallel/test-process-exception-capture-should-abort-on-uncaught-setflagsfromstring.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-exception-capture-should-abort-on-uncaught-setflagsfromstring.js)
 - [parallel/test-process-exception-capture-should-abort-on-uncaught.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-exception-capture-should-abort-on-uncaught.js)
 - [parallel/test-process-exception-capture.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-exception-capture.js)
 - [parallel/test-process-exec-argv.js](https://github.com/nodejs/node/tree/v18.12.0/test/parallel/test-process-exec-argv.js)

--- a/node/_tools/TODO.md
+++ b/node/_tools/TODO.md
@@ -1,6 +1,7 @@
 # Remaining Node Tests
 
-NOTE: This file should not be manually edited. Please edit `config.json` and run `deno task node:setup` instead.
+NOTE: This file should not be manually edited. Please edit `config.json` and run
+`deno task node:setup` instead.
 
 Total: 2822
 

--- a/node/_tools/check_circular_deps.ts
+++ b/node/_tools/check_circular_deps.ts
@@ -2,7 +2,7 @@
 import {
   createGraph,
   ModuleGraph,
-} from "https://deno.land/x/deno_graph@0.37.1/mod.ts";
+} from "https://deno.land/x/deno_graph@0.40.0/mod.ts";
 
 const root = `${new URL("../module_all.ts", import.meta.url)}`;
 const seen = new Set<string>();

--- a/node/_tools/list_remaining_tests.ts
+++ b/node/_tools/list_remaining_tests.ts
@@ -70,6 +70,11 @@ export async function updateToDo() {
 
   await file.write(encoder.encode("# Remaining Node Tests\n\n"));
   await file.write(
+    encoder.encode(
+      "NOTE: This file should not be manually edited. Please edit `config.json` and run `deno task node:setup` instead.\n\n",
+    ),
+  );
+  await file.write(
     encoder.encode(`Total: ${missingTests.length}\n\n`),
   );
 

--- a/node/_tools/test/parallel/test-path-dirname.js
+++ b/node/_tools/test/parallel/test-path-dirname.js
@@ -10,7 +10,7 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 
-assert.strictEqual(path.dirname(__filename).slice(-13),
+assert.strictEqual(path.dirname(__filename).substr(-13),
                    common.isWindows ? 'test\\parallel' : 'test/parallel');
 
 assert.strictEqual(path.posix.dirname('/a/b/'), '/a');

--- a/node/_tools/test/parallel/test-zlib-truncated.js
+++ b/node/_tools/test/parallel/test-zlib-truncated.js
@@ -59,13 +59,13 @@ const errMessage = /unexpected end of file/;
 
     // Sync truncated input test, finishFlush = Z_SYNC_FLUSH
     const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
-    assert.strictEqual(result, inputString.slice(0, result.length));
+    assert.strictEqual(result, inputString.substr(0, result.length));
 
     // Async truncated input test, finishFlush = Z_SYNC_FLUSH
     zlib[methods.decomp](truncated, syncFlushOpt, function(err, decompressed) {
       assert.ifError(err);
       const result = toUTF8(decompressed);
-      assert.strictEqual(result, inputString.slice(0, result.length));
+      assert.strictEqual(result, inputString.substr(0, result.length));
     });
   });
 });


### PR DESCRIPTION
This change:
- updates the `deno_graph` dep
- adds proper instructions to `TODO.md` on how to update
- runs `deno task node:setup` again causing the rest of these changes

In https://github.com/denoland/deno_std/pull/2993, `.substr` was replaced by `.slice`, even in the vendored node test code which I think probably wasn't the best idea. Running `node:setup` reverts this change incidentally.

It looks like the changes to `TODO.md` were caused by people updating it by hand instead of changing the config and just running `node:setup` (I am one of those guilty of doing this). I have added a line in `TODO.md` to remedy this.