### PR TITLE
refactor(CI): pin runner to macOS-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macOS-latest
+          - macOS-12
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
For the same reason that Ubuntu and Windows runner versions are pinned.