### PR TITLE
fix: make encoding/front_matter work in a browser

### DIFF
--- a/encoding/front_matter/mod.ts
+++ b/encoding/front_matter/mod.ts
@@ -212,7 +212,7 @@ function createRegExp(...dv: Delimiter[]): [RegExp, RegExp] {
     "$([\\s\\S]+?)" +
     "^(?:" + dv.map(getEndToken).join("|") + ")\\s*" +
     "$" +
-    (Deno.build.os === "windows" ? "\\r?" : "") +
+    (globalThis?.Deno?.build?.os === "windows" ? "\\r?" : "") +
     "(?:\\n)?)";
 
   return [


### PR DESCRIPTION
This safely access the Deno namespace so encoding/front_matter can be used in a browser (like an interactive island in Fresh).