### PR TITLE
csv: rename bom to byteOrderMark

### DIFF
--- a/encoding/csv.ts
+++ b/encoding/csv.ts
@@ -234,7 +234,7 @@ export type StringifyOptions = {
    *
    * @default {false}
    */
-  bom?: boolean;
+  byteOrderMark?: boolean;
 };
 
 /**
@@ -300,7 +300,7 @@ export type StringifyOptions = {
  */
 export function stringify(
   data: DataItem[],
-  { headers = true, separator: sep = ",", columns = [], bom = false }:
+  { headers = true, separator: sep = ",", columns = [], byteOrderMark = false }:
     StringifyOptions = {},
 ): string {
   if (sep.includes(QUOTE) || sep.includes(CRLF)) {
@@ -315,7 +315,7 @@ export function stringify(
   const normalizedColumns = columns.map(normalizeColumn);
   let output = "";
 
-  if (bom) {
+  if (byteOrderMark) {
     output += BYTE_ORDER_MARK;
   }
 

--- a/encoding/csv_test.ts
+++ b/encoding/csv_test.ts
@@ -1318,11 +1318,11 @@ Deno.test({
     });
     await t.step(
       {
-        name: "byte-order mark with bom=true",
+        name: "byte-order mark with byteOrderMark=true",
         fn() {
           const data = [["abc"]];
           const output = `${BYTE_ORDER_MARK}abc${CRLF}`;
-          const options = { headers: false, bom: true };
+          const options = { headers: false, byteOrderMark: true };
           assertStringIncludes(stringify(data, options), BYTE_ORDER_MARK);
           assertEquals(stringify(data, options), output);
         },
@@ -1342,11 +1342,11 @@ Deno.test({
     );
     await t.step(
       {
-        name: "no byte-order mark with bom=false",
+        name: "no byte-order mark with byteOrderMark=false",
         fn() {
           const data = [["abc"]];
           const output = `abc${CRLF}`;
-          const options = { headers: false, bom: false };
+          const options = { headers: false, byteOrderMark: false };
           assert(!stringify(data, options).includes(BYTE_ORDER_MARK));
           assertEquals(stringify(data, options), output);
         },


### PR DESCRIPTION
- rename `bom` option to `byteOrderMark` for more clarity