### PR TITLE
fix(path): Correctly handle trailing slashes for posix basename

### DIFF
--- a/path/basename_test.ts
+++ b/path/basename_test.ts
@@ -22,6 +22,7 @@ Deno.test("basename", function () {
   assertEquals(path.basename("/aaa/bbb", "a/bbb"), "bbb");
   assertEquals(path.basename("/aaa/bbb", "bbb"), "bbb");
   assertEquals(path.basename("/aaa/bbb//", "bbb"), "bbb");
+  assertEquals(path.basename("/aaa/bbb//", "a/bbb"), "bbb");
   assertEquals(path.basename("/aaa/bbb", "bb"), "b");
   assertEquals(path.basename("/aaa/bbb", "b"), "bb");
   assertEquals(path.basename("/aaa/bbb"), "bbb");

--- a/path/posix.ts
+++ b/path/posix.ts
@@ -266,7 +266,7 @@ export function basename(path: string, ext = ""): string {
     let firstNonSlashEnd = -1;
     for (i = path.length - 1; i >= 0; --i) {
       const code = path.charCodeAt(i);
-      if (code === CHAR_FORWARD_SLASH) {
+      if (isPosixPathSeparator(code)) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -275,24 +275,24 @@ export function basename(path: string, ext = ""): string {
         }
       } else {
         if (firstNonSlashEnd === -1) {
-          // We saw the first non-path separator, remember this index in case
-          // we need it if the extension ends up not matching
+          // We saw the first non-path separator, mark this as the end of our
+          // path component in case we don't match a whole suffix
           matchedSlash = false;
           firstNonSlashEnd = i + 1;
+          end = firstNonSlashEnd;
         }
         if (extIdx >= 0) {
-          // Try to match the explicit extension
+          // Try to match the explicit suffix
           if (code === ext.charCodeAt(extIdx)) {
             if (--extIdx === -1) {
-              // We matched the extension, so mark this as the end of our path
+              // We matched whole suffix, so mark this as the end of our path
               // component
               end = i;
             }
           } else {
-            // Extension does not match, so our result is the entire path
-            // component
+            // Suffix character does not match, so bail out early
+            // from checking rest of characters
             extIdx = -1;
-            end = firstNonSlashEnd;
           }
         }
       }
@@ -303,7 +303,7 @@ export function basename(path: string, ext = ""): string {
     return path.slice(start, end);
   } else {
     for (i = path.length - 1; i >= 0; --i) {
-      if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+      if (isPosixPathSeparator(path.charCodeAt(i))) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {

--- a/path/win32.ts
+++ b/path/win32.ts
@@ -668,24 +668,24 @@ export function basename(path: string, ext = ""): string {
         }
       } else {
         if (firstNonSlashEnd === -1) {
-          // We saw the first non-path separator, remember this index in case
-          // we need it if the extension ends up not matching
+          // We saw the first non-path separator, mark this as the end of our
+          // path component in case we don't match a whole suffix
           matchedSlash = false;
           firstNonSlashEnd = i + 1;
+          end = firstNonSlashEnd;
         }
         if (extIdx >= 0) {
-          // Try to match the explicit extension
+          // Try to match the explicit suffix
           if (code === ext.charCodeAt(extIdx)) {
             if (--extIdx === -1) {
-              // We matched the extension, so mark this as the end of our path
+              // We matched whole suffix, so mark this as the end of our path
               // component
               end = i;
             }
           } else {
-            // Extension does not match, so our result is the entire path
-            // component
+            // Suffix character does not match, so bail out early
+            // from checking rest of characters
             extIdx = -1;
-            end = firstNonSlashEnd;
           }
         }
       }


### PR DESCRIPTION
The only "real" change here is marking `end = firstNonSlashEnd` when we first encounter the non-slash character. This way, if we don't match the whole suffix (which happens when using input like `a/bb`, as it contains a slash, and can never be matched), it will still trim all trailing slashes.

Fixes https://github.com/denoland/deno_std/issues/3063