### PR TITLE
feat(streams/delimiter_stream): add disposition option

### DIFF
--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -13,6 +13,10 @@ export type DelimiterDisposition =
   | "discard" // delimiter discarded
 ;
 
+export interface DelimiterStreamOptions {
+  disposition?: DelimiterDisposition
+}
+
 /**
  * Divide a stream into chunks delimited by a given byte sequence.
  *
@@ -57,7 +61,7 @@ export class DelimiterStream extends TransformStream<Uint8Array, Uint8Array> {
 
   constructor(
     delimiter: Uint8Array,
-    options?: { disposition?: DelimiterDisposition },
+    options?: DelimiterStreamOptions,
   ) {
     super({
       transform: (chunk, controller) => {

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -11,7 +11,7 @@ export type DelimiterDisposition =
   | "prefix"
   /** Discard the delimiter. */
   | "discard" // delimiter discarded
-  ;
+;
 
 export interface DelimiterStreamOptions {
   /** Disposition of the delimiter. */

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -3,21 +3,48 @@
 import { BytesList } from "../bytes/bytes_list.ts";
 import { createLPS } from "./_common.ts";
 
+/** Disposition of the delimiter. */
 type DelimiterDisposition =
-  | "suffix" // delimiter included in chunk
-  | "prefix" // delimiter included in subsequent chunk
+  /** Include delimiter in the found chunk. */
+  | "suffix"
+  /** Include delimiter in the subsequent chunk. */
+  | "prefix"
+  /** Discard the delimiter. */
   | "discard" // delimiter discarded
 ;
 
-/** Transform a stream into a stream where each chunk is divided by a given delimiter.
+/**
+ * Divide a stream into chunks delimited by a given byte sequence.
  *
+ * @example
+ * Divide a CSV stream by commas, discarding the commas:
  * ```ts
  * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
- * const res = await fetch("https://example.com");
+ * const res = await fetch("https://example.com/data.csv");
  * const parts = res.body!
- *   .pipeThrough(new DelimiterStream(new TextEncoder().encode("foo")))
+ *   .pipeThrough(new DelimiterStream(new TextEncoder().encode(",")))
  *   .pipeThrough(new TextDecoderStream());
  * ```
+ *
+ * @example
+ * Divide a stream after semi-colons, keeping the semi-colons in the output:
+ * ```ts
+ * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
+ * const res = await Deno.openFileSync("/home/dino/main.js");
+ * const parts = res.body!
+ *   .pipeThrough(
+ *     new DelimiterStream(
+ *       new TextEncoder().encode(";"),
+ *       { disposition: "suffix" },
+ *     )
+ *   )
+ *   .pipeThrough(new TextDecoderStream());
+ * ```
+ *
+ * @param delimiter Delimiter byte sequence
+ * @param options Options for the transform stream
+ * @param options.disposition Disposition of the delimiter
+ * @returns Transform stream
  */
 export class DelimiterStream extends TransformStream<Uint8Array, Uint8Array> {
   #bufs = new BytesList();

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -14,7 +14,7 @@ export type DelimiterDisposition =
 ;
 
 export interface DelimiterStreamOptions {
-  disposition?: DelimiterDisposition
+  disposition?: DelimiterDisposition;
 }
 
 /**

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -34,7 +34,7 @@ export interface DelimiterStreamOptions {
  * Divide a stream after semi-colons, keeping the semi-colons in the output:
  * ```ts
  * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
- * const res = await Deno.openFileSync("/home/dino/main.js");
+ * const res = await Deno.openSync("/home/dino/main.js");
  * const parts = res.body!
  *   .pipeThrough(
  *     new DelimiterStream(

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -11,9 +11,10 @@ export type DelimiterDisposition =
   | "prefix"
   /** Discard the delimiter. */
   | "discard" // delimiter discarded
-;
+  ;
 
 export interface DelimiterStreamOptions {
+  /** Disposition of the delimiter. */
   disposition?: DelimiterDisposition;
 }
 
@@ -47,7 +48,6 @@ export interface DelimiterStreamOptions {
  *
  * @param delimiter Delimiter byte sequence
  * @param options Options for the transform stream
- * @param options.disposition Disposition of the delimiter
  * @returns Transform stream
  */
 export class DelimiterStream extends TransformStream<Uint8Array, Uint8Array> {

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -4,7 +4,7 @@ import { BytesList } from "../bytes/bytes_list.ts";
 import { createLPS } from "./_common.ts";
 
 /** Disposition of the delimiter. */
-type DelimiterDisposition =
+export type DelimiterDisposition =
   /** Include delimiter in the found chunk. */
   | "suffix"
   /** Include delimiter in the subsequent chunk. */

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -34,7 +34,7 @@ export interface DelimiterStreamOptions {
  * Divide a stream after semi-colons, keeping the semi-colons in the output:
  * ```ts
  * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
- * const res = await Deno.openSync("/home/dino/main.js");
+ * const res = await fetch("https://example.com/file.js");
  * const parts = res.body!
  *   .pipeThrough(
  *     new DelimiterStream(

--- a/streams/delimiter_stream_test.ts
+++ b/streams/delimiter_stream_test.ts
@@ -4,6 +4,12 @@ import { DelimiterStream } from "./delimiter_stream.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
 import { readableStreamFromIterable } from "./readable_stream_from_iterable.ts";
 
+/**
+ * Verify that a transform stream produces the expected output data.
+ * @param transform The transform stream to test
+ * @param inputs Source input data
+ * @param outputs Expected output data
+ */
 async function testTransformStream<T, U>(
   transform: TransformStream<T, U>,
   inputs: Iterable<T> | AsyncIterable<T>,

--- a/streams/delimiter_stream_test.ts
+++ b/streams/delimiter_stream_test.ts
@@ -2,35 +2,90 @@
 
 import { DelimiterStream } from "./delimiter_stream.ts";
 import { assert, assertEquals } from "../testing/asserts.ts";
+import { readableStreamFromIterable } from "./readable_stream_from_iterable.ts";
 
-Deno.test("[streams] DelimiterStream", async () => {
-  const textStream = new ReadableStream({
-    start(controller) {
-      controller.enqueue("qwertzu");
-      controller.enqueue("iopasdfoomnbvc");
-      controller.enqueue("xylkjhfoogfdsapfoooiuzt");
-      controller.enqueue("rewq098765432fo");
-      controller.enqueue("o349012i491290");
-      controller.close();
-    },
-  });
-
-  const lines = textStream
-    .pipeThrough(new TextEncoderStream())
-    .pipeThrough(new DelimiterStream(new TextEncoder().encode("foo")))
-    .pipeThrough(new TextDecoderStream());
-  const reader = lines.getReader();
-
-  const a = await reader.read();
-  assertEquals(a.value, "qwertzuiopasd");
-  const b = await reader.read();
-  assertEquals(b.value, "mnbvcxylkjh");
-  const c = await reader.read();
-  assertEquals(c.value, "gfdsap");
-  const d = await reader.read();
-  assertEquals(d.value, "oiuztrewq098765432");
-  const e = await reader.read();
-  assertEquals(e.value, "349012i491290");
+async function testTransformStream<T, U>(
+  transform: TransformStream<T, U>,
+  inputs: Iterable<T> | AsyncIterable<T>,
+  outputs: Iterable<U> | AsyncIterable<U>,
+) {
+  const reader = readableStreamFromIterable(inputs)
+    .pipeThrough(transform)
+    .getReader();
+  for await (const output of outputs) {
+    const { value, done } = await reader.read();
+    assertEquals(value, output);
+    assertEquals(done, false);
+  }
   const f = await reader.read();
-  assert(f.done);
+  assert(f.done, `stream not done, value was: ${f.value}`);
+}
+
+Deno.test("[streams] DelimiterStream, discard", async () => {
+  const crlf = new TextEncoder().encode("CRLF");
+  const delimStream = new DelimiterStream(crlf, { disposition: "discard" });
+  const inputs = [
+    "qwertzu", // no delimiter
+    "iopasdCRLFmnbvc", // one delimiter in the middle
+    "xylkjhCRLFgfdsapCRLFoiuzt", // two separate delimiters
+    "euoiCRLFCRLFaueiou", // two consecutive delimiters
+    "rewq098765432CR", // split delimiter (1/2)
+    "LF349012i491290", // split delimiter (2/2)
+  ].map((s) => new TextEncoder().encode(s));
+  const outputs = [
+    "qwertzuiopasd",
+    "mnbvcxylkjh",
+    "gfdsap",
+    "oiuzteuoi",
+    "",
+    "aueiourewq098765432",
+    "349012i491290",
+  ].map((s) => new TextEncoder().encode(s));
+  await testTransformStream(delimStream, inputs, outputs);
+});
+
+Deno.test("[streams] DelimiterStream, suffix", async () => {
+  const crlf = new TextEncoder().encode("CRLF");
+  const delimStream = new DelimiterStream(crlf, { disposition: "suffix" });
+  const inputs = [
+    "qwertzu", // no delimiter
+    "iopasdCRLFmnbvc", // one delimiter in the middle
+    "xylkjhCRLFgfdsapCRLFoiuzt", // two separate delimiters
+    "euoiCRLFCRLFaueiou", // two consecutive delimiters
+    "rewq098765432CR", // split delimiter (1/2)
+    "LF349012i491290", // split delimiter (2/2)
+  ].map((s) => new TextEncoder().encode(s));
+  const outputs = [
+    "qwertzuiopasdCRLF",
+    "mnbvcxylkjhCRLF",
+    "gfdsapCRLF",
+    "oiuzteuoiCRLF",
+    "CRLF",
+    "aueiourewq098765432CRLF",
+    "349012i491290",
+  ].map((s) => new TextEncoder().encode(s));
+  await testTransformStream(delimStream, inputs, outputs);
+});
+
+Deno.test("[streams] DelimiterStream, prefix", async () => {
+  const crlf = new TextEncoder().encode("CRLF");
+  const delimStream = new DelimiterStream(crlf, { disposition: "prefix" });
+  const inputs = [
+    "qwertzu", // no delimiter
+    "iopasdCRLFmnbvc", // one delimiter in the middle
+    "xylkjhCRLFgfdsapCRLFoiuzt", // two separate delimiters
+    "euoiCRLFCRLFaueiou", // two consecutive delimiters
+    "rewq098765432CR", // split delimiter (1/2)
+    "LF349012i491290", // split delimiter (2/2)
+  ].map((s) => new TextEncoder().encode(s));
+  const outputs = [
+    "qwertzuiopasd",
+    "CRLFmnbvcxylkjh",
+    "CRLFgfdsap",
+    "CRLFoiuzteuoi",
+    "CRLF",
+    "CRLFaueiourewq098765432",
+    "CRLF349012i491290",
+  ].map((s) => new TextEncoder().encode(s));
+  await testTransformStream(delimStream, inputs, outputs);
 });


### PR DESCRIPTION
Adds the option to include the delimiter in the output chunks, either as a suffix in the found chunk or as a prefix to the subsequent chunk. The default behavior is preserved, but can be explicitly enabled by passing `{ disposition: "discard" }`.

Let me know what you think!