### PR TITLE
refactor(node): replace std/path references from std/node

### DIFF
--- a/node/_crypto/crypto_browserify/browserify_aes/test/test.js
+++ b/node/_crypto/crypto_browserify/browserify_aes/test/test.js
@@ -9,7 +9,7 @@ import {
   assertEquals,
   assertThrows,
 } from "../../../../../testing/asserts.ts";
-import { fromFileUrl } from "../../../../../path/mod.ts";
+import { fromFileUrl } from "../../../../path.ts";
 import * as crypto from "../mod.js";
 import { MODES } from "../modes/mod.js";
 const CIPHERS = Object.keys(MODES);

--- a/node/_fs/_fs_chmod.ts
+++ b/node/_fs/_fs_chmod.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import type { CallbackWithError } from "./_fs_common.ts";
 import { getValidatedPath } from "../internal/fs/utils.mjs";
-import * as pathModule from "../../path/mod.ts";
+import * as pathModule from "../path.ts";
 import { parseFileMode } from "../internal/validators.mjs";
 import { Buffer } from "../buffer.ts";
 import { promisify } from "../internal/util.mjs";

--- a/node/_fs/_fs_chown.ts
+++ b/node/_fs/_fs_chown.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { type CallbackWithError, makeCallback } from "./_fs_common.ts";
 import { getValidatedPath, kMaxUserId } from "../internal/fs/utils.mjs";
-import * as pathModule from "../../path/mod.ts";
+import * as pathModule from "../path.ts";
 import { validateInteger } from "../internal/validators.mjs";
 import type { Buffer } from "../buffer.ts";
 import { promisify } from "../internal/util.mjs";

--- a/node/_module/cjs/test_cjs_import.js
+++ b/node/_module/cjs/test_cjs_import.js
@@ -1,4 +1,4 @@
-import * as path from "../../../path/mod.ts";
+import * as path from "../../path.ts";
 import Module from "../../module.ts";
 
 const modulePath = path.join(

--- a/node/module.ts
+++ b/node/module.ts
@@ -26,7 +26,7 @@ import { core } from "./_core.ts";
 import nodeMods from "./module_all.ts";
 import upstreamMods from "./upstream_modules.ts";
 
-import * as path from "../path/mod.ts";
+import * as path from "./path.ts";
 import { assert } from "../_util/asserts.ts";
 import { fileURLToPath, pathToFileURL } from "./url.ts";
 import { isWindows } from "../_util/os.ts";

--- a/node/process.ts
+++ b/node/process.ts
@@ -11,7 +11,7 @@ import {
 } from "./internal/errors.ts";
 import { getOptionValue } from "./internal/options.ts";
 import { assert } from "../_util/asserts.ts";
-import { fromFileUrl, join } from "../path/mod.ts";
+import { fromFileUrl, join } from "./path.ts";
 import {
   arch,
   chdir,

--- a/node/testdata/child_process_unref.js
+++ b/node/testdata/child_process_unref.js
@@ -1,5 +1,5 @@
 import cp from "../child_process.ts";
-import * as path from "../../path/mod.ts";
+import * as path from "../path.ts";
 
 const script = path.join(
   path.dirname(path.fromFileUrl(import.meta.url)),

--- a/node/worker_threads.ts
+++ b/node/worker_threads.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
-import { resolve, toFileUrl } from "../path/mod.ts";
+import { resolve, toFileUrl } from "./path.ts";
 import { notImplemented } from "./_utils.ts";
 import { EventEmitter } from "./events.ts";
 


### PR DESCRIPTION
This PR replaces `std/path` references from `std/node` with `node/path` references

part of #3171 

(Note: This reduces outside reference count from 70 to 63)