### PR TITLE
fix(node): disable worker_threads

### DIFF
--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -51,6 +51,7 @@ class _Worker extends EventEmitter {
     if (options?.eval === true) {
       specifier = `data:text/javascript,${specifier}`;
     } else if (typeof specifier === "string") {
+      // @ts-ignore This API is temporarily disabled
       specifier = toFileUrl(resolve(specifier));
     }
     const handle = this[kHandle] = new Worker(

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -3,9 +3,9 @@
 
 import { resolve, toFileUrl } from "../path/mod.ts";
 import { notImplemented } from "./_utils.ts";
-import { EventEmitter, once } from "./events.ts";
+import { EventEmitter } from "./events.ts";
 
-let environmentData = new Map();
+const environmentData = new Map();
 let threads = 0;
 
 export interface WorkerOptions {
@@ -46,6 +46,7 @@ class _Worker extends EventEmitter {
   postMessage: Worker["postMessage"];
 
   constructor(specifier: URL | string, options?: WorkerOptions) {
+    notImplemented("Worker");
     super();
     if (options?.eval === true) {
       specifier = `data:text/javascript,${specifier}`;
@@ -103,8 +104,8 @@ export const resourceLimits = isMainThread ? {} : {
   stackSizeMb: 4,
 };
 
-let threadId = 0;
-let workerData: unknown = null;
+const threadId = 0;
+const workerData: unknown = null;
 
 // Like https://github.com/nodejs/node/blob/48655e17e1d84ba5021d7a94b4b88823f7c9c6cf/lib/internal/event_target.js#L611
 interface NodeEventTarget extends
@@ -127,8 +128,9 @@ interface NodeEventTarget extends
 type ParentPort = typeof self & NodeEventTarget;
 
 // deno-lint-ignore no-explicit-any
-let parentPort: ParentPort = null as any;
+const parentPort: ParentPort = null as any;
 
+/*
 if (!isMainThread) {
   // deno-lint-ignore no-explicit-any
   delete (globalThis as any).name;
@@ -185,12 +187,15 @@ if (!isMainThread) {
     parentPort.emit("close");
   });
 }
+*/
 
 export function getEnvironmentData(key: unknown) {
+  notImplemented("getEnvironmentData");
   return environmentData.get(key);
 }
 
 export function setEnvironmentData(key: unknown, value?: unknown) {
+  notImplemented("setEnvironmentData");
   if (value === undefined) {
     environmentData.delete(key);
   } else {

--- a/node/worker_threads_test.ts
+++ b/node/worker_threads_test.ts
@@ -6,6 +6,7 @@ import * as workerThreads from "./worker_threads.ts";
 
 Deno.test({
   name: "[worker_threads] isMainThread",
+  ignore: true,
   fn() {
     assertEquals(workerThreads.isMainThread, true);
   },
@@ -13,6 +14,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] threadId",
+  ignore: true,
   fn() {
     assertEquals(workerThreads.threadId, 0);
   },
@@ -20,6 +22,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] resourceLimits",
+  ignore: true,
   fn() {
     assertObjectMatch(workerThreads.resourceLimits, {});
   },
@@ -27,6 +30,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] parentPort",
+  ignore: true,
   fn() {
     assertEquals(workerThreads.parentPort, null);
   },
@@ -34,6 +38,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] workerData",
+  ignore: true,
   fn() {
     assertEquals(workerThreads.workerData, null);
   },
@@ -41,6 +46,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] setEnvironmentData / getEnvironmentData",
+  ignore: true,
   fn() {
     workerThreads.setEnvironmentData("test", "test");
     assertEquals(workerThreads.getEnvironmentData("test"), "test");
@@ -52,6 +58,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] Worker threadId",
+  ignore: true,
   async fn() {
     const worker = new workerThreads.Worker(
       new URL("./testdata/worker_threads.ts", import.meta.url),
@@ -73,6 +80,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] Worker basics",
+  ignore: true,
   async fn() {
     workerThreads.setEnvironmentData("test", "test");
     workerThreads.setEnvironmentData(1, {
@@ -109,6 +117,7 @@ const workerThreadsURL = JSON.stringify(
 
 Deno.test({
   name: "[worker_threads] Worker eval",
+  ignore: true,
   async fn() {
     const worker = new workerThreads.Worker(
       `
@@ -126,6 +135,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] inheritences",
+  ignore: true,
   async fn() {
     const eventsURL = JSON.stringify(
       new URL("./events.ts", import.meta.url).toString(),
@@ -152,6 +162,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] Worker workerData",
+  ignore: true,
   async fn() {
     const worker = new workerThreads.Worker(
       new URL("./testdata/worker_threads.ts", import.meta.url),
@@ -176,6 +187,7 @@ Deno.test({
 
 Deno.test({
   name: "[worker_threads] Worker with relative path",
+  ignore: true,
   async fn() {
     const worker = new workerThreads.Worker(relative(
       Deno.cwd(),


### PR DESCRIPTION
This is a blocker for embedding `std/node` in the Deno binary: https://github.com/denoland/deno/pull/16748

When trying to get rid of Top-Level Await we found out that this module is buggy, because it behaves differently
depending if user import `worker_threads` module inside the worker or not. Disabling it temporarily to enable 
embedding std/node in the binary. We'll revisit it after that PR lands.