### PR TITLE
fix(node): do not ask env permission from process.env access

### DIFF
--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -34,11 +34,11 @@ export const nextTick = _nextTick;
 /** Wrapper of Deno.env.get, which doesn't throw type error when
  * the env name has "=" or "\0" in it. */
 function denoEnvGet(name: string) {
-  // Returns silently undefined if the env permission is unavailable
-  if (
-    Deno.permissions.querySync({ name: "env", variable: name }).state !==
-      "granted"
-  ) {
+  const perm =
+    Deno.permissions.querySync?.({ name: "env", variable: name }).state ??
+      "granted"; // for Deno Deploy
+  // Returns undefined if the env permission is unavailable
+  if (perm !== "granted") {
     return undefined;
   }
   try {

--- a/node/_process/process.ts
+++ b/node/_process/process.ts
@@ -34,6 +34,13 @@ export const nextTick = _nextTick;
 /** Wrapper of Deno.env.get, which doesn't throw type error when
  * the env name has "=" or "\0" in it. */
 function denoEnvGet(name: string) {
+  // Returns silently undefined if the env permission is unavailable
+  if (
+    Deno.permissions.querySync({ name: "env", variable: name }).state !==
+      "granted"
+  ) {
+    return undefined;
+  }
   try {
     return Deno.env.get(name);
   } catch (e) {

--- a/node/process_test.ts
+++ b/node/process_test.ts
@@ -293,13 +293,9 @@ Deno.test({
   fn() {
     Deno.env.set("FOO", "1");
     assert("FOO" in process.env);
-    assertThrows(() => {
-      "BAR" in process.env;
-    });
+    assertFalse("BAR" in process.env);
     assert(Object.hasOwn(process.env, "FOO"));
-    assertThrows(() => {
-      Object.hasOwn(process.env, "BAR");
-    });
+    assertFalse(Object.hasOwn(process.env, "BAR"));
   },
 });
 


### PR DESCRIPTION
This PR changes the behavior of `process.env`. Now the property access doesn't ask env permission, but works as if the env var is not set.

This reduces the number of env permission prompts when using npm modules