### PR TITLE
refactor(encoding/varint): deprecate Wasm implementation in favour of native TypeScript

### DIFF
--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2020 Keith Cirkel. All rights reserved. MIT license.
 
 /**
  * Functions for encoding typed integers in array buffers.

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -7,3 +7,112 @@
  */
 
 export * from "./varint/mod.ts";
+
+// This implementation is a port of https://deno.land/x/varint@v2.0.0 by @keithamus
+// This module is browser compatible.
+
+export const MaxUInt64 = 18446744073709551615n;
+export const MaxVarIntLen64 = 10;
+export const MaxVarIntLen32 = 5;
+
+const MSB = 0x80;
+const REST = 0x7f;
+const SHIFT = 7;
+const MSBN = 0x80n;
+const SHIFTN = 7n;
+
+/**
+ * Given a `buf`, starting at `offset` (default: 0), begin decoding bytes as
+ * VarInt encoded bytes, for a maximum of 10 bytes (offset + 10). The returned
+ * tuple is of the decoded varint 32-bit number, and the new offset with which
+ * to continue decoding other data.
+ *
+ * If a `bigint` in return is undesired, the `decode32` function will return a
+ * `number`, but this should only be used in cases where the varint is
+ * _assured_ to be 32-bits. If in doubt, use `decode()`.
+ *
+ * To know how many bytes the VarInt took to encode, simply negate `offset`
+ * from the returned new `offset`.
+ */
+export function decode(buf: Uint8Array, offset = 0): [bigint, number] {
+  for (
+    let i = offset,
+      len = Math.min(buf.length, offset + MaxVarIntLen64),
+      shift = 0,
+      decoded = 0n;
+    i < len;
+    i += 1, shift += SHIFT
+  ) {
+    const byte = buf[i];
+    decoded += BigInt((byte & REST) * Math.pow(2, shift));
+    if (!(byte & MSB) && decoded > MaxUInt64) {
+      throw new RangeError("overflow varint");
+    }
+    if (!(byte & MSB)) return [decoded, i + 1];
+  }
+  throw new RangeError("malformed or overflow varint");
+}
+
+/**
+ * Given a `buf`, starting at `offset` (default: 0), begin decoding bytes as
+ * VarInt encoded bytes, for a maximum of 5 bytes (offset + 5). The returned
+ * tuple is of the decoded varint 32-bit number, and the new offset with which
+ * to continue decoding other data.
+ *
+ * VarInts are _not 32-bit by default_ so this should only be used in cases
+ * where the varint is _assured_ to be 32-bits. If in doubt, use `decode()`.
+ *
+ * To know how many bytes the VarInt took to encode, simply negate `offset`
+ * from the returned new `offset`.
+ */
+export function decode32(buf: Uint8Array, offset = 0): [number, number] {
+  for (
+    let i = offset,
+      len = Math.min(buf.length, offset + MaxVarIntLen32),
+      shift = 0,
+      decoded = 0;
+    i <= len;
+    i += 1, shift += SHIFT
+  ) {
+    const byte = buf[i];
+    decoded += (byte & REST) * Math.pow(2, shift);
+    if (!(byte & MSB)) return [decoded, i + 1];
+  }
+  throw new RangeError("malformed or overflow varint");
+}
+
+/**
+ * Takes unsigned number `num` and converts it into a VarInt encoded
+ * `Uint8Array`, returning a tuple consisting of a `Uint8Array` slice of the
+ * encoded VarInt, and an offset where the VarInt encoded bytes end within the
+ * `Uint8Array`.
+ *
+ * If `buf` is not given then a Uint8Array will be created.
+ * `offset` defaults to `0`.
+ *
+ * If passed `buf` then that will be written into, starting at `offset`. The
+ * resulting returned `Uint8Array` will be a slice of `buf`. The resulting
+ * returned number is effectively `offset + bytesWritten`.
+ */
+export function encode(
+  num: bigint | number,
+  buf: Uint8Array = new Uint8Array(MaxVarIntLen64),
+  offset = 0,
+): [Uint8Array, number] {
+  num = BigInt(num);
+  if (num < 0n) throw new RangeError("signed input given");
+  for (
+    let i = offset, len = Math.min(buf.length, MaxVarIntLen64);
+    i <= len;
+    i += 1
+  ) {
+    if (num < MSBN) {
+      buf[i] = Number(num);
+      i += 1;
+      return [buf.slice(offset, i), i];
+    }
+    buf[i] = Number((num & 0xFFn) | MSBN);
+    num >>= SHIFTN;
+  }
+  throw new RangeError(`${num} overflows uint64`);
+}

