### PR TITLE
refactor(io): rework single-export files

### DIFF
--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -2,18 +2,6 @@
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";
 import type { Reader, ReaderSync } from "../types.d.ts";
-import {
-  BufferFullError as _BufferFullError,
-  BufReader as _BufReader,
-  PartialReadError as _PartialReadError,
-} from "./buf_reader.ts";
-import {
-  BufWriter as _BufWriter,
-  BufWriterSync as _BufWriterSync,
-} from "./buf_writer.ts";
-import { readDelim as _readDelim } from "./read_delim.ts";
-import { readStringDelim as _readStringDelim } from "./read_string_delim.ts";
-import { readLines as _readLines } from "./read_lines.ts";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
@@ -258,95 +246,98 @@ export class Buffer {
   }
 }
 
-/** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
-export const BufferFullError = _BufferFullError;
+export {
+  /** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
+  type BufferFullError,
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
+   *
+   * BufReader implements buffering for a Reader object.
+   */
+  BufReader,
+  /** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
+  type PartialReadError,
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
+   *
+   * Result type returned by of BufReader.readLine().
+   */
+  type ReadLineResult,
+} from "./buf_reader.ts";
 
-/** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
-export const PartialReadError = _PartialReadError;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_writer.ts` instead
+   *
+   * BufWriter implements buffering for an deno.Writer object.
+   * If an error occurs writing to a Writer, no more data will be
+   * accepted and all subsequent writes, and flush(), will return the error.
+   * After all data has been written, the client should call the
+   * flush() method to guarantee all data has been forwarded to
+   * the underlying deno.Writer.
+   */
+  BufWriter,
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_writer.ts` instead
+   *
+   * BufWriterSync implements buffering for a deno.WriterSync object.
+   * If an error occurs writing to a WriterSync, no more data will be
+   * accepted and all subsequent writes, and flush(), will return the error.
+   * After all data has been written, the client should call the
+   * flush() method to guarantee all data has been forwarded to
+   * the underlying deno.WriterSync.
+   */
+  BufWriterSync,
+} from "./buf_writer.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
- *
- * Result type returned by of BufReader.readLine().
- */
-export interface ReadLineResult {
-  line: Uint8Array;
-  more: boolean;
-}
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_delim.ts` instead
+   *
+   * Read delimited bytes from a Reader. */
+  readDelim,
+} from "./read_delim.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
- *
- * BufReader implements buffering for a Reader object.
- */
-export const BufReader = _BufReader;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_string_delim.ts` instead
+   *
+   * Read Reader chunk by chunk, splitting based on delimiter.
+   *
+   * @example
+   * ```ts
+   * import { readStringDelim } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
+   * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+   *
+   * const filename = path.join(Deno.cwd(), "std/io/README.md");
+   * let fileReader = await Deno.open(filename);
+   *
+   * for await (let line of readStringDelim(fileReader, "\n")) {
+   *   console.log(line);
+   * }
+   * ```
+   */
+  readStringDelim,
+} from "./read_string_delim.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_writer.ts` instead
- *
- * BufWriter implements buffering for an deno.Writer object.
- * If an error occurs writing to a Writer, no more data will be
- * accepted and all subsequent writes, and flush(), will return the error.
- * After all data has been written, the client should call the
- * flush() method to guarantee all data has been forwarded to
- * the underlying deno.Writer.
- */
-export const BufWriter = _BufWriter;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_writer.ts` instead
- *
- * BufWriterSync implements buffering for a deno.WriterSync object.
- * If an error occurs writing to a WriterSync, no more data will be
- * accepted and all subsequent writes, and flush(), will return the error.
- * After all data has been written, the client should call the
- * flush() method to guarantee all data has been forwarded to
- * the underlying deno.WriterSync.
- */
-export const BufWriterSync = _BufWriterSync;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_delim.ts` instead
- *
- * Read delimited bytes from a Reader. */
-export const readDelim = _readDelim;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_string_delim.ts` instead
- *
- * Read Reader chunk by chunk, splitting based on delimiter.
- *
- * @example
- * ```ts
- * import { readStringDelim } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
- *
- * const filename = path.join(Deno.cwd(), "std/io/README.md");
- * let fileReader = await Deno.open(filename);
- *
- * for await (let line of readStringDelim(fileReader, "\n")) {
- *   console.log(line);
- * }
- * ```
- */
-export const readStringDelim = _readStringDelim;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_lines.ts` instead
- *
- * Read strings line-by-line from a Reader.
- *
- *  @example
- * ```ts
- * import { readLines } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
- *
- * const filename = path.join(Deno.cwd(), "std/io/README.md");
- * let fileReader = await Deno.open(filename);
- *
- * for await (let line of readLines(fileReader)) {
- *   console.log(line);
- * }
- * ```
- */
-export const readLines = _readLines;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_lines.ts` instead
+   *
+   * Read strings line-by-line from a Reader.
+   *
+   *  @example
+   * ```ts
+   * import { readLines } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
+   * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+   *
+   * const filename = path.join(Deno.cwd(), "std/io/README.md");
+   * let fileReader = await Deno.open(filename);
+   *
+   * for await (let line of readLines(fileReader)) {
+   *   console.log(line);
+   * }
+   * ```
+   */
+  readLines,
+} from "./read_lines.ts";

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -248,7 +248,7 @@ export class Buffer {
 
 export {
   /** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
-  type BufferFullError,
+  BufferFullError,
   /**
    * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
    *
@@ -256,7 +256,7 @@ export {
    */
   BufReader,
   /** @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead */
-  type PartialReadError,
+  PartialReadError,
   /**
    * @deprecated (will be removed after 0.172.0) Import from `std/io/buf_reader.ts` instead
    *

--- a/io/files.ts
+++ b/io/files.ts
@@ -1,53 +1,42 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import {
-  readRange as _readRange,
-  readRangeSync as _readRangeSync,
+export {
+  /** @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead */
+  type ByteRange,
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead
+   *
+   * Read a range of bytes from a file or other resource that is readable and
+   * seekable.  The range start and end are inclusive of the bytes within that
+   * range.
+   *
+   * ```ts
+   * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { readRange } from "https://deno.land/std@$STD_VERSION/io/files.ts";
+   *
+   * // Read the first 10 bytes of a file
+   * const file = await Deno.open("example.txt", { read: true });
+   * const bytes = await readRange(file, { start: 0, end: 9 });
+   * assertEquals(bytes.length, 10);
+   * ```
+   */
+  readRange,
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead
+   *
+   * Read a range of bytes synchronously from a file or other resource that is
+   * readable and seekable.  The range start and end are inclusive of the bytes
+   * within that range.
+   *
+   * ```ts
+   * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/files.ts";
+   *
+   * // Read the first 10 bytes of a file
+   * const file = Deno.openSync("example.txt", { read: true });
+   * const bytes = readRangeSync(file, { start: 0, end: 9 });
+   * assertEquals(bytes.length, 10);
+   * ```
+   */
+  readRangeSync,
 } from "./read_range.ts";
-
-/** @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead */
-export interface ByteRange {
-  /** The 0 based index of the start byte for a range. */
-  start: number;
-
-  /** The 0 based index of the end byte for a range, which is inclusive. */
-  end: number;
-}
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead
- *
- * Read a range of bytes from a file or other resource that is readable and
- * seekable.  The range start and end are inclusive of the bytes within that
- * range.
- *
- * ```ts
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
- * import { readRange } from "https://deno.land/std@$STD_VERSION/io/files.ts";
- *
- * // Read the first 10 bytes of a file
- * const file = await Deno.open("example.txt", { read: true });
- * const bytes = await readRange(file, { start: 0, end: 9 });
- * assertEquals(bytes.length, 10);
- * ```
- */
-export const readRange = _readRange;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_range.ts` instead
- *
- * Read a range of bytes synchronously from a file or other resource that is
- * readable and seekable.  The range start and end are inclusive of the bytes
- * within that range.
- *
- * ```ts
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
- * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/files.ts";
- *
- * // Read the first 10 bytes of a file
- * const file = Deno.openSync("example.txt", { read: true });
- * const bytes = readRangeSync(file, { start: 0, end: 9 });
- * assertEquals(bytes.length, 10);
- * ```
- */
-export const readRangeSync = _readRangeSync;

