### PR TITLE
refactor(CI): enable ubuntu to upload coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,12 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
-        if: matrix.os != 'ubuntu-22.04'
         with:
           name: ${{ matrix.os }}-${{ matrix.deno }}
           files: cov.lcov
 
       - name: Remove coverage report
         shell: bash
-        if: matrix.os != 'ubuntu-22.04'
         run: |
           rm -rf ./cov/
           rm cov.lcov


### PR DESCRIPTION
Uploading coverage from Ubuntu was disabled in denoland/deno#10420 due to a panic caused by `readAll()` within `std/streams`. This change is an experiment that re-enables coverage upload.