### PR TITLE
fix: change `BigInt` type to `bigint` type

### DIFF
--- a/encoding/varint/mod.ts
+++ b/encoding/varint/mod.ts
@@ -84,7 +84,7 @@ export function decodeU32(val: Uint8Array): number {
  * console.log(decodedValue === 25565n);
  * ```
  */
-export function decodeU64(val: Uint8Array): BigInt {
+export function decodeU64(val: Uint8Array): bigint {
   if (val.length > 10) throw RangeError("Too many bytes");
   const wasm = instantiate();
   try {

--- a/node/_fs/_fs_stat.ts
+++ b/node/_fs/_fs_stat.ts
@@ -82,42 +82,42 @@ export type BigIntStats = {
   /** ID of the device containing the file.
    *
    * _Linux/Mac OS only._ */
-  dev: BigInt | null;
+  dev: bigint | null;
   /** Inode number.
    *
    * _Linux/Mac OS only._ */
-  ino: BigInt | null;
+  ino: bigint | null;
   /** **UNSTABLE**: Match behavior with Go on Windows for `mode`.
    *
    * The underlying raw `st_mode` bits that contain the standard Unix
    * permissions for this file/directory. */
-  mode: BigInt | null;
+  mode: bigint | null;
   /** Number of hard links pointing to this file.
    *
    * _Linux/Mac OS only._ */
-  nlink: BigInt | null;
+  nlink: bigint | null;
   /** User ID of the owner of this file.
    *
    * _Linux/Mac OS only._ */
-  uid: BigInt | null;
+  uid: bigint | null;
   /** Group ID of the owner of this file.
    *
    * _Linux/Mac OS only._ */
-  gid: BigInt | null;
+  gid: bigint | null;
   /** Device ID of this file.
    *
    * _Linux/Mac OS only._ */
-  rdev: BigInt | null;
+  rdev: bigint | null;
   /** The size of the file, in bytes. */
-  size: BigInt;
+  size: bigint;
   /** Blocksize for filesystem I/O.
    *
    * _Linux/Mac OS only._ */
-  blksize: BigInt | null;
+  blksize: bigint | null;
   /** Number of blocks allocated to the file, in 512-byte units.
    *
    * _Linux/Mac OS only._ */
-  blocks: BigInt | null;
+  blocks: bigint | null;
   /** The last modification time of the file. This corresponds to the `mtime`
    * field from `stat` on Linux/Mac OS and `ftLastWriteTime` on Windows. This
    * may not be available on all platforms. */
@@ -133,21 +133,21 @@ export type BigIntStats = {
   /** change time */
   ctime: Date | null;
   /** atime in milliseconds */
-  atimeMs: BigInt | null;
+  atimeMs: bigint | null;
   /** atime in milliseconds */
-  mtimeMs: BigInt | null;
+  mtimeMs: bigint | null;
   /** atime in milliseconds */
-  ctimeMs: BigInt | null;
+  ctimeMs: bigint | null;
   /** atime in nanoseconds */
-  birthtimeMs: BigInt | null;
+  birthtimeMs: bigint | null;
   /** atime in nanoseconds */
-  atimeNs: BigInt | null;
+  atimeNs: bigint | null;
   /** atime in nanoseconds */
-  mtimeNs: BigInt | null;
+  mtimeNs: bigint | null;
   /** atime in nanoseconds */
-  ctimeNs: BigInt | null;
+  ctimeNs: bigint | null;
   /** atime in nanoseconds */
-  birthtimeNs: BigInt | null;
+  birthtimeNs: bigint | null;
   isBlockDevice: () => boolean;
   isCharacterDevice: () => boolean;
   isDirectory: () => boolean;

--- a/node/internal_binding/types.ts
+++ b/node/internal_binding/types.ts
@@ -230,7 +230,7 @@ export function isNumberObject(value: unknown): value is Number {
   }
 }
 
-export function isBigIntObject(value: unknown): value is BigInt {
+export function isBigIntObject(value: unknown): value is bigint {
   if (!isObjectLike(value)) {
     return false;
   }

--- a/node/process.ts
+++ b/node/process.ts
@@ -232,7 +232,7 @@ export function hrtime(time?: [number, number]): [number, number] {
   return [sec - prevSec, nano - prevNano];
 }
 
-hrtime.bigint = function (): BigInt {
+hrtime.bigint = function (): bigint {
   const [sec, nano] = hrtime();
   return BigInt(sec) * 1_000_000_000n + BigInt(nano);
 };


### PR DESCRIPTION
Fix the currently failing CI. (ref: https://github.com/denoland/deno_std/pull/3184#issuecomment-1426354288)
The cause of CI failures is that BigInt types are now reported as lint errors.(https://github.com/denoland/deno_lint/pull/1124)
This PR fixes CI by replacing BigInt with bigint.


