### PR TITLE
feat(collections): refactored binary search tree and red black tree to remove by node

### DIFF
--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -235,29 +235,34 @@ export class BinarySearchTree<T> implements Iterable<T> {
     return null;
   }
 
+  /** Removes the given node, and returns the node that was physically removed from the tree. */
   protected removeNode(
     node: BinarySearchNode<T>,
   ): BinarySearchNode<T> | null {
-    if (node) {
-      const successorNode: BinarySearchNode<T> | null =
-        !node.left || !node.right ? node : node.findSuccessorNode()!;
-      const replacementNode: BinarySearchNode<T> | null = successorNode.left ??
-        successorNode.right;
-      if (replacementNode) replacementNode.parent = successorNode.parent;
+    /**
+     * The node to physically remove from the tree.
+     * Guaranteed to not have both left and right children.
+     */
+    const flaggedNode: BinarySearchNode<T> | null = !node.left || !node.right
+      ? node
+      : node.findSuccessorNode()!;
+    /** Replaces the flagged node. */
+    const replacementNode: BinarySearchNode<T> | null = flaggedNode.left ??
+      flaggedNode.right;
 
-      if (!successorNode.parent) {
-        this.root = replacementNode;
-      } else {
-        successorNode.parent[successorNode.directionFromParent()!] =
-          replacementNode;
-      }
-
-      if (successorNode !== node) {
-        node.value = successorNode.value;
-        node = successorNode;
-      }
-      this._size--;
+    if (replacementNode) replacementNode.parent = flaggedNode.parent;
+    if (!flaggedNode.parent) {
+      this.root = replacementNode;
+    } else {
+      flaggedNode.parent[flaggedNode.directionFromParent()!] = replacementNode;
     }
+    if (flaggedNode !== node) {
+      /** Swaps values, in case value of the removed node is still needed by consumer. */
+      [node.value, flaggedNode.value] = [flaggedNode.value, node.value];
+      node = flaggedNode;
+    }
+
+    this._size--;
     return node;
   }
 
@@ -275,7 +280,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
    */
   remove(value: T): boolean {
     const node: BinarySearchNode<T> | null = this.findNode(value);
-    return !!(node && this.removeNode(node));
+    if (node) this.removeNode(node);
+    return node !== null;
   }
 
   /** Returns node value if found in the binary search tree. */

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -261,12 +261,10 @@ export class BinarySearchTree<T> implements Iterable<T> {
       const swapValue = node.value;
       node.value = flaggedNode.value;
       flaggedNode.value = swapValue;
-
-      node = flaggedNode;
     }
 
     this._size--;
-    return node;
+    return flaggedNode;
   }
 
   /**

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -236,14 +236,12 @@ export class BinarySearchTree<T> implements Iterable<T> {
   }
 
   protected removeNode(
-    value: T,
+    node: BinarySearchNode<T>,
   ): BinarySearchNode<T> | null {
-    let removeNode: BinarySearchNode<T> | null = this.findNode(value);
-    if (removeNode) {
+    // let node: BinarySearchNode<T> | null = this.findNode(value);
+    if (node) {
       const successorNode: BinarySearchNode<T> | null =
-        !removeNode.left || !removeNode.right
-          ? removeNode
-          : removeNode.findSuccessorNode()!;
+        !node.left || !node.right ? node : node.findSuccessorNode()!;
       const replacementNode: BinarySearchNode<T> | null = successorNode.left ??
         successorNode.right;
       if (replacementNode) replacementNode.parent = successorNode.parent;
@@ -255,13 +253,13 @@ export class BinarySearchTree<T> implements Iterable<T> {
           replacementNode;
       }
 
-      if (successorNode !== removeNode) {
-        removeNode.value = successorNode.value;
-        removeNode = successorNode;
+      if (successorNode !== node) {
+        node.value = successorNode.value;
+        node = successorNode;
       }
       this._size--;
     }
-    return removeNode;
+    return node;
   }
 
   /**
@@ -277,7 +275,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Returns true if found and removed.
    */
   remove(value: T): boolean {
-    return !!this.removeNode(value);
+    const node: BinarySearchNode<T> | null = this.findNode(value);
+    return !!(node && this.removeNode(node));
   }
 
   /** Returns node value if found in the binary search tree. */

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -241,7 +241,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
   ): BinarySearchNode<T> | null {
     /**
      * The node to physically remove from the tree.
-     * Guaranteed to not have both left and right children.
+     * Guaranteed to have at most one child.
      */
     const flaggedNode: BinarySearchNode<T> | null = !node.left || !node.right
       ? node

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -261,6 +261,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
       const swapValue = node.value;
       node.value = flaggedNode.value;
       flaggedNode.value = swapValue;
+
+      node = flaggedNode;
     }
 
     this._size--;

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -238,7 +238,6 @@ export class BinarySearchTree<T> implements Iterable<T> {
   protected removeNode(
     node: BinarySearchNode<T>,
   ): BinarySearchNode<T> | null {
-    // let node: BinarySearchNode<T> | null = this.findNode(value);
     if (node) {
       const successorNode: BinarySearchNode<T> | null =
         !node.left || !node.right ? node : node.findSuccessorNode()!;

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -258,8 +258,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
     }
     if (flaggedNode !== node) {
       /** Swaps values, in case value of the removed node is still needed by consumer. */
-      [node.value, flaggedNode.value] = [flaggedNode.value, node.value];
-      node = flaggedNode;
+      const swapValue = node.value;
+      node.value = flaggedNode.value;
+      flaggedNode.value = swapValue;
     }
 
     this._size--;

--- a/collections/red_black_tree.ts
+++ b/collections/red_black_tree.ts
@@ -266,7 +266,10 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
     );
 
     if (removedNode && !removedNode.red) {
-      this.removeFixup(removedNode.parent, removedNode.left ?? removedNode.right);
+      this.removeFixup(
+        removedNode.parent,
+        removedNode.left ?? removedNode.right,
+      );
     }
 
     return true;

--- a/collections/red_black_tree.ts
+++ b/collections/red_black_tree.ts
@@ -254,20 +254,21 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * Returns true if found and removed.
    */
   override remove(value: T): boolean {
-    const nodeToRemove = this.findNode(value) as (RedBlackNode<T> | null);
+    const node = this.findNode(value) as (RedBlackNode<T> | null);
 
-    if (!nodeToRemove) {
+    if (!node) {
       return false;
     }
 
-    const node = this.removeNode(nodeToRemove) as (
+    const removedNode = this.removeNode(node) as (
       | RedBlackNode<T>
       | null
     );
 
-    if (node && !node.red) {
-      this.removeFixup(node.parent, node.left ?? node.right);
+    if (removedNode && !removedNode.red) {
+      this.removeFixup(removedNode.parent, removedNode.left ?? removedNode.right);
     }
-    return !!node;
+
+    return true;
   }
 }

--- a/collections/red_black_tree.ts
+++ b/collections/red_black_tree.ts
@@ -254,7 +254,17 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * Returns true if found and removed.
    */
   override remove(value: T): boolean {
-    const node = this.removeNode(value) as (RedBlackNode<T> | null);
+    const nodeToRemove = this.findNode(value) as (RedBlackNode<T> | null);
+
+    if (!nodeToRemove) {
+      return false;
+    }
+
+    const node = this.removeNode(nodeToRemove) as (
+      | RedBlackNode<T>
+      | null
+    );
+
     if (node && !node.red) {
       this.removeFixup(node.parent, node.left ?? node.right);
     }


### PR DESCRIPTION
Fixes #3055

Changes `removeNode` to take in a node as a parameter, without exposing the functions as public. This should allow for extending these functions for further use.

@KyleJune These are more or less what you've suggested so would appreciate your thoughts.