### PR TITLE
feat(semver): Add support for build metadata

### DIFF
--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -4,7 +4,11 @@ import { assertEquals } from "../testing/asserts.ts";
 import * as semver from "./mod.ts";
 
 Deno.test("format", async (t) => {
-  const versions: [string, "release" | "prerelease" | "build" | "full" | undefined, string][] = [
+  const versions: [
+    string,
+    "release" | "prerelease" | "build" | "full" | undefined,
+    string,
+  ][] = [
     ["1.2.3", undefined, "1.2.3"],
     ["1.2.3", "release", "1.2.3"],
     ["1.2.3", "prerelease", "1.2.3"],
@@ -47,9 +51,9 @@ Deno.test("format", async (t) => {
       name: `format(${version} ${style} ${expected})`,
       fn: () => {
         const v = semver.parse(version)!;
-        const actual = v.format({ style })
+        const actual = v.format({ style });
         assertEquals(actual, expected);
-      }
-    })
+      },
+    });
   }
 });

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -1,0 +1,55 @@
+// Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../testing/asserts.ts";
+import * as semver from "./mod.ts";
+
+Deno.test("format", async (t) => {
+  const versions: [string, "release" | "prerelease" | "build" | "full" | undefined, string][] = [
+    ["1.2.3", undefined, "1.2.3"],
+    ["1.2.3", "release", "1.2.3"],
+    ["1.2.3", "prerelease", "1.2.3"],
+    ["1.2.3", "build", "1.2.3"],
+    ["1.2.3", "full", "1.2.3"],
+
+    ["1.2.3-pre", undefined, "1.2.3-pre"],
+    ["1.2.3-pre", "release", "1.2.3"],
+    ["1.2.3-pre", "prerelease", "1.2.3-pre"],
+    ["1.2.3-pre", "build", "1.2.3"],
+    ["1.2.3-pre", "full", "1.2.3-pre"],
+
+    ["1.2.3-pre.0", undefined, "1.2.3-pre.0"],
+    ["1.2.3-pre.0", "release", "1.2.3"],
+    ["1.2.3-pre.0", "prerelease", "1.2.3-pre.0"],
+    ["1.2.3-pre.0", "build", "1.2.3"],
+    ["1.2.3-pre.0", "full", "1.2.3-pre.0"],
+
+    ["1.2.3+b", undefined, "1.2.3"],
+    ["1.2.3+b", "release", "1.2.3"],
+    ["1.2.3+b", "prerelease", "1.2.3"],
+    ["1.2.3+b", "build", "1.2.3+b"],
+    ["1.2.3+b", "full", "1.2.3+b"],
+
+    ["1.2.3+b.0", undefined, "1.2.3"],
+    ["1.2.3+b.0", "release", "1.2.3"],
+    ["1.2.3+b.0", "prerelease", "1.2.3"],
+    ["1.2.3+b.0", "build", "1.2.3+b.0"],
+    ["1.2.3+b.0", "full", "1.2.3+b.0"],
+
+    ["1.2.3-pre.0+b.1", undefined, "1.2.3-pre.0"],
+    ["1.2.3-pre.0+b.1", "release", "1.2.3"],
+    ["1.2.3-pre.0+b.1", "prerelease", "1.2.3-pre.0"],
+    ["1.2.3-pre.0+b.1", "build", "1.2.3+b.1"],
+    ["1.2.3-pre.0+b.1", "full", "1.2.3-pre.0+b.1"],
+  ];
+
+  for (const [version, style, expected] of versions) {
+    await t.step({
+      name: `format(${version} ${style} ${expected})`,
+      fn: () => {
+        const v = semver.parse(version)!;
+        const actual = v.format({ style })
+        assertEquals(actual, expected);
+      }
+    })
+  }
+});

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -4,10 +4,10 @@ import { assertEquals, assertThrows } from "../testing/asserts.ts";
 import * as semver from "./mod.ts";
 import type { Options, ReleaseType } from "./mod.ts";
 
