### PR TITLE
feat!: include `msg` in assertion errors

### DIFF
--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -308,7 +308,9 @@ export function assertNotStrictEquals<T>(
 
   const msgSuffix = msg ? `: ${msg}` : ".";
   throw new AssertionError(
-    `Expected "actual" to be strictly unequal to: ${format(actual)}${msgSuffix}\n`,
+    `Expected "actual" to be strictly unequal to: ${
+      format(actual)
+    }${msgSuffix}\n`,
   );
 }
 
@@ -346,7 +348,7 @@ export function assertAlmostEquals(
   const msgSuffix = msg ? `: ${msg}` : ".";
   const f = (n: number) => Number.isInteger(n) ? n : n.toExponential();
   throw new AssertionError(
-      `Expected actual: "${f(actual)}" to be close to "${f(expected)}": \
+    `Expected actual: "${f(actual)}" to be close to "${f(expected)}": \
 delta "${f(delta)}" is greater than "${f(tolerance)}"${msgSuffix}`,
   );
 }
@@ -383,10 +385,11 @@ export function assertInstanceOf<T extends AnyConstructor>(
   }
 
   if (expectedTypeStr == actualTypeStr) {
-    msg = `Expected object to be an instance of "${expectedTypeStr}"${msgSuffix}`;
+    msg =
+      `Expected object to be an instance of "${expectedTypeStr}"${msgSuffix}`;
   } else if (actualTypeStr == "function") {
     msg =
-      `Expected object to be an instance of "${expectedTypeStr}" but was not an instanced object${msgSuffix}`
+      `Expected object to be an instance of "${expectedTypeStr}" but was not an instanced object${msgSuffix}`;
   } else {
     msg =
       `Expected object to be an instance of "${expectedTypeStr}" but was "${actualTypeStr}"${msgSuffix}`;
@@ -403,10 +406,11 @@ export function assertNotInstanceOf<A, T>(
   actual: A,
   // deno-lint-ignore no-explicit-any
   unexpectedType: new (...args: any[]) => T,
-  msg?: string
+  msg?: string,
 ): asserts actual is Exclude<A, T> {
   const msgSuffix = msg ? `: ${msg}` : ".";
-  msg = `Expected object to not be an instance of "${typeof unexpectedType}"${msgSuffix}`;
+  msg =
+    `Expected object to not be an instance of "${typeof unexpectedType}"${msgSuffix}`;
   assertFalse(actual instanceof unexpectedType, msg);
 }
 
@@ -420,7 +424,8 @@ export function assertExists<T>(
 ): asserts actual is NonNullable<T> {
   if (actual === undefined || actual === null) {
     const msgSuffix = msg ? `: ${msg}` : ".";
-    msg = `Expected actual: "${actual}" to not be null or undefined${msgSuffix}`;
+    msg =
+      `Expected actual: "${actual}" to not be null or undefined${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -510,7 +515,8 @@ export function assertNotMatch(
 ) {
   if (expected.test(actual)) {
     const msgSuffix = msg ? `: ${msg}` : ".";
-    msg = `Expected actual: "${actual}" to not match: "${expected}"${msgSuffix}`;
+    msg =
+      `Expected actual: "${actual}" to not match: "${expected}"${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -618,7 +624,9 @@ export function assertIsError<E extends Error = Error>(
 ): asserts error is E {
   const msgSuffix = msg ? `: ${msg}` : ".";
   if (error instanceof Error === false) {
-    throw new AssertionError(`Expected "error" to be an Error object${msgSuffix}}`);
+    throw new AssertionError(
+      `Expected "error" to be an Error object${msgSuffix}}`,
+    );
   }
   if (ErrorClass && !(error instanceof ErrorClass)) {
     msg = `Expected error to be instance of "${ErrorClass.name}", but was "${

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -170,7 +170,9 @@ export function assertEquals<T>(actual: T, expected: T, msg?: string) {
   if (equal(actual, expected)) {
     return;
   }
-  let message = "";
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  let message = `Values are not equal${msgSuffix}`;
+
   const actualString = format(actual);
   const expectedString = format(expected);
   try {
@@ -180,12 +182,9 @@ export function assertEquals<T>(actual: T, expected: T, msg?: string) {
       ? diffstr(actual as string, expected as string)
       : diff(actualString.split("\n"), expectedString.split("\n"));
     const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
-    message = `Values are not equal:\n${diffMsg}`;
+    message = `${message}\n${diffMsg}`;
   } catch {
-    message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
-  }
-  if (msg) {
-    message = msg;
+    message = `${message}\n${red(CAN_NOT_DISPLAY)} + \n\n`;
   }
   throw new AssertionError(message);
 }
@@ -219,10 +218,10 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   } catch {
     expectedString = "[Cannot display]";
   }
-  if (!msg) {
-    msg = `actual: ${actualString} expected not to be: ${expectedString}`;
-  }
-  throw new AssertionError(msg);
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  throw new AssertionError(
+    `Expected actual: ${actualString} not to be: ${expectedString}${msgSuffix}`,
+  );
 }
 
 /**
@@ -256,35 +255,32 @@ export function assertStrictEquals<T>(
     return;
   }
 
+  const msgSuffix = msg ? `: ${msg}` : ".";
   let message: string;
 
-  if (msg) {
-    message = msg;
-  } else {
-    const actualString = format(actual);
-    const expectedString = format(expected);
+  const actualString = format(actual);
+  const expectedString = format(expected);
 
-    if (actualString === expectedString) {
-      const withOffset = actualString
-        .split("\n")
-        .map((l) => `    ${l}`)
-        .join("\n");
-      message =
-        `Values have the same structure but are not reference-equal:\n\n${
-          red(withOffset)
-        }\n`;
-    } else {
-      try {
-        const stringDiff = (typeof actual === "string") &&
-          (typeof expected === "string");
-        const diffResult = stringDiff
-          ? diffstr(actual as string, expected as string)
-          : diff(actualString.split("\n"), expectedString.split("\n"));
-        const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
-        message = `Values are not strictly equal:\n${diffMsg}`;
-      } catch {
-        message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
-      }
+  if (actualString === expectedString) {
+    const withOffset = actualString
+      .split("\n")
+      .map((l) => `    ${l}`)
+      .join("\n");
+    message =
+      `Values have the same structure but are not reference-equal${msgSuffix}\n\n${
+        red(withOffset)
+      }\n`;
+  } else {
+    try {
+      const stringDiff = (typeof actual === "string") &&
+        (typeof expected === "string");
+      const diffResult = stringDiff
+        ? diffstr(actual as string, expected as string)
+        : diff(actualString.split("\n"), expectedString.split("\n"));
+      const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
+      message = `Values are not strictly equal${msgSuffix}\n${diffMsg}`;
+    } catch {
+      message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
     }
   }
 
@@ -310,8 +306,9 @@ export function assertNotStrictEquals<T>(
     return;
   }
 
+  const msgSuffix = msg ? `: ${msg}` : ".";
   throw new AssertionError(
-    msg ?? `Expected "actual" to be strictly unequal to: ${format(actual)}\n`,
+    `Expected "actual" to be strictly unequal to: ${format(actual)}${msgSuffix}\n`,
   );
 }
 
@@ -345,11 +342,12 @@ export function assertAlmostEquals(
   if (delta <= tolerance) {
     return;
   }
+
+  const msgSuffix = msg ? `: ${msg}` : ".";
   const f = (n: number) => Number.isInteger(n) ? n : n.toExponential();
   throw new AssertionError(
-    msg ??
-      `actual: "${f(actual)}" expected to be close to "${f(expected)}": \
-delta "${f(delta)}" is greater than "${f(tolerance)}"`,
+      `Expected actual: "${f(actual)}" to be close to "${f(expected)}": \
+delta "${f(delta)}" is greater than "${f(tolerance)}"${msgSuffix}`,
   );
 }
 
@@ -368,31 +366,33 @@ export function assertInstanceOf<T extends AnyConstructor>(
   expectedType: T,
   msg = "",
 ): asserts actual is GetConstructorType<T> {
-  if (!msg) {
-    const expectedTypeStr = expectedType.name;
+  if (actual instanceof expectedType) return;
 
-    let actualTypeStr = "";
-    if (actual === null) {
-      actualTypeStr = "null";
-    } else if (actual === undefined) {
-      actualTypeStr = "undefined";
-    } else if (typeof actual === "object") {
-      actualTypeStr = actual.constructor?.name ?? "Object";
-    } else {
-      actualTypeStr = typeof actual;
-    }
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  const expectedTypeStr = expectedType.name;
 
-    if (expectedTypeStr == actualTypeStr) {
-      msg = `Expected object to be an instance of "${expectedTypeStr}".`;
-    } else if (actualTypeStr == "function") {
-      msg =
-        `Expected object to be an instance of "${expectedTypeStr}" but was not an instanced object.`;
-    } else {
-      msg =
-        `Expected object to be an instance of "${expectedTypeStr}" but was "${actualTypeStr}".`;
-    }
+  let actualTypeStr = "";
+  if (actual === null) {
+    actualTypeStr = "null";
+  } else if (actual === undefined) {
+    actualTypeStr = "undefined";
+  } else if (typeof actual === "object") {
+    actualTypeStr = actual.constructor?.name ?? "Object";
+  } else {
+    actualTypeStr = typeof actual;
   }
-  assert(actual instanceof expectedType, msg);
+
+  if (expectedTypeStr == actualTypeStr) {
+    msg = `Expected object to be an instance of "${expectedTypeStr}"${msgSuffix}`;
+  } else if (actualTypeStr == "function") {
+    msg =
+      `Expected object to be an instance of "${expectedTypeStr}" but was not an instanced object${msgSuffix}`
+  } else {
+    msg =
+      `Expected object to be an instance of "${expectedTypeStr}" but was "${actualTypeStr}"${msgSuffix}`;
+  }
+
+  throw new AssertionError(msg);
 }
 
 /**
@@ -403,8 +403,10 @@ export function assertNotInstanceOf<A, T>(
   actual: A,
   // deno-lint-ignore no-explicit-any
   unexpectedType: new (...args: any[]) => T,
-  msg = `Expected object to not be an instance of "${typeof unexpectedType}"`,
+  msg?: string
 ): asserts actual is Exclude<A, T> {
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  msg = `Expected object to not be an instance of "${typeof unexpectedType}"${msgSuffix}`;
   assertFalse(actual instanceof unexpectedType, msg);
 }
 
@@ -417,9 +419,8 @@ export function assertExists<T>(
   msg?: string,
 ): asserts actual is NonNullable<T> {
   if (actual === undefined || actual === null) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to not be null or undefined`;
-    }
+    const msgSuffix = msg ? `: ${msg}` : ".";
+    msg = `Expected actual: "${actual}" to not be null or undefined${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -434,9 +435,8 @@ export function assertStringIncludes(
   msg?: string,
 ) {
   if (!actual.includes(expected)) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to contain: "${expected}"`;
-    }
+    const msgSuffix = msg ? `: ${msg}` : ".";
+    msg = `Expected actual: "${actual}" to contain: "${expected}"${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -475,11 +475,11 @@ export function assertArrayIncludes<T>(
   if (missing.length === 0) {
     return;
   }
-  if (!msg) {
-    msg = `actual: "${format(actual)}" expected to include: "${
-      format(expected)
-    }"\nmissing: ${format(missing)}`;
-  }
+
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  msg = `Expected actual: "${format(actual)}" to include: "${
+    format(expected)
+  }"${msgSuffix}\nmissing: ${format(missing)}`;
   throw new AssertionError(msg);
 }
 
@@ -493,9 +493,8 @@ export function assertMatch(
   msg?: string,
 ) {
   if (!expected.test(actual)) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to match: "${expected}"`;
-    }
+    const msgSuffix = msg ? `: ${msg}` : ".";
+    msg = `Expected actual: "${actual}" to match: "${expected}"${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -510,9 +509,8 @@ export function assertNotMatch(
   msg?: string,
 ) {
   if (expected.test(actual)) {
-    if (!msg) {
-      msg = `actual: "${actual}" expected to not match: "${expected}"`;
-    }
+    const msgSuffix = msg ? `: ${msg}` : ".";
+    msg = `Expected actual: "${actual}" to not match: "${expected}"${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -525,6 +523,7 @@ export function assertObjectMatch(
   // deno-lint-ignore no-explicit-any
   actual: Record<PropertyKey, any>,
   expected: Record<PropertyKey, unknown>,
+  msg?: string,
 ) {
   type loose = Record<PropertyKey, unknown>;
 
@@ -592,6 +591,7 @@ export function assertObjectMatch(
     // set (nested) instances' constructor field to be "Object" without changing expected value.
     // see https://github.com/denoland/deno_std/pull/1419
     filter(expected, expected),
+    msg,
   );
 }
 
@@ -599,7 +599,8 @@ export function assertObjectMatch(
  * Forcefully throws a failed assertion
  */
 export function fail(msg?: string): never {
-  assert(false, `Failed assertion${msg ? `: ${msg}` : "."}`);
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  assert(false, `Failed assertion${msgSuffix}`);
 }
 
 /**
@@ -615,13 +616,14 @@ export function assertIsError<E extends Error = Error>(
   msgIncludes?: string,
   msg?: string,
 ): asserts error is E {
+  const msgSuffix = msg ? `: ${msg}` : ".";
   if (error instanceof Error === false) {
-    throw new AssertionError(`Expected "error" to be an Error object.`);
+    throw new AssertionError(`Expected "error" to be an Error object${msgSuffix}}`);
   }
   if (ErrorClass && !(error instanceof ErrorClass)) {
     msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
       typeof error === "object" ? error?.constructor?.name : "[not an object]"
-    }"${msg ? `: ${msg}` : "."}`;
+    }"${msgSuffix}`;
     throw new AssertionError(msg);
   }
   if (
@@ -630,7 +632,7 @@ export function assertIsError<E extends Error = Error>(
   ) {
     msg = `Expected error message to include "${msgIncludes}", but got "${
       error instanceof Error ? error.message : "[not an Error]"
-    }"${msg ? `: ${msg}` : "."}`;
+    }"${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }
@@ -729,13 +731,13 @@ export function assertThrows<E extends Error = Error>(
     msg = errorClassOrMsg;
   }
   let doesThrow = false;
-  const msgToAppendToError = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : ".";
   try {
     fn();
   } catch (error) {
     if (ErrorClass) {
       if (error instanceof Error === false) {
-        throw new AssertionError("A non-Error object was thrown.");
+        throw new AssertionError(`A non-Error object was thrown${msgSuffix}`);
       }
       assertIsError(
         error,
@@ -748,7 +750,7 @@ export function assertThrows<E extends Error = Error>(
     doesThrow = true;
   }
   if (!doesThrow) {
-    msg = `Expected function to throw${msgToAppendToError}`;
+    msg = `Expected function to throw${msgSuffix}`;
     throw new AssertionError(msg);
   }
   return err;
@@ -856,7 +858,7 @@ export async function assertRejects<E extends Error = Error>(
   }
   let doesThrow = false;
   let isPromiseReturned = false;
-  const msgToAppendToError = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : ".";
   try {
     const possiblePromise = fn();
     if (
@@ -870,12 +872,12 @@ export async function assertRejects<E extends Error = Error>(
   } catch (error) {
     if (!isPromiseReturned) {
       throw new AssertionError(
-        `Function throws when expected to reject${msgToAppendToError}`,
+        `Function throws when expected to reject${msgSuffix}`,
       );
     }
     if (ErrorClass) {
       if (error instanceof Error === false) {
-        throw new AssertionError("A non-Error object was rejected.");
+        throw new AssertionError(`A non-Error object was rejected${msgSuffix}`);
       }
       assertIsError(
         error,
@@ -889,7 +891,7 @@ export async function assertRejects<E extends Error = Error>(
   }
   if (!doesThrow) {
     throw new AssertionError(
-      `Expected function to reject${msgToAppendToError}`,
+      `Expected function to reject${msgSuffix}`,
     );
   }
   return err;
@@ -897,7 +899,8 @@ export async function assertRejects<E extends Error = Error>(
 
 /** Use this to stub out methods that will throw when invoked. */
 export function unimplemented(msg?: string): never {
-  throw new AssertionError(msg || "unimplemented");
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  throw new AssertionError(`Unimplemented${msgSuffix}`);
 }
 
 /** Use this to assert unreachable code. */

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -1199,7 +1199,7 @@ Deno.test({
   name: "strict failed with custom msg",
   fn() {
     assertThrows(
-      () => assertStrictEquals({ a: 1}, { a: 1}, "CUSTOM MESSAGE"),
+      () => assertStrictEquals({ a: 1 }, { a: 1 }, "CUSTOM MESSAGE"),
       AssertionError,
       `Values have the same structure but are not reference-equal: CUSTOM MESSAGE
 

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -375,18 +375,18 @@ Deno.test("ArrayContains", function () {
   assertThrows(
     () => assertArrayIncludes(fixtureObject, [{ deno: "node" }]),
     AssertionError,
-    `actual: "[
+    `Expected actual: "[
   {
     deno: "luv",
   },
   {
     deno: "Js",
   },
-]" expected to include: "[
+]" to include: "[
   {
     deno: "node",
   },
-]"
+]".
 missing: [
   {
     deno: "node",
@@ -403,7 +403,7 @@ Deno.test("AssertStringContainsThrow", function () {
     assert(e instanceof AssertionError);
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to contain: "Raptor"`,
+        `Expected actual: "Denosaurus from Jurassic" to contain: "Raptor".`,
     );
     didThrow = true;
   }
@@ -422,7 +422,7 @@ Deno.test("AssertStringMatchingThrows", function () {
     assert(e instanceof AssertionError);
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to match: "/Raptor/"`,
+        `Expected actual: "Denosaurus from Jurassic" to match: "/Raptor/".`,
     );
     didThrow = true;
   }
@@ -441,7 +441,7 @@ Deno.test("AssertStringNotMatchingThrows", function () {
     assert(e instanceof AssertionError);
     assert(
       e.message ===
-        `actual: "Denosaurus from Jurassic" expected to not match: "/from/"`,
+        `Expected actual: "Denosaurus from Jurassic" to not match: "/from/".`,
     );
     didThrow = true;
   }
@@ -751,7 +751,7 @@ Deno.test("AssertsUnimplemented", function () {
     unimplemented();
   } catch (e) {
     assert(e instanceof AssertionError);
-    assert(e.message === "unimplemented");
+    assert(e.message === "Unimplemented.");
     didThrow = true;
   }
   assert(didThrow);
@@ -1006,7 +1006,7 @@ Deno.test({
       () => assertEquals(1, 2),
       AssertionError,
       [
-        "Values are not equal:",
+        "Values are not equal.",
         ...createHeader(),
         removed(`-   ${yellow("1")}`),
         added(`+   ${yellow("2")}`),
@@ -1023,7 +1023,7 @@ Deno.test({
       () => assertEquals<unknown>(1, "1"),
       AssertionError,
       [
-        "Values are not equal:",
+        "Values are not equal.",
         ...createHeader(),
         removed(`-   ${yellow("1")}`),
         added(`+   "1"`),
@@ -1080,7 +1080,7 @@ Deno.test({
         ),
       AssertionError,
       [
-        "Values are not equal:",
+        "Values are not equal.",
         ...createHeader(),
         removed(`-   ${new Date(2019, 0, 3, 4, 20, 1, 10).toISOString()}`),
         added(`+   ${new Date(2019, 0, 3, 4, 20, 1, 20).toISOString()}`),
@@ -1092,10 +1092,27 @@ Deno.test({
         assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
       AssertionError,
       [
-        "Values are not equal:",
+        "Values are not equal.",
         ...createHeader(),
         removed(`-   ${new Date("invalid")}`),
         added(`+   ${new Date(2019, 0, 3, 4, 20, 1, 20).toISOString()}`),
+        "",
+      ].join("\n"),
+    );
+  },
+});
+
+Deno.test({
+  name: "failed with custom msg",
+  fn() {
+    assertThrows(
+      () => assertEquals(1, 2, "CUSTOM MESSAGE"),
+      AssertionError,
+      [
+        "Values are not equal: CUSTOM MESSAGE",
+        ...createHeader(),
+        removed(`-   ${yellow("1")}`),
+        added(`+   ${yellow("2")}`),
         "",
       ].join("\n"),
     );
@@ -1168,11 +1185,26 @@ Deno.test({
     assertThrows(
       () => assertStrictEquals({ a: 1, b: 2 }, { a: 1, b: 2 }),
       AssertionError,
-      `Values have the same structure but are not reference-equal:
+      `Values have the same structure but are not reference-equal.
 
     {
       a: 1,
       b: 2,
+    }`,
+    );
+  },
+});
+
+Deno.test({
+  name: "strict failed with custom msg",
+  fn() {
+    assertThrows(
+      () => assertStrictEquals({ a: 1}, { a: 1}, "CUSTOM MESSAGE"),
+      AssertionError,
+      `Values have the same structure but are not reference-equal: CUSTOM MESSAGE
+
+    {
+      a: 1,
     }`,
     );
   },
@@ -1220,11 +1252,11 @@ Deno.test("assert almost equals number", () => {
   assertThrows(
     () => assertAlmostEquals(0.1 + 0.2, 0.3, 1e-17),
     AssertionError,
-    `"${
+    `Expected actual: "${
       (
         0.1 + 0.2
       ).toExponential()
-    }" expected to be close to "${(0.3).toExponential()}"`,
+    }" to be close to "${(0.3).toExponential()}"`,
   );
 
   //Special cases
@@ -1232,17 +1264,17 @@ Deno.test("assert almost equals number", () => {
   assertThrows(
     () => assertAlmostEquals(0, Infinity),
     AssertionError,
-    '"0" expected to be close to "Infinity"',
+    'Expected actual: "0" to be close to "Infinity"',
   );
   assertThrows(
     () => assertAlmostEquals(-Infinity, +Infinity),
     AssertionError,
-    '"-Infinity" expected to be close to "Infinity"',
+    'Expected actual: "-Infinity" to be close to "Infinity"',
   );
   assertThrows(
     () => assertAlmostEquals(Infinity, NaN),
     AssertionError,
-    '"Infinity" expected to be close to "NaN"',
+    'Expected actual: "Infinity" to be close to "NaN"',
   );
 });
 

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -1420,7 +1420,15 @@ Deno.test("assertSpyArg", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 0, 2),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+-   undefined
++   2`,
+
   );
 
   spyFunc(7, 9);
@@ -1430,17 +1438,38 @@ Deno.test("assertSpyArg", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 0, 9),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+-   undefined
++   9`
   );
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 1, 7),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+-   undefined
++   7`
   );
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 2, 7),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+-   undefined
++   7`
   );
 });
 
