### PR TITLE
chore: remove powershell note in snapshot docs

### DIFF
--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -47,7 +47,6 @@
  * deno test --allow-all -- --update
  * ```
  *
- *
  * Additionally, new snapshots will only be created when this flag is present.
  *
  * ## Permissions:

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -47,11 +47,6 @@
  * deno test --allow-all -- --update
  * ```
  *
- * Note: In Powershell, you need to quote `--`.
- *
- * ```powershell
- * deno test --allow-all "--" --update
- * ```
  *
  * Additionally, new snapshots will only be created when this flag is present.
  *


### PR DESCRIPTION
Updating snapshots works on Powershell nowadays using `-- --update` rather than `"--" --update`, so maybe this note can be cleaned up now.

I am on `deno` 1.30.3, `std` 0.177.0 and `pwsh` 7.3.2.