-Deno.test("increment", function () {
+Deno.test("increment", async (t) => {
   //  [version, inc, result, identifier]
   //  increment(version, inc) -> result
-  const versions: [string, ReleaseType, string | null, Options?, string?][] = [
+  const versions: [string, ReleaseType, string | null, Options?, string?, string?][] = [
     ["1.2.3", "major", "2.0.0"],
     ["1.2.3", "minor", "1.3.0"],
     ["1.2.3", "patch", "1.2.4"],
@@ -147,30 +147,44 @@ Deno.test("increment", function () {
     ["1.2.0-1", "minor", "1.2.0", undefined, "dev"],
     ["1.0.0-1", "major", "1.0.0", "dev" as Options],
     ["1.2.3-dev.bar", "prerelease", "1.2.3-dev.0", undefined, "dev"],
+
+    ["1.2.3+1", "major", "2.0.0", undefined, undefined, "2"],
+    ["1.2.3+1", "minor", "1.3.0", undefined, undefined, "2"],
+    ["1.2.3+1", "patch", "1.2.4", undefined, undefined, "2"],
+    ["1.2.3+1", "premajor", "2.0.0-0", undefined, undefined, "2"],
+    ["1.2.3+1", "preminor", "1.3.0-0", undefined, undefined, "2"],
+    ["1.2.3+1", "prepatch", "1.2.4-0", undefined, undefined, "2"],
+    ["1.2.3+1", "premajor", "2.0.0-dev.0", undefined, "dev", "2"],
+    ["1.2.3+1", "preminor", "1.3.0-dev.0", undefined, "dev", "2"],
+    ["1.2.3+1", "prepatch", "1.2.4-dev.0", undefined, "dev", "2"],
+    ["1.2.3", "pre", "1.2.3-pr123.0", undefined, "pr123", "1"],
+    ["1.2.3-pr123.0+1", "pre", "1.2.3-pr123.1", undefined, "pr123", "2"],
+    ["1.2.3-pr123.0+1", "pre", "1.2.3-pr123.1", undefined, "pr123", "a.b.c"],
   ];
 
-  versions.forEach(function (v) {
-    const pre = v[0];
-    const what = v[1];
-    const wanted = v[2];
-    const options = v[3];
-    const id = v[4];
-    const found = semver.increment(pre, what, options, id);
-    const cmd = "increment(" + pre + ", " + what + ", " + id + ")";
-    assertEquals(found, wanted, cmd + " === " + wanted);
+  for (const [pre, what, wanted, options, id, metadata] of versions) {
+    await t.step({
+      name: `${pre}, ${what}, ${id}, ${metadata}`,
+      fn: () => {
+        const found = semver.increment(pre, what, options, id);
+        const cmd = "increment(" + pre + ", " + what + ", " + id + ")";
+        assertEquals(found, wanted, cmd + " === " + wanted);
 
-    const parsed = semver.parse(pre, options);
-    if (wanted && parsed) {
-      //todo ?
-      parsed.increment(what, id);
-      assertEquals(parsed.version, wanted, cmd + " object version updated");
-      assertEquals(parsed.raw, wanted, cmd + " object raw field updated");
-    } else if (parsed) {
-      assertThrows(function () {
-        parsed.increment(what, id);
-      });
-    } else {
-      assertEquals(parsed, null);
-    }
-  });
+        const parsed = semver.parse(pre, options);
+        if (wanted && parsed) {
+          parsed.increment(what, id, metadata);
+          assertEquals(parsed.version, wanted, cmd + " object version updated");
+          assertEquals(parsed.raw, wanted, cmd + " object raw field updated");
+          assertEquals(parsed.build, metadata?.split('.') ?? [], cmd + " build updated");
+          assertEquals(parsed.format({ style: 'full' }), [parsed.version, metadata].filter(v => v).join('+'), cmd + " full version updated");
+        } else if (parsed) {
+          assertThrows(function () {
+            parsed.increment(what, id, metadata);
+          });
+        } else {
+          assertEquals(parsed, null);
+        }
+      }
+    });
+  }
 });

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -7,7 +7,14 @@ import type { Options, ReleaseType } from "./mod.ts";
 Deno.test("increment", async (t) => {
   //  [version, inc, result, identifier]
   //  increment(version, inc) -> result
-  const versions: [string, ReleaseType, string | null, Options?, string?, string?][] = [
+  const versions: [
+    string,
+    ReleaseType,
+    string | null,
+    Options?,
+    string?,
+    string?,
+  ][] = [
     ["1.2.3", "major", "2.0.0"],
     ["1.2.3", "minor", "1.3.0"],
     ["1.2.3", "patch", "1.2.4"],
@@ -175,8 +182,16 @@ Deno.test("increment", async (t) => {
           parsed.increment(what, id, metadata);
           assertEquals(parsed.version, wanted, cmd + " object version updated");
           assertEquals(parsed.raw, wanted, cmd + " object raw field updated");
-          assertEquals(parsed.build, metadata?.split('.') ?? [], cmd + " build updated");
-          assertEquals(parsed.format({ style: 'full' }), [parsed.version, metadata].filter(v => v).join('+'), cmd + " full version updated");
+          assertEquals(
+            parsed.build,
+            metadata?.split(".") ?? [],
+            cmd + " build updated",
+          );
+          assertEquals(
+            parsed.format({ style: "full" }),
+            [parsed.version, metadata].filter((v) => v).join("+"),
+            cmd + " full version updated",
+          );
         } else if (parsed) {
           assertThrows(function () {
             parsed.increment(what, id, metadata);
@@ -184,7 +199,7 @@ Deno.test("increment", async (t) => {
         } else {
           assertEquals(parsed, null);
         }
-      }
+      },
     });
   }
 });

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -542,29 +542,32 @@ export class SemVer {
     this.format();
   }
 
-  format(opts: { style?: "release" | "prerelease" | "build" | "full" } = {}): string {
+  format(
+    opts: { style?: "release" | "prerelease" | "build" | "full" } = {},
+  ): string {
     const { style } = opts;
 
     // todo: Consider a refactor of this class to have no side effects. Increment should return
     // a new SemVer instance with the new values. This would be a breaking change.
-    const release = this.version = this.major + "." + this.minor + "." + this.patch;
+    const release = this.version = this.major + "." + this.minor + "." +
+      this.patch;
     if (this.prerelease.length) {
       this.version += "-" + this.prerelease.join(".");
     }
 
     switch (style) {
       case "build":
-        return [release, this.build.join(".")].filter(v => v).join("+");
+        return [release, this.build.join(".")].filter((v) => v).join("+");
       case "full":
-        return [this.version, this.build.join(".")].filter(v => v).join("+");
+        return [this.version, this.build.join(".")].filter((v) => v).join("+");
       case "release":
         return release;
       case "prerelease":
-        return this.version
+        return this.version;
       default:
         // todo: Have this function return the full version by default. This would be a breaking change.
         // see this issue for discussion details https://github.com/denoland/deno_std/issues/3110
-        return this.version
+        return this.version;
     }
   }
 
@@ -645,7 +648,11 @@ export class SemVer {
     return 1;
   }
 
-  increment(release: ReleaseType, identifier?: string, metadata?: string): SemVer {
+  increment(
+    release: ReleaseType,
+    identifier?: string,
+    metadata?: string,
+  ): SemVer {
     switch (release) {
       case "premajor":
         this.prerelease.length = 0;

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -549,6 +549,7 @@ export class SemVer {
 
     // todo: Consider a refactor of this class to have no side effects. Increment should return
     // a new SemVer instance with the new values. This would be a breaking change.
+    // see https://github.com/denoland/deno_std/issues/3110 for discussion details
     const release = this.version = this.major + "." + this.minor + "." +
       this.patch;
     if (this.prerelease.length) {

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -542,12 +542,30 @@ export class SemVer {
     this.format();
   }
 
-  format(): string {
-    this.version = this.major + "." + this.minor + "." + this.patch;
+  format(opts: { style?: "release" | "prerelease" | "build" | "full" } = {}): string {
+    const { style } = opts;
+
+    // todo: Consider a refactor of this class to have no side effects. Increment should return
+    // a new SemVer instance with the new values. This would be a breaking change.
+    const release = this.version = this.major + "." + this.minor + "." + this.patch;
     if (this.prerelease.length) {
       this.version += "-" + this.prerelease.join(".");
     }
-    return this.version;
+
+    switch (style) {
+      case "build":
+        return [release, this.build.join(".")].filter(v => v).join("+");
+      case "full":
+        return [this.version, this.build.join(".")].filter(v => v).join("+");
+      case "release":
+        return release;
+      case "prerelease":
+        return this.version
+      default:
+        // todo: Have this function return the full version by default. This would be a breaking change.
+        // see this issue for discussion details https://github.com/denoland/deno_std/issues/3110
+        return this.version
+    }
   }
 
   compare(other: string | SemVer): 1 | 0 | -1 {
@@ -627,7 +645,7 @@ export class SemVer {
     return 1;
   }
 
-  increment(release: ReleaseType, identifier?: string): SemVer {
+  increment(release: ReleaseType, identifier?: string, metadata?: string): SemVer {
     switch (release) {
       case "premajor":
         this.prerelease.length = 0;
@@ -731,6 +749,7 @@ export class SemVer {
       default:
         throw new Error("invalid increment argument: " + release);
     }
+    this.build = metadata ? metadata.split(".") : this.build;
     this.format();
     this.raw = this.version;
     return this;


### PR DESCRIPTION
# Overview

Currently the build metadata is parsed but is not printed out in any form. A semver which is parsed will not be identical to 
the printed output:

```ts
console.log(semver.parse("1.2.3+4").format()) // 1.2.3
```

Additionally, once set, there is no way to alter the metadata on the SemVer instance without formatting into a new string and re-parsing:

```ts
const build = "5";
const v0 = semver.parse("1.2.3+4").increment("pre");
const v1 = semver.parse(`${v0}+${build}`);
```

Therefore this PR attempts to address these two issues with the following APIs:

1. Add a new, optional, options object parameter onto the `.format()` function which contains a single field `style`. The style will dictate the format of the _output_ of the function, it will not affect the format internal mutated fields `this.version` or `this.raw`, to preserve backwards compatibility and not require an extensive refactor.
2. The `.increment()` function will now have a new, optional, `metadata: string` parameter which will set the `this.build` field with the new metadata or reset it to empty. Incrementing with no build data will not retain the previous build metadata.

```ts
console.log(semver.parse("1.2.3+4").format({ style: "full" )) // 1.2.3+4

const build = "5";
const v0 = semver.parse("1.2.3+4").increment("pre", undefined, build);
console.log(v0.format({ style: "full" })) // 1.2.3-0+5
```

## Related To

* fixes https://github.com/denoland/deno_std/issues/3110
* replaces #3117
* related https://github.com/npm/node-semver/issues/174

### Notes
* According to the semver spec the build metadata must not be used during the comparison calculations. For this reason the internal `this.version` and `this.raw` fields are preserved as they were since those fields can be part of the comparison calculations. The only modifications are to the _output_ of the format function.
* Currently the parsing functions do actually _parse_ the build metadata correctly, so there was no need to modify this. It handles it safely it simply does not output it or support modification correctly.