### PR TITLE
refactor(node): allow partial availability of Deno.core

### DIFF
--- a/node/_core.ts
+++ b/node/_core.ts
@@ -7,7 +7,7 @@
 // usages.
 
 // deno-lint-ignore no-explicit-any
-export let core: any;
+let DenoCore: any;
 
 // deno-lint-ignore no-explicit-any
 const { Deno } = globalThis as any;
@@ -15,63 +15,67 @@ const { Deno } = globalThis as any;
 // @ts-ignore Deno.core is not defined in types
 if (Deno?.[Deno.internal]?.core) {
   // @ts-ignore Deno[Deno.internal].core is not defined in types
-  core = Deno[Deno.internal].core;
+  DenoCore = Deno[Deno.internal].core;
 } else if (Deno?.core) {
   // @ts-ignore Deno.core is not defined in types
-  core = Deno.core;
+  DenoCore = Deno.core;
 } else {
-  core = {
-    runMicrotasks() {
-      throw new Error(
-        "Deno.core.runMicrotasks() is not supported in this environment",
-      );
-    },
-    setHasTickScheduled() {
-      throw new Error(
-        "Deno.core.setHasTickScheduled() is not supported in this environment",
-      );
-    },
-    hasTickScheduled() {
-      throw new Error(
-        "Deno.core.hasTickScheduled() is not supported in this environment",
-      );
-    },
-    setNextTickCallback: undefined,
-    setMacrotaskCallback() {
-      throw new Error(
-        "Deno.core.setNextTickCallback() is not supported in this environment",
-      );
-    },
-    evalContext(_code: string, _filename: string) {
+  DenoCore = {};
+}
+
+export const core = {
+  runMicrotasks: DenoCore.runMicrotasks ?? function () {
+    throw new Error(
+      "Deno.core.runMicrotasks() is not supported in this environment",
+    );
+  },
+  setHasTickScheduled: DenoCore.setHasTickScheduled ?? function () {
+    throw new Error(
+      "Deno.core.setHasTickScheduled() is not supported in this environment",
+    );
+  },
+  hasTickScheduled: DenoCore.hasTickScheduled ?? function () {
+    throw new Error(
+      "Deno.core.hasTickScheduled() is not supported in this environment",
+    );
+  },
+  setNextTickCallback: DenoCore.setNextTickCallback ?? undefined,
+  setMacrotaskCallback: DenoCore.setMacrotaskCallback ?? function () {
+    throw new Error(
+      "Deno.core.setNextTickCallback() is not supported in this environment",
+    );
+  },
+  evalContext: DenoCore.evalContext ??
+    function (_code: string, _filename: string) {
       throw new Error(
         "Deno.core.evalContext is not supported in this environment",
       );
     },
-    encode(chunk: string): Uint8Array {
-      return new TextEncoder().encode(chunk);
-    },
-    eventLoopHasMoreWork(): boolean {
-      return false;
-    },
-    isProxy(): boolean {
-      return false;
-    },
-    getPromiseDetails(_promise: Promise<unknown>): [number, unknown] {
+  encode: DenoCore.encode ?? function (chunk: string): Uint8Array {
+    return new TextEncoder().encode(chunk);
+  },
+  eventLoopHasMoreWork: DenoCore.eventLoopHasMoreWork ?? function (): boolean {
+    return false;
+  },
+  isProxy: DenoCore.isProxy ?? function (): boolean {
+    return false;
+  },
+  getPromiseDetails: DenoCore.getPromiseDetails ??
+    function (_promise: Promise<unknown>): [number, unknown] {
       throw new Error(
         "Deno.core.getPromiseDetails is not supported in this environment",
       );
     },
-    setPromiseHooks() {
+  setPromiseHooks: DenoCore.setPromiseHooks ?? function () {
+    throw new Error(
+      "Deno.core.setPromiseHooks is not supported in this environment",
+    );
+  },
+  ops: DenoCore.ops ?? {
+    op_napi_open(_filename: string) {
       throw new Error(
-        "Deno.core.setPromiseHooks is not supported in this environment",
+        "Node API is not supported in this environment",
       );
     },
-    ops: {
-      op_napi_open(_filename: string) {
-        throw new Error(
-          "Node API is not supported in this environment",
-        );
-      },
-    },
-  };
-}
+  },
+};


### PR DESCRIPTION
This change allows to only a part of `Deno.core` namespace to be available,
while still missing some APIs. This is needed for `AsyncLocalStorage` polyfill
in Deno Deploy.