### PR TITLE
fix(node/util): Stricter runtime type checking

### DIFF
--- a/node/internal/crypto/keys.ts
+++ b/node/internal/crypto/keys.ts
@@ -24,7 +24,26 @@ import {
 } from "./_keys.ts";
 
 const getArrayBufferOrView = hideStackFrames(
-  (buffer, name, encoding): Buffer => {
+  (
+    buffer,
+    name,
+    encoding,
+  ):
+    | ArrayBuffer
+    | SharedArrayBuffer
+    | Buffer
+    | DataView
+    | BigInt64Array
+    | BigUint64Array
+    | Float32Array
+    | Float64Array
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Uint16Array
+    | Uint32Array => {
     if (isAnyArrayBuffer(buffer)) {
       return buffer;
     }

--- a/node/internal/util/comparisons.ts
+++ b/node/internal/util/comparisons.ts
@@ -139,15 +139,28 @@ function innerDeepEqual(
       return false;
     }
   } else if (isArrayBufferView(val1)) {
-    const TypedArrayPrototypeGetSymbolToStringTag = (val: []) =>
+    const TypedArrayPrototypeGetSymbolToStringTag = (
+      val:
+        | BigInt64Array
+        | BigUint64Array
+        | Float32Array
+        | Float64Array
+        | Int8Array
+        | Int16Array
+        | Int32Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Uint16Array
+        | Uint32Array,
+    ) =>
       Object.getOwnPropertySymbols(val)
         .map((item) => item.toString())
         .toString();
     if (
       isTypedArray(val1) &&
       isTypedArray(val2) &&
-      (TypedArrayPrototypeGetSymbolToStringTag(val1 as []) !==
-        TypedArrayPrototypeGetSymbolToStringTag(val2 as []))
+      (TypedArrayPrototypeGetSymbolToStringTag(val1) !==
+        TypedArrayPrototypeGetSymbolToStringTag(val2))
     ) {
       return false;
     }
@@ -189,8 +202,7 @@ function innerDeepEqual(
     );
   } else if (isMap(val1)) {
     if (
-      !isMap(val2) ||
-      (val1 as Set<unknown>).size !== (val2 as Set<unknown>).size
+      !isMap(val2) || val1.size !== val2.size
     ) {
       return false;
     }

--- a/node/internal/util/types.ts
+++ b/node/internal/util/types.ts
@@ -30,39 +30,64 @@ const _getTypedArrayToStringTag = Object.getOwnPropertyDescriptor(
   Symbol.toStringTag,
 )!.get!;
 
-export function isArrayBufferView(value: unknown): boolean {
+export function isArrayBufferView(
+  value: unknown,
+): value is
+  | DataView
+  | BigInt64Array
+  | BigUint64Array
+  | Float32Array
+  | Float64Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array {
   return ArrayBuffer.isView(value);
 }
 
-export function isBigInt64Array(value: unknown): boolean {
+export function isBigInt64Array(value: unknown): value is BigInt64Array {
   return _getTypedArrayToStringTag.call(value) === "BigInt64Array";
 }
 
-export function isBigUint64Array(value: unknown): boolean {
+export function isBigUint64Array(value: unknown): value is BigUint64Array {
   return _getTypedArrayToStringTag.call(value) === "BigUint64Array";
 }
 
-export function isFloat32Array(value: unknown): boolean {
+export function isFloat32Array(value: unknown): value is Float32Array {
   return _getTypedArrayToStringTag.call(value) === "Float32Array";
 }
 
-export function isFloat64Array(value: unknown): boolean {
+export function isFloat64Array(value: unknown): value is Float64Array {
   return _getTypedArrayToStringTag.call(value) === "Float64Array";
 }
 
-export function isInt8Array(value: unknown): boolean {
+export function isInt8Array(value: unknown): value is Int8Array {
   return _getTypedArrayToStringTag.call(value) === "Int8Array";
 }
 
-export function isInt16Array(value: unknown): boolean {
+export function isInt16Array(value: unknown): value is Int16Array {
   return _getTypedArrayToStringTag.call(value) === "Int16Array";
 }
 
-export function isInt32Array(value: unknown): boolean {
+export function isInt32Array(value: unknown): value is Int32Array {
   return _getTypedArrayToStringTag.call(value) === "Int32Array";
 }
 
-export function isTypedArray(value: unknown): boolean {
+export function isTypedArray(value: unknown): value is
+  | BigInt64Array
+  | BigUint64Array
+  | Float32Array
+  | Float64Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array {
   return _getTypedArrayToStringTag.call(value) !== undefined;
 }
 
@@ -70,15 +95,17 @@ export function isUint8Array(value: unknown): value is Uint8Array {
   return _getTypedArrayToStringTag.call(value) === "Uint8Array";
 }
 
-export function isUint8ClampedArray(value: unknown): boolean {
+export function isUint8ClampedArray(
+  value: unknown,
+): value is Uint8ClampedArray {
   return _getTypedArrayToStringTag.call(value) === "Uint8ClampedArray";
 }
 
-export function isUint16Array(value: unknown): boolean {
+export function isUint16Array(value: unknown): value is Uint16Array {
   return _getTypedArrayToStringTag.call(value) === "Uint16Array";
 }
 
-export function isUint32Array(value: unknown): boolean {
+export function isUint32Array(value: unknown): value is Uint32Array {
   return _getTypedArrayToStringTag.call(value) === "Uint32Array";
 }
 

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -82,10 +82,11 @@ const _getMapSize = Object.getOwnPropertyDescriptor(
   "size",
 )!.get!;
 
-const isObjectLike = (
+function isObjectLike(
   value: unknown,
-): value is Record<string | number | symbol, unknown> =>
-  value !== null && typeof value === "object";
+): value is Record<string | number | symbol, unknown> {
+  return value !== null && typeof value === "object";
+}
 
 export function isAnyArrayBuffer(
   value: unknown,

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -28,17 +28,10 @@ const _toString = Object.prototype.toString;
 const _isObjectLike = (value: unknown): boolean =>
   value !== null && typeof value === "object";
 
-const _isFunctionLike = (value: unknown): boolean =>
-  value !== null && typeof value === "function";
-
 export function isAnyArrayBuffer(
   value: unknown,
 ): value is ArrayBuffer | SharedArrayBuffer {
-  return (
-    _isObjectLike(value) &&
-    (_toString.call(value) === "[object ArrayBuffer]" ||
-      _toString.call(value) === "[object SharedArrayBuffer]")
-  );
+  return isArrayBuffer(value) || isSharedArrayBuffer(value);
 }
 
 export function isArgumentsObject(value: unknown): value is IArguments {
@@ -55,7 +48,8 @@ export function isAsyncFunction(
   value: unknown,
 ): value is (...args: unknown[]) => Promise<unknown> {
   return (
-    _isFunctionLike(value) && _toString.call(value) === "[object AsyncFunction]"
+    typeof value === "function" &&
+    _toString.call(value) === "[object AsyncFunction]"
   );
 }
 
@@ -89,7 +83,7 @@ export function isGeneratorFunction(
   value: unknown,
 ): value is GeneratorFunction {
   return (
-    _isFunctionLike(value) &&
+    typeof value === "function" &&
     _toString.call(value) === "[object GeneratorFunction]"
   );
 }

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -23,10 +23,8 @@
 
 import { core } from "../_core.ts";
 
+// https://tc39.es/ecma262/#sec-object.prototype.tostring
 const _toString = Object.prototype.toString;
-
-const _isObjectLike = (value: unknown): boolean =>
-  value !== null && typeof value === "object";
 
 // https://tc39.es/ecma262/#sec-bigint.prototype.valueof
 const _bigIntValueOf = BigInt.prototype.valueOf;
@@ -84,6 +82,9 @@ const _getMapSize = Object.getOwnPropertyDescriptor(
   "size",
 )!.get!;
 
+const isObjectLike = (value: unknown): value is Record<string | number | symbol, unknown> =>
+  value !== null && typeof value === "object";
+
 export function isAnyArrayBuffer(
   value: unknown,
 ): value is ArrayBuffer | SharedArrayBuffer {
@@ -91,7 +92,11 @@ export function isAnyArrayBuffer(
 }
 
 export function isArgumentsObject(value: unknown): value is IArguments {
-  return _isObjectLike(value) && _toString.call(value) === "[object Arguments]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === undefined &&
+    _toString.call(value) === "[object Arguments]"
+  );
 }
 
 export function isArrayBuffer(value: unknown): value is ArrayBuffer {
@@ -108,13 +113,14 @@ export function isAsyncFunction(
 ): value is (...args: unknown[]) => Promise<unknown> {
   return (
     typeof value === "function" &&
-    _toString.call(value) === "[object AsyncFunction]"
+    // @ts-ignore: function is a kind of object
+    value[Symbol.toStringTag] === "AsyncFunction"
   );
 }
 
 // deno-lint-ignore ban-types
 export function isBooleanObject(value: unknown): value is Boolean {
-  if (!_isObjectLike(value)) {
+  if (!isObjectLike(value)) {
     return false;
   }
 
@@ -160,12 +166,16 @@ export function isGeneratorFunction(
 ): value is GeneratorFunction {
   return (
     typeof value === "function" &&
-    _toString.call(value) === "[object GeneratorFunction]"
+    // @ts-ignore: function is a kind of object
+    value[Symbol.toStringTag] === "GeneratorFunction"
   );
 }
 
 export function isGeneratorObject(value: unknown): value is Generator {
-  return _isObjectLike(value) && _toString.call(value) === "[object Generator]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === "Generator"
+  );
 }
 
 export function isMap(value: unknown): value is Map<unknown, unknown> {
@@ -181,23 +191,31 @@ export function isMapIterator(
   value: unknown,
 ): value is IterableIterator<[unknown, unknown]> {
   return (
-    _isObjectLike(value) && _toString.call(value) === "[object Map Iterator]"
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === "Map Iterator"
   );
 }
 
 export function isModuleNamespaceObject(
   value: unknown,
 ): value is Record<string | number | symbol, unknown> {
-  return _isObjectLike(value) && _toString.call(value) === "[object Module]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === "Module"
+  );
 }
 
 export function isNativeError(value: unknown): value is Error {
-  return _isObjectLike(value) && _toString.call(value) === "[object Error]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === undefined &&
+    _toString.call(value) === "[object Error]"
+  );
 }
 
 // deno-lint-ignore ban-types
 export function isNumberObject(value: unknown): value is Number {
-  if (!_isObjectLike(value)) {
+  if (!isObjectLike(value)) {
     return false;
   }
 
@@ -210,7 +228,7 @@ export function isNumberObject(value: unknown): value is Number {
 }
 
 export function isBigIntObject(value: unknown): value is BigInt {
-  if (!_isObjectLike(value)) {
+  if (!isObjectLike(value)) {
     return false;
   }
 
@@ -223,7 +241,10 @@ export function isBigIntObject(value: unknown): value is BigInt {
 }
 
 export function isPromise(value: unknown): value is Promise<unknown> {
-  return _isObjectLike(value) && _toString.call(value) === "[object Promise]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === "Promise"
+  );
 }
 
 export function isProxy(
@@ -233,7 +254,11 @@ export function isProxy(
 }
 
 export function isRegExp(value: unknown): value is RegExp {
-  return _isObjectLike(value) && _toString.call(value) === "[object RegExp]";
+  return (
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === undefined &&
+    _toString.call(value) === "[object RegExp]"
+  );
 }
 
 export function isSet(value: unknown): value is Set<unknown> {
@@ -249,7 +274,8 @@ export function isSetIterator(
   value: unknown,
 ): value is IterableIterator<unknown> {
   return (
-    _isObjectLike(value) && _toString.call(value) === "[object Set Iterator]"
+    isObjectLike(value) &&
+    value[Symbol.toStringTag] === "Set Iterator"
   );
 }
 
@@ -271,7 +297,7 @@ export function isSharedArrayBuffer(
 
 // deno-lint-ignore ban-types
 export function isStringObject(value: unknown): value is String {
-  if (!_isObjectLike(value)) {
+  if (!isObjectLike(value)) {
     return false;
   }
 
@@ -285,7 +311,7 @@ export function isStringObject(value: unknown): value is String {
 
 // deno-lint-ignore ban-types
 export function isSymbolObject(value: unknown): value is Symbol {
-  if (!_isObjectLike(value)) {
+  if (!isObjectLike(value)) {
     return false;
   }
 

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -82,7 +82,9 @@ const _getMapSize = Object.getOwnPropertyDescriptor(
   "size",
 )!.get!;
 
-const isObjectLike = (value: unknown): value is Record<string | number | symbol, unknown> =>
+const isObjectLike = (
+  value: unknown,
+): value is Record<string | number | symbol, unknown> =>
   value !== null && typeof value === "object";
 
 export function isAnyArrayBuffer(

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -31,7 +31,9 @@ const _isObjectLike = (value: unknown): boolean =>
 const _isFunctionLike = (value: unknown): boolean =>
   value !== null && typeof value === "function";
 
-export function isAnyArrayBuffer(value: unknown): boolean {
+export function isAnyArrayBuffer(
+  value: unknown,
+): value is ArrayBuffer | SharedArrayBuffer {
   return (
     _isObjectLike(value) &&
     (_toString.call(value) === "[object ArrayBuffer]" ||
@@ -39,27 +41,33 @@ export function isAnyArrayBuffer(value: unknown): boolean {
   );
 }
 
-export function isArgumentsObject(value: unknown): boolean {
+export function isArgumentsObject(value: unknown): value is IArguments {
   return _isObjectLike(value) && _toString.call(value) === "[object Arguments]";
 }
 
-export function isArrayBuffer(value: unknown): boolean {
+export function isArrayBuffer(value: unknown): value is ArrayBuffer {
   return (
     _isObjectLike(value) && _toString.call(value) === "[object ArrayBuffer]"
   );
 }
 
-export function isAsyncFunction(value: unknown): boolean {
+export function isAsyncFunction(
+  value: unknown,
+): value is (...args: unknown[]) => Promise<unknown> {
   return (
     _isFunctionLike(value) && _toString.call(value) === "[object AsyncFunction]"
   );
 }
 
-export function isBooleanObject(value: unknown): boolean {
+// deno-lint-ignore ban-types
+export function isBooleanObject(value: unknown): value is Boolean {
   return _isObjectLike(value) && _toString.call(value) === "[object Boolean]";
 }
 
-export function isBoxedPrimitive(value: unknown): boolean {
+export function isBoxedPrimitive(
+  value: unknown,
+  // deno-lint-ignore ban-types
+): value is Boolean | String | Number | Symbol | BigInt {
   return (
     isBooleanObject(value) ||
     isStringObject(value) ||
@@ -69,93 +77,112 @@ export function isBoxedPrimitive(value: unknown): boolean {
   );
 }
 
-export function isDataView(value: unknown): boolean {
+export function isDataView(value: unknown): value is DataView {
   return _isObjectLike(value) && _toString.call(value) === "[object DataView]";
 }
 
-export function isDate(value: unknown): boolean {
+export function isDate(value: unknown): value is Date {
   return _isObjectLike(value) && _toString.call(value) === "[object Date]";
 }
 
-export function isGeneratorFunction(value: unknown): boolean {
+export function isGeneratorFunction(
+  value: unknown,
+): value is GeneratorFunction {
   return (
     _isFunctionLike(value) &&
     _toString.call(value) === "[object GeneratorFunction]"
   );
 }
 
-export function isGeneratorObject(value: unknown): boolean {
+export function isGeneratorObject(value: unknown): value is Generator {
   return _isObjectLike(value) && _toString.call(value) === "[object Generator]";
 }
 
-export function isMap(value: unknown): boolean {
+export function isMap(value: unknown): value is Map<unknown, unknown> {
   return _isObjectLike(value) && _toString.call(value) === "[object Map]";
 }
 
-export function isMapIterator(value: unknown): boolean {
+export function isMapIterator(
+  value: unknown,
+): value is IterableIterator<[unknown, unknown]> {
   return (
     _isObjectLike(value) && _toString.call(value) === "[object Map Iterator]"
   );
 }
 
-export function isModuleNamespaceObject(value: unknown): boolean {
+export function isModuleNamespaceObject(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
   return _isObjectLike(value) && _toString.call(value) === "[object Module]";
 }
 
-export function isNativeError(value: unknown): boolean {
+export function isNativeError(value: unknown): value is Error {
   return _isObjectLike(value) && _toString.call(value) === "[object Error]";
 }
 
-export function isNumberObject(value: unknown): boolean {
+// deno-lint-ignore ban-types
+export function isNumberObject(value: unknown): value is Number {
   return _isObjectLike(value) && _toString.call(value) === "[object Number]";
 }
 
-export function isBigIntObject(value: unknown): boolean {
+export function isBigIntObject(value: unknown): value is BigInt {
   return _isObjectLike(value) && _toString.call(value) === "[object BigInt]";
 }
 
-export function isPromise(value: unknown): boolean {
+export function isPromise(value: unknown): value is Promise<unknown> {
   return _isObjectLike(value) && _toString.call(value) === "[object Promise]";
 }
 
-export function isProxy(value: unknown): boolean {
+export function isProxy(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
   return core.isProxy(value);
 }
 
-export function isRegExp(value: unknown): boolean {
+export function isRegExp(value: unknown): value is RegExp {
   return _isObjectLike(value) && _toString.call(value) === "[object RegExp]";
 }
 
-export function isSet(value: unknown): boolean {
+export function isSet(value: unknown): value is Set<unknown> {
   return _isObjectLike(value) && _toString.call(value) === "[object Set]";
 }
 
-export function isSetIterator(value: unknown): boolean {
+export function isSetIterator(
+  value: unknown,
+): value is IterableIterator<unknown> {
   return (
     _isObjectLike(value) && _toString.call(value) === "[object Set Iterator]"
   );
 }
 
-export function isSharedArrayBuffer(value: unknown): boolean {
+export function isSharedArrayBuffer(
+  value: unknown,
+): value is SharedArrayBuffer {
   return (
     _isObjectLike(value) &&
     _toString.call(value) === "[object SharedArrayBuffer]"
   );
 }
 
-export function isStringObject(value: unknown): boolean {
+// deno-lint-ignore ban-types
+export function isStringObject(value: unknown): value is String {
   return _isObjectLike(value) && _toString.call(value) === "[object String]";
 }
 
-export function isSymbolObject(value: unknown): boolean {
+// deno-lint-ignore ban-types
+export function isSymbolObject(value: unknown): value is Symbol {
   return _isObjectLike(value) && _toString.call(value) === "[object Symbol]";
 }
 
-export function isWeakMap(value: unknown): boolean {
+export function isWeakMap(
+  value: unknown,
+): value is WeakMap<Record<string | number | symbol, unknown>, unknown> {
   return _isObjectLike(value) && _toString.call(value) === "[object WeakMap]";
 }
 
-export function isWeakSet(value: unknown): boolean {
+export function isWeakSet(
+  value: unknown,
+): value is WeakSet<Record<string | number | symbol, unknown>> {
   return _isObjectLike(value) && _toString.call(value) === "[object WeakSet]";
 }
 

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -210,7 +210,7 @@ export function isNumberObject(value: unknown): value is Number {
 }
 
 export function isBigIntObject(value: unknown): value is BigInt {
-  if (_isObjectLike(value)) {
+  if (!_isObjectLike(value)) {
     return false;
   }
 


### PR DESCRIPTION
In accordance with the ECMAScript specification, internal slots are used for runtime type checking whenever possible.