### PR TITLE
feat(encoding/csv): handle CSV byte-order marks

### DIFF
--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -27,6 +27,7 @@ export type { ReadOptions } from "./csv/_io.ts";
 const QUOTE = '"';
 const LF = "\n";
 const CRLF = "\r\n";
+const BYTE_ORDER_MARK = "\ufeff";
 
 export class StringifyError extends Error {
   override readonly name = "StringifyError";
@@ -225,6 +226,15 @@ export type StringifyOptions = {
    * name for the column.
    */
   columns?: Column[];
+  /**
+   * Whether to add a
+   * [byte-order mark](https://en.wikipedia.org/wiki/Byte_order_mark) to the
+   * beginning of the file content. Required by software such as MS Excel to
+   * properly display Unicode text.
+   *
+   * @default {false}
+   */
+  bom?: boolean;
 };
 
 /**
@@ -290,7 +300,8 @@ export type StringifyOptions = {
  */
 export function stringify(
   data: DataItem[],
-  { headers = true, separator: sep = ",", columns = [] }: StringifyOptions = {},
+  { headers = true, separator: sep = ",", columns = [], bom = false }:
+    StringifyOptions = {},
 ): string {
   if (sep.includes(QUOTE) || sep.includes(CRLF)) {
     const message = [
@@ -303,6 +314,10 @@ export function stringify(
 
   const normalizedColumns = columns.map(normalizeColumn);
   let output = "";
+
+  if (bom) {
+    output += BYTE_ORDER_MARK;
+  }
 
   if (headers) {
     output += normalizedColumns

--- a/encoding/csv/_parser.ts
+++ b/encoding/csv/_parser.ts
@@ -9,6 +9,8 @@ import {
   ReadOptions,
 } from "./_io.ts";
 
+const BYTE_ORDER_MARK = "\ufeff";
+
 export class Parser {
   #input = "";
   #cursor = 0;
@@ -225,7 +227,7 @@ export class Parser {
     return result;
   }
   parse(input: string): string[][] {
-    this.#input = input;
+    this.#input = input.startsWith(BYTE_ORDER_MARK) ? input.slice(1) : input;
     this.#cursor = 0;
     const result: string[][] = [];
     let _nbFields: number | undefined;

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -4,10 +4,16 @@
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "../testing/asserts.ts";
 import { parse, ParseError, stringify, StringifyError } from "./csv.ts";
 
 const CRLF = "\r\n";
+const BYTE_ORDER_MARK = "\ufeff";
 
 Deno.test({
   name: "parse",
@@ -766,6 +772,52 @@ Deno.test({
         );
       },
     });
+    await t.step({
+      name: "Strips leading byte-order mark with bare cell",
+      fn() {
+        const input = `${BYTE_ORDER_MARK}abc`;
+        const output = [["abc"]];
+        assert(!JSON.stringify(output).includes(BYTE_ORDER_MARK));
+        assertEquals(parse(input), output);
+      },
+    });
+    await t.step({
+      name: "Strips leading byte-order mark with quoted cell",
+      fn() {
+        const input = `${BYTE_ORDER_MARK}"a""b"`;
+        const output = [['a"b']];
+        assert(!JSON.stringify(output).includes(BYTE_ORDER_MARK));
+        assertEquals(parse(input), output);
+      },
+    });
+    await t.step({
+      name: "Does not strip byte-order mark after position [0]",
+      fn() {
+        const input = `a${BYTE_ORDER_MARK}bc`;
+        const output = [[`a${BYTE_ORDER_MARK}bc`]];
+        assertEquals(parse(input), output);
+      },
+    });
+    await t.step({
+      name:
+        "trimLeadingSpace strips leading byte-order mark followed by whitespace",
+      fn() {
+        const input = `${BYTE_ORDER_MARK} abc`;
+        const output = [["abc"]];
+        assertEquals(parse(input, { trimLeadingSpace: true }), output);
+      },
+    });
+    await t.step({
+      // This behavior is due to String#trimStart including U+FEFF in the set of
+      // characters to be trimmed
+      name:
+        "trimLeadingSpace strips leading whitespace followed by byte-order mark",
+      fn() {
+        const input = ` ${BYTE_ORDER_MARK}abc`;
+        const output = [["abc"]];
+        assertEquals(parse(input, { trimLeadingSpace: true }), output);
+      },
+    });
   },
 });
 
@@ -1257,12 +1309,48 @@ Deno.test({
     );
     await t.step({
       name: "Valid data, no columns",
-      async fn() {
+      fn() {
         const data = [[1, 2, 3], [4, 5, 6]];
         const output = `${CRLF}1,2,3${CRLF}4,5,6${CRLF}`;
 
-        assertEquals(await stringify(data), output);
+        assertEquals(stringify(data), output);
       },
     });
+    await t.step(
+      {
+        name: "byte-order mark with bom=true",
+        fn() {
+          const data = [["abc"]];
+          const output = `${BYTE_ORDER_MARK}abc${CRLF}`;
+          const options = { headers: false, bom: true };
+          assertStringIncludes(stringify(data, options), BYTE_ORDER_MARK);
+          assertEquals(stringify(data, options), output);
+        },
+      },
+    );
+    await t.step(
+      {
+        name: "no byte-order mark with omitted bom option",
+        fn() {
+          const data = [["abc"]];
+          const output = `abc${CRLF}`;
+          const options = { headers: false };
+          assert(!stringify(data, options).includes(BYTE_ORDER_MARK));
+          assertEquals(stringify(data, options), output);
+        },
+      },
+    );
+    await t.step(
+      {
+        name: "no byte-order mark with bom=false",
+        fn() {
+          const data = [["abc"]];
+          const output = `abc${CRLF}`;
+          const options = { headers: false, bom: false };
+          assert(!stringify(data, options).includes(BYTE_ORDER_MARK));
+          assertEquals(stringify(data, options), output);
+        },
+      },
+    );
   },
 });


### PR DESCRIPTION
* Adds a `bom` option to CSV `StringifyOptions`, which prepends `U+FEFF` ([BOM/byte-order mark](https://en.wikipedia.org/wiki/Byte_order_mark)) to the output
* Automatically strips leading BOM when parsing CSVs, even if `trimLeadingSpace` option is not set

This is largely for compatibility with MS Excel's handling of CSV files containing Unicode text:
* When opening a CSV file with no BOM, Excel assumes the encoding is some ANSI encoding (Windows-1252?), rather than anything sensible like UTF-8. As a result, a UTF-8 file containing `文,字\r\n` is displayed as `æ–‡ å­—`, rather than the expected `文 字`.
* When opening a CSV file with a UTF-8 BOM, Excel correctly treats it as UTF-8.
* When using "Save As", you're given multiple CSV options:
   - The first is "CSV UTF-8", which adds a BOM.
   - The second, a ways down the list, is simply called "CSV". This doesn't add a BOM and instead transforms all non-Windows-1252 characters into question marks, permanently corrupting the file without warning.
   - There are also options for Macintosh and MS-DOS, which I haven't looked into what they do as they seem pretty niche.

For comparison, Google Sheets:
* When opening a UTF-8 CSV file with no BOM, Google Sheets correctly treats it as UTF-8.
* When opening a CSV file with a UTF-8 BOM, Google Sheets correctly treats it as UTF-8. However, when re-saving, it omits the BOM, which limits interoperability with Excel.

The _current_ behavior of `std/encoding/csv` is to treat the BOM as a literal character when reading and always omit it when writing. This PR makes the new default behavior the same as what Google Sheets does (at least for UTF-8 files) — read either with or without BOM, but still always omit BOM when writing. Alternatively, by supplying the new `bom: true` option to `stringify`, a BOM is also prepended when writing.

For completeness, some other possible behaviors could be:
* Only truncate BOM on parsing if a specific option is supplied (`trimLeadingSpace` or a dedicated `trimBom` option). This seems like a bad idea, as certain valid UTF-8 CSVs generated by Excel would cause a parser error (e.g. `${BYTE_ORDER_MARK}"a""b"\r\n`), while others would contain invalid data in the first cell (e.g. `` /\D/.test(parse(`${BYTE_ORDER_MARK}123\r\n`)[0][0]) == true ``).
* Default `bom` in `StringifyOptions` to `true`. Advantage would be ensuring round-trip compatibility with Excel given default options. However, that would be a breaking change, plus it seems uncalled for to choose a default solely due to Excel's bad behavior.
* Automatically detect whether to prepend a BOM based on whether the input contains non-Windows-1252 characters. Significant additional complexity, potential performance cost, plus hard-to-reason-about "magic" behavior.