### PR TITLE
fix(node/http): ignore body when status code is one of 101, 204, 205, 304

### DIFF
--- a/node/http.ts
+++ b/node/http.ts
@@ -299,6 +299,12 @@ export class ServerResponse extends NodeWritable {
     }
   }
 
+  /** Returns true if the response body should be null with the given
+   * http status code */
+  static #bodyShouldBeNull(status: number) {
+    return status === 101 || status === 204 || status === 205 || status === 304;
+  }
+
   constructor(
     reqEvent: undefined | Deno.RequestEvent,
     resolve: undefined | ((value: Response | PromiseLike<Response>) => void),
@@ -392,7 +398,10 @@ export class ServerResponse extends NodeWritable {
   respond(final: boolean, singleChunk?: Chunk) {
     this.headersSent = true;
     this.#ensureHeaders(singleChunk);
-    const body = singleChunk ?? (final ? null : this.#readable);
+    let body = singleChunk ?? (final ? null : this.#readable);
+    if (ServerResponse.#bodyShouldBeNull(this.statusCode!)) {
+      body = null;
+    }
     if (this.#isFlashRequest) {
       this.#resolve!(
         new Response(body, {

--- a/node/http_test.ts
+++ b/node/http_test.ts
@@ -150,6 +150,23 @@ Deno.test("[node/http] empty chunk in the middle of response", async () => {
   await promise;
 });
 
+Deno.test("[node/http] server can respond with 101, 204, 205, 304 status", async () => {
+  for (const status of [101, 204, 205, 304]) {
+    const promise = deferred<void>();
+    const server = http.createServer((_req, res) => {
+      res.statusCode = status;
+      res.end("");
+    });
+    server.listen(async () => {
+      const res = await fetch(`http://127.0.0.1:${server.address().port}/`);
+      await res.arrayBuffer();
+      assertEquals(res.status, status);
+      server.close(() => promise.resolve());
+    });
+    await promise;
+  }
+});
+
 Deno.test("[node/http] request default protocol", async () => {
   const promise = deferred<void>();
   const server = http.createServer((_, res) => {


### PR DESCRIPTION
Currently the http server of `std/node` can't respond when the status code is one of 101, 204, 205, 304 and response body is specified. `Response` constructor throws in those cases.

(This problem seems causing the issue https://github.com/denoland/deno/issues/17142 )

This PR ignores specified body and makes body null when the status code is one of those.

closes https://github.com/denoland/deno/issues/17142