### PR TITLE
fix(node/events): do not reference global process

### DIFF
--- a/node/_events.mjs
+++ b/node/_events.mjs
@@ -32,6 +32,8 @@ import {
   ERR_OUT_OF_RANGE,
   ERR_UNHANDLED_ERROR,
 } from "./internal/errors.ts";
+import { nextTick } from "./_next_tick.ts";
+import { processHolder } from "./_process_holder.ts";
 
 import {
   validateAbortSignal,
@@ -203,7 +205,7 @@ function addCatch(that, promise, type, args) {
       then.call(promise, undefined, function (err) {
         // The callback is called with nextTick to avoid a follow-up
         // rejection from this promise.
-        process.nextTick(emitUnhandledRejectionOrErr, that, err, type, args);
+        nextTick(emitUnhandledRejectionOrErr, that, err, type, args);
       });
     }
   } catch (err) {
@@ -461,7 +463,7 @@ function _addListener(target, type, listener, prepend) {
       w.emitter = target;
       w.type = type;
       w.count = existing.length;
-      process.emitWarning(w);
+      processHolder.process?.emitWarning(w);
     }
   }
 

--- a/node/_process_holder.ts
+++ b/node/_process_holder.ts
@@ -1,0 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore no-explicit-any
+export const processHolder: { process?: any } = { process: undefined };

--- a/node/process.ts
+++ b/node/process.ts
@@ -43,6 +43,7 @@ import {
 } from "./_process/streams.mjs";
 import { core } from "./_core.ts";
 import { processTicksAndRejections } from "./_next_tick.ts";
+import { processHolder } from "./_process_holder.ts";
 
 // TODO(kt3k): Give better types to stdio objects
 // deno-lint-ignore no-explicit-any
@@ -703,3 +704,5 @@ export default process;
 //Remove on 1.0
 //Kept for backwards compatibility with std
 export { process };
+
+processHolder.process = process;


### PR DESCRIPTION
supersedes #3156
closes #3155 

This PR replaces the references to global `process` with local references. (Also introduces `processHolder` object to avoid circular dependencies)