@@ -1458,12 +1487,28 @@ Deno.test("assertSpyArgs without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, [undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, [2]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     2,
+    ]`
   );
 
   spyFunc(7, 9);
@@ -1471,12 +1516,32 @@ Deno.test("assertSpyArgs without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, [7, 9, undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      7,
+      9,
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, [9, 7]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+-     7,
+      9,
++     7,
+    ]`
   );
 });
 
@@ -1494,12 +1559,28 @@ Deno.test("assertSpyArgs with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, [undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, [2]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     2,
+    ]`
   );
 
   spyFunc(7, 9, 8);
@@ -1507,12 +1588,32 @@ Deno.test("assertSpyArgs with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, [9, 8, undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      9,
+      8,
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, [9, 7]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      9,
+-     8,
++     7,
+    ]`
   );
 });
 
@@ -1530,12 +1631,30 @@ Deno.test("assertSpyArgs with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, 3, [undefined, undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     undefined,
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, 3, [2, 4]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
++     2,
++     4,
+    ]`
   );
 
   spyFunc(7, 9, 8, 5, 6);
@@ -1543,12 +1662,32 @@ Deno.test("assertSpyArgs with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, 3, [9, 8, undefined]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      9,
+      8,
++     undefined,
+    ]`
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, 3, [9, 7]),
     AssertionError,