--- a/io/readers.ts
+++ b/io/readers.ts
@@ -4,56 +4,58 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { StringReader as _StringReader } from "./string_reader.ts";
-import { MultiReader as _MultiReader } from "./multi_reader.ts";
-import { LimitedReader as _LimitedReader } from "./limited_reader.ts";
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/string_reader.ts` instead
+   *
+   * Reader utility for strings.
+   *
+   * @example
+   * ```ts
+   * import { StringReader } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
+   *
+   * const data = new Uint8Array(6);
+   * const r = new StringReader("abcdef");
+   * const res0 = await r.read(data);
+   * const res1 = await r.read(new Uint8Array(6));
+   *
+   * // Number of bytes read
+   * console.log(res0); // 6
+   * console.log(res1); // null, no byte left to read. EOL
+   *
+   * // text
+   *
+   * console.log(new TextDecoder().decode(data)); // abcdef
+   * ```
+   *
+   * **Output:**
+   *
+   * ```text
+   * 6
+   * null
+   * abcdef
+   * ```
+   */
+  StringReader,
+} from "./string_reader.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/string_reader.ts` instead
- *
- * Reader utility for strings.
- *
- * @example
- * ```ts
- * import { StringReader } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- *
- * const data = new Uint8Array(6);
- * const r = new StringReader("abcdef");
- * const res0 = await r.read(data);
- * const res1 = await r.read(new Uint8Array(6));
- *
- * // Number of bytes read
- * console.log(res0); // 6
- * console.log(res1); // null, no byte left to read. EOL
- *
- * // text
- *
- * console.log(new TextDecoder().decode(data)); // abcdef
- * ```
- *
- * **Output:**
- *
- * ```text
- * 6
- * null
- * abcdef
- * ```
- */
-export const StringReader = _StringReader;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/multi_reader.ts` instead
+   *
+   * Reader utility for combining multiple readers
+   */
+  MultiReader,
+} from "./multi_reader.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/multi_reader.ts` instead
- *
- * Reader utility for combining multiple readers
- */
-export const MultiReader = _MultiReader;
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/limited_reader.ts` instead
- *
- * A `LimitedReader` reads from `reader` but limits the amount of data returned to just `limit` bytes.
- * Each call to `read` updates `limit` to reflect the new amount remaining.
- * `read` returns `null` when `limit` <= `0` or
- * when the underlying `reader` returns `null`.
- */
-export const LimitedReader = _LimitedReader;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/limited_reader.ts` instead
+   *
+   * A `LimitedReader` reads from `reader` but limits the amount of data returned to just `limit` bytes.
+   * Each call to `read` updates `limit` to reflect the new amount remaining.
+   * `read` returns `null` when `limit` <= `0` or
+   * when the underlying `reader` returns `null`.
+   */
+  LimitedReader,
+} from "./limited_reader.ts";

