### PR TITLE
chore(fs): Refactor the test of ensureFile and ensureDir

### DIFF
--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -110,7 +110,7 @@ Deno.test("ensureDirSyncIfItAsFile", function () {
 Deno.test("ensureDirIfInvalidPath", async function () {
   await assertRejects(
     async () => {
-      await ensureDir("<invalid>");
+      await ensureDir("<invalid\0>");
     },
     Error,
   );
@@ -119,7 +119,7 @@ Deno.test("ensureDirIfInvalidPath", async function () {
 Deno.test("ensureDirSyncIfInvalidPath", function () {
   assertThrows(
     () => {
-      ensureDirSync("<invalid>");
+      ensureDirSync("<invalid\0>");
     },
     Error,
   );

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -107,20 +107,35 @@ Deno.test("ensureDirSyncIfItAsFile", function () {
   }
 });
 
-Deno.test("ensureDirIfInvalidPath", async function () {
-  await assertRejects(
-    async () => {
-      await ensureDir("<invalid\0>");
-    },
-    Error,
-  );
+Deno.test({
+  name: "ensureDirShouldNotSwallowErrors",
+  permissions: { read: true },
+  async fn() {
+    const baseDir = path.join(testdataDir, "ensure_dir_without_permission");
+
+    // ensureDir fails because this test doesn't have write permissions,
+    // but don't swallow that error.
+    await assertRejects(
+      async () => await ensureDir(baseDir),
+      Deno.errors.PermissionDenied,
+    );
+  },
 });
 
-Deno.test("ensureDirSyncIfInvalidPath", function () {
-  assertThrows(
-    () => {
-      ensureDirSync("<invalid\0>");
-    },
-    Error,
-  );
+Deno.test({
+  name: "ensureDirSyncShouldNotSwallowErrors",
+  permissions: { read: true },
+  fn() {
+    const baseDir = path.join(
+      testdataDir,
+      "ensure_dir_sync_without_permission",
+    );
+
+    // ensureDirSync fails because this test doesn't have write permissions,
+    // but don't swallow that error.
+    assertThrows(
+      () => ensureDirSync(baseDir),
+      Deno.errors.PermissionDenied,
+    );
+  },
 });

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -11,97 +11,116 @@ Deno.test("ensureDirIfItNotExist", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_not_exist");
   const testDir = path.join(baseDir, "test");
 
-  await ensureDir(testDir);
+  try {
+    await ensureDir(testDir);
 
-  await assertRejects(
-    async () => {
-      await Deno.stat(testDir).then(() => {
-        throw new Error("test dir should exists.");
-      });
-    },
-  );
-
-  await Deno.remove(baseDir, { recursive: true });
+    // test dir should exists.
+    await Deno.stat(testDir);
+  } finally {
+    await Deno.remove(baseDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureDirSyncIfItNotExist", function () {
   const baseDir = path.join(testdataDir, "ensure_dir_sync_not_exist");
   const testDir = path.join(baseDir, "test");
 
-  ensureDirSync(testDir);
+  try {
+    ensureDirSync(testDir);
 
-  Deno.statSync(testDir);
-
-  Deno.removeSync(baseDir, { recursive: true });
+    // test dir should exists.
+    Deno.statSync(testDir);
+  } finally {
+    Deno.removeSync(baseDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureDirIfItExist", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_exist");
   const testDir = path.join(baseDir, "test");
 
-  // create test directory
-  await Deno.mkdir(testDir, { recursive: true });
+  try {
+    // create test directory
+    await Deno.mkdir(testDir, { recursive: true });
 
-  await ensureDir(testDir);
+    await ensureDir(testDir);
 
-  await assertRejects(
-    async () => {
-      await Deno.stat(testDir).then(() => {
-        throw new Error("test dir should still exists.");
-      });
-    },
-  );
-
-  await Deno.remove(baseDir, { recursive: true });
+    // test dir should still exists.
+    await Deno.stat(testDir);
+  } finally {
+    await Deno.remove(baseDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureDirSyncIfItExist", function () {
   const baseDir = path.join(testdataDir, "ensure_dir_sync_exist");
   const testDir = path.join(baseDir, "test");
 
-  // create test directory
-  Deno.mkdirSync(testDir, { recursive: true });
+  try {
+    // create test directory
+    Deno.mkdirSync(testDir, { recursive: true });
 
-  ensureDirSync(testDir);
+    ensureDirSync(testDir);
 
-  assertThrows(() => {
+    // test dir should still exists.
     Deno.statSync(testDir);
-    throw new Error("test dir should still exists.");
-  });
-
-  Deno.removeSync(baseDir, { recursive: true });
+  } finally {
+    Deno.removeSync(baseDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureDirIfItAsFile", async function () {
   const baseDir = path.join(testdataDir, "ensure_dir_exist_file");
   const testFile = path.join(baseDir, "test");
 
-  await ensureFile(testFile);
+  try {
+    await ensureFile(testFile);
 
-  await assertRejects(
-    async () => {
-      await ensureDir(testFile);
-    },
-    Error,
-    `Ensure path exists, expected 'dir', got 'file'`,
-  );
-
-  await Deno.remove(baseDir, { recursive: true });
+    await assertRejects(
+      async () => {
+        await ensureDir(testFile);
+      },
+      Error,
+      `Ensure path exists, expected 'dir', got 'file'`,
+    );
+  } finally {
+    await Deno.remove(baseDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureDirSyncIfItAsFile", function () {
   const baseDir = path.join(testdataDir, "ensure_dir_exist_file_async");
   const testFile = path.join(baseDir, "test");
 
-  ensureFileSync(testFile);
+  try {
+    ensureFileSync(testFile);
 
-  assertThrows(
-    () => {
-      ensureDirSync(testFile);
+    assertThrows(
+      () => {
+        ensureDirSync(testFile);
+      },
+      Error,
+      `Ensure path exists, expected 'dir', got 'file'`,
+    );
+  } finally {
+    Deno.removeSync(baseDir, { recursive: true });
+  }
+});
+
+Deno.test("ensureDirIfInvalidPath", async function () {
+  await assertRejects(
+    async () => {
+      await ensureDir("<invalid>");
     },
     Error,
-    `Ensure path exists, expected 'dir', got 'file'`,
   );
+});
 
-  Deno.removeSync(baseDir, { recursive: true });
+Deno.test("ensureDirSyncIfInvalidPath", function () {
+  assertThrows(
+    () => {
+      ensureDirSync("<invalid>");
+    },
+    Error,
+  );
 });

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -104,20 +104,34 @@ Deno.test("ensureFileSyncIfItExistAsDir", function () {
   }
 });
 
-Deno.test("ensureFileIfInvalidPath", async function () {
-  await assertRejects(
-    async () => {
-      await ensureFile("<invalid>");
-    },
-    Error,
-  );
+Deno.test({
+  name: "ensureFileShouldNotSwallowErrors",
+  permissions: { read: true },
+  async fn() {
+    const testDir = path.join(testdataDir, "ensure_file_7");
+    const testFile = path.join(testDir, "test.txt");
+
+    // ensureFile fails because this test doesn't have write permissions,
+    // but don't swallow that error.
+    await assertRejects(
+      async () => await ensureFile(testFile),
+      Deno.errors.PermissionDenied,
+    );
+  },
 });
 
-Deno.test("ensureFileSyncIfInvalidPath", function () {
-  assertThrows(
-    () => {
-      ensureFileSync("<invalid>");
-    },
-    Error,
-  );
+Deno.test({
+  name: "ensureFileSyncShouldNotSwallowErrors",
+  permissions: { read: true },
+  fn() {
+    const testDir = path.join(testdataDir, "ensure_file_8");
+    const testFile = path.join(testDir, "test.txt");
+
+    // ensureFileSync fails because this test doesn't have write permissions,
+    // but don't swallow that error.
+    assertThrows(
+      () => ensureFileSync(testFile),
+      Deno.errors.PermissionDenied,
+    );
+  },
 });

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -10,98 +10,114 @@ Deno.test("ensureFileIfItNotExist", async function () {
   const testDir = path.join(testdataDir, "ensure_file_1");
   const testFile = path.join(testDir, "test.txt");
 
-  await ensureFile(testFile);
+  try {
+    await ensureFile(testFile);
 
-  await assertRejects(
-    async () => {
-      await Deno.stat(testFile).then(() => {
-        throw new Error("test file should exists.");
-      });
-    },
-  );
-
-  await Deno.remove(testDir, { recursive: true });
+    // test file should exists.
+    await Deno.stat(testFile);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureFileSyncIfItNotExist", function () {
   const testDir = path.join(testdataDir, "ensure_file_2");
   const testFile = path.join(testDir, "test.txt");
 
-  ensureFileSync(testFile);
+  try {
+    ensureFileSync(testFile);
 
-  assertThrows(() => {
+    // test file should exists.
     Deno.statSync(testFile);
-    throw new Error("test file should exists.");
-  });
-
-  Deno.removeSync(testDir, { recursive: true });
+  } finally {
+    Deno.removeSync(testDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureFileIfItExist", async function () {
   const testDir = path.join(testdataDir, "ensure_file_3");
   const testFile = path.join(testDir, "test.txt");
 
-  await Deno.mkdir(testDir, { recursive: true });
-  await Deno.writeFile(testFile, new Uint8Array());
+  try {
+    await Deno.mkdir(testDir, { recursive: true });
+    await Deno.writeFile(testFile, new Uint8Array());
 
-  await ensureFile(testFile);
+    await ensureFile(testFile);
 
-  await assertRejects(
-    async () => {
-      await Deno.stat(testFile).then(() => {
-        throw new Error("test file should exists.");
-      });
-    },
-  );
-
-  await Deno.remove(testDir, { recursive: true });
+    // test file should exists.
+    await Deno.stat(testFile);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureFileSyncIfItExist", function () {
   const testDir = path.join(testdataDir, "ensure_file_4");
   const testFile = path.join(testDir, "test.txt");
 
-  Deno.mkdirSync(testDir, { recursive: true });
-  Deno.writeFileSync(testFile, new Uint8Array());
+  try {
+    Deno.mkdirSync(testDir, { recursive: true });
+    Deno.writeFileSync(testFile, new Uint8Array());
 
-  ensureFileSync(testFile);
+    ensureFileSync(testFile);
 
-  assertThrows(() => {
+    // test file should exists.
     Deno.statSync(testFile);
-    throw new Error("test file should exists.");
-  });
-
-  Deno.removeSync(testDir, { recursive: true });
+  } finally {
+    Deno.removeSync(testDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureFileIfItExistAsDir", async function () {
   const testDir = path.join(testdataDir, "ensure_file_5");
 
-  await Deno.mkdir(testDir, { recursive: true });
+  try {
+    await Deno.mkdir(testDir, { recursive: true });
 
-  await assertRejects(
-    async () => {
-      await ensureFile(testDir);
-    },
-    Error,
-    `Ensure path exists, expected 'file', got 'dir'`,
-  );
-
-  await Deno.remove(testDir, { recursive: true });
+    await assertRejects(
+      async () => {
+        await ensureFile(testDir);
+      },
+      Error,
+      `Ensure path exists, expected 'file', got 'dir'`,
+    );
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
 });
 
 Deno.test("ensureFileSyncIfItExistAsDir", function () {
   const testDir = path.join(testdataDir, "ensure_file_6");
 
-  Deno.mkdirSync(testDir, { recursive: true });
+  try {
+    Deno.mkdirSync(testDir, { recursive: true });
 
-  assertThrows(
-    () => {
-      ensureFileSync(testDir);
+    assertThrows(
+      () => {
+        ensureFileSync(testDir);
+      },
+      Error,
+      `Ensure path exists, expected 'file', got 'dir'`,
+    );
+  } finally {
+    Deno.removeSync(testDir, { recursive: true });
+  }
+});
+
+Deno.test("ensureFileIfInvalidPath", async function () {
+  await assertRejects(
+    async () => {
+      await ensureFile("<invalid>");
     },
     Error,
-    `Ensure path exists, expected 'file', got 'dir'`,
   );
+});
 
-  Deno.removeSync(testDir, { recursive: true });
+Deno.test("ensureFileSyncIfInvalidPath", function () {
+  assertThrows(
+    () => {
+      ensureFileSync("<invalid>");
+    },
+    Error,
+  );
 });


### PR DESCRIPTION
When I was investigating #3233, these test cases seemed incorrect, so I changed some.

The following three points have been updated.

- Changed `assertThrows()` that looks like nothing ([comment](https://github.com/denoland/deno_std/pull/3240#discussion_r1128484467))
- Use try-finally to make the directory clean up correctly
- A small test case that is useful for debugging when implementing [#3233](https://github.com/denoland/deno_std/issues/3233) has been added. (`ensureDirShouldNotSwallowErrors` and `ensureDirSyncShouldNotSwallowErrors`)