### PR TITLE
fix(node/fs): chmod function throws unnecessary TypeError on Windows

### DIFF
--- a/node/_fs/_fs_chmod.ts
+++ b/node/_fs/_fs_chmod.ts
@@ -12,7 +12,18 @@ export function chmod(
   callback: CallbackWithError,
 ) {
   path = getValidatedPath(path).toString();
-  mode = parseFileMode(mode, "mode");
+
+  try {
+    mode = parseFileMode(mode, "mode");
+  } catch (error) {
+    // TODO(PolarETech): Errors should not be ignored when Deno.chmod is supported on Windows.
+    // https://github.com/denoland/deno_std/issues/2916
+    if (Deno.build.os === "windows") {
+      mode = 0; // set dummy value to avoid type checking error at Deno.chmod
+    } else {
+      throw error;
+    }
+  }
 
   Deno.chmod(pathModule.toNamespacedPath(path), mode).catch((error) => {
     // Ignore NotSupportedError that occurs on windows
@@ -33,7 +44,18 @@ export const chmodPromise = promisify(chmod) as (
 
 export function chmodSync(path: string | URL, mode: string | number) {
   path = getValidatedPath(path).toString();
-  mode = parseFileMode(mode, "mode");
+
+  try {
+    mode = parseFileMode(mode, "mode");
+  } catch (error) {
+    // TODO(PolarETech): Errors should not be ignored when Deno.chmodSync is supported on Windows.
+    // https://github.com/denoland/deno_std/issues/2916
+    if (Deno.build.os === "windows") {
+      mode = 0; // set dummy value to avoid type checking error at Deno.chmodSync
+    } else {
+      throw error;
+    }
+  }
 
   try {
     Deno.chmodSync(pathModule.toNamespacedPath(path), mode);

--- a/node/_fs/_fs_chmod_test.ts
+++ b/node/_fs/_fs_chmod_test.ts
@@ -35,6 +35,23 @@ Deno.test({
 });
 
 Deno.test({
+  name: "ASYNC: don't throw errors for mode parameter (Windows)",
+  ignore: !isWindows,
+  async fn() {
+    const tempFile: string = await Deno.makeTempFile();
+    await new Promise<void>((resolve, reject) => {
+      // @ts-ignore for test
+      chmod(tempFile, null, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    }).finally(() => {
+      Deno.removeSync(tempFile);
+    });
+  },
+});
+
+Deno.test({
   name: "ASYNC: don't throw NotSupportedError (Windows)",
   ignore: !isWindows,
   async fn() {
@@ -77,6 +94,20 @@ Deno.test({
       const newFileMode: number | null = Deno.lstatSync(tempFile).mode;
       assert(newFileMode && originalFileMode);
       assert(newFileMode === 33279 && newFileMode > originalFileMode);
+    } finally {
+      Deno.removeSync(tempFile);
+    }
+  },
+});
+
+Deno.test({
+  name: "SYNC: don't throw errors for mode parameter (Windows)",
+  ignore: !isWindows,
+  fn() {
+    const tempFile: string = Deno.makeTempFileSync();
+    try {
+      // @ts-ignore for test
+      chmodSync(tempFile, null);
     } finally {
       Deno.removeSync(tempFile);
     }


### PR DESCRIPTION
Fixes: #2916
Part of: #3149

This PR fixes an error that occurs when an invalid value is unintentionally passed to the `mode` parameter of the `chmod` and `chmodSync` functions on Windows.
This change will make `npm:fs-extra.copy()` work on Windows.

___NOTE: This change must be reverted if `Deno.chmod` and `Deno.chmodSync` were supported on Windows.___
