### PR TITLE
fix: make encoding/front_matter work in a browser

### DIFF
--- a/encoding/front_matter/mod.ts
+++ b/encoding/front_matter/mod.ts
@@ -212,7 +212,7 @@ function createRegExp(...dv: Delimiter[]): [RegExp, RegExp] {
     "$([\\s\\S]+?)" +
     "^(?:" + dv.map(getEndToken).join("|") + ")\\s*" +
     "$" +
-    (Deno.build.os === "windows" ? "\\r?" : "") +
+    (globalThis?.Deno?.build?.os === "windows" ? "\\r?" : "") +
     "(?:\\n)?)";
 
   return [

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -10,12 +10,13 @@ import { _exiting } from "./exiting.ts";
 
 /** Returns the operating system CPU architecture for which the Deno binary was compiled */
 function _arch(): string {
-  if (Deno.build.arch == "x86_64") {
+  if (globalThis?.Deno?.build?.arch == "x86_64") {
     return "x64";
-  } else if (Deno.build.arch == "aarch64") {
+  } else if (globalThis?.Deno?.build?.arch == "aarch64") {
     return "arm64";
   } else {
-    throw Error("unreachable");
+    console.error("unrecognized architecture");
+    return "unknown";
   }
 }
 

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -24,10 +24,10 @@ function _arch(): string {
 export const arch = _arch();
 
 /** https://nodejs.org/api/process.html#process_process_chdir_directory */
-export const chdir = Deno.chdir;
+export const chdir = globalThis?.Deno?.chdir;
 
 /** https://nodejs.org/api/process.html#process_process_cwd */
-export const cwd = Deno.cwd;
+export const cwd = globalThis?.Deno?.cwd;
 
 /** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
 export const nextTick = _nextTick;

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -88,7 +88,7 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
   });
 
 /** https://nodejs.org/api/process.html#process_process_pid */
-export const pid = Deno.pid;
+export const pid = globalThis?.Deno?.pid;
 
 /** https://nodejs.org/api/process.html#process_process_platform */
 export const platform = isWindows ? "win32" : Deno.build.os;
@@ -128,5 +128,5 @@ export const versions = {
   unicode: "14.0",
   ngtcp2: "0.8.1",
   nghttp3: "0.7.0",
-  ...Deno.version,
+  ...globalThis?.Deno?.version,
 };

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -91,14 +91,14 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
 export const pid = globalThis?.Deno?.pid;
 
 /** https://nodejs.org/api/process.html#process_process_platform */
-export const platform = isWindows ? "win32" : Deno.build.os;
+export const platform = isWindows ? "win32" : globalThis?.Deno?.build?.os;
 
 /**
  * https://nodejs.org/api/process.html#process_process_version
  *
  * This value is hard coded to latest stable release of Node, as
  * some packages are checking it for compatibility. Previously
- * it pointed to Deno version, but that led to incompability
+ * it pointed to Deno version, but that led to incompatibility
  * with some packages.
  */
 export const version = "v18.12.1";
@@ -108,7 +108,7 @@ export const version = "v18.12.1";
  *
  * This value is hard coded to latest stable release of Node, as
  * some packages are checking it for compatibility. Previously
- * it contained only output of `Deno.version`, but that led to incompability
+ * it contained only output of `Deno.version`, but that led to incompatibility
  * with some packages. Value of `v8` field is still taken from `Deno.version`.
  */
 export const versions = {

--- a/node/internal/constants.ts
+++ b/node/internal/constants.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
-const isWindows = Deno.build.os === "windows";
+const isWindows = globalThis?.Deno?.build?.os === "windows";
 
 // Alphabet chars.
 export const CHAR_UPPERCASE_A = 65; /* A */

--- a/node/internal_binding/constants.ts
+++ b/node/internal_binding/constants.ts
@@ -195,7 +195,7 @@ let os: {
   UV_UDP_IPV6ONLY?: number;
   UV_UDP_REUSEADDR: number;
 };
-if (Deno.build.os === "darwin") {
+if (globalThis?.Deno?.build?.os === "darwin") {
   os = {
     UV_UDP_REUSEADDR: 4,
     dlopen: {
@@ -327,7 +327,7 @@ if (Deno.build.os === "darwin") {
       PRIORITY_HIGHEST: -20,
     },
   };
-} else if (Deno.build.os === "linux") {
+} else if (globalThis?.Deno?.build?.os === "linux") {
   os = {
     UV_UDP_REUSEADDR: 4,
     dlopen: {


### PR DESCRIPTION
This PR ensures that encoding/front_matter can work in a browser context by accessing the Deno namespace safely.