### PR TITLE
fix: Create DataView with correct byteLength in timingSafeEqual

### DIFF
--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -12,10 +12,14 @@ export function timingSafeEqual(
     return false;
   }
   if (!(a instanceof DataView)) {
-    a = ArrayBuffer.isView(a) ? new DataView(a.buffer, a.byteOffset, a.byteLength) : new DataView(a);
+    a = ArrayBuffer.isView(a)
+      ? new DataView(a.buffer, a.byteOffset, a.byteLength)
+      : new DataView(a);
   }
   if (!(b instanceof DataView)) {
-    b = ArrayBuffer.isView(b) ? new DataView(b.buffer, b.byteOffset, b.byteLength) : new DataView(b);
+    b = ArrayBuffer.isView(b)
+      ? new DataView(b.buffer, b.byteOffset, b.byteLength)
+      : new DataView(b);
   }
   assert(a instanceof DataView);
   assert(b instanceof DataView);

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -12,10 +12,10 @@ export function timingSafeEqual(
     return false;
   }
   if (!(a instanceof DataView)) {
-    a = new DataView(ArrayBuffer.isView(a) ? a.buffer : a, 0, a.byteLength);
+    a = ArrayBuffer.isView(a) ? new DataView(a.buffer, a.byteOffset, a.byteLength) : new DataView(a);
   }
   if (!(b instanceof DataView)) {
-    b = new DataView(ArrayBuffer.isView(b) ? b.buffer : b, 0, b.byteLength);
+    b = ArrayBuffer.isView(b) ? new DataView(b.buffer, b.byteOffset, b.byteLength) : new DataView(b);
   }
   assert(a instanceof DataView);
   assert(b instanceof DataView);

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -12,10 +12,10 @@ export function timingSafeEqual(
     return false;
   }
   if (!(a instanceof DataView)) {
-    a = new DataView(ArrayBuffer.isView(a) ? a.buffer : a);
+    a = new DataView(ArrayBuffer.isView(a) ? a.buffer : a, 0, a.byteLength);
   }
   if (!(b instanceof DataView)) {
-    b = new DataView(ArrayBuffer.isView(b) ? b.buffer : b);
+    b = new DataView(ArrayBuffer.isView(b) ? b.buffer : b, 0, b.byteLength);
   }
   assert(a instanceof DataView);
   assert(b instanceof DataView);

--- a/crypto/timing_safe_equal_test.ts
+++ b/crypto/timing_safe_equal_test.ts
@@ -118,3 +118,27 @@ Deno.test({
     assert(!timingSafeEqual(ua, ub));
   },
 });
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array w. non-0 byteOffset",
+  fn() {
+    const a = new SharedArrayBuffer(4);
+    const va = new DataView(a);
+    va.setUint8(1, 212);
+    va.setUint8(2, 213);
+    const ua = new Uint8Array(a, 1, 2);
+
+    const b = new SharedArrayBuffer(4);
+    const vb = new DataView(b);
+    vb.setUint8(2, 212);
+    vb.setUint8(3, 213);
+    const ub = new Uint8Array(b, 2, 2);
+
+    assert(timingSafeEqual(ua, ub));
+
+    vb.setUint8(1, 214);
+    vb.setUint8(2, 215);
+
+    assert(!timingSafeEqual(ua, ub));
+  },
+});

--- a/crypto/timing_safe_equal_test.ts
+++ b/crypto/timing_safe_equal_test.ts
@@ -52,7 +52,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[timingSafeEqual] - Uint8Array comparison - equal",
+  name: "[timingSafeEqual] - Uint8Array comparison #2 - equal",
   fn() {
     const encoder = new TextEncoder();
     const a = encoder.encode("hello deno");
@@ -62,11 +62,59 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[timingSafeEqual] - Uint8Array comparison - not equal",
+  name: "[timingSafeEqual] - Uint8Array comparison #2 - not equal",
   fn() {
     const encoder = new TextEncoder();
     const a = encoder.encode("hello deno");
     const b = encoder.encode("hello Deno");
     assert(!timingSafeEqual(a, b));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array w. different buffer sizes (a > b)",
+  fn() {
+    const a = new SharedArrayBuffer(4);
+    const va = new DataView(a);
+    va.setUint8(0, 212);
+    va.setUint8(1, 213);
+    const ua = new Uint8Array(a, 0, 2);
+
+    const b = new SharedArrayBuffer(2);
+    const vb = new DataView(b);
+    vb.setUint8(0, 212);
+    vb.setUint8(1, 213);
+    const ub = new Uint8Array(b, 0, 2);
+
+    assert(timingSafeEqual(ua, ub));
+
+    vb.setUint8(0, 214);
+    vb.setUint8(1, 215);
+
+    assert(!timingSafeEqual(ua, ub));
+  },
+});
+
+Deno.test({
+  name: "[timingSafeEqual] - Uint8Array w. different buffer sizes (b > a)",
+  fn() {
+    const a = new SharedArrayBuffer(2);
+    const va = new DataView(a);
+    va.setUint8(0, 212);
+    va.setUint8(1, 213);
+    const ua = new Uint8Array(a, 0, 2);
+
+    const b = new SharedArrayBuffer(4);
+    const vb = new DataView(b);
+    vb.setUint8(0, 212);
+    vb.setUint8(1, 213);
+    const ub = new Uint8Array(b, 0, 2);
+
+    assert(timingSafeEqual(ua, ub));
+
+    vb.setUint8(0, 214);
+    vb.setUint8(1, 215);
+
+    assert(!timingSafeEqual(ua, ub));
   },
 });


### PR DESCRIPTION
The example presented in https://github.com/denoland/deno_std/issues/3207 uses `argontwo`, which under the hood returns `Uint8Array` which memory buffer is taken directly from a WASM instance, making original `b.getUint8(i)` access out of bounds for 2nd argument to `timingSafeEqual`.

ref: https://deno.land/x/argontwo@0.1.1/wasm/mod.ts?source#L14
ref: https://deno.land/x/argontwo@0.1.1/mod.ts?source#L126

Fixes https://github.com/denoland/deno_std/issues/3207

Note#1: I use `SharedArrayBuffer` for cleaner assertions.
Note#2: changed names of 2 tests, because VS Code integration deduplicates tests with the same name.