### PR TITLE
test(encoding): re-enable csv stream leak test on non-windows

### DIFF
--- a/encoding/csv/stream_test.ts
+++ b/encoding/csv/stream_test.ts
@@ -308,18 +308,19 @@ export const MyTextDecoderStream = () => {
   });
 };
 
-// This test is flaky. See https://github.com/denoland/deno_std/issues/3160
-//
-// Deno.test({
-//   name:
-//     "[encoding/csv/stream] cancel CsvStream during iteration does not leak file",
-//   permissions: { read: [testdataDir] },
-//   fn: async () => {
-//     const file = await Deno.open(join(testdataDir, "large.csv"));
-//     const readable = file.readable.pipeThrough(MyTextDecoderStream())
-//       .pipeThrough(new CsvStream());
-//     for await (const _record of readable) {
-//       break;
-//     }
-//   },
-// });
+Deno.test({
+  name:
+    "[encoding/csv/stream] cancel CsvStream during iteration does not leak file",
+  permissions: { read: [testdataDir] },
+  // TODO(kt3k): Enable this test on windows.
+  // See https://github.com/denoland/deno_std/issues/3160
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const file = await Deno.open(join(testdataDir, "large.csv"));
+    const readable = file.readable.pipeThrough(MyTextDecoderStream())
+      .pipeThrough(new CsvStream());
+    for await (const _record of readable) {
+      break;
+    }
+  },
+});


### PR DESCRIPTION
This PR re-enables the test case `[encoding/csv/stream] cancel CsvStream during iteration does not leak file` on non-windows platforms.