### PR TITLE
fix(fs): Change globstar default to true for expandGlob and expandGlobSync

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -80,7 +80,7 @@ export async function* expandGlob(
     exclude = [],
     includeDirs = true,
     extended = true,
-    globstar = false,
+    globstar = true,
     caseInsensitive,
   }: ExpandGlobOptions = {},
 ): AsyncIterableIterator<WalkEntry> {
@@ -199,7 +199,7 @@ export function* expandGlobSync(
     exclude = [],
     includeDirs = true,
     extended = true,
-    globstar = false,
+    globstar = true,
     caseInsensitive,
   }: ExpandGlobOptions = {},
 ): IterableIterator<WalkEntry> {

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -46,7 +46,6 @@ const EG_OPTIONS: ExpandGlobOptions = {
   root: fromFileUrl(new URL(join("testdata", "glob"), import.meta.url)),
   includeDirs: true,
   extended: false,
-  globstar: false,
 };
 
 Deno.test("expandGlobWildcard", async function () {
@@ -97,9 +96,9 @@ Deno.test("expandGlobExt", async function () {
 });
 
 Deno.test("expandGlobGlobstar", async function () {
-  const options = { ...EG_OPTIONS, globstar: true };
+  const options = { ...EG_OPTIONS };
   assertEquals(
-    await expandGlobArray(joinGlobs(["**", "abc"], options), options),
+    await expandGlobArray("**/abc", options),
     ["abc", join("subdir", "abc")],
   );
 });


### PR DESCRIPTION
https://deno.land/std@0.172.0/fs/expand_glob.ts?s=ExpandGlobOptions extends https://deno.land/std@0.172.0/path/mod.ts?s=GlobOptions which states that `globstar: boolean = true`.

Fixes https://github.com/denoland/deno_std/issues/3099