### PR TITLE
refactor(node): move std/_util usages to node/_util

### DIFF
--- a/node/_crypto/crypto_browserify/asn1.js/base/node.js
+++ b/node/_crypto/crypto_browserify/asn1.js/base/node.js
@@ -3,7 +3,7 @@
 
 import { Reporter } from "./reporter.js";
 import { DecoderBuffer, EncoderBuffer } from "./buffer.js";
-import { assert } from "../../../../../_util/asserts.ts";
+import { assert } from "../../../../_util/asserts.ts";
 
 // Supported tags
 const tags = [

--- a/node/_fs/_fs_dir.ts
+++ b/node/_fs/_fs_dir.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import Dirent from "./_fs_dirent.ts";
-import { assert } from "../../_util/asserts.ts";
+import { assert } from "../_util/asserts.ts";
 import { ERR_MISSING_ARGS } from "../internal/errors.ts";
 
 export default class Dir {

--- a/node/_fs/_fs_writeFile.ts
+++ b/node/_fs/_fs_writeFile.ts
@@ -11,7 +11,7 @@ import {
   isFileOptions,
   WriteFileOptions,
 } from "./_fs_common.ts";
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 import { AbortError, denoErrorToNodeError } from "../internal/errors.ts";
 import {
   showStringCoercionDeprecation,

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -4,7 +4,7 @@
 // The following are all the process APIs that don't depend on the stream module
 // They have to be split this way to prevent a circular dependency
 
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 import { nextTick as _nextTick } from "../_next_tick.ts";
 import { _exiting } from "./exiting.ts";
 

--- a/node/_util/asserts.ts
+++ b/node/_util/asserts.ts
@@ -1,0 +1,21 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+/** Assertion error class for node compat layer's internal code. */
+export class NodeCompatAssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NodeCompatAssertionError";
+  }
+}
+
+/** Make an assertion, if not `true`, then throw. */
+export function assert(expr: unknown, msg = ""): asserts expr {
+  if (!expr) {
+    throw new NodeCompatAssertionError(msg);
+  }
+}
+
+/** Use this to assert unreachable code. */
+export function unreachable(): never {
+  throw new NodeCompatAssertionError("unreachable");
+}

--- a/node/_util/os.ts
+++ b/node/_util/os.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+export type OSType = "windows" | "linux" | "darwin" | "freebsd";
+
+export const osType: OSType = (() => {
+  // deno-lint-ignore no-explicit-any
+  const { Deno } = globalThis as any;
+  if (typeof Deno?.build?.os === "string") {
+    return Deno.build.os;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const { navigator } = globalThis as any;
+  if (navigator?.appVersion?.includes?.("Win")) {
+    return "windows";
+  }
+
+  return "linux";
+})();
+
+export const isWindows = osType === "windows";
+export const isLinux = osType === "linux";

--- a/node/internal/child_process.ts
+++ b/node/internal/child_process.ts
@@ -2,13 +2,13 @@
 
 // This module implements 'child_process' module of Node.JS API.
 // ref: https://nodejs.org/api/child_process.html
-import { assert } from "../../_util/asserts.ts";
+import { assert } from "../_util/asserts.ts";
 import { EventEmitter } from "../events.ts";
 import { os } from "../internal_binding/constants.ts";
 import { notImplemented, warnNotImplemented } from "../_utils.ts";
 import { Readable, Stream, Writable } from "../stream.ts";
 import { deferred } from "../../async/deferred.ts";
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 import { nextTick } from "../_next_tick.ts";
 import {
   AbortError,

--- a/node/internal/errors.ts
+++ b/node/internal/errors.ts
@@ -20,8 +20,8 @@ import {
   errorMap,
   mapSysErrnoToUvErrno,
 } from "../internal_binding/uv.ts";
-import { assert } from "../../_util/asserts.ts";
-import { isWindows } from "../../_util/os.ts";
+import { assert } from "../_util/asserts.ts";
+import { isWindows } from "../_util/os.ts";
 import { os as osConstants } from "../internal_binding/constants.ts";
 const {
   errno: { ENOTDIR, ENOENT },

--- a/node/internal/fs/utils.mjs
+++ b/node/internal/fs/utils.mjs
@@ -36,7 +36,7 @@ const kStats = Symbol("stats");
 import assert from "../assert.mjs";
 import { lstat, lstatSync } from "../../_fs/_fs_lstat.ts";
 import { stat, statSync } from "../../_fs/_fs_stat.ts";
-import { isWindows } from "../../../_util/os.ts";
+import { isWindows } from "../../_util/os.ts";
 import process from "../../process.ts";
 
 import {

--- a/node/internal_binding/cares_wrap.ts
+++ b/node/internal_binding/cares_wrap.ts
@@ -30,7 +30,7 @@ import { codeMap } from "./uv.ts";
 import { AsyncWrap, providerType } from "./async_wrap.ts";
 import { ares_strerror } from "./ares.ts";
 import { notImplemented } from "../_utils.ts";
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 
 interface LookupAddress {
   address: string;

--- a/node/internal_binding/handle_wrap.ts
+++ b/node/internal_binding/handle_wrap.ts
@@ -24,7 +24,7 @@
 // - https://github.com/nodejs/node/blob/master/src/handle_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/handle_wrap.h
 
-import { unreachable } from "../../_util/asserts.ts";
+import { unreachable } from "../_util/asserts.ts";
 import { AsyncWrap, providerType } from "./async_wrap.ts";
 
 export class HandleWrap extends AsyncWrap {

--- a/node/internal_binding/node_file.ts
+++ b/node/internal_binding/node_file.ts
@@ -25,7 +25,7 @@
 // - https://github.com/nodejs/node/blob/master/src/node_file.cc
 // - https://github.com/nodejs/node/blob/master/src/node_file.h
 
-import { assert } from "../../_util/asserts.ts";
+import { assert } from "../_util/asserts.ts";
 
 /**
  * Write to the given file from the given buffer synchronously.

--- a/node/internal_binding/pipe_wrap.ts
+++ b/node/internal_binding/pipe_wrap.ts
@@ -25,7 +25,7 @@
 // - https://github.com/nodejs/node/blob/master/src/pipe_wrap.h
 
 import { notImplemented } from "../_utils.ts";
-import { unreachable } from "../../_util/asserts.ts";
+import { unreachable } from "../_util/asserts.ts";
 import { ConnectionWrap } from "./connection_wrap.ts";
 import { AsyncWrap, providerType } from "./async_wrap.ts";
 import { LibuvStreamWrap } from "./stream_wrap.ts";
@@ -37,7 +37,7 @@ import {
   INITIAL_ACCEPT_BACKOFF_DELAY,
   MAX_ACCEPT_BACKOFF_DELAY,
 } from "./_listen.ts";
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 import { fs } from "./constants.ts";
 
 export enum socketType {

--- a/node/internal_binding/tcp_wrap.ts
+++ b/node/internal_binding/tcp_wrap.ts
@@ -25,7 +25,7 @@
 // - https://github.com/nodejs/node/blob/master/src/tcp_wrap.h
 
 import { notImplemented } from "../_utils.ts";
-import { unreachable } from "../../_util/asserts.ts";
+import { unreachable } from "../_util/asserts.ts";
 import { ConnectionWrap } from "./connection_wrap.ts";
 import { AsyncWrap, providerType } from "./async_wrap.ts";
 import { LibuvStreamWrap } from "./stream_wrap.ts";

--- a/node/internal_binding/udp_wrap.ts
+++ b/node/internal_binding/udp_wrap.ts
@@ -30,7 +30,7 @@ import { Buffer } from "../buffer.ts";
 import type { ErrnoException } from "../internal/errors.ts";
 import { isIP } from "../internal/net.ts";
 
-import { isLinux, isWindows } from "../../_util/os.ts";
+import { isLinux, isWindows } from "../_util/os.ts";
 
 // @ts-ignore Deno[Deno.internal] is used on purpose here
 const DenoListenDatagram = Deno[Deno.internal]?.nodeUnstable?.listenDatagram ||

--- a/node/internal_binding/uv.ts
+++ b/node/internal_binding/uv.ts
@@ -26,8 +26,8 @@
 //
 // See also: http://docs.libuv.org/en/v1.x/errors.html#error-constants
 
-import { unreachable } from "../../_util/asserts.ts";
-import { osType } from "../../_util/os.ts";
+import { unreachable } from "../_util/asserts.ts";
+import { osType } from "../_util/os.ts";
 import { uvTranslateSysError } from "./_libuv_winerror.ts";
 
 // In Node these values are coming from libuv:

--- a/node/module.ts
+++ b/node/module.ts
@@ -27,9 +27,9 @@ import nodeMods from "./module_all.ts";
 import upstreamMods from "./upstream_modules.ts";
 
 import * as path from "../path/mod.ts";
-import { assert } from "../_util/asserts.ts";
+import { assert } from "./_util/asserts.ts";
 import { fileURLToPath, pathToFileURL } from "./url.ts";
-import { isWindows } from "../_util/os.ts";
+import { isWindows } from "./_util/os.ts";
 import {
   ERR_INVALID_MODULE_SPECIFIER,
   ERR_MODULE_NOT_FOUND,

--- a/node/net.ts
+++ b/node/net.ts
@@ -87,8 +87,8 @@ import {
   PipeConnectWrap,
 } from "./internal_binding/pipe_wrap.ts";
 import { ShutdownWrap } from "./internal_binding/stream_wrap.ts";
-import { assert } from "../_util/asserts.ts";
-import { isWindows } from "../_util/os.ts";
+import { assert } from "./_util/asserts.ts";
+import { isWindows } from "./_util/os.ts";
 import { ADDRCONFIG, lookup as dnsLookup } from "./dns.ts";
 import { codeMap } from "./internal_binding/uv.ts";
 import { guessHandleType } from "./internal_binding/util.ts";

--- a/node/os.ts
+++ b/node/os.ts
@@ -24,7 +24,7 @@ import { notImplemented } from "./_utils.ts";
 import { validateIntegerRange } from "./_utils.ts";
 import { EOL as fsEOL } from "../fs/eol.ts";
 import process from "./process.ts";
-import { isWindows, osType } from "../_util/os.ts";
+import { isWindows, osType } from "./_util/os.ts";
 import { os } from "./internal_binding/constants.ts";
 
 export const constants = os;

--- a/node/path/glob.ts
+++ b/node/path/glob.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { isWindows, osType } from "../../_util/os.ts";
+import { isWindows, osType } from "../_util/os.ts";
 import { SEP, SEP_PATTERN } from "./separator.ts";
 import * as _win32 from "./win32.ts";
 import * as _posix from "./posix.ts";
-import type { OSType } from "../../_util/os.ts";
+import type { OSType } from "../_util/os.ts";
 
 const path = isWindows ? _win32 : _posix;
 const { join, normalize } = path;

--- a/node/path/mod.ts
+++ b/node/path/mod.ts
@@ -2,7 +2,7 @@
 // Ported mostly from https://github.com/browserify/path-browserify/
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 import _win32 from "./win32.ts";
 import _posix from "./posix.ts";
 

--- a/node/path/separator.ts
+++ b/node/path/separator.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { isWindows } from "../../_util/os.ts";
+import { isWindows } from "../_util/os.ts";
 
 export const SEP = isWindows ? "\\" : "/";
 export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;

--- a/node/path/win32.ts
+++ b/node/path/win32.ts
@@ -19,7 +19,7 @@ import {
   isWindowsDeviceRoot,
   normalizeString,
 } from "./_util.ts";
-import { assert } from "../../_util/asserts.ts";
+import { assert } from "../_util/asserts.ts";
 
 export const sep = "\\";
 export const delimiter = ";";

--- a/node/process.ts
+++ b/node/process.ts
@@ -10,7 +10,7 @@ import {
   errnoException,
 } from "./internal/errors.ts";
 import { getOptionValue } from "./internal/options.ts";
-import { assert } from "../_util/asserts.ts";
+import { assert } from "./_util/asserts.ts";
 import { fromFileUrl, join } from "../path/mod.ts";
 import {
   arch,

--- a/node/url.ts
+++ b/node/url.ts
@@ -73,7 +73,7 @@ import {
   toASCII,
   toUnicode,
 } from "./internal/idna.ts";
-import { isWindows, osType } from "../_util/os.ts";
+import { isWindows, osType } from "./_util/os.ts";
 import { encodeStr, hexTable } from "./internal/querystring.ts";
 import querystring from "./querystring.ts";
 import type { ParsedUrlQuery, ParsedUrlQueryInput } from "./querystring.ts";


### PR DESCRIPTION
part of #3171 

This PR moves the references to `std/_util` to `node/_util` (by creating copies of `_util/asserts.ts` and `_util/os.ts` in `node/_util`)

(Note: this reduces the number of outside imports from `std/node` to `std` from 70 to 40.)