### PR TITLE
test(node): prevent leak of permission requirement

### DIFF
--- a/node/module_all_test.ts
+++ b/node/module_all_test.ts
@@ -246,6 +246,20 @@ Deno.test("modules", () => {
   assertEquals(keys(moduleAll.zlib), keys(zlib));
 });
 
+Deno.test("modules can be imported without any permission", async () => {
+  const { code, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "module_all.ts",
+    ],
+    cwd: path.dirname(path.fromFileUrl(import.meta.url)),
+  }).output();
+  if (stderr.length > 0) {
+    console.log(new TextDecoder().decode(stderr));
+  }
+  assertEquals(code, 0);
+});
+
 // deno-lint-ignore no-explicit-any
 function keys(obj: any): Set<string> {
   const keys = new Set(Object.keys(obj));


### PR DESCRIPTION
This test case detects the error like https://github.com/denoland/deno/issues/17414, and prevents similar errors

This PR will pass the CI when the current env permission error is fixed in CLI (needs another release) and STD ( https://github.com/denoland/deno_std/pull/3111 ) repos.