### PR TITLE
refactor: remove unnecessary returns

### DIFF
--- a/encoding/_yaml/loader/loader.ts
+++ b/encoding/_yaml/loader/loader.ts
@@ -1712,8 +1712,6 @@ function readDocument(state: LoaderState) {
       state,
       "end of the stream or a document separator is expected",
     );
-  } else {
-    return;
   }
 }
 

--- a/encoding/testdata/jsonc/test262/assert.js
+++ b/encoding/testdata/jsonc/test262/assert.js
@@ -38,6 +38,7 @@ assert.sameValue = function (actual, expected, message) {
     }
   } catch (error) {
     throw new Test262Error(message + ' (_isSameValue operation threw) ' + error);
+    return;
   }
 
   if (message === undefined) {

--- a/encoding/testdata/jsonc/test262/assert.js
+++ b/encoding/testdata/jsonc/test262/assert.js
@@ -38,7 +38,6 @@ assert.sameValue = function (actual, expected, message) {
     }
   } catch (error) {
     throw new Test262Error(message + ' (_isSameValue operation threw) ' + error);
-    return;
   }
 
   if (message === undefined) {
@@ -73,7 +72,6 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   if (typeof func !== "function") {
     throw new Test262Error('assert.throws requires two arguments: the error constructor ' +
       'and a function to run');
-    return;
   }
   if (message === undefined) {
     message = '';

--- a/encoding/testdata/jsonc/test262/assert.js
+++ b/encoding/testdata/jsonc/test262/assert.js
@@ -73,6 +73,7 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   if (typeof func !== "function") {
     throw new Test262Error('assert.throws requires two arguments: the error constructor ' +
       'and a function to run');
+    return;
   }
   if (message === undefined) {
     message = '';

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -427,7 +427,6 @@ class Printf {
       err = true;
     }
     this.argNum = err ? this.argNum : positional - 1;
-    return;
   }
 
   /** Handle less than */

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -72,6 +72,5 @@ export function emptyDirSync(dir: string | URL) {
     }
     // if not exist. then create it
     Deno.mkdirSync(dir, { recursive: true });
-    return;
   }
 }

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -48,8 +48,6 @@ export async function move(
   }
 
   await Deno.rename(src, dest);
-
-  return;
 }
 
 /**

--- a/node/assert.ts
+++ b/node/assert.ts
@@ -230,7 +230,6 @@ function doesNotThrow(
   } catch (e) {
     gotUnwantedException(e, expected, message, doesNotThrow);
   }
-  return;
 }
 
 function equal(


### PR DESCRIPTION
Noticed a few of these while looking at codebase, and I thought it could use a refactor.

LMK if there is a reason for these but to me these just look like dubious code.