--- a/encoding/varint/mod.ts
+++ b/encoding/varint/mod.ts
@@ -12,6 +12,8 @@ const U32MAX = 4_294_967_295;
 const U64MAX = 18_446_744_073_709_551_615n;
 
 /**
+ * @deprecated (will be removed after 0.181.0) Use `encode` from `std/encoding/varint.ts` instead.
+ *
  * Encodes the given `number` into `Uint8Array` with LEB128. The number needs to be in the range of `0` and `0xffffffff`.
  * ```ts
  * import { encodeU32 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
@@ -33,6 +35,8 @@ export function encodeU32(val: number): Uint8Array {
 }
 
 /**
+ * @deprecated (will be removed after 0.181.0) Use `encode()` from `std/encoding/varint.ts` instead.
+ *
  * Encodes the given `BigInt` into `Uint8Array` with LEB128. The number needs to be in the range of `0` and `0xffffffffffffffff`.
  * ```ts
  * import { encodeU64 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
@@ -53,6 +57,8 @@ export function encodeU64(val: bigint): Uint8Array {
 }
 
 /**
+ * @deprecated (will be removed after 0.181.0) Use `decode32()` from `std/encoding/varint.ts` instead.
+ *
  * Decodes the given `Uint8Array` into a `number` with LEB128.
  * ```ts
  * import { decodeU32 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";
@@ -74,6 +80,8 @@ export function decodeU32(val: Uint8Array): number {
 }
 
 /**
+ * @deprecated (will be removed after 0.181.0) Use `decode64()` from `std/encoding/varint.ts` instead.
+ *
  * Decodes the given `Uint8Array` into a `BigInt` with LEB128.
  * ```ts
  * import { decodeU64 } from "https://deno.land/std@$STD_VERSION/encoding/varint/mod.ts";

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2020 Keith Cirkel. All rights reserved. MIT license.
 // This implementation is a port of https://deno.land/x/varint@v2.0.0 by @keithamus
 
 import { assertEquals, assertThrows } from "../testing/asserts.ts";

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -1,0 +1,164 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This implementation is a port of https://deno.land/x/varint@v2.0.0 by @keithamus
+
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import {
+  decode,
+  decode32,
+  encode,
+  MaxUInt64,
+  MaxVarIntLen64,
+} from "./varint.ts";
+
+function encodeDecode(i: number | bigint) {
+  const [buf, n] = encode(i, new Uint8Array(MaxVarIntLen64));
+  const fn = (typeof i === "bigint") ? decode : decode32;
+  const [j, m] = fn(buf);
+  assertEquals(i, j, `${fn.name}(encode(${i})): ${i} !== ${j}`);
+  assertEquals(n, m, `${fn.name}(encode(${i})): buffer lengths ${n} !== ${m}`);
+}
+
+Deno.test("VarInt decode manual", () => {
+  assertEquals(decode(Uint8Array.of(172, 2)), [300n, 2]);
+});
+Deno.test("VarInt decode max size", () => {
+  assertEquals(
+    decode(Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 255, 1)),
+    [18446744073709551615n, 10],
+  );
+});
+Deno.test("VarInt decode overflow", () => {
+  assertThrows(
+    () => decode(Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 255, 2)),
+    RangeError,
+  );
+});
+Deno.test("VarInt decode with offset", () => {
+  assertEquals(
+    decode(
+      Uint8Array.of(
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        1,
+      ),
+      4,
+    ),
+    [18446744073709551615n, 14],
+  );
+});
+Deno.test("VarInt decode32 manual", () => {
+  assertEquals(decode32(Uint8Array.of(172, 2)), [300, 2]);
+});
+Deno.test("VarInt decode32 max size", () => {
+  assertEquals(
+    decode32(Uint8Array.of(255, 255, 255, 255, 15, 0, 0, 0, 0, 0)),
+    [4294967295, 5],
+  );
+});
+Deno.test("VarInt decode32 overflow", () => {
+  assertThrows(
+    () =>
+      decode32(Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 15, 0)),
+    RangeError,
+  );
+});
+Deno.test("VarInt decode32 with offset", () => {
+  assertEquals(
+    decode32(Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 15, 0), 4),
+    [4294967295, 9],
+  );
+});
+Deno.test("VarInt encode manual", () => {
+  assertEquals(encode(300, new Uint8Array(2)), [Uint8Array.of(172, 2), 2]);
+  assertEquals(
+    encode(4294967295),
+    [Uint8Array.of(255, 255, 255, 255, 15), 5],
+  );
+  assertEquals(
+    encode(18446744073709551615n),
+    [Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 255, 1), 10],
+  );
+});
+Deno.test("VarInt encode overflow with negative", () => {
+  assertThrows(() => encode(-1), RangeError);
+});
+Deno.test("VarInt encode with offset", () => {
+  let uint = new Uint8Array(3);
+  assertEquals(
+    encode(300, uint, 1),
+    [Uint8Array.of(172, 2), 3],
+  );
+  assertEquals(uint, Uint8Array.of(0, 172, 2));
+  uint = new Uint8Array(MaxVarIntLen64);
+  uint[0] = uint[1] = uint[2] = 12;
+  assertEquals(
+    encode(4294967295, uint, 3),
+    [Uint8Array.of(255, 255, 255, 255, 15), 8],
+  );
+  assertEquals(uint, Uint8Array.of(12, 12, 12, 255, 255, 255, 255, 15, 0, 0));
+});
+Deno.test("VarInt encode<->decode", () => {
+  for (
+    const i of [
+      0n,
+      1n,
+      2n,
+      10n,
+      20n,
+      63n,
+      64n,
+      65n,
+      127n,
+      128n,
+      129n,
+      255n,
+      256n,
+      257n,
+      300n,
+      18446744073709551615n,
+    ]
+  ) {
+    encodeDecode(i);
+  }
+  for (let i = 0x7n; i < MaxUInt64; i <<= 1n) {
+    encodeDecode(i);
+  }
+});
+Deno.test("VarInt encode<->decode32", () => {
+  for (
+    const i of [
+      0,
+      1,
+      2,
+      10,
+      20,
+      63,
+      64,
+      65,
+      127,
+      128,
+      129,
+      255,
+      256,
+      257,
+      300,
+      4294967295,
+    ]
+  ) {
+    encodeDecode(i);
+  }
+  for (let i = 0x7; i > 0; i <<= 1) {
+    encodeDecode(i);
+  }
+});


### PR DESCRIPTION
This change replaces the Wasm implementation of `encoding/varint` with a native-TypeScript implementation ported from the [x/varint module](https://deno.land/x/varint@v2.0.0) by @keithamus.

My benchmarks show that this implementation is 2x slower than its Wasm predecessor. However, the benefit is the implementation is simpler, and a step in CI is removed.

This PR supersedes #3213.

Ref:
* https://github.com/denoland/deno_std/issues/3123#issuecomment-1437857122
* https://github.com/denoland/deno_std/pull/3213#discussion_r1115252163