-    "Values are not equal:",
+    `Values are not equal.
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      9,
+-     8,
++     7,
+    ]`
   );
 });
 

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -1428,7 +1428,6 @@ Deno.test("assertSpyArg", () => {
 
 -   undefined
 +   2`,
-
   );
 
   spyFunc(7, 9);
@@ -1445,7 +1444,7 @@ Deno.test("assertSpyArg", () => {
 
 
 -   undefined
-+   9`
++   9`,
   );
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 1, 7),
@@ -1457,7 +1456,7 @@ Deno.test("assertSpyArg", () => {
 
 
 -   undefined
-+   7`
++   7`,
   );
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 2, 7),
@@ -1469,7 +1468,7 @@ Deno.test("assertSpyArg", () => {
 
 
 -   undefined
-+   7`
++   7`,
   );
 });
 
@@ -1495,7 +1494,7 @@ Deno.test("assertSpyArgs without range", () => {
 
     [
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, [2]),
@@ -1508,7 +1507,7 @@ Deno.test("assertSpyArgs without range", () => {
 
     [
 +     2,
-    ]`
+    ]`,
   );
 
   spyFunc(7, 9);
@@ -1526,7 +1525,7 @@ Deno.test("assertSpyArgs without range", () => {
       7,
       9,
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, [9, 7]),
@@ -1541,7 +1540,7 @@ Deno.test("assertSpyArgs without range", () => {
 -     7,
       9,
 +     7,
-    ]`
+    ]`,
   );
 });
 
@@ -1567,7 +1566,7 @@ Deno.test("assertSpyArgs with start only", () => {
 
     [
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, [2]),
@@ -1580,7 +1579,7 @@ Deno.test("assertSpyArgs with start only", () => {
 
     [
 +     2,
-    ]`
+    ]`,
   );
 
   spyFunc(7, 9, 8);
@@ -1598,7 +1597,7 @@ Deno.test("assertSpyArgs with start only", () => {
       9,
       8,
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, [9, 7]),
@@ -1613,7 +1612,7 @@ Deno.test("assertSpyArgs with start only", () => {
       9,
 -     8,
 +     7,
-    ]`
+    ]`,
   );
 });
 
@@ -1640,7 +1639,7 @@ Deno.test("assertSpyArgs with range", () => {
     [
 +     undefined,
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, 3, [2, 4]),
@@ -1654,7 +1653,7 @@ Deno.test("assertSpyArgs with range", () => {
     [
 +     2,
 +     4,
-    ]`
+    ]`,
   );
 
   spyFunc(7, 9, 8, 5, 6);
@@ -1672,7 +1671,7 @@ Deno.test("assertSpyArgs with range", () => {
       9,
       8,
 +     undefined,
-    ]`
+    ]`,
   );
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, 3, [9, 7]),
@@ -1687,7 +1686,7 @@ Deno.test("assertSpyArgs with range", () => {
       9,
 -     8,
 +     7,
-    ]`
+    ]`,
   );
 });
 


### PR DESCRIPTION
Rework assertion functions to always include custom `msg` text in the failure message when `msg` is provided.

Since this change touches almost all assertion functions, I used the opportunity to improve the assertion error messages to be more consistent.

This commit also fixes `assertObjectMatch` to propagate the `msg` argument to the underlying `assertEquals()` call. (It was always ignored before this change.)

**BREAKING CHANGE:**
Assertion error messages have slightly different content now. This may break downstream consumers that depend on the exact error message strings.

Resolve https://github.com/denoland/deno_std/issues/2461

_Note: the changes are best viewed with whitespace-only changes ignored._
