### PR TITLE
fix(http/file_server): Redirect directory URLs that don't end with a slash

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -520,8 +520,8 @@ export async function serveDir(req: Request, opts: ServeDirOptions = {}) {
             // relative URLs in the index file will resolve against the parent
             // directory, rather than the current directory. To prevent that, we
             // return a 301 redirect to the URL with a slash.
-            const url = new URL(req.url);
-            if (!url.pathname.endsWith("/")) {
+            if (!fsPath.endsWith("/")) {
+              const url = new URL(req.url);
               url.pathname += "/";
               return Response.redirect(url, 301);
             }

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -516,6 +516,15 @@ export async function serveDir(req: Request, opts: ServeDirOptions = {}) {
           const path = posix.join(fsPath, "index.html");
           const indexFileInfo = await Deno.lstat(path);
           if (indexFileInfo.isFile) {
+            // If the current URL's pathname doesn't end with a slash, any
+            // relative URLs in the index file will resolve against the parent
+            // directory, rather than the current directory. To prevent that, we
+            // return a 301 redirect to the URL with a slash.
+            const url = new URL(req.url);
+            if (!url.pathname.endsWith("/")) {
+              url.pathname += "/";
+              return Response.redirect(url, 301);
+            }
             response = await serveFile(req, path, {
               etagAlgorithm: opts.etagAlgorithm,
               fileInfo: indexFileInfo,

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1202,6 +1202,32 @@ Deno.test(
 );
 
 Deno.test(
+  "serveDir redirects a directory URL not ending with a slash if it has an index",
+  async () => {
+    const url = "http://localhost:4507/http/testdata/subdir-with-index";
+    const res = await serveDir(new Request(url), { showIndex: true });
+    assertEquals(res.status, 301);
+    assertEquals(
+      res.headers.get("Location"),
+      "http://localhost:4507/http/testdata/subdir-with-index/",
+    );
+  },
+);
+
+Deno.test(
+  "serveDir redirects a directory URL not ending with a slash correctly even with a query string",
+  async () => {
+    const url = "http://localhost:4507/http/testdata/subdir-with-index?test";
+    const res = await serveDir(new Request(url), { showIndex: true });
+    assertEquals(res.status, 301);
+    assertEquals(
+      res.headers.get("Location"),
+      "http://localhost:4507/http/testdata/subdir-with-index/?test",
+    );
+  },
+);
+
+Deno.test(
   "file_server returns 304 for requests with if-none-match set with the etag but with W/ prefixed etag in request headers.",
   async () => {
     await startFileServer();


### PR DESCRIPTION
When `showIndex` is true and `directory/index.html` exists, loading `http://example.com/directory` (without a final slash) can cause relative URLs in the index file to resolve against the wrong directory. This change redirects such URLs to the version ending with a slash to avoid this.

Fixes #3219.
