### PR TITLE
chore: formatting updates in deno 1.29.2

### DIFF
--- a/node/_crypto/crypto_browserify/asn1.js/test/der_encode_test.js
+++ b/node/_crypto/crypto_browserify/asn1.js/test/der_encode_test.js
@@ -10,7 +10,7 @@ Deno.test("asn1.js DER encoder", async function (t) {
   /*
    * Explicit value shold be wrapped with A0 | EXPLICIT tag
    * this adds two more bytes to resulting buffer.
-   * */
+   */
   await t.step("should code explicit tag as 0xA2", function () {
     const E = asn1.define("E", function () {
       this.explicit(2).octstr();

--- a/node/_events.mjs
+++ b/node/_events.mjs
@@ -321,7 +321,7 @@ function enhanceStackTrace(err, own) {
  * @returns {boolean}
  */
 EventEmitter.prototype.emit = function emit(type, ...args) {
-  let doError = (type === "error");
+  let doError = type === "error";
 
   const events = this._events;
   if (events !== undefined) {

--- a/node/_pako.mjs
+++ b/node/_pako.mjs
@@ -1556,7 +1556,7 @@ const MAX_BITS = 15;
 
 const MIN_MATCH = 3;
 const MAX_MATCH = 258;
-const MIN_LOOKAHEAD = (MAX_MATCH + MIN_MATCH + 1);
+const MIN_LOOKAHEAD = MAX_MATCH + MIN_MATCH + 1;
 
 const PRESET_DICT = 0x20;
 
@@ -5655,12 +5655,12 @@ const inflate$2 = (strm, flush) => {
         //---//
 
         switch ((hold & 0x03) /*BITS(2)*/) {
-          case 0:/* stored block */
+          case 0: /* stored block */
             //Tracev((stderr, "inflate:     stored block%s\n",
             //        state.last ? " (last)" : ""));
             state.mode = STORED;
             break;
-          case 1:/* fixed block */
+          case 1: /* fixed block */
             fixedtables(state);
             //Tracev((stderr, "inflate:     fixed codes block%s\n",
             //        state.last ? " (last)" : ""));
@@ -5673,7 +5673,7 @@ const inflate$2 = (strm, flush) => {
               break inf_leave;
             }
             break;
-          case 2:/* dynamic block */
+          case 2: /* dynamic block */
             //Tracev((stderr, "inflate:     dynamic codes block%s\n",
             //        state.last ? " (last)" : ""));
             state.mode = TABLE;

--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -547,7 +547,7 @@ export class AssertionError extends Error {
 
     for (const name of ["actual", "expected"]) {
       if (typeof this[name] === "string") {
-        const value = (this[name] as string);
+        const value = this[name] as string;
         const lines = value.split("\n");
         if (lines.length > 10) {
           lines.length = 10;

--- a/node/internal/buffer.mjs
+++ b/node/internal/buffer.mjs
@@ -346,7 +346,7 @@ function byteLength(string, encoding) {
   }
 
   const len = string.length;
-  const mustMatch = (arguments.length > 2 && arguments[2] === true);
+  const mustMatch = arguments.length > 2 && arguments[2] === true;
   if (!mustMatch && len === 0) {
     return 0;
   }
@@ -598,8 +598,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
 
   if (isUint8Array(val)) {
-    const encodingVal =
-      (ops === undefined ? encodingsMap.utf8 : ops.encodingVal);
+    const encodingVal = ops === undefined ? encodingsMap.utf8 : ops.encodingVal;
     return indexOfBuffer(buffer, val, byteOffset, encodingVal, dir);
   }
 

--- a/node/internal/readline/utils.mjs
+++ b/node/internal/readline/utils.mjs
@@ -155,7 +155,6 @@ export function* emitKeys(stream) {
          *
          * We have basically two classes of ascii characters to process:
          *
-         *
          * 1. `\x1b[24;5~` should be parsed as { code: '[24~', modifier: 5 }
          *
          * This particular example is featuring Ctrl+F12 in xterm.
@@ -165,7 +164,6 @@ export function* emitKeys(stream) {
          *
          * So the generic regexp is like /^\d\d?(;\d)?[~^$]$/
          *
-         *
          * 2. `\x1b[1;5H` should be parsed as { code: '[H', modifier: 5 }
          *
          * This particular example is featuring Ctrl+Home in xterm.
@@ -174,7 +172,6 @@ export function* emitKeys(stream) {
          *  - `1;` part is optional, e.g. it could be `\x1b[5H`
          *
          * So the generic regexp is like /^((\d;)?\d)?[A-Za-z]$/
-         *
          */
         const cmdStart = s.length - 1;
 

--- a/node/module.ts
+++ b/node/module.ts
@@ -277,7 +277,7 @@ class Module {
 
   /*
    * Check for node modules paths.
-   * */
+   */
   static _resolveLookupPaths(
     request: string,
     parent: Module | null,

--- a/node/querystring.ts
+++ b/node/querystring.ts
@@ -142,8 +142,8 @@ export function parse(
     return obj;
   }
 
-  const sepCodes = (!sep ? [38] /* & */ : charCodes(String(sep)));
-  const eqCodes = (!eq ? [61] /* = */ : charCodes(String(eq)));
+  const sepCodes = !sep ? [38] /* & */ : charCodes(String(sep));
+  const eqCodes = !eq ? [61] /* = */ : charCodes(String(eq));
   const sepLen = sepCodes.length;
   const eqLen = eqCodes.length;
 
@@ -162,7 +162,7 @@ export function parse(
   if (decodeURIComponent) {
     decode = decodeURIComponent;
   }
-  const customDecode = (decode !== unescape);
+  const customDecode = decode !== unescape;
 
   let lastPos = 0;
   let sepIdx = 0;
@@ -171,7 +171,7 @@ export function parse(
   let value = "";
   let keyEncoded = customDecode;
   let valEncoded = customDecode;
-  const plusChar = (customDecode ? "%20" : " ");
+  const plusChar = customDecode ? "%20" : " ";
   let encodeCheck = 0;
   for (let i = 0; i < str.length; ++i) {
     const code = str.charCodeAt(i);

--- a/node/string_decoder.ts
+++ b/node/string_decoder.ts
@@ -49,7 +49,7 @@ function isBufferType(buf: Buffer) {
 /*
  * Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
  * continuation byte. If an invalid byte is detected, -2 is returned.
- * */
+ */
 function utf8CheckByte(byte: number): number {
   if (byte <= 0x7f) return 0;
   else if (byte >> 5 === 0x06) return 2;
@@ -62,7 +62,7 @@ function utf8CheckByte(byte: number): number {
  * Checks at most 3 bytes at the end of a Buffer in order to detect an
  * incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
  * needed to complete the UTF-8 character (if applicable) are returned.
- * */
+ */
 function utf8CheckIncomplete(
   self: StringDecoderBase,
   buf: Buffer,
@@ -102,7 +102,7 @@ function utf8CheckIncomplete(
  * where all of the continuation bytes for a character exist in the same buffer.
  * It is also done this way as a slight performance increase instead of using a
  * loop.
- * */
+ */
 function utf8CheckExtraBytes(
   self: StringDecoderBase,
   buf: Buffer,
@@ -127,7 +127,7 @@ function utf8CheckExtraBytes(
 
 /*
  * Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
- * */
+ */
 function utf8FillLastComplete(
   this: StringDecoderBase,
   buf: Buffer,
@@ -145,7 +145,7 @@ function utf8FillLastComplete(
 
 /*
  * Attempts to complete a partial non-UTF-8 character using bytes from a Buffer
- * */
+ */
 function utf8FillLastIncomplete(
   this: StringDecoderBase,
   buf: Buffer,
@@ -162,7 +162,7 @@ function utf8FillLastIncomplete(
  * Returns all complete UTF-8 characters in a Buffer. If the Buffer ended on a
  * partial character, the character's bytes are buffered until the required
  * number of bytes are available.
- * */
+ */
 function utf8Text(this: StringDecoderBase, buf: Buffer, i: number): string {
   const total = utf8CheckIncomplete(this, buf, i);
   if (!this.lastNeed) return buf.toString("utf8", i);
@@ -175,7 +175,7 @@ function utf8Text(this: StringDecoderBase, buf: Buffer, i: number): string {
 /*
  * For UTF-8, a replacement character is added when ending on a partial
  * character.
- * */
+ */
 function utf8End(this: Utf8Decoder, buf?: Buffer): string {
   const r = buf && buf.length ? this.write(buf) : "";
   if (this.lastNeed) return r + "\ufffd";
@@ -292,7 +292,7 @@ class Utf8Decoder extends StringDecoderBase {
  * StringDecoder provides an interface for efficiently splitting a series of
  * buffers into a series of JS strings without breaking apart multi-byte
  * characters.
- * */
+ */
 export class StringDecoder {
   public encoding: string;
   public end: (buf?: Buffer) => string;

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1424,21 +1424,17 @@ export default class Context {
           options.write = true;
         }
 
-        const read = (
-          RIGHTS_FD_READ |
-          RIGHTS_FD_READDIR
-        );
+        const read = RIGHTS_FD_READ |
+          RIGHTS_FD_READDIR;
 
         if ((rightsBase & read) != 0n) {
           options.read = true;
         }
 
-        const write = (
-          RIGHTS_FD_DATASYNC |
+        const write = RIGHTS_FD_DATASYNC |
           RIGHTS_FD_WRITE |
           RIGHTS_FD_ALLOCATE |
-          RIGHTS_FD_FILESTAT_SET_SIZE
-        );
+          RIGHTS_FD_FILESTAT_SET_SIZE;
 
         if ((rightsBase & write) != 0n) {
           options.write = true;


### PR DESCRIPTION
Upgraded dprint-plugin-typescript, which had some formatting improvements over the break. This will fail because the change hasn't been merged to canary yet.