### PR TITLE
fix(encoding/csv): Escape cells containing newlines

### DIFF
--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -25,7 +25,8 @@ export {
 export type { ReadOptions } from "./csv/_io.ts";
 
 const QUOTE = '"';
-export const NEWLINE = "\r\n";
+const LF = "\n";
+const CRLF = "\r\n";
 
 export class StringifyError extends Error {
   override readonly name = "StringifyError";
@@ -40,7 +41,7 @@ function getEscapedString(value: unknown, sep: string): string {
 
   // Is regex.test more performant here? If so, how to dynamically create?
   // https://stackoverflow.com/questions/3561493/
-  if (str.includes(sep) || str.includes(NEWLINE) || str.includes(QUOTE)) {
+  if (str.includes(sep) || str.includes(LF) || str.includes(QUOTE)) {
     return `${QUOTE}${str.replaceAll(QUOTE, `${QUOTE}${QUOTE}`)}${QUOTE}`;
   }
 
@@ -291,7 +292,7 @@ export function stringify(
   data: DataItem[],
   { headers = true, separator: sep = ",", columns = [] }: StringifyOptions = {},
 ): string {
-  if (sep.includes(QUOTE) || sep.includes(NEWLINE)) {
+  if (sep.includes(QUOTE) || sep.includes(CRLF)) {
     const message = [
       "Separator cannot include the following strings:",
       '  - U+0022: Quotation mark (")',
@@ -307,7 +308,7 @@ export function stringify(
     output += normalizedColumns
       .map((column) => getEscapedString(column.header, sep))
       .join(sep);
-    output += NEWLINE;
+    output += CRLF;
   }
 
   for (const item of data) {
@@ -315,7 +316,7 @@ export function stringify(
     output += values
       .map((value) => getEscapedString(value, sep))
       .join(sep);
-    output += NEWLINE;
+    output += CRLF;
   }
 
   return output;

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -5,13 +5,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals, assertThrows } from "../testing/asserts.ts";
-import {
-  NEWLINE,
-  parse,
-  ParseError,
-  stringify,
-  StringifyError,
-} from "./csv.ts";
+import { parse, ParseError, stringify, StringifyError } from "./csv.ts";
+
+const CRLF = "\r\n";
 
 Deno.test({
   name: "parse",
@@ -864,7 +860,7 @@ Deno.test({
         fn() {
           const columns: string[] = [];
           const data: string[][] = [];
-          const output = NEWLINE;
+          const output = CRLF;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -887,7 +883,7 @@ Deno.test({
         fn() {
           const columns = ["a"];
           const data: string[][] = [];
-          const output = `a${NEWLINE}`;
+          const output = `a${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -911,7 +907,7 @@ Deno.test({
         fn() {
           const columns = [0, 1];
           const data = [["foo", "bar"], ["baz", "qux"]];
-          const output = `0\r1${NEWLINE}foo\rbar${NEWLINE}baz\rqux${NEWLINE}`;
+          const output = `0\r1${CRLF}foo\rbar${CRLF}baz\rqux${CRLF}`;
           const options = { separator: "\r", columns };
           assertEquals(stringify(data, options), output);
         },
@@ -924,7 +920,7 @@ Deno.test({
         fn() {
           const columns = [0, 1];
           const data = [["foo", "bar"], ["baz", "qux"]];
-          const output = `0\n1${NEWLINE}foo\nbar${NEWLINE}baz\nqux${NEWLINE}`;
+          const output = `0\n1${CRLF}foo\nbar${CRLF}baz\nqux${CRLF}`;
           const options = { separator: "\n", columns };
           assertEquals(stringify(data, options), output);
         },
@@ -936,7 +932,7 @@ Deno.test({
         fn() {
           const columns = [1];
           const data = [{ 1: 1 }, { 1: 2 }];
-          const output = `1${NEWLINE}1${NEWLINE}2${NEWLINE}`;
+          const output = `1${CRLF}1${CRLF}2${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -948,7 +944,7 @@ Deno.test({
         fn() {
           const columns = [{ header: "Value", prop: "value" }];
           const data = [{ value: "foo" }, { value: "bar" }];
-          const output = `foo${NEWLINE}bar${NEWLINE}`;
+          const output = `foo${CRLF}bar${CRLF}`;
           const options = { headers: false, columns };
           assertEquals(stringify(data, options), output);
         },
@@ -960,7 +956,7 @@ Deno.test({
         fn() {
           const columns = [1];
           const data = [["key", "foo"], ["key", "bar"]];
-          const output = `1${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `1${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -972,7 +968,7 @@ Deno.test({
         fn() {
           const columns = [[1]];
           const data = [{ 1: 1 }, { 1: 2 }];
-          const output = `1${NEWLINE}1${NEWLINE}2${NEWLINE}`;
+          const output = `1${CRLF}1${CRLF}2${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -983,7 +979,7 @@ Deno.test({
         fn() {
           const columns = [[1]];
           const data = [["key", "foo"], ["key", "bar"]];
-          const output = `1${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `1${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -995,7 +991,7 @@ Deno.test({
         fn() {
           const columns = [[1, 1]];
           const data = [["key", ["key", "foo"]], ["key", ["key", "bar"]]];
-          const output = `1${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `1${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1006,7 +1002,7 @@ Deno.test({
         fn() {
           const columns = ["value"];
           const data = [{ value: "foo" }, { value: "bar" }];
-          const output = `value${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `value${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1017,7 +1013,7 @@ Deno.test({
         fn() {
           const columns = [["value"]];
           const data = [{ value: "foo" }, { value: "bar" }];
-          const output = `value${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `value${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1028,7 +1024,7 @@ Deno.test({
         fn() {
           const columns = [["msg", "value"]];
           const data = [{ msg: { value: "foo" } }, { msg: { value: "bar" } }];
-          const output = `value${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `value${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1044,7 +1040,7 @@ Deno.test({
             },
           ];
           const data = [{ msg: { value: "foo" } }, { msg: { value: "bar" } }];
-          const output = `Value${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `Value${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1057,7 +1053,7 @@ Deno.test({
           const columns = [0];
           const data = [[{ value: "foo" }], [{ value: "bar" }]];
           const output =
-            `0${NEWLINE}"{""value"":""foo""}"${NEWLINE}"{""value"":""bar""}"${NEWLINE}`;
+            `0${CRLF}"{""value"":""foo""}"${CRLF}"{""value"":""bar""}"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1072,7 +1068,7 @@ Deno.test({
             [[{ value: "baz" }, { value: "qux" }]],
           ];
           const output =
-            `0${NEWLINE}"[{""value"":""foo""},{""value"":""bar""}]"${NEWLINE}"[{""value"":""baz""},{""value"":""qux""}]"${NEWLINE}`;
+            `0${CRLF}"[{""value"":""foo""},{""value"":""bar""}]"${CRLF}"[{""value"":""baz""},{""value"":""qux""}]"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1084,7 +1080,7 @@ Deno.test({
           const columns = [0];
           const data = [[["foo", "bar"]], [["baz", "qux"]]];
           const output =
-            `0${NEWLINE}"[""foo"",""bar""]"${NEWLINE}"[""baz"",""qux""]"${NEWLINE}`;
+            `0${CRLF}"[""foo"",""bar""]"${CRLF}"[""baz"",""qux""]"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1097,7 +1093,7 @@ Deno.test({
           const columns = [0];
           const data = [[["foo", "bar"]], [["baz", "qux"]]];
           const output =
-            `0${NEWLINE}"[""foo"",""bar""]"${NEWLINE}"[""baz"",""qux""]"${NEWLINE}`;
+            `0${CRLF}"[""foo"",""bar""]"${CRLF}"[""baz"",""qux""]"${CRLF}`;
           const options = { separator: "\t", columns };
           assertEquals(stringify(data, options), output);
         },
@@ -1109,7 +1105,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[], []];
-          const output = `0${NEWLINE}${NEWLINE}${NEWLINE}`;
+          const output = `0${CRLF}${CRLF}${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1120,7 +1116,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[null], [null]];
-          const output = `0${NEWLINE}${NEWLINE}${NEWLINE}`;
+          const output = `0${CRLF}${CRLF}${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1131,7 +1127,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[0xa], [0xb]];
-          const output = `0${NEWLINE}10${NEWLINE}11${NEWLINE}`;
+          const output = `0${CRLF}10${CRLF}11${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1142,7 +1138,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[BigInt("1")], [BigInt("2")]];
-          const output = `0${NEWLINE}1${NEWLINE}2${NEWLINE}`;
+          const output = `0${CRLF}1${CRLF}2${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1153,7 +1149,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[true], [false]];
-          const output = `0${NEWLINE}true${NEWLINE}false${NEWLINE}`;
+          const output = `0${CRLF}true${CRLF}false${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1164,7 +1160,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo"], ["bar"]];
-          const output = `0${NEWLINE}foo${NEWLINE}bar${NEWLINE}`;
+          const output = `0${CRLF}foo${CRLF}bar${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1175,8 +1171,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[Symbol("foo")], [Symbol("bar")]];
-          const output =
-            `0${NEWLINE}Symbol(foo)${NEWLINE}Symbol(bar)${NEWLINE}`;
+          const output = `0${CRLF}Symbol(foo)${CRLF}Symbol(bar)${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1187,7 +1182,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [[(n: number) => n]];
-          const output = `0${NEWLINE}(n)=>n${NEWLINE}`;
+          const output = `0${CRLF}(n)=>n${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1198,7 +1193,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [['foo"']];
-          const output = `0${NEWLINE}"foo"""${NEWLINE}`;
+          const output = `0${CRLF}"foo"""${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1209,7 +1204,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo\r\n"]];
-          const output = `0${NEWLINE}"foo\r\n"${NEWLINE}`;
+          const output = `0${CRLF}"foo\r\n"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1220,7 +1215,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo\r"]];
-          const output = `0${NEWLINE}foo\r${NEWLINE}`;
+          const output = `0${CRLF}foo\r${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1231,7 +1226,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo\n"]];
-          const output = `0${NEWLINE}foo\n${NEWLINE}`;
+          const output = `0${CRLF}"foo\n"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1242,7 +1237,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo,"]];
-          const output = `0${NEWLINE}"foo,"${NEWLINE}`;
+          const output = `0${CRLF}"foo,"${CRLF}`;
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -1253,7 +1248,7 @@ Deno.test({
         fn() {
           const columns = [0];
           const data = [["foo,"]];
-          const output = `0${NEWLINE}foo,${NEWLINE}`;
+          const output = `0${CRLF}foo,${CRLF}`;
 
           const options = { separator: "\t", columns };
           assertEquals(stringify(data, options), output);
@@ -1264,7 +1259,7 @@ Deno.test({
       name: "Valid data, no columns",
       async fn() {
         const data = [[1, 2, 3], [4, 5, 6]];
-        const output = `${NEWLINE}1,2,3${NEWLINE}4,5,6${NEWLINE}`;
+        const output = `${CRLF}1,2,3${CRLF}4,5,6${CRLF}`;
 
         assertEquals(await stringify(data), output);
       },


### PR DESCRIPTION
Escapes CSV cells containing newlines, so that they can be displayed correctly when opened in MS Excel.

**Old behavior:**

```js
stringify([['(1)\n(2)', '(3)']], { headers: false })
// => (1)\n(2),(3)\r\n
```

**New behavior:**

```js
stringify([['(1)\n(2)', '(3)']], { headers: false })
// => "(1)\n(2)",(3)\r\n
```

Note that this PR does _not_ normalize newlines within cells, so this results in a file with plain LFs within a cell but CRLFs delimiting rows. I'd argue that this doesn't constitute inconsistent line endings, as only the end-of-row ones are really "line endings" within the context of the file. In any case, the user can normalize the text within cells however they wish, if necessary.

Note also that this doesn't resolve all MS Excel compatibility issues — for files containing Unicode text, a BOM (`U+FEFF`) still needs to be prepended to force encoding to UTF-8. However, that's out of the scope of this PR.

I've changed the name of ~~the exported~~ `const NEWLINE`, which is used in testing, to `CRLF` ("newline" typically refers to LF, i.e. `\n`). Almost all changed lines within `encoding/csv_test.ts` are due to this change — the only substantive change to a test is "Value with LF":

```diff
  await t.step(
    {
      name: "Value with LF",
      fn() {
        const columns = [0];
        const data = [["foo\n"]];
-       const output = `0${CRLF}foo\n${CRLF}`;
+       const output = `0${CRLF}"foo\n"${CRLF}`;
        assertEquals(stringify(data, { columns }), output);
      },
    },
  );
```
