### PR TITLE
feat(node): Add support for os.uptime

### DIFF
--- a/node/_tools/test/parallel/test-os.js
+++ b/node/_tools/test/parallel/test-os.js
@@ -90,14 +90,12 @@ const hostname = os.hostname();
 is.string(hostname);
 assert.ok(hostname.length > 0);
 
-/** TODO(kt3k): Emable this test
 // On IBMi, os.uptime() returns 'undefined'
 if (!common.isIBMi) {
   const uptime = os.uptime();
   is.number(uptime);
   assert.ok(uptime > 0);
 }
-*/
 
 const cpus = os.cpus();
 is.array(cpus);
@@ -262,14 +260,12 @@ assert.strictEqual(`${os.version}`, os.version());
 
 assert.strictEqual(+os.totalmem, os.totalmem());
 
-/* TODO(kt3k): Enable this test
 // Assert that the following values are coercible to numbers.
 // On IBMi, os.uptime() returns 'undefined'
 if (!common.isIBMi) {
   is.number(+os.uptime, 'uptime');
   is.number(os.uptime(), 'uptime');
 }
-*/
 
 is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');

--- a/node/os.ts
+++ b/node/os.ts
@@ -307,7 +307,7 @@ export function type(): string {
 
 /** Not yet implemented */
 export function uptime(): number {
-  notImplemented(SEE_GITHUB_ISSUE);
+  return Deno.uptime();
 }
 
 /** Not yet implemented */

--- a/node/os.ts
+++ b/node/os.ts
@@ -31,6 +31,9 @@ export const constants = os;
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno_std/issues/1436";
 
+// @ts-ignore Deno[Deno.internal] is used on purpose here
+const DenoOsUptime = Deno[Deno.internal]?.nodeUnstable?.osUptime || Deno.osUptime;
+
 interface CPUTimes {
   /** The number of milliseconds the CPU has spent in user mode */
   user: number;
@@ -307,7 +310,7 @@ export function type(): string {
 
 /** Returns the Operating System uptime in number of seconds. */
 export function uptime(): number {
-  return Deno.osUptime();
+  return DenoOsUptime();
 }
 
 /** Not yet implemented */

--- a/node/os.ts
+++ b/node/os.ts
@@ -32,7 +32,8 @@ export const constants = os;
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno_std/issues/1436";
 
 // @ts-ignore Deno[Deno.internal] is used on purpose here
-const DenoOsUptime = Deno[Deno.internal]?.nodeUnstable?.osUptime || Deno.osUptime;
+const DenoOsUptime = Deno[Deno.internal]?.nodeUnstable?.osUptime ||
+  Deno.osUptime;
 
 interface CPUTimes {
   /** The number of milliseconds the CPU has spent in user mode */

--- a/node/os.ts
+++ b/node/os.ts
@@ -305,9 +305,9 @@ export function type(): string {
   }
 }
 
-/** Not yet implemented */
+/** Returns the Operating System uptime in number of seconds. */
 export function uptime(): number {
-  return Deno.uptime();
+  return Deno.osUptime();
 }
 
 /** Not yet implemented */

--- a/node/os_test.ts
+++ b/node/os_test.ts
@@ -222,6 +222,13 @@ Deno.test({
 });
 
 Deno.test({
+  name: "Uptime should be greater than 0",
+  fn() {
+    assert(os.uptime() > 0);
+  },
+});
+
+Deno.test({
   name: "os.cpus()",
   fn() {
     assertEquals(os.cpus().length, navigator.hardwareConcurrency);
@@ -251,13 +258,6 @@ Deno.test({
     assertThrows(
       () => {
         os.setPriority(0);
-      },
-      Error,
-      "Not implemented",
-    );
-    assertThrows(
-      () => {
-        os.uptime();
       },
       Error,
       "Not implemented",


### PR DESCRIPTION
Dependent on https://github.com/denoland/deno/pull/17179

A part of https://github.com/denoland/deno_std/issues/1436
This will also allow for out-of-the-box support for `npm:@sentry/node`, ref: https://github.com/getsentry/sentry-javascript/issues/3009#issuecomment-1364503874