### PR TITLE
refactor(archive): rework single-export files

### DIFF
--- a/archive/_common.ts
+++ b/archive/_common.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { PartialReadError } from "../io/buffer.ts";
+import { PartialReadError } from "../io/buf_reader.ts";
 import type { Reader } from "../types.d.ts";
 
 export interface TarInfo {

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -1,11 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import {
-  TarEntry as _TarEntry,
-  TarHeader as _TarHeader,
-  Untar as _Untar,
-} from "./untar.ts";
-import {
   FileTypes,
   type TarInfo,
   type TarMeta,
@@ -45,7 +40,7 @@ export { type TarInfo, type TarMeta, type TarOptions };
  * THE SOFTWARE.
  */
 
-import { MultiReader } from "../io/readers.ts";
+import { MultiReader } from "../io/multi_reader.ts";
 import { Buffer } from "../io/buffer.ts";
 import { assert } from "../_util/asserts.ts";
 import { recordSize } from "./_common.ts";
@@ -102,10 +97,6 @@ function formatHeader(data: TarData): Uint8Array {
   });
   return buffer;
 }
-
-/** @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead. */
-// deno-lint-ignore no-empty-interface
-export interface TarHeader extends _TarHeader {}
 
 export interface TarData {
   fileName?: string;
@@ -307,38 +298,41 @@ export class Tar {
   }
 }
 
-/**
- * @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead.
- *
- * A class to extract a tar archive
- *
- * @example
- * ```ts
- * import { Untar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
- * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/ensure_file.ts";
- * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
- *
- * const reader = await Deno.open("./out.tar", { read: true });
- * const untar = new Untar(reader);
- *
- * for await (const entry of untar) {
- *   console.log(entry); // metadata
- *
- *   if (entry.type === "directory") {
- *     await ensureDir(entry.fileName);
- *     continue;
- *   }
- *
- *   await ensureFile(entry.fileName);
- *   const file = await Deno.open(entry.fileName, { write: true });
- *   // <entry> is a reader.
- *   await copy(entry, file);
- * }
- * reader.close();
- * ```
- */
-export const Untar = _Untar;
-
-/** @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead. */
-export const TarEntry = _TarEntry;
+export {
+  /** @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead. */
+  TarEntry,
+  /** @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead. */
+  type TarHeader,
+  /**
+   * @deprecated (will be removed after 0.171.0) Import from `std/archive/untar.ts` instead.
+   *
+   * A class to extract a tar archive
+   *
+   * @example
+   * ```ts
+   * import { Untar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
+   * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/ensure_file.ts";
+   * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts";
+   * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+   *
+   * const reader = await Deno.open("./out.tar", { read: true });
+   * const untar = new Untar(reader);
+   *
+   * for await (const entry of untar) {
+   *   console.log(entry); // metadata
+   *
+   *   if (entry.type === "directory") {
+   *     await ensureDir(entry.fileName);
+   *     continue;
+   *   }
+   *
+   *   await ensureFile(entry.fileName);
+   *   const file = await Deno.open(entry.fileName, { write: true });
+   *   // <entry> is a reader.
+   *   await copy(entry, file);
+   * }
+   * reader.close();
+   * ```
+   */
+  Untar,
+} from "./untar.ts";

--- a/encoding/csv/stream_test.ts
+++ b/encoding/csv/stream_test.ts
@@ -11,7 +11,7 @@ import {
   assertStringIncludes,
 } from "../../testing/asserts.ts";
 import { fromFileUrl, join } from "../../path/mod.ts";
-import { StringReader } from "../../io/readers.ts";
+import { StringReader } from "../../io/string_reader.ts";
 
 const testdataDir = join(fromFileUrl(import.meta.url), "../../testdata");
 const encoder = new TextEncoder();

--- a/examples/echo_server_test.ts
+++ b/examples/echo_server_test.ts
@@ -4,7 +4,7 @@ import {
   assertNotEquals,
   assertStrictEquals,
 } from "../testing/asserts.ts";
-import { BufReader, ReadLineResult } from "../io/buffer.ts";
+import { BufReader, ReadLineResult } from "../io/buf_reader.ts";
 import { dirname, fromFileUrl } from "../path/mod.ts";
 import { TextLineStream } from "../streams/text_line_stream.ts";
 


### PR DESCRIPTION
This change simplifies how functions and types are re-exported while maintaining deprecation warnings introduced in #2958. It also cleans up a couple of little remaining bits for single-export files in `io`.