### PR TITLE
fix: Do not mutate tokens when creating details

### DIFF
--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -318,8 +318,8 @@ export function diffstr(A: string, B: string) {
       ) {
         return {
           ...result,
-          type: t[i - 1].type
-        }
+          type: t[i - 1].type,
+        };
       }
       return result;
     });

--- a/testing/_diff.ts
+++ b/testing/_diff.ts
@@ -316,7 +316,10 @@ export function diffstr(A: string, B: string) {
         (result.type === DiffType.common) && (t[i - 1]) &&
         (t[i - 1]?.type === t[i + 1]?.type) && /\s+/.test(result.value)
       ) {
-        result.type = t[i - 1].type;
+        return {
+          ...result,
+          type: t[i - 1].type
+        }
       }
       return result;
     });

--- a/testing/_diff_test.ts
+++ b/testing/_diff_test.ts
@@ -236,7 +236,37 @@ Deno.test({
         value: "c d\n",
         details: [
           { type: DiffType.added, value: "c" },
+          { type: DiffType.added, value: " " },
           { type: DiffType.added, value: "d" },
+          { type: DiffType.common, value: "\n" },
+        ],
+      },
+    ]);
+  },
+});
+
+Deno.test({
+  name: `single line, different word length "a bc" vs "cd e" (diffstr)`,
+  fn() {
+    const diffResult = diffstr("a bc", "cd e");
+    assertEquals(diffResult, [
+      {
+        type: DiffType.removed,
+        value: "a bc\n",
+        details: [
+          { type: DiffType.removed, value: "a" },
+          { type: DiffType.removed, value: " " },
+          { type: DiffType.removed, value: "bc" },
+          { type: DiffType.common, value: "\n" },
+        ],
+      },
+      {
+        type: DiffType.added,
+        value: "cd e\n",
+        details: [
+          { type: DiffType.added, value: "cd" },
+          { type: DiffType.added, value: " " },
+          { type: DiffType.added, value: "e" },
           { type: DiffType.common, value: "\n" },
         ],
       },


### PR DESCRIPTION
Input:
```ts
import { assertEquals } from "https://deno.land/std@0.166.0/testing/asserts.ts";

assertEquals(`foo bar`, `fooo baz`);
```

Before:
```diff
-   foo bar
+   fooobaz
```

After:
```diff
-   foo bar
+   fooo baz
```

---

Input:
```ts
import { assertEquals } from "https://deno.land/std@0.166.0/testing/asserts.ts";

assertEquals(`foo bar`, `foo baz`);
```

Before/after:
```diff
-   foo bar
+   foo baz
```