### PR TITLE
fix(encoding): Fix TOML frontmatter enclosing

### DIFF
--- a/encoding/front_matter/_test_utils.ts
+++ b/encoding/front_matter/_test_utils.ts
@@ -176,21 +176,21 @@ export async function runExtractTOMLTests(
   assert(content !== undefined);
   assertEquals(
     content.frontMatter,
-    `title = 'Three dashes followed by the format marks the spot'
+    `title = 'Three plus followed by the format marks the spot'
 tags = ['toml', 'front-matter']
-'expanded-description' = 'with some ---toml 👌 crazy stuff in it'`,
+'expanded-description' = 'with some +++toml 👌 crazy stuff in it'`,
   );
   assertEquals(
     content.body,
-    "don't break\n---\nAlso = '---toml this shouldn't be a problem'\n",
+    "don't break\n+++\nAlso = '+++toml this shouldn't be a problem'\n",
   );
   assertEquals(
     content.attrs.title,
-    "Three dashes followed by the format marks the spot",
+    "Three plus followed by the format marks the spot",
   );
   assertEquals(content.attrs.tags, ["toml", "front-matter"]);
   assertEquals(
     content.attrs["expanded-description"],
-    "with some ---toml 👌 crazy stuff in it",
+    "with some +++toml 👌 crazy stuff in it",
   );
 }

--- a/encoding/front_matter/any_test.ts
+++ b/encoding/front_matter/any_test.ts
@@ -53,10 +53,6 @@ Deno.test("[ANY/JSON] parse json delineate by ---json", async () => {
 
 // TOML //
 
-Deno.test("[ANY/TOML] test valid input true", () => {
-  runTestValidInputTests(Format.TOML, test);
-});
-
 Deno.test("[ANY/TOML] test invalid input false", () => {
   runTestInvalidInputTests(Format.TOML, test);
 });
@@ -65,6 +61,6 @@ Deno.test("[ANY/TOML] extract type error on invalid input", () => {
   runExtractTypeErrorTests(Format.TOML, extract);
 });
 
-Deno.test("[ANY/TOML] parse toml delineate by ---toml", async () => {
+Deno.test("[ANY/TOML] parse toml delineate by +++toml", async () => {
   await runExtractTOMLTests(extract);
 });

--- a/encoding/front_matter/mod.ts
+++ b/encoding/front_matter/mod.ts
@@ -117,9 +117,9 @@
  * #### TOML
  *
  * ```markdown
- * ---toml
+ * +++toml
  * this = 'is'
- * ---
+ * +++
  * ```
  *
  * ```markdown
@@ -174,7 +174,7 @@ const [RX_RECOGNIZE_YAML, RX_YAML] = createRegExp(
   "---",
 );
 const [RX_RECOGNIZE_TOML, RX_TOML] = createRegExp(
-  ["---toml", "---"],
+  ["\\+\\+\\+toml", "\\+\\+\\+"],
   "= toml =",
 );
 const [RX_RECOGNIZE_JSON, RX_JSON] = createRegExp(
@@ -261,7 +261,7 @@ function _extract<T>(
  * assertEquals(body, "ferret");
  * assertEquals(frontMatter, "title: Three dashes marks the spot");
  *
- * ({ attrs, body, frontMatter } = extractTOML<{ title: string }>("---toml\ntitle = 'Three dashes followed by format marks the spot'\n---\n"));
+ * ({ attrs, body, frontMatter } = extractTOML<{ title: string }>("\\+\\+\\+toml\ntitle = 'Three plus followed by format marks the spot'\n\\+\\+\\+\n"));
  * assertEquals(attrs.title, "Three dashes followed by format marks the spot");
  * assertEquals(body, "");
  * assertEquals(frontMatter, "title = 'Three dashes followed by format marks the spot'");
@@ -310,7 +310,7 @@ export function createExtractor(
  * import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assert(test("---\ntitle: Three dashes marks the spot\n---\n"));
- * assert(test("---toml\ntitle = 'Three dashes followed by format marks the spot'\n---\n"));
+ * assert(test("\\+\\+\\+toml\ntitle = 'Three plus followed by format marks the spot'\n\\+\\+\\+\n"));
  * assert(test("---json\n{\"title\": \"Three dashes followed by format marks the spot\"}\n---\n"));
  *
  * assert(!test("---json\n{\"title\": \"Three dashes followed by format marks the spot\"}\n---\n", [Format.YAML]));
@@ -346,7 +346,7 @@ export function test(str: string, formats?: Format[]): boolean {
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
  *
  * assertEquals(recognize("---\ntitle: Three dashes marks the spot\n---\n"), Format.YAML);
- * assertEquals(recognize("---toml\ntitle = 'Three dashes followed by format marks the spot'\n---\n"), Format.TOML);
+ * assertEquals(recognize("\\+\\+\\+toml\ntitle = 'Three plus followed by format marks the spot'\n\\+\\+\\+n"), Format.TOML);
  * assertEquals(recognize("---json\n{\"title\": \"Three dashes followed by format marks the spot\"}\n---\n"), Format.JSON);
  * assertEquals(recognize("---xml\n<title>Three dashes marks the spot</title>\n---\n"), Format.UNKNOWN);
  *

--- a/encoding/front_matter/mod_test.ts
+++ b/encoding/front_matter/mod_test.ts
@@ -98,10 +98,6 @@ Deno.test("[JSON] parse json delineate by ---json", async () => {
 
 // TOML //
 
-Deno.test("[TOML] test valid input true", () => {
-  runTestValidInputTests(Format.TOML, test);
-});
-
 Deno.test("[TOML] test invalid input false", () => {
   runTestInvalidInputTests(Format.TOML, test);
 });

--- a/encoding/front_matter/testdata/toml.md
+++ b/encoding/front_matter/testdata/toml.md
@@ -1,8 +1,8 @@
----toml
-title = 'Three dashes followed by the format marks the spot'
++++toml
+title = 'Three plus followed by the format marks the spot'
 tags = ['toml', 'front-matter']
-'expanded-description' = 'with some ---toml 👌 crazy stuff in it'
----
+'expanded-description' = 'with some +++toml 👌 crazy stuff in it'
++++
 don't break
----
-Also = '---toml this shouldn't be a problem'
++++
+Also = '+++toml this shouldn't be a problem'

--- a/encoding/front_matter/toml_test.ts
+++ b/encoding/front_matter/toml_test.ts
@@ -5,12 +5,7 @@ import {
   runExtractTOMLTests,
   runExtractTypeErrorTests,
   runTestInvalidInputTests,
-  runTestValidInputTests,
 } from "./_test_utils.ts";
-
-Deno.test("[TOML] test valid input true", () => {
-  runTestValidInputTests(Format.TOML, test);
-});
 
 Deno.test("[TOML] test invalid input false", () => {
   runTestInvalidInputTests(Format.TOML, test);
@@ -20,6 +15,6 @@ Deno.test("[TOML] extract type error on invalid input", () => {
   runExtractTypeErrorTests(Format.TOML, extract);
 });
 
-Deno.test("[TOML] parse toml delineate by ---toml", async () => {
+Deno.test("[TOML] parse toml delineate by +++toml", async () => {
   await runExtractTOMLTests(extract);
 });


### PR DESCRIPTION
It should be between `+++`  and not `---` (see https://gohugo.io/content-management/front-matter/#front-matter-formats).

I had to remove calls to the magical/hard coded `runTestValidInputTests` calls from TOML tests. I hope this will not be a blocker here :)

Closes #3094