### PR TITLE
refactor(node): replace std/fmt usages in std/node

### DIFF
--- a/node/_util/strip_color.ts
+++ b/node/_util/strip_color.ts
@@ -1,0 +1,18 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// https://github.com/chalk/ansi-regex/blob/02fa893d619d3da85411acc8fd4e2eea0e95a9d9/index.js
+const ANSI_PATTERN = new RegExp(
+  [
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+  ].join("|"),
+  "g",
+);
+
+/**
+ * Remove ANSI escape codes from the string.
+ * @param string to remove ANSI escape codes from
+ */
+export function stripColor(string: string): string {
+  return string.replace(ANSI_PATTERN, "");
+}

--- a/node/assertion_error.ts
+++ b/node/assertion_error.ts
@@ -22,7 +22,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import { inspect } from "./util.ts";
-import { stripColor as removeColors } from "../fmt/colors.ts";
+import { stripColor as removeColors } from "./_util/strip_color.ts";
 
 function getConsoleWidth(): number {
   try {

--- a/node/internal/util/debuglog.ts
+++ b/node/internal/util/debuglog.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
-import { sprintf } from "../../../fmt/printf.ts";
 import { inspect } from "./inspect.mjs";
 
 // `debugImpls` and `testEnabled` are deliberately not initialized so any call
@@ -47,7 +46,7 @@ function debuglogImpl(
       emitWarningIfNeeded(set);
       debugImpls[set] = function debug(...args: unknown[]) {
         const msg = args.map((arg) => inspect(arg)).join(" ");
-        console.error(sprintf("%s %s: %s", set, String(Deno.pid), msg));
+        console.error("%s %s: %s", set, String(Deno.pid), msg);
       };
     } else {
       debugImpls[set] = noop;


### PR DESCRIPTION
This PR replaces `std/fmt` usages in `std/node`.

part of #3171 