### PR TITLE
chore(node/_http_outgoing): cleaned up OutgoingMessage to use class

### DIFF
--- a/node/_http_outgoing.ts
+++ b/node/_http_outgoing.ts
@@ -675,11 +675,11 @@ export class OutgoingMessage extends Stream {
 
   end(
     // deno-lint-ignore no-explicit-any
-    chunk: any,
+    chunk?: any,
     // deno-lint-ignore no-explicit-any
-    encoding: any,
+    encoding?: any,
     // deno-lint-ignore no-explicit-any
-    callback: any,
+    callback?: any,
   ) {
     if (typeof chunk === "function") {
       callback = chunk;

--- a/node/_http_outgoing.ts
+++ b/node/_http_outgoing.ts
@@ -45,7 +45,8 @@ const HIGH_WATER_MARK = getDefaultHighWaterMark();
 
 const kCorked = Symbol("corked");
 
-const nop = () => {};
+// deno-lint-ignore no-explicit-any
+const nop = (..._args: any[]) => {};
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 
@@ -56,452 +57,805 @@ function isCookieField(s: string) {
   return s.length === 6 && s.toLowerCase() === "cookie";
 }
 
-// deno-lint-ignore no-explicit-any
-export function OutgoingMessage(this: any) {
-  Stream.call(this);
-
+export class OutgoingMessage extends Stream {
   // Queue that holds all currently pending data, until the response will be
   // assigned to the socket (until it will its turn in the HTTP pipeline).
-  this.outputData = [];
+  outputData: {
+    data: string;
+    encoding: string;
+    callback?: ((error: Error | null | undefined) => void) | null;
+  }[] = [];
 
   // `outputSize` is an approximate measure of how much data is queued on this
   // response. `_onPendingData` will be invoked to update similar global
   // per-connection counter. That counter will be used to pause/unpause the
   // TCP socket and HTTP Parser and thus handle the backpressure.
-  this.outputSize = 0;
+  outputSize = 0;
 
-  this.writable = true;
-  this.destroyed = false;
+  writable = true;
+  destroyed = false;
 
-  this._last = false;
-  this.chunkedEncoding = false;
-  this.shouldKeepAlive = true;
-  this.maxRequestsOnConnectionReached = false;
-  this._defaultKeepAlive = true;
-  this.useChunkedEncodingByDefault = true;
-  this.sendDate = false;
-  this._removedConnection = false;
-  this._removedContLen = false;
-  this._removedTE = false;
+  _last = false;
+  chunkedEncoding = false;
+  shouldKeepAlive = true;
+  maxRequestsOnConnectionReached = false;
+  _defaultKeepAlive = true;
+  useChunkedEncodingByDefault = true;
+  sendDate = false;
+  _removedConnection = false;
+  _removedContLen = false;
+  _removedTE = false;
 
-  this._contentLength = null;
-  this._hasBody = true;
-  this._trailer = "";
-  this[kNeedDrain] = false;
+  _contentLength: number | null = null;
+  _hasBody = true;
+  _trailer = "";
+  [kNeedDrain] = false;
 
-  this.finished = false;
-  this._headerSent = false;
-  this[kCorked] = 0;
-  this._closed = false;
+  finished = false;
+  _headerSent = false;
+  [kCorked] = 0;
+  _closed = false;
 
-  this.socket = null;
-  this._header = null;
-  this[kOutHeaders] = null;
+  socket: null | Socket = null;
+  _header: string | null = null;
+  [kOutHeaders]: Record<string, [string, string]> | null = null;
 
-  this._keepAliveTimeout = 0;
+  _keepAliveTimeout = 0;
 
-  this._onPendingData = nop;
-}
-Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
-Object.setPrototypeOf(OutgoingMessage, Stream);
+  _onPendingData = nop;
 
-Object.defineProperty(OutgoingMessage.prototype, "writableFinished", {
-  get() {
+  constructor() {
+    super();
+    Object.defineProperty(OutgoingMessage.prototype, "headersSent", {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        return !!this._header;
+      },
+    });
+  }
+
+  get writableFinished() {
     return (
       this.finished &&
       this.outputSize === 0 &&
       (!this.socket || this.socket.writableLength === 0)
     );
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "writableObjectMode", {
-  get() {
+  get writableObjectMode() {
     return false;
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "writableLength", {
-  get() {
+  get writableLength() {
     return this.outputSize + (this.socket ? this.socket.writableLength : 0);
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "writableHighWaterMark", {
-  get() {
+  get writableHighWaterMark() {
     return this.socket ? this.socket.writableHighWaterMark : HIGH_WATER_MARK;
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "writableCorked", {
-  get() {
+  get writableCorked() {
     const corked = this.socket ? this.socket.writableCorked : 0;
     return corked + this[kCorked];
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "_headers", {
-  get: deprecate(
-    // deno-lint-ignore no-explicit-any
-    function (this: any) {
-      return this.getHeaders();
-    },
-    "OutgoingMessage.prototype._headers is deprecated",
-    "DEP0066",
-  ),
-  set: deprecate(
-    // deno-lint-ignore no-explicit-any
-    function (this: any, val: any) {
-      if (val == null) {
-        this[kOutHeaders] = null;
-      } else if (typeof val === "object") {
-        const headers = this[kOutHeaders] = Object.create(null);
-        const keys = Object.keys(val);
-        // Retain for(;;) loop for performance reasons
-        // Refs: https://github.com/nodejs/node/pull/30958
-        for (let i = 0; i < keys.length; ++i) {
-          const name = keys[i];
-          headers[name.toLowerCase()] = [name, val[name]];
+  get _headers() {
+    return deprecate(
+      (outgoingMessage: OutgoingMessage) => {
+        return outgoingMessage.getHeaders();
+      },
+      "OutgoingMessage.prototype._headers is deprecated",
+      "DEP0066",
+    )(this);
+  }
+
+  set _headers(val) {
+    deprecate(
+      // deno-lint-ignore no-explicit-any
+      (outgoingMessage: OutgoingMessage, val: any) => {
+        if (val == null) {
+          this[kOutHeaders] = null;
+        } else if (typeof val === "object") {
+          const headers = outgoingMessage[kOutHeaders] = Object.create(null);
+          const keys = Object.keys(val);
+          // Retain for(;;) loop for performance reasons
+          // Refs: https://github.com/nodejs/node/pull/30958
+          for (let i = 0; i < keys.length; ++i) {
+            const name = keys[i];
+            headers[name.toLowerCase()] = [name, val[name]];
+          }
         }
-      }
-    },
-    "OutgoingMessage.prototype._headers is deprecated",
-    "DEP0066",
-  ),
-});
+      },
+      "OutgoingMessage.prototype._headers is deprecated",
+      "DEP0066",
+    )(this, val);
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "connection", {
-  get: function () {
+  get connection() {
     return this.socket;
-  },
-  set: function (val) {
-    this.socket = val;
-  },
-});
+  }
 
-Object.defineProperty(OutgoingMessage.prototype, "_headerNames", {
-  get: deprecate(
-    // deno-lint-ignore no-explicit-any
-    function (this: any) {
-      const headers = this[kOutHeaders];
-      if (headers !== null) {
-        const out = Object.create(null);
-        const keys = Object.keys(headers);
-        // Retain for(;;) loop for performance reasons
-        // Refs: https://github.com/nodejs/node/pull/30958
-        for (let i = 0; i < keys.length; ++i) {
-          const key = keys[i];
-          const val = headers[key][0];
-          out[key] = val;
+  set connection(val) {
+    this.socket = val;
+  }
+
+  get _headerNames() {
+    return deprecate(
+      (outgoingMessage: OutgoingMessage) => {
+        const headers = outgoingMessage[kOutHeaders];
+        if (headers !== null) {
+          const out = Object.create(null);
+          const keys = Object.keys(headers);
+          // Retain for(;;) loop for performance reasons
+          // Refs: https://github.com/nodejs/node/pull/30958
+          for (let i = 0; i < keys.length; ++i) {
+            const key = keys[i];
+            const val = headers[key][0];
+            out[key] = val;
+          }
+          return out;
         }
-        return out;
+        return null;
+      },
+      "OutgoingMessage.prototype._headerNames is deprecated",
+      "DEP0066",
+    )(this);
+  }
+
+  set _headerNames(val) {
+    deprecate(
+      // deno-lint-ignore no-explicit-any
+      (outgoingMessage: OutgoingMessage, val: any) => {
+        if (typeof val === "object" && val !== null) {
+          const headers = outgoingMessage[kOutHeaders];
+          if (!headers) {
+            return;
+          }
+          const keys = Object.keys(val);
+          // Retain for(;;) loop for performance reasons
+          // Refs: https://github.com/nodejs/node/pull/30958
+          for (let i = 0; i < keys.length; ++i) {
+            const header = headers[keys[i]];
+            if (header) {
+              header[0] = val[keys[i]];
+            }
+          }
+        }
+      },
+      "OutgoingMessage.prototype._headerNames is deprecated",
+      "DEP0066",
+    )(this, val);
+  }
+
+  _renderHeaders() {
+    if (this._header) {
+      throw new ERR_HTTP_HEADERS_SENT("render");
+    }
+
+    const headersMap = this[kOutHeaders];
+    // deno-lint-ignore no-explicit-any
+    const headers: any = {};
+
+    if (headersMap !== null) {
+      const keys = Object.keys(headersMap);
+      // Retain for(;;) loop for performance reasons
+      // Refs: https://github.com/nodejs/node/pull/30958
+      for (let i = 0, l = keys.length; i < l; i++) {
+        const key = keys[i];
+        headers[headersMap[key][0]] = headersMap[key][1];
       }
-      return null;
-    },
-    "OutgoingMessage.prototype._headerNames is deprecated",
-    "DEP0066",
-  ),
-  set: deprecate(
+    }
+    return headers;
+  }
+
+  cork() {
+    if (this.socket) {
+      this.socket.cork();
+    } else {
+      this[kCorked]++;
+    }
+  }
+
+  uncork() {
+    if (this.socket) {
+      this.socket.uncork();
+    } else if (this[kCorked]) {
+      this[kCorked]--;
+    }
+  }
+
+  setTimeout(
+    msecs: number,
+    callback?: (...args: unknown[]) => void,
+  ) {
+    if (callback) {
+      this.on("timeout", callback);
+    }
+
+    if (!this.socket) {
+      // deno-lint-ignore no-explicit-any
+      this.once("socket", function socketSetTimeoutOnConnect(socket: any) {
+        socket.setTimeout(msecs);
+      });
+    } else {
+      this.socket.setTimeout(msecs);
+    }
+    return this;
+  }
+
+  // It's possible that the socket will be destroyed, and removed from
+  // any messages, before ever calling this.  In that case, just skip
+  // it, since something else is destroying this connection anyway.
+  destroy(error?: Error) {
+    if (this.destroyed) {
+      return this;
+    }
+    this.destroyed = true;
+
+    if (this.socket) {
+      this.socket.destroy(error);
+    } else {
+      // deno-lint-ignore no-explicit-any
+      this.once("socket", function socketDestroyOnConnect(socket: any) {
+        socket.destroy(error);
+      });
+    }
+
+    return this;
+  }
+
+  // This abstract either writing directly to the socket or buffering it.
+  _send(
     // deno-lint-ignore no-explicit-any
-    function (this: any, val: any) {
-      if (typeof val === "object" && val !== null) {
-        const headers = this[kOutHeaders];
-        if (!headers) {
-          return;
+    data: any,
+    encoding?: string | null,
+    callback?: () => void,
+  ) {
+    // This is a shameful hack to get the headers and first body chunk onto
+    // the same packet. Future versions of Node are going to take care of
+    // this at a lower level and in a more general way.
+    if (!this._headerSent) {
+      if (
+        typeof data === "string" &&
+        (encoding === "utf8" || encoding === "latin1" || !encoding)
+      ) {
+        data = this._header + data;
+      } else {
+        const header = this._header;
+
+        if (!header) throw "Header is null";
+
+        this.outputData.unshift({
+          data: header,
+          encoding: "latin1",
+          callback: null,
+        });
+        this.outputSize += header.length;
+        this._onPendingData(header.length);
+      }
+      this._headerSent = true;
+    }
+    return this._writeRaw(data, encoding, callback);
+  }
+
+  _writeRaw(
+    // deno-lint-ignore no-explicit-any
+    this: any,
+    // deno-lint-ignore no-explicit-any
+    data: any,
+    encoding?: string | null,
+    callback?: () => void,
+  ) {
+    const conn = this.socket;
+    if (conn && conn.destroyed) {
+      // The socket was destroyed. If we're still trying to write to it,
+      // then we haven't gotten the 'close' event yet.
+      return false;
+    }
+
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = null;
+    }
+
+    if (conn && conn._httpMessage === this && conn.writable) {
+      // There might be pending data in the this.output buffer.
+      if (this.outputData.length) {
+        this._flushOutput(conn);
+      }
+      // Directly write to socket.
+      return conn.write(data, encoding, callback);
+    }
+    // Buffer, as long as we're not destroyed.
+    this.outputData.push({ data, encoding, callback });
+    this.outputSize += data.length;
+    this._onPendingData(data.length);
+    return this.outputSize < HIGH_WATER_MARK;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  _storeHeader(this: any, firstLine: any, headers: any) {
+    // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
+    // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
+    const state = {
+      connection: false,
+      contLen: false,
+      te: false,
+      date: false,
+      expect: false,
+      trailer: false,
+      header: firstLine,
+    };
+
+    if (headers) {
+      if (headers === this[kOutHeaders]) {
+        for (const key in headers) {
+          const entry = headers[key];
+          processHeader(this, state, entry[0], entry[1], false);
         }
-        const keys = Object.keys(val);
-        // Retain for(;;) loop for performance reasons
-        // Refs: https://github.com/nodejs/node/pull/30958
-        for (let i = 0; i < keys.length; ++i) {
-          const header = headers[keys[i]];
-          if (header) {
-            header[0] = val[keys[i]];
+      } else if (Array.isArray(headers)) {
+        if (headers.length && Array.isArray(headers[0])) {
+          for (let i = 0; i < headers.length; i++) {
+            const entry = headers[i];
+            processHeader(this, state, entry[0], entry[1], true);
+          }
+        } else {
+          if (headers.length % 2 !== 0) {
+            throw new ERR_INVALID_ARG_VALUE("headers", headers);
+          }
+
+          for (let n = 0; n < headers.length; n += 2) {
+            processHeader(this, state, headers[n + 0], headers[n + 1], true);
+          }
+        }
+      } else {
+        for (const key in headers) {
+          if (Object.hasOwn(headers, key)) {
+            processHeader(this, state, key, headers[key], true);
           }
         }
       }
-    },
-    "OutgoingMessage.prototype._headerNames is deprecated",
-    "DEP0066",
-  ),
-});
+    }
 
-OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
-  if (this._header) {
-    throw new ERR_HTTP_HEADERS_SENT("render");
+    let { header } = state;
+
+    // Date header
+    if (this.sendDate && !state.date) {
+      header += "Date: " + utcDate() + "\r\n";
+    }
+
+    // Force the connection to close when the response is a 204 No Content or
+    // a 304 Not Modified and the user has set a "Transfer-Encoding: chunked"
+    // header.
+    //
+    // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body but
+    // node.js used to send out a zero chunk anyway to accommodate clients
+    // that don't have special handling for those responses.
+    //
+    // It was pointed out that this might confuse reverse proxies to the point
+    // of creating security liabilities, so suppress the zero chunk and force
+    // the connection to close.
+    if (
+      this.chunkedEncoding && (this.statusCode === 204 ||
+        this.statusCode === 304)
+    ) {
+      debug(
+        this.statusCode + " response should not use chunked encoding," +
+          " closing connection.",
+      );
+      this.chunkedEncoding = false;
+      this.shouldKeepAlive = false;
+    }
+
+    // keep-alive logic
+    if (this._removedConnection) {
+      this._last = true;
+      this.shouldKeepAlive = false;
+    } else if (!state.connection) {
+      const shouldSendKeepAlive = this.shouldKeepAlive &&
+        (state.contLen || this.useChunkedEncodingByDefault || this.agent);
+      if (shouldSendKeepAlive && this.maxRequestsOnConnectionReached) {
+        header += "Connection: close\r\n";
+      } else if (shouldSendKeepAlive) {
+        header += "Connection: keep-alive\r\n";
+        if (this._keepAliveTimeout && this._defaultKeepAlive) {
+          const timeoutSeconds = Math.floor(this._keepAliveTimeout / 1000);
+          header += `Keep-Alive: timeout=${timeoutSeconds}\r\n`;
+        }
+      } else {
+        this._last = true;
+        header += "Connection: close\r\n";
+      }
+    }
+
+    if (!state.contLen && !state.te) {
+      if (!this._hasBody) {
+        // Make sure we don't end the 0\r\n\r\n at the end of the message.
+        this.chunkedEncoding = false;
+      } else if (!this.useChunkedEncodingByDefault) {
+        this._last = true;
+      } else if (
+        !state.trailer &&
+        !this._removedContLen &&
+        typeof this._contentLength === "number"
+      ) {
+        header += "Content-Length: " + this._contentLength + "\r\n";
+      } else if (!this._removedTE) {
+        header += "Transfer-Encoding: chunked\r\n";
+        this.chunkedEncoding = true;
+      } else {
+        // We should only be able to get here if both Content-Length and
+        // Transfer-Encoding are removed by the user.
+        // See: test/parallel/test-http-remove-header-stays-removed.js
+        debug("Both Content-Length and Transfer-Encoding are removed");
+      }
+    }
+
+    // Test non-chunked message does not have trailer header set,
+    // message will be terminated by the first empty line after the
+    // header fields, regardless of the header fields present in the
+    // message, and thus cannot contain a message body or 'trailers'.
+    if (this.chunkedEncoding !== true && state.trailer) {
+      throw new ERR_HTTP_TRAILER_INVALID();
+    }
+
+    this._header = header + "\r\n";
+    this._headerSent = false;
+
+    // Wait until the first body chunk, or close(), is sent to flush,
+    // UNLESS we're sending Expect: 100-continue.
+    if (state.expect) this._send("");
   }
 
-  const headersMap = this[kOutHeaders];
-  // deno-lint-ignore no-explicit-any
-  const headers: any = {};
+  setHeader(
+    name: string,
+    value: string,
+  ) {
+    if (this._header) {
+      throw new ERR_HTTP_HEADERS_SENT("set");
+    }
+    validateHeaderName(name);
+    validateHeaderValue(name, value);
 
-  if (headersMap !== null) {
-    const keys = Object.keys(headersMap);
+    let headers = this[kOutHeaders];
+    if (headers === null) {
+      this[kOutHeaders] = headers = Object.create(null);
+    }
+
+    headers![name.toLowerCase()] = [name, value];
+    return this;
+  }
+
+  getHeader(name: string) {
+    validateString(name, "name");
+
+    const headers = this[kOutHeaders];
+    if (headers === null) {
+      return;
+    }
+
+    const entry = headers[name.toLowerCase()];
+    return entry && entry[1];
+  }
+
+  // Returns an array of the names of the current outgoing headers.
+  getHeaderNames() {
+    return this[kOutHeaders] !== null ? Object.keys(this[kOutHeaders]) : [];
+  }
+
+  // Returns an array of the names of the current outgoing raw headers.
+  getRawHeaderNames() {
+    const headersMap = this[kOutHeaders];
+    if (headersMap === null) return [];
+
+    const values = Object.values(headersMap);
+    const headers = Array(values.length);
+    // Retain for(;;) loop for performance reasons
+    // Refs: https://github.com/nodejs/node/pull/30958
+    for (let i = 0, l = values.length; i < l; i++) {
+      // deno-lint-ignore no-explicit-any
+      headers[i] = (values as any)[i][0];
+    }
+
+    return headers;
+  }
+
+  // Returns a shallow copy of the current outgoing headers.
+  getHeaders() {
+    const headers = this[kOutHeaders];
+    const ret = Object.create(null);
+    if (headers) {
+      const keys = Object.keys(headers);
+      // Retain for(;;) loop for performance reasons
+      // Refs: https://github.com/nodejs/node/pull/30958
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
+        const val = headers[key][1];
+        ret[key] = val;
+      }
+    }
+    return ret;
+  }
+
+  hasHeader(name: string) {
+    validateString(name, "name");
+    return this[kOutHeaders] !== null &&
+      !!this[kOutHeaders][name.toLowerCase()];
+  }
+
+  removeHeader(name: string) {
+    validateString(name, "name");
+
+    if (this._header) {
+      throw new ERR_HTTP_HEADERS_SENT("remove");
+    }
+
+    const key = name.toLowerCase();
+
+    switch (key) {
+      case "connection":
+        this._removedConnection = true;
+        break;
+      case "content-length":
+        this._removedContLen = true;
+        break;
+      case "transfer-encoding":
+        this._removedTE = true;
+        break;
+      case "date":
+        this.sendDate = false;
+        break;
+    }
+
+    if (this[kOutHeaders] !== null) {
+      delete this[kOutHeaders][key];
+    }
+  }
+
+  _implicitHeader() {
+    throw new ERR_METHOD_NOT_IMPLEMENTED("_implicitHeader()");
+  }
+
+  get writableEnded() {
+    return this.finished;
+  }
+
+  get writableNeedDrain() {
+    return !this.destroyed && !this.finished && this[kNeedDrain];
+  }
+
+  write(
+    // deno-lint-ignore no-explicit-any
+    chunk: any,
+    encoding: string | null,
+    callback: () => void,
+  ) {
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = null;
+    }
+
+    const ret = write_(this, chunk, encoding, callback, false);
+    if (!ret) {
+      this[kNeedDrain] = true;
+    }
+    return ret;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  addTrailers(headers: any) {
+    this._trailer = "";
+    const keys = Object.keys(headers);
+    const isArray = Array.isArray(headers);
     // Retain for(;;) loop for performance reasons
     // Refs: https://github.com/nodejs/node/pull/30958
     for (let i = 0, l = keys.length; i < l; i++) {
+      let field, value;
       const key = keys[i];
-      headers[headersMap[key][0]] = headersMap[key][1];
+      if (isArray) {
+        // deno-lint-ignore no-explicit-any
+        field = headers[key as any][0];
+        // deno-lint-ignore no-explicit-any
+        value = headers[key as any][1];
+      } else {
+        field = key;
+        value = headers[key];
+      }
+      if (typeof field !== "string" || !field || !checkIsHttpToken(field)) {
+        throw new ERR_INVALID_HTTP_TOKEN("Trailer name", field);
+      }
+      if (checkInvalidHeaderChar(value)) {
+        debug('Trailer "%s" contains invalid characters', field);
+        throw new ERR_INVALID_CHAR("trailer content", field);
+      }
+      this._trailer += field + ": " + value + "\r\n";
     }
   }
-  return headers;
-};
 
-OutgoingMessage.prototype.cork = function () {
-  if (this.socket) {
-    this.socket.cork();
-  } else {
-    this[kCorked]++;
-  }
-};
-
-OutgoingMessage.prototype.uncork = function () {
-  if (this.socket) {
-    this.socket.uncork();
-  } else if (this[kCorked]) {
-    this[kCorked]--;
-  }
-};
-
-OutgoingMessage.prototype.setTimeout = function setTimeout(
-  msecs: number,
-  callback?: (...args: unknown[]) => void,
-) {
-  if (callback) {
-    this.on("timeout", callback);
-  }
-
-  if (!this.socket) {
+  end(
     // deno-lint-ignore no-explicit-any
-    this.once("socket", function socketSetTimeoutOnConnect(socket: any) {
-      socket.setTimeout(msecs);
-    });
-  } else {
-    this.socket.setTimeout(msecs);
-  }
-  return this;
-};
+    chunk: any,
+    // deno-lint-ignore no-explicit-any
+    encoding: any,
+    // deno-lint-ignore no-explicit-any
+    callback: any,
+  ) {
+    if (typeof chunk === "function") {
+      callback = chunk;
+      chunk = null;
+      encoding = null;
+    } else if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = null;
+    }
 
-// It's possible that the socket will be destroyed, and removed from
-// any messages, before ever calling this.  In that case, just skip
-// it, since something else is destroying this connection anyway.
-OutgoingMessage.prototype.destroy = function destroy(error: unknown) {
-  if (this.destroyed) {
+    if (chunk) {
+      if (this.finished) {
+        onError(
+          this,
+          new ERR_STREAM_WRITE_AFTER_END(),
+          typeof callback !== "function" ? nop : callback,
+        );
+        return this;
+      }
+
+      if (this.socket) {
+        this.socket.cork();
+      }
+
+      write_(this, chunk, encoding, null, true);
+    } else if (this.finished) {
+      if (typeof callback === "function") {
+        if (!this.writableFinished) {
+          this.on("finish", callback);
+        } else {
+          callback(new ERR_STREAM_ALREADY_FINISHED("end"));
+        }
+      }
+      return this;
+    } else if (!this._header) {
+      if (this.socket) {
+        this.socket.cork();
+      }
+
+      this._contentLength = 0;
+      this._implicitHeader();
+    }
+
+    if (typeof callback === "function") {
+      this.once("finish", callback);
+    }
+
+    const finish = onFinish.bind(undefined, this);
+
+    if (this._hasBody && this.chunkedEncoding) {
+      this._send("0\r\n" + this._trailer + "\r\n", "latin1", finish);
+    } else if (!this._headerSent || this.writableLength || chunk) {
+      this._send("", "latin1", finish);
+    } else {
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).process.nextTick(finish);
+    }
+
+    if (this.socket) {
+      // Fully uncork connection on end().
+      // @ts-ignore TODO(@lino-levan): Our type definitions might be out of date
+      this.socket._writableState.corked = 1;
+      this.socket.uncork();
+    }
+    this[kCorked] = 0;
+
+    this.finished = true;
+
+    // There is the first message on the outgoing queue, and we've sent
+    // everything to the socket.
+    debug("outgoing message end.");
+    if (
+      this.outputData.length === 0 &&
+      this.socket &&
+      // @ts-ignore TODO(@lino-levan): Our type definitions might be out of date
+      this.socket._httpMessage === this
+    ) {
+      this._finish();
+    }
+
     return this;
   }
-  this.destroyed = true;
 
-  if (this.socket) {
-    this.socket.destroy(error);
-  } else {
+  _finish() {
+    assert(this.socket);
+    this.emit("prefinish");
+  }
+
+  // This logic is probably a bit confusing. Let me explain a bit:
+  //
+  // In both HTTP servers and clients it is possible to queue up several
+  // outgoing messages. This is easiest to imagine in the case of a client.
+  // Take the following situation:
+  //
+  //    req1 = client.request('GET', '/');
+  //    req2 = client.request('POST', '/');
+  //
+  // When the user does
+  //
+  //   req2.write('hello world\n');
+  //
+  // it's possible that the first request has not been completely flushed to
+  // the socket yet. Thus the outgoing messages need to be prepared to queue
+  // up data internally before sending it on further to the socket's queue.
+  //
+  // This function, outgoingFlush(), is called by both the Server and Client
+  // to attempt to flush any pending messages out to the socket.
+  _flush() {
+    const socket = this.socket;
+
+    if (socket && socket.writable) {
+      // There might be remaining data in this.output; write it out
+      const ret = this._flushOutput(socket);
+
+      if (this.finished) {
+        // This is a queue to the server or client to bring in the next this.
+        this._finish();
+      } else if (ret && this[kNeedDrain]) {
+        this[kNeedDrain] = false;
+        this.emit("drain");
+      }
+    }
+  }
+
+  _flushOutput(socket: Socket) {
+    while (this[kCorked]) {
+      this[kCorked]--;
+      socket.cork();
+    }
+
+    const outputLength = this.outputData.length;
+    if (outputLength <= 0) {
+      return undefined;
+    }
+
+    const outputData = this.outputData;
+    socket.cork();
+    let ret;
+    // Retain for(;;) loop for performance reasons
+    // Refs: https://github.com/nodejs/node/pull/30958
+    for (let i = 0; i < outputLength; i++) {
+      const { data, encoding, callback } = outputData[i];
+      ret = socket.write(data, encoding, callback!);
+    }
+    socket.uncork();
+
+    this.outputData = [];
+    this._onPendingData(-this.outputSize);
+    this.outputSize = 0;
+
+    return ret;
+  }
+
+  flushHeaders() {
+    if (!this._header) {
+      this._implicitHeader();
+    }
+
+    // Force-flush the headers.
+    this._send("");
+  }
+
+  // @ts-ignore We are overriding the pipe method to do nothing, of course we changed the type signature
+  override pipe() {
+    // OutgoingMessage should be write-only. Piping from it is disabled.
+    this.emit("error", new ERR_STREAM_CANNOT_PIPE());
+  }
+
+  [EE.captureRejectionSymbol] = (
     // deno-lint-ignore no-explicit-any
-    this.once("socket", function socketDestroyOnConnect(socket: any) {
-      socket.destroy(error);
-    });
-  }
-
-  return this;
-};
-
-// This abstract either writing directly to the socket or buffering it.
-OutgoingMessage.prototype._send = function _send(
-  // deno-lint-ignore no-explicit-any
-  data: any,
-  encoding: string | null,
-  callback: () => void,
-) {
-  // This is a shameful hack to get the headers and first body chunk onto
-  // the same packet. Future versions of Node are going to take care of
-  // this at a lower level and in a more general way.
-  if (!this._headerSent) {
-    if (
-      typeof data === "string" &&
-      (encoding === "utf8" || encoding === "latin1" || !encoding)
-    ) {
-      data = this._header + data;
-    } else {
-      const header = this._header;
-      this.outputData.unshift({
-        data: header,
-        encoding: "latin1",
-        callback: null,
-      });
-      this.outputSize += header.length;
-      this._onPendingData(header.length);
-    }
-    this._headerSent = true;
-  }
-  return this._writeRaw(data, encoding, callback);
-};
-
-OutgoingMessage.prototype._writeRaw = _writeRaw;
-function _writeRaw(
-  // deno-lint-ignore no-explicit-any
-  this: any,
-  // deno-lint-ignore no-explicit-any
-  data: any,
-  encoding: string | null,
-  callback: () => void,
-) {
-  const conn = this.socket;
-  if (conn && conn.destroyed) {
-    // The socket was destroyed. If we're still trying to write to it,
-    // then we haven't gotten the 'close' event yet.
-    return false;
-  }
-
-  if (typeof encoding === "function") {
-    callback = encoding;
-    encoding = null;
-  }
-
-  if (conn && conn._httpMessage === this && conn.writable) {
-    // There might be pending data in the this.output buffer.
-    if (this.outputData.length) {
-      this._flushOutput(conn);
-    }
-    // Directly write to socket.
-    return conn.write(data, encoding, callback);
-  }
-  // Buffer, as long as we're not destroyed.
-  this.outputData.push({ data, encoding, callback });
-  this.outputSize += data.length;
-  this._onPendingData(data.length);
-  return this.outputSize < HIGH_WATER_MARK;
-}
-
-OutgoingMessage.prototype._storeHeader = _storeHeader;
-// deno-lint-ignore no-explicit-any
-function _storeHeader(this: any, firstLine: any, headers: any) {
-  // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
-  // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
-  const state = {
-    connection: false,
-    contLen: false,
-    te: false,
-    date: false,
-    expect: false,
-    trailer: false,
-    header: firstLine,
+    err: any,
+    // deno-lint-ignore no-explicit-any
+    _event: any,
+  ) => {
+    this.destroy(err);
   };
-
-  if (headers) {
-    if (headers === this[kOutHeaders]) {
-      for (const key in headers) {
-        const entry = headers[key];
-        processHeader(this, state, entry[0], entry[1], false);
-      }
-    } else if (Array.isArray(headers)) {
-      if (headers.length && Array.isArray(headers[0])) {
-        for (let i = 0; i < headers.length; i++) {
-          const entry = headers[i];
-          processHeader(this, state, entry[0], entry[1], true);
-        }
-      } else {
-        if (headers.length % 2 !== 0) {
-          throw new ERR_INVALID_ARG_VALUE("headers", headers);
-        }
-
-        for (let n = 0; n < headers.length; n += 2) {
-          processHeader(this, state, headers[n + 0], headers[n + 1], true);
-        }
-      }
-    } else {
-      for (const key in headers) {
-        if (Object.hasOwn(headers, key)) {
-          processHeader(this, state, key, headers[key], true);
-        }
-      }
-    }
-  }
-
-  let { header } = state;
-
-  // Date header
-  if (this.sendDate && !state.date) {
-    header += "Date: " + utcDate() + "\r\n";
-  }
-
-  // Force the connection to close when the response is a 204 No Content or
-  // a 304 Not Modified and the user has set a "Transfer-Encoding: chunked"
-  // header.
-  //
-  // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body but
-  // node.js used to send out a zero chunk anyway to accommodate clients
-  // that don't have special handling for those responses.
-  //
-  // It was pointed out that this might confuse reverse proxies to the point
-  // of creating security liabilities, so suppress the zero chunk and force
-  // the connection to close.
-  if (
-    this.chunkedEncoding && (this.statusCode === 204 ||
-      this.statusCode === 304)
-  ) {
-    debug(
-      this.statusCode + " response should not use chunked encoding," +
-        " closing connection.",
-    );
-    this.chunkedEncoding = false;
-    this.shouldKeepAlive = false;
-  }
-
-  // keep-alive logic
-  if (this._removedConnection) {
-    this._last = true;
-    this.shouldKeepAlive = false;
-  } else if (!state.connection) {
-    const shouldSendKeepAlive = this.shouldKeepAlive &&
-      (state.contLen || this.useChunkedEncodingByDefault || this.agent);
-    if (shouldSendKeepAlive && this.maxRequestsOnConnectionReached) {
-      header += "Connection: close\r\n";
-    } else if (shouldSendKeepAlive) {
-      header += "Connection: keep-alive\r\n";
-      if (this._keepAliveTimeout && this._defaultKeepAlive) {
-        const timeoutSeconds = Math.floor(this._keepAliveTimeout / 1000);
-        header += `Keep-Alive: timeout=${timeoutSeconds}\r\n`;
-      }
-    } else {
-      this._last = true;
-      header += "Connection: close\r\n";
-    }
-  }
-
-  if (!state.contLen && !state.te) {
-    if (!this._hasBody) {
-      // Make sure we don't end the 0\r\n\r\n at the end of the message.
-      this.chunkedEncoding = false;
-    } else if (!this.useChunkedEncodingByDefault) {
-      this._last = true;
-    } else if (
-      !state.trailer &&
-      !this._removedContLen &&
-      typeof this._contentLength === "number"
-    ) {
-      header += "Content-Length: " + this._contentLength + "\r\n";
-    } else if (!this._removedTE) {
-      header += "Transfer-Encoding: chunked\r\n";
-      this.chunkedEncoding = true;
-    } else {
-      // We should only be able to get here if both Content-Length and
-      // Transfer-Encoding are removed by the user.
-      // See: test/parallel/test-http-remove-header-stays-removed.js
-      debug("Both Content-Length and Transfer-Encoding are removed");
-    }
-  }
-
-  // Test non-chunked message does not have trailer header set,
-  // message will be terminated by the first empty line after the
-  // header fields, regardless of the header fields present in the
-  // message, and thus cannot contain a message body or 'trailers'.
-  if (this.chunkedEncoding !== true && state.trailer) {
-    throw new ERR_HTTP_TRAILER_INVALID();
-  }
-
-  this._header = header + "\r\n";
-  this._headerSent = false;
-
-  // Wait until the first body chunk, or close(), is sent to flush,
-  // UNLESS we're sending Expect: 100-continue.
-  if (state.expect) this._send("");
 }
 
 function processHeader(
@@ -606,154 +960,7 @@ export const validateHeaderValue = hideStackFrames((name, value) => {
   }
 });
 
-OutgoingMessage.prototype.setHeader = function setHeader(
-  name: string,
-  value: string,
-) {
-  if (this._header) {
-    throw new ERR_HTTP_HEADERS_SENT("set");
-  }
-  validateHeaderName(name);
-  validateHeaderValue(name, value);
-
-  let headers = this[kOutHeaders];
-  if (headers === null) {
-    this[kOutHeaders] = headers = Object.create(null);
-  }
-
-  headers[name.toLowerCase()] = [name, value];
-  return this;
-};
-
-OutgoingMessage.prototype.getHeader = function getHeader(name: string) {
-  validateString(name, "name");
-
-  const headers = this[kOutHeaders];
-  if (headers === null) {
-    return;
-  }
-
-  const entry = headers[name.toLowerCase()];
-  return entry && entry[1];
-};
-
-// Returns an array of the names of the current outgoing headers.
-OutgoingMessage.prototype.getHeaderNames = function getHeaderNames() {
-  return this[kOutHeaders] !== null ? Object.keys(this[kOutHeaders]) : [];
-};
-
-// Returns an array of the names of the current outgoing raw headers.
-OutgoingMessage.prototype.getRawHeaderNames = function getRawHeaderNames() {
-  const headersMap = this[kOutHeaders];
-  if (headersMap === null) return [];
-
-  const values = Object.values(headersMap);
-  const headers = Array(values.length);
-  // Retain for(;;) loop for performance reasons
-  // Refs: https://github.com/nodejs/node/pull/30958
-  for (let i = 0, l = values.length; i < l; i++) {
-    // deno-lint-ignore no-explicit-any
-    headers[i] = (values as any)[i][0];
-  }
-
-  return headers;
-};
-
-// Returns a shallow copy of the current outgoing headers.
-OutgoingMessage.prototype.getHeaders = function getHeaders() {
-  const headers = this[kOutHeaders];
-  const ret = Object.create(null);
-  if (headers) {
-    const keys = Object.keys(headers);
-    // Retain for(;;) loop for performance reasons
-    // Refs: https://github.com/nodejs/node/pull/30958
-    for (let i = 0; i < keys.length; ++i) {
-      const key = keys[i];
-      const val = headers[key][1];
-      ret[key] = val;
-    }
-  }
-  return ret;
-};
-
-OutgoingMessage.prototype.hasHeader = function hasHeader(name: string) {
-  validateString(name, "name");
-  return this[kOutHeaders] !== null &&
-    !!this[kOutHeaders][name.toLowerCase()];
-};
-
-OutgoingMessage.prototype.removeHeader = function removeHeader(name: string) {
-  validateString(name, "name");
-
-  if (this._header) {
-    throw new ERR_HTTP_HEADERS_SENT("remove");
-  }
-
-  const key = name.toLowerCase();
-
-  switch (key) {
-    case "connection":
-      this._removedConnection = true;
-      break;
-    case "content-length":
-      this._removedContLen = true;
-      break;
-    case "transfer-encoding":
-      this._removedTE = true;
-      break;
-    case "date":
-      this.sendDate = false;
-      break;
-  }
-
-  if (this[kOutHeaders] !== null) {
-    delete this[kOutHeaders][key];
-  }
-};
-
-OutgoingMessage.prototype._implicitHeader = function _implicitHeader() {
-  throw new ERR_METHOD_NOT_IMPLEMENTED("_implicitHeader()");
-};
-
-Object.defineProperty(OutgoingMessage.prototype, "headersSent", {
-  configurable: true,
-  enumerable: true,
-  get: function () {
-    return !!this._header;
-  },
-});
-
-Object.defineProperty(OutgoingMessage.prototype, "writableEnded", {
-  get: function () {
-    return this.finished;
-  },
-});
-
-Object.defineProperty(OutgoingMessage.prototype, "writableNeedDrain", {
-  get: function () {
-    return !this.destroyed && !this.finished && this[kNeedDrain];
-  },
-});
-
-// deno-lint-ignore camelcase
 const crlf_buf = Buffer.from("\r\n");
-OutgoingMessage.prototype.write = function write(
-  // deno-lint-ignore no-explicit-any
-  chunk: any,
-  encoding: string | null,
-  callback: () => void,
-) {
-  if (typeof encoding === "function") {
-    callback = encoding;
-    encoding = null;
-  }
-
-  const ret = write_(this, chunk, encoding, callback, false);
-  if (!ret) {
-    this[kNeedDrain] = true;
-  }
-  return ret;
-};
 
 // deno-lint-ignore no-explicit-any
 function onError(msg: any, err: any, callback: any) {
@@ -867,221 +1074,10 @@ function connectionCorkNT(conn: any) {
 }
 
 // deno-lint-ignore no-explicit-any
-OutgoingMessage.prototype.addTrailers = function addTrailers(headers: any) {
-  this._trailer = "";
-  const keys = Object.keys(headers);
-  const isArray = Array.isArray(headers);
-  // Retain for(;;) loop for performance reasons
-  // Refs: https://github.com/nodejs/node/pull/30958
-  for (let i = 0, l = keys.length; i < l; i++) {
-    let field, value;
-    const key = keys[i];
-    if (isArray) {
-      // deno-lint-ignore no-explicit-any
-      field = headers[key as any][0];
-      // deno-lint-ignore no-explicit-any
-      value = headers[key as any][1];
-    } else {
-      field = key;
-      value = headers[key];
-    }
-    if (typeof field !== "string" || !field || !checkIsHttpToken(field)) {
-      throw new ERR_INVALID_HTTP_TOKEN("Trailer name", field);
-    }
-    if (checkInvalidHeaderChar(value)) {
-      debug('Trailer "%s" contains invalid characters', field);
-      throw new ERR_INVALID_CHAR("trailer content", field);
-    }
-    this._trailer += field + ": " + value + "\r\n";
-  }
-};
-
-// deno-lint-ignore no-explicit-any
 function onFinish(outmsg: any) {
   if (outmsg && outmsg.socket && outmsg.socket._hadError) return;
   outmsg.emit("finish");
 }
-
-OutgoingMessage.prototype.end = function end(
-  // deno-lint-ignore no-explicit-any
-  chunk: any,
-  // deno-lint-ignore no-explicit-any
-  encoding: any,
-  // deno-lint-ignore no-explicit-any
-  callback: any,
-) {
-  if (typeof chunk === "function") {
-    callback = chunk;
-    chunk = null;
-    encoding = null;
-  } else if (typeof encoding === "function") {
-    callback = encoding;
-    encoding = null;
-  }
-
-  if (chunk) {
-    if (this.finished) {
-      onError(
-        this,
-        new ERR_STREAM_WRITE_AFTER_END(),
-        typeof callback !== "function" ? nop : callback,
-      );
-      return this;
-    }
-
-    if (this.socket) {
-      this.socket.cork();
-    }
-
-    write_(this, chunk, encoding, null, true);
-  } else if (this.finished) {
-    if (typeof callback === "function") {
-      if (!this.writableFinished) {
-        this.on("finish", callback);
-      } else {
-        callback(new ERR_STREAM_ALREADY_FINISHED("end"));
-      }
-    }
-    return this;
-  } else if (!this._header) {
-    if (this.socket) {
-      this.socket.cork();
-    }
-
-    this._contentLength = 0;
-    this._implicitHeader();
-  }
-
-  if (typeof callback === "function") {
-    this.once("finish", callback);
-  }
-
-  const finish = onFinish.bind(undefined, this);
-
-  if (this._hasBody && this.chunkedEncoding) {
-    this._send("0\r\n" + this._trailer + "\r\n", "latin1", finish);
-  } else if (!this._headerSent || this.writableLength || chunk) {
-    this._send("", "latin1", finish);
-  } else {
-    // deno-lint-ignore no-explicit-any
-    (globalThis as any).process.nextTick(finish);
-  }
-
-  if (this.socket) {
-    // Fully uncork connection on end().
-    this.socket._writableState.corked = 1;
-    this.socket.uncork();
-  }
-  this[kCorked] = 0;
-
-  this.finished = true;
-
-  // There is the first message on the outgoing queue, and we've sent
-  // everything to the socket.
-  debug("outgoing message end.");
-  if (
-    this.outputData.length === 0 &&
-    this.socket &&
-    this.socket._httpMessage === this
-  ) {
-    this._finish();
-  }
-
-  return this;
-};
-
-OutgoingMessage.prototype._finish = function _finish() {
-  assert(this.socket);
-  this.emit("prefinish");
-};
-
-// This logic is probably a bit confusing. Let me explain a bit:
-//
-// In both HTTP servers and clients it is possible to queue up several
-// outgoing messages. This is easiest to imagine in the case of a client.
-// Take the following situation:
-//
-//    req1 = client.request('GET', '/');
-//    req2 = client.request('POST', '/');
-//
-// When the user does
-//
-//   req2.write('hello world\n');
-//
-// it's possible that the first request has not been completely flushed to
-// the socket yet. Thus the outgoing messages need to be prepared to queue
-// up data internally before sending it on further to the socket's queue.
-//
-// This function, outgoingFlush(), is called by both the Server and Client
-// to attempt to flush any pending messages out to the socket.
-OutgoingMessage.prototype._flush = function _flush() {
-  const socket = this.socket;
-
-  if (socket && socket.writable) {
-    // There might be remaining data in this.output; write it out
-    const ret = this._flushOutput(socket);
-
-    if (this.finished) {
-      // This is a queue to the server or client to bring in the next this.
-      this._finish();
-    } else if (ret && this[kNeedDrain]) {
-      this[kNeedDrain] = false;
-      this.emit("drain");
-    }
-  }
-};
-
-OutgoingMessage.prototype._flushOutput = function _flushOutput(socket: Socket) {
-  while (this[kCorked]) {
-    this[kCorked]--;
-    socket.cork();
-  }
-
-  const outputLength = this.outputData.length;
-  if (outputLength <= 0) {
-    return undefined;
-  }
-
-  const outputData = this.outputData;
-  socket.cork();
-  let ret;
-  // Retain for(;;) loop for performance reasons
-  // Refs: https://github.com/nodejs/node/pull/30958
-  for (let i = 0; i < outputLength; i++) {
-    const { data, encoding, callback } = outputData[i];
-    ret = socket.write(data, encoding, callback);
-  }
-  socket.uncork();
-
-  this.outputData = [];
-  this._onPendingData(-this.outputSize);
-  this.outputSize = 0;
-
-  return ret;
-};
-
-OutgoingMessage.prototype.flushHeaders = function flushHeaders() {
-  if (!this._header) {
-    this._implicitHeader();
-  }
-
-  // Force-flush the headers.
-  this._send("");
-};
-
-OutgoingMessage.prototype.pipe = function pipe() {
-  // OutgoingMessage should be write-only. Piping from it is disabled.
-  this.emit("error", new ERR_STREAM_CANNOT_PIPE());
-};
-
-OutgoingMessage.prototype[EE.captureRejectionSymbol] = function (
-  // deno-lint-ignore no-explicit-any
-  err: any,
-  // deno-lint-ignore no-explicit-any
-  _event: any,
-) {
-  this.destroy(err);
-};
 
 export default {
   validateHeaderName,

--- a/node/_http_outgoing.ts
+++ b/node/_http_outgoing.ts
@@ -627,16 +627,16 @@ export class OutgoingMessage extends Stream {
 
   write(
     // deno-lint-ignore no-explicit-any
-    chunk: any,
-    encoding: string | null,
-    callback: () => void,
+    chunk?: any,
+    encoding?: string | null,
+    callback?: () => void,
   ) {
     if (typeof encoding === "function") {
       callback = encoding;
       encoding = null;
     }
 
-    const ret = write_(this, chunk, encoding, callback, false);
+    const ret = write_(this, chunk, encoding!, callback, false);
     if (!ret) {
       this[kNeedDrain] = true;
     }

--- a/node/http.ts
+++ b/node/http.ts
@@ -93,7 +93,7 @@ export interface RequestOptions {
 
 // TODO: Implement ClientRequest methods (e.g. setHeader())
 /** ClientRequest represents the http(s) request from the client */
-class ClientRequest extends OutgoingMessage {
+class ClientRequest extends NodeWritable {
   defaultProtocol = "http:";
   body: null | ReadableStream = null;
   controller: ReadableStreamDefaultController | null = null;

--- a/node/http.ts
+++ b/node/http.ts
@@ -105,7 +105,7 @@ class ClientRequest extends NodeWritable {
   }
 
   // deno-lint-ignore no-explicit-any
-  _write(chunk: any, _enc: string, cb: () => void) {
+  override _write(chunk: any, _enc: string, cb: () => void) {
     if (this.controller) {
       this.controller.enqueue(chunk);
       cb();
@@ -121,7 +121,7 @@ class ClientRequest extends NodeWritable {
     });
   }
 
-  async _final() {
+  override async _final() {
     if (this.controller) {
       this.controller.close();
     }
@@ -212,6 +212,10 @@ class ClientRequest extends NodeWritable {
     return `${protocol}//${auth ? `${auth}@` : ""}${host}${
       port === 80 ? "" : `:${port}`
     }${path}`;
+  }
+
+  setTimeout() {
+    console.log("not implemented: ClientRequest.setTimeout");
   }
 }
 

--- a/node/http.ts
+++ b/node/http.ts
@@ -93,7 +93,7 @@ export interface RequestOptions {
 
 // TODO: Implement ClientRequest methods (e.g. setHeader())
 /** ClientRequest represents the http(s) request from the client */
-class ClientRequest extends NodeWritable {
+class ClientRequest extends OutgoingMessage {
   defaultProtocol = "http:";
   body: null | ReadableStream = null;
   controller: ReadableStreamDefaultController | null = null;
@@ -105,7 +105,7 @@ class ClientRequest extends NodeWritable {
   }
 
   // deno-lint-ignore no-explicit-any
-  override _write(chunk: any, _enc: string, cb: () => void) {
+  _write(chunk: any, _enc: string, cb: () => void) {
     if (this.controller) {
       this.controller.enqueue(chunk);
       cb();
@@ -121,7 +121,7 @@ class ClientRequest extends NodeWritable {
     });
   }
 
-  override async _final() {
+  async _final() {
     if (this.controller) {
       this.controller.close();
     }
@@ -212,10 +212,6 @@ class ClientRequest extends NodeWritable {
     return `${protocol}//${auth ? `${auth}@` : ""}${host}${
       port === 80 ? "" : `:${port}`
     }${path}`;
-  }
-
-  setTimeout() {
-    console.log("not implemented: ClientRequest.setTimeout");
   }
 }
 


### PR DESCRIPTION
I'm on a quest to fix node compat's `http.ClientRequest`. This PR is step zero in this process.

`ClientRequest` currently extends `NodeWritable` when it should really be extending `OutgoingMessage`.

This PR makes `OutgoingMessage` a class (without changing any other semantics about it)