### PR TITLE
fix(streams): prevent artificial terminal newline in `TextLineStream`

### DIFF
--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -23,7 +23,16 @@ export class TextLineStream extends TransformStream<string, string> {
   constructor(options?: TextLineStreamOptions) {
     super({
       transform: (chunk, controller) => this.#handle(chunk, controller),
-      flush: (controller) => this.#handle("\r\n", controller),
+      flush: (controller) => {
+        if (this.#buf.length > 0) {
+          if (
+            this.#allowCR &&
+            this.#buf.length > 1 &&
+            this.#buf[this.#buf.length - 1] === "\r"
+          ) controller.enqueue(this.#buf.slice(0, -1));
+          else controller.enqueue(this.#buf);
+        }
+      },
     });
     this.#allowCR = options?.allowCR ?? false;
   }

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -27,7 +27,6 @@ export class TextLineStream extends TransformStream<string, string> {
         if (this.#buf.length > 0) {
           if (
             this.#allowCR &&
-            this.#buf.length > 1 &&
             this.#buf[this.#buf.length - 1] === "\r"
           ) controller.enqueue(this.#buf.slice(0, -1));
           else controller.enqueue(this.#buf);

--- a/streams/text_line_stream_test.ts
+++ b/streams/text_line_stream_test.ts
@@ -46,8 +46,7 @@ Deno.test("[streams] TextLineStream", async () => {
   assertEquals(lines2, [
     "rewq0987",
     "",
-    "654321",
-    "",
+    "654321"
   ]);
 });
 
@@ -84,7 +83,6 @@ Deno.test("[streams] TextLineStream - allowCR", async () => {
     "rewq0987",
     "",
     "654321",
-    "",
   ]);
 
   const textStream2 = new ReadableStream({
@@ -102,7 +100,6 @@ Deno.test("[streams] TextLineStream - allowCR", async () => {
     "rewq0987",
     "",
     "654321",
-    "",
   ]);
 });
 
@@ -120,5 +117,5 @@ Deno.test("[streams] TextLineStream - large chunks", async () => {
     assertEquals(chunk, "");
     lines++;
   }
-  assertEquals(lines, 20001);
+  assertEquals(lines, 20000);
 });

--- a/streams/text_line_stream_test.ts
+++ b/streams/text_line_stream_test.ts
@@ -46,7 +46,7 @@ Deno.test("[streams] TextLineStream", async () => {
   assertEquals(lines2, [
     "rewq0987",
     "",
-    "654321"
+    "654321",
   ]);
 });
 


### PR DESCRIPTION
Resolves #3075. (Alternative to #3096)

For details, see: https://github.com/denoland/deno_std/issues/3075#issue-1515492150 — quick summary:

`TextLineStream` is for breaking streams of text content into chunks of _lines_. My understanding of the conventional definition of _variable length lines_ is:

> each line is an EOL character sequence of 1+ bytes (e.g. `\n`), preceded by a character sequence of 0+ bytes containing no EOL character sequences

It seems that the class was written to expect the exception to this definition (the stream does not terminate with an EOL character sequence), and this PR updates the class to handle both cases.