### PR TITLE
Added option to TextLineStream to ignore newlines at the end of the last line

### DIFF
--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -3,7 +3,8 @@
 interface TextLineStreamOptions {
   /** Allow splitting by solo \r */
   allowCR: boolean;
-  flush: string;
+  /** Ignore last line trailing \n */
+  ignoreLastLF: boolean;
 }
 
 /** Transform a stream into a stream where each chunk is divided by a newline,
@@ -25,11 +26,12 @@ export class TextLineStream extends TransformStream<string, string> {
     super({
       transform: (chunk, controller) => this.#handle(chunk, controller),
       flush: (controller) => {
-        this.#handle(options?.flush ?? "\r\n", controller);
-        if (this.#buf.length > 0) {
+        if (!options?.ignoreLastLF ?? false) {
+          this.#handle("\r\n", controller);
+        } else if (this.#buf.length > 0) {
           controller.enqueue(this.#buf);
         }
-      }
+      },
     });
     this.#allowCR = options?.allowCR ?? false;
   }

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -3,6 +3,7 @@
 interface TextLineStreamOptions {
   /** Allow splitting by solo \r */
   allowCR: boolean;
+  flush: string;
 }
 
 /** Transform a stream into a stream where each chunk is divided by a newline,
@@ -23,7 +24,12 @@ export class TextLineStream extends TransformStream<string, string> {
   constructor(options?: TextLineStreamOptions) {
     super({
       transform: (chunk, controller) => this.#handle(chunk, controller),
-      flush: (controller) => this.#handle("\r\n", controller),
+      flush: (controller) => {
+        this.#handle(options?.flush ?? "\r\n", controller);
+        if (this.#buf.length > 0) {
+          controller.enqueue(this.#buf);
+        }
+      }
     });
     this.#allowCR = options?.allowCR ?? false;
   }


### PR DESCRIPTION
Rel https://github.com/denoland/deno_std/issues/3075
This PR allows you to delete blank lines that would appear if "\n" was at the end of a chunk.

example
```example.ts
const test_case = ["foo\n\nbar\n", "foo\nbar\n\n", "foo\nbar"];

for (const str of test_case) {
  const textLineStream = new File([str], "untitled")
    .stream()
    .pipeThrough(new TextDecoderStream())
    .pipeThrough(new TextLineStream());
  console.log("");
  let lineNumber = 0;
  for await (const line of textLineStream) {
    lineNumber += 1;
    console.log(lineNumber, line);
  }
}
```

example output
```
1 foo
2
3 bar
4

1 foo
2 bar
3
4

1 foo
2 bar
```

Output when using this PR and `.pipeThrough(new TextLineStream({ignoreLastLF: false}));`
```
1 foo
2
3 bar

1 foo
2 bar
3

1 foo
2 bar
```