### PR TITLE
Add method toArray to Heap

### DIFF
--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -1,7 +1,8 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 /** This module is browser compatible. */
 
 import { descend } from "./_comparators.ts";
+
 export * from "./_comparators.ts";
 
 /** Swaps the values at two indexes in an array. */
@@ -61,7 +62,9 @@ function getParentIndex(index: number) {
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
   constructor(private compare: (a: T, b: T) => number = descend) {}
-
+  toArray() {
+    return Array.from(this.#data);
+  }
   /** Creates a new binary heap from an array like or iterable object. */
   static from<T>(
     collection: ArrayLike<T> | Iterable<T> | BinaryHeap<T>,

--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -62,6 +62,7 @@ function getParentIndex(index: number) {
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
   constructor(private compare: (a: T, b: T) => number = descend) {}
+  /** Returns the underlying cloned array in arbitrary order */  
   toArray() {
     return Array.from(this.#data);
   }

--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -62,7 +62,7 @@ function getParentIndex(index: number) {
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
   constructor(private compare: (a: T, b: T) => number = descend) {}
-  /** Returns the underlying cloned array in arbitrary order */  
+  /** Returns the underlying cloned array in arbitrary order without sorting */  
   toArray() {
     return Array.from(this.#data);
   }

--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -62,7 +62,7 @@ function getParentIndex(index: number) {
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
   constructor(private compare: (a: T, b: T) => number = descend) {}
-  /** Returns the underlying cloned array in arbitrary order without sorting */  
+  /** Returns the underlying cloned array in arbitrary order without sorting */
   toArray() {
     return Array.from(this.#data);
   }


### PR DESCRIPTION
fixes https://github.com/denoland/deno_std/issues/3076

Returns the underlying cloned array in arbitrary order without sorting