--- a/io/util.ts
+++ b/io/util.ts
@@ -1,49 +1,54 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { copyN as _copyN } from "./copy_n.ts";
-import { readShort as _readShort } from "./read_short.ts";
-import { readInt as _readInt } from "./read_int.ts";
-import { readLong as _readLong } from "./read_long.ts";
-import { sliceLongToBytes as _sliceLongToBytes } from "./slice_long_to_bytes.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/copy_reader.ts` instead
- *
- * Copy N size at the most. If read size is lesser than N, then returns nread
- * @param r Reader
- * @param dest Writer
- * @param size Read size
- */
-export const copyN = _copyN;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/copy_reader.ts` instead
+   *
+   * Copy N size at the most. If read size is lesser than N, then returns nread
+   * @param r Reader
+   * @param dest Writer
+   * @param size Read size
+   */
+  copyN,
+} from "./copy_n.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_short.ts` instead
- *
- * Read big endian 16bit short from BufReader
- * @param buf
- */
-export const readShort = _readShort;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_short.ts` instead
+   *
+   * Read big endian 16bit short from BufReader
+   * @param buf
+   */
+  readShort,
+} from "./read_short.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_int.ts` instead
- *
- * Read big endian 32bit integer from BufReader
- * @param buf
- */
-export const readInt = _readInt;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_int.ts` instead
+   *
+   * Read big endian 32bit integer from BufReader
+   * @param buf
+   */
+  readInt,
+} from "./read_int.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/read_long.ts` instead
- *
- * Read big endian 64bit long from BufReader
- * @param buf
- */
-export const readLong = _readLong;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/read_long.ts` instead
+   *
+   * Read big endian 64bit long from BufReader
+   * @param buf
+   */
+  readLong,
+} from "./read_long.ts";
 
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/slice_long_to_bytes.ts` instead
- *
- * Slice number into 64bit big endian byte array
- * @param d The number to be sliced
- * @param dest The sliced array
- */
-export const sliceLongToBytes = _sliceLongToBytes;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/slice_long_to_bytes.ts` instead
+   *
+   * Slice number into 64bit big endian byte array
+   * @param d The number to be sliced
+   * @param dest The sliced array
+   */
+  sliceLongToBytes,
+} from "./slice_long_to_bytes.ts";

--- a/io/writers.ts
+++ b/io/writers.ts
@@ -1,38 +1,38 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { StringWriter as _StringWriter } from "./string_writer.ts";
-
-/**
- * @deprecated (will be removed after 0.172.0) Import from `std/io/string_writer.ts` instead
- *
- * Writer utility for buffering string chunks.
- *
- * @example
- * ```ts
- * import {
- *   copyN,
- *   StringReader,
- *   StringWriter,
- * } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
- *
- * const w = new StringWriter("base");
- * const r = new StringReader("0123456789");
- * await copyN(r, w, 4); // copy 4 bytes
- *
- * // Number of bytes read
- * console.log(w.toString()); //base0123
- *
- * await copy(r, w); // copy all
- * console.log(w.toString()); // base0123456789
- * ```
- *
- * **Output:**
- *
- * ```text
- * base0123
- * base0123456789
- * ```
- */
-export const StringWriter = _StringWriter;
+export {
+  /**
+   * @deprecated (will be removed after 0.172.0) Import from `std/io/string_writer.ts` instead
+   *
+   * Writer utility for buffering string chunks.
+   *
+   * @example
+   * ```ts
+   * import {
+   *   copyN,
+   *   StringReader,
+   *   StringWriter,
+   * } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
+   * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+   *
+   * const w = new StringWriter("base");
+   * const r = new StringReader("0123456789");
+   * await copyN(r, w, 4); // copy 4 bytes
+   *
+   * // Number of bytes read
+   * console.log(w.toString()); //base0123
+   *
+   * await copy(r, w); // copy all
+   * console.log(w.toString()); // base0123456789
+   * ```
+   *
+   * **Output:**
+   *
+   * ```text
+   * base0123
+   * base0123456789
+   * ```
+   */
+  StringWriter,
+} from "./string_writer.ts";


### PR DESCRIPTION
This change simplifies how functions and types are re-exported while maintaining deprecation warnings introduced in #2975. This also fixes an issue blocking https://github.com/denoland/deno/pull/16881.

CC @bartlomieju