### PR TITLE
feat(http/file_server): etag value falls back to `DENO_DEPLOYMENT_ID` if `fileInfo.mtime` is not available

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -24,13 +24,13 @@ interface EntryInfo {
   name: string;
 }
 
+const encoder = new TextEncoder();
 const envPermissionStatus =
   Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
     .state ?? "granted"; // for deno deploy
-const DENO_DEPLOYMENT_ID = envPermissionStatus === "granted"
-  ? Deno.env.get("DENO_DEPLOYMENT_ID")
+const hashedDenoDeploymentId = envPermissionStatus === "granted"
+  ? toHashString(encoder.encode(Deno.env.get("DENO_DEPLOYMENT_ID")))
   : undefined;
-const encoder = new TextEncoder();
 
 function modeToString(isDir: boolean, maybeMode: number | null): string {
   const modeMap = ["---", "--x", "-w-", "-wx", "r--", "r-x", "rw-", "rwx"];
@@ -132,7 +132,7 @@ export async function serveFile(
         `${fileInfo.mtime.toJSON()}${fileInfo.size}`,
       ),
     )
-    : DENO_DEPLOYMENT_ID;
+    : hashedDenoDeploymentId;
 
   // Set last modified header if last modification timestamp is available
   if (fileInfo.mtime) {

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -150,12 +150,11 @@ export async function serveFile(
     const ifNoneMatch = req.headers.get("if-none-match");
     const ifModifiedSince = req.headers.get("if-modified-since");
     if (
-      (etag && ifNoneMatch && compareEtag(ifNoneMatch, etag)) || (
-        ifNoneMatch === null &&
+      (etag && ifNoneMatch && compareEtag(ifNoneMatch, etag)) ||
+      (ifNoneMatch === null &&
         fileInfo.mtime &&
         ifModifiedSince &&
-        fileInfo.mtime.getTime() < new Date(ifModifiedSince).getTime() + 1000
-      )
+        fileInfo.mtime.getTime() < new Date(ifModifiedSince).getTime() + 1000)
     ) {
       file.close();
 

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -24,11 +24,13 @@ interface EntryInfo {
   name: string;
 }
 
-const DENO_DEPLOYMENT_ID =
-  Deno.permissions.querySync({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
-      .state === "granted"
-    ? Deno.env.get("DENO_DEPLOYMENT_ID")
-    : undefined;
+const envPermissionStatus = await Deno.permissions.query({
+  name: "env",
+  variable: "DENO_DEPLOYMENT_ID",
+});
+const DENO_DEPLOYMENT_ID = envPermissionStatus.state === "granted"
+  ? Deno.env.get("DENO_DEPLOYMENT_ID")
+  : undefined;
 const encoder = new TextEncoder();
 
 function modeToString(isDir: boolean, maybeMode: number | null): string {

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -24,11 +24,10 @@ interface EntryInfo {
   name: string;
 }
 
-const envPermissionStatus = await Deno.permissions.query({
-  name: "env",
-  variable: "DENO_DEPLOYMENT_ID",
-});
-const DENO_DEPLOYMENT_ID = envPermissionStatus.state === "granted"
+const envPermissionStatus =
+  Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
+    .state ?? "granted"; // for deno deploy
+const DENO_DEPLOYMENT_ID = envPermissionStatus === "granted"
   ? Deno.env.get("DENO_DEPLOYMENT_ID")
   : undefined;
 const encoder = new TextEncoder();

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1110,7 +1110,11 @@ Deno.test(
 Deno.test(
   "file_server `serveFile` etag value falls back to DENO_DEPLOYMENT_ID if fileInfo.mtime is not available",
   async () => {
+    const encoder = new TextEncoder();
     const testDenoDeploymentId = "__THIS_IS_DENO_DEPLOYMENT_ID__";
+    const hashedDenoDeploymentId = toHashString(
+      encoder.encode(testDenoDeploymentId),
+    );
     // deno-fmt-ignore
     const code = `
       import { serveFile } from "${import.meta.resolve("./file_server.ts")}";
@@ -1121,7 +1125,7 @@ Deno.test(
       fileInfo.mtime = null;
       const req = new Request("http://localhost:4507/testdata/test file.txt");
       const res = await serveFile(req, fromFileUrl(testdataPath), { fileInfo });
-      assertEquals(res.headers.get("etag"), "${testDenoDeploymentId}");
+      assertEquals(res.headers.get("etag"), "${hashedDenoDeploymentId}");
     `;
     const command = new Deno.Command(Deno.execPath(), {
       args: ["eval", code],

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1110,10 +1110,9 @@ Deno.test(
 Deno.test(
   "file_server `serveFile` etag value falls back to DENO_DEPLOYMENT_ID if fileInfo.mtime is not available",
   async () => {
-    const encoder = new TextEncoder();
     const testDenoDeploymentId = "__THIS_IS_DENO_DEPLOYMENT_ID__";
     const hashedDenoDeploymentId = toHashString(
-      encoder.encode(testDenoDeploymentId),
+      await createHash("FNV32A", testDenoDeploymentId),
     );
     // deno-fmt-ignore
     const code = `


### PR DESCRIPTION
close #3182 

some questions:

- Now always fallback to `DENO_DEPLOYMENT_ID`. Should this be optionally configurable?
    ```ts
    interface ServeDirOptions {
      etagFallbackToDenoDeploymentId?: boolean; // default is true
    }
    // or
    interface ServeDirOptions {
      defaultEtag?: string; // default value is Deno.env.get("DENO_DEPLOYMENT_ID")
    }
    ````


Note: This PR is not necessary if https://github.com/denoland/deploy_feedback/issues/334 is expected to be resolved soon. If so, feel free to close this.