### PR TITLE
chore(_tools): fix create_pr script

### DIFF
--- a/_tools/release/02_create_pr.ts
+++ b/_tools/release/02_create_pr.ts
@@ -35,10 +35,10 @@ function getPrBody() {
     `Please ensure:\n` +
     `- [ ] Version in version.ts is updated correctly\n` +
     `- [ ] Releases.md is updated correctly\n` +
-    `- [ ] All the tests in this branch have been run against the CLI release being done` +
-    "      ```shell" +
-    `      ../deno/target/release/deno task test` +
-    "      ```\n" +
+    `- [ ] All the tests in this branch have been run against the CLI release being done\n` +
+    "     ```shell\n" +
+    `     ../deno/target/release/deno task test\n` +
+    "     ```\n" +
     `To make edits to this PR:\n` +
     "```shell\n" +
     `git fetch upstream ${newBranchName} && git checkout -b ${newBranchName} upstream/${newBranchName}\n` +


### PR DESCRIPTION
This fixes the release PR description which is created by create_pr script

BEFORE
<img width="925" alt="Screen Shot 2023-03-10 at 17 21 44" src="https://user-images.githubusercontent.com/613956/224262271-d41d0ccb-66f5-4d57-91d2-04c1e7477a0f.png">

AFTER
<img width="929" alt="Screen Shot 2023-03-10 at 17 21 29" src="https://user-images.githubusercontent.com/613956/224262304-7c13d677-783e-4275-ab71-52a85411f9ed.png">
