### PR TITLE
Update _yaml/parse.ts: YAMLException doesn't exist

### DIFF
--- a/encoding/_yaml/parse.ts
+++ b/encoding/_yaml/parse.ts
@@ -11,7 +11,7 @@ export type ParseOptions = LoaderStateOptions;
 /**
  * Parses `content` as single YAML document.
  *
- * Returns a JavaScript object or throws `YAMLException` on error.
+ * Returns a JavaScript object or throws `YAMLError` on error.
  * By default, does not support regexps, functions and undefined. This method is safe for untrusted data.
  */
 export function parse(content: string, options?: ParseOptions): unknown {


### PR DESCRIPTION
YAMLException doesn't exist, changed documentation to actual name.

This is a single-line change that does not substantially effect how the script runs.