### PR TITLE
feat(tools): improved web-compatibility checks

### DIFF
--- a/_tools/check_browser_compat.ts
+++ b/_tools/check_browser_compat.ts
@@ -1,0 +1,71 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { walk } from "../fs/walk.ts";
+
+const ROOT = new URL("../", import.meta.url);
+const SKIP = [/(test|bench|\/_|\\_|testdata)/];
+const DECLARATION = "// This module is browser compatible.";
+
+function isBrowserCompatible(filePath: string): boolean {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "check",
+      "--config",
+      "browser-compat.tsconfig.json",
+      filePath,
+    ],
+  });
+  const { success } = command.outputSync();
+  return success;
+}
+
+function hasBrowserCompatibleComment(path: string): boolean {
+  const output = Deno.readTextFileSync(path);
+  return output.includes(DECLARATION);
+}
+
+const needsBrowserCompatibleCommentAddedList: string[] = [];
+const needsBrowserCompatibleCommentRemovedList: string[] = [];
+
+for await (const { path } of walk(ROOT, { exts: [".ts"], skip: SKIP })) {
+  const result = {
+    isBrowserCompatible: isBrowserCompatible(path),
+    hasBrowserCompatibleComment: hasBrowserCompatibleComment(path),
+  };
+
+  if (!result.isBrowserCompatible && result.hasBrowserCompatibleComment) {
+    needsBrowserCompatibleCommentRemovedList.push(path);
+    continue;
+  }
+
+  if (result.isBrowserCompatible && !result.hasBrowserCompatibleComment) {
+    needsBrowserCompatibleCommentAddedList.push(path);
+    continue;
+  }
+}
+
+let failed = false;
+
+if (needsBrowserCompatibleCommentRemovedList.length > 0) {
+  failed = true;
+  console.error(
+    `The following files must have their "${DECLARATION}" comment removed:`,
+  );
+  needsBrowserCompatibleCommentRemovedList.forEach((path, index) =>
+    console.log(`${index + 1}. ${path}`)
+  );
+}
+
+if (needsBrowserCompatibleCommentAddedList.length > 0) {
+  failed = true;
+  console.error(
+    `The following files must have their "${DECLARATION}" comment added:`,
+  );
+  needsBrowserCompatibleCommentAddedList.forEach((path, index) =>
+    console.log(`${index + 1}. ${path}`)
+  );
+}
+
+if (failed) {
+  Deno.exit(1);
+}

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { deferred } from "./deferred.ts";
 
 /**

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 export class RetryError extends Error {
   constructor(cause: unknown, count: number) {

--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-/** This module is browser compatible. */
+// This module is browser compatible.
 
 import { descend } from "./_comparators.ts";
 

--- a/collections/binary_search_node.ts
+++ b/collections/binary_search_node.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-/** This module is browser compatible. */
+// This module is browser compatible.
 
 export type Direction = "left" | "right";
 

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-/** This module is browser compatible. */
+// This module is browser compatible.
 
 import { ascend } from "./_comparators.ts";
 import { BinarySearchNode, Direction } from "./binary_search_node.ts";

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Functions for specific common tasks around collection types like `Array` and
  * `Record`. This module is heavily inspired by `kotlin`s stdlib.

--- a/collections/red_black_node.ts
+++ b/collections/red_black_node.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-/** This module is browser compatible. */
+// This module is browser compatible.
 
 import { BinarySearchNode, Direction } from "./binary_search_node.ts";
 export type { Direction };

--- a/collections/red_black_tree.ts
+++ b/collections/red_black_tree.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-/** This module is browser compatible. */
+// This module is browser compatible.
 
 import { ascend, BinarySearchTree } from "./binary_search_tree.ts";
 import { Direction, RedBlackNode } from "./red_black_node.ts";

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Extensions to the

--- a/crypto/mod.ts
+++ b/crypto/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Extensions to the

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { assert } from "../_util/asserts.ts";
 

--- a/crypto/to_hash_string.ts
+++ b/crypto/to_hash_string.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { encode as hexEncode } from "../encoding/hex.ts";
 import { encode as base64Encode } from "../encoding/base64.ts";
 

--- a/csv/mod.ts
+++ b/csv/mod.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 export * from "./stringify.ts";
 export * from "./parse.ts";
 export * from "./stream.ts";

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import {
   convertRowToObject,
   ERR_BARE_QUOTE,

--- a/csv/stream.ts
+++ b/csv/stream.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import {
   convertRowToObject,
   defaultReadOptions,

--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 type PropertyAccessor = number | string;
 type ObjectWithStringPropertyKeys = Record<string, unknown>;
 

--- a/datetime/constants.ts
+++ b/datetime/constants.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * The number of milliseconds in a second.
  *

--- a/datetime/day_of_year.ts
+++ b/datetime/day_of_year.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { DAY } from "./constants.ts";
 
 /**

--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { DAY, HOUR, MINUTE, SECOND, WEEK } from "./constants.ts";
 
 export type Unit =

--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { DateTimeFormatter } from "./_common.ts";
 
 /**

--- a/datetime/is_leap.ts
+++ b/datetime/is_leap.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * Returns whether the given date or year (in number) is a leap year or not.
  * based on: https://docs.microsoft.com/en-us/office/troubleshoot/excel/determine-a-leap-year

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Utilities for dealing with {@linkcode Date} objects.

--- a/datetime/parse.ts
+++ b/datetime/parse.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { DateTimeFormatter } from "./_common.ts";
 
 /**

--- a/datetime/to_imf.ts
+++ b/datetime/to_imf.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * Formats the given date to IMF date time format. (Reference:
  * https://tools.ietf.org/html/rfc7231#section-7.1.1.1).

--- a/datetime/week_of_year.ts
+++ b/datetime/week_of_year.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { DAY, WEEK } from "./constants.ts";
 
 const DAYS_PER_WEEK = 7;

--- a/deno.json
+++ b/deno.json
@@ -32,8 +32,8 @@
     }
   },
   "tasks": {
-    "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=_tools/testdata",
-    "test:browser": "deno run -A _tools/check_browser_compat.ts",
+    "test": "deno test --doc --unstable --allow-all --coverage=./cov",
+    "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",
     "lint:doc-imports": "deno run --allow-env --allow-read ./_tools/check_doc_imports.ts",

--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,7 @@
   },
   "tasks": {
     "test": "deno test --doc --unstable --allow-all --coverage=./cov --ignore=_tools/testdata",
-    "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | xargs deno cache --check --reload --config browser-compat.tsconfig.json",
+    "test:browser": "deno run -A _tools/check_browser_compat.ts",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",
     "lint:doc-imports": "deno run --allow-env --allow-read ./_tools/check_doc_imports.ts",

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * {@linkcode encode} and {@linkcode decode} for

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright (c) 2014 Jameson Little. MIT License.
+// This module is browser compatible.
 
 /**
  * {@linkcode encode} and {@linkcode decode} for

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * {@linkcode encode} and {@linkcode decode} for

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * {@linkcode encode} and {@linkcode decode} for

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * {@linkcode encode} and {@linkcode decode} for

--- a/encoding/csv/stream.ts
+++ b/encoding/csv/stream.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 export {
   /** @deprecated (will be removed after 0.182.0) Import from `csv/stream.ts` instead. */
   CsvStream,

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -1,6 +1,7 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // https://github.com/golang/go/blob/master/LICENSE
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Port of the Go
  * [encoding/hex](https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go)

--- a/encoding/jsonc.ts
+++ b/encoding/jsonc.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * @deprecated (will be removed after 0.182.0) Import from `std/jsonc` instead.

--- a/encoding/toml.ts
+++ b/encoding/toml.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * @deprecated (will be removed after 0.182.0) Import from `std/toml` instead.

--- a/encoding/varint/mod.ts
+++ b/encoding/varint/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Functions for encoding typed integers in array buffers.

--- a/encoding/yaml.ts
+++ b/encoding/yaml.ts
@@ -1,5 +1,6 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * @deprecated (will be removed after 0.182.0) Import from `std/yaml` instead.

--- a/examples/welcome.ts
+++ b/examples/welcome.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Welcome to Deno!
  *

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * Command line arguments parser based on
  * [minimist](https://github.com/minimistjs/minimist).

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -1,6 +1,7 @@
 // Copyright 2014-2021 Sindre Sorhus. All rights reserved. MIT license.
 // Copyright 2021 Yoshiya Hinosawa. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Pretty print bytes.
  *

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 // A module to print ANSI terminal colors. Inspired by chalk, kleur, and colors
 // on npm.
 

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Format milliseconds to time duration.

--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Provides a iterable map interfaces for managing cookies server side.
  *

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** A collection of HTTP errors and utilities.
  *

--- a/http/negotiation.ts
+++ b/http/negotiation.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Contains the functions {@linkcode accepts}, {@linkcode acceptsEncodings}, and

--- a/http/server_sent_event.ts
+++ b/http/server_sent_event.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Provides {@linkcode ServerSentEvent} and

--- a/http/util.ts
+++ b/http/util.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { Status, STATUS_TEXT } from "./http_status.ts";
 import { deepMerge } from "../collections/deep_merge.ts";
 

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { copy } from "../bytes/copy.ts";
 import type { Writer, WriterSync } from "../types.d.ts";

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";
 import type { Reader, ReaderSync } from "../types.d.ts";

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { assert } from "../_util/asserts.ts";
 import type { Reader, Writer } from "../types.d.ts";

--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * A `LimitedReader` reads from `reader` but limits the amount of data returned to just `limit` bytes.
  * Each call to `read` updates `limit` to reflect the new amount remaining.

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import type { Reader } from "../types.d.ts";
 

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { BytesList } from "../bytes/bytes_list.ts";
 import type { Reader } from "../types.d.ts";

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { type Reader } from "../types.d.ts";
 import { BufReader } from "./buf_reader.ts";

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { type Reader } from "../types.d.ts";
 import { readDelim } from "./read_delim.ts";

--- a/io/slice_long_to_bytes.ts
+++ b/io/slice_long_to_bytes.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Slice number into 64bit big endian byte array

--- a/io/string_reader.ts
+++ b/io/string_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Buffer } from "./buffer.ts";
 

--- a/json/common.ts
+++ b/json/common.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /** The type of the result of parsing JSON. */
 export type JsonValue =
   | { [key: string]: JsonValue | undefined }

--- a/json/json_parse_stream.ts
+++ b/json/json_parse_stream.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import type { JsonValue, ParseStreamOptions } from "./common.ts";
 import { parse } from "./_common.ts";
 

--- a/json/json_stringify_stream.ts
+++ b/json/json_stringify_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Optional object interface for `JsonStringifyStream`. */
 export interface StringifyStreamOptions {

--- a/jsonc/mod.ts
+++ b/jsonc/mod.ts
@@ -1,2 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 export * from "./parse.ts";

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** {@linkcode parse} function for parsing
  * [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments)

--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { parseMediaType } from "./parse_media_type.ts";
 import { typeByExtension } from "./type_by_extension.ts";
 import { getCharset } from "./get_charset.ts";

--- a/media_types/extension.ts
+++ b/media_types/extension.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { extensionsByType } from "./extensions_by_type.ts";
 
 /**

--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { parseMediaType } from "./parse_media_type.ts";
 import { extensions } from "./_util.ts";
 

--- a/media_types/format_media_type.ts
+++ b/media_types/format_media_type.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { isIterator, isToken, needsEncoding } from "./_util.ts";
 
 /** Serializes the media type and the optional parameters as a media type

--- a/media_types/get_charset.ts
+++ b/media_types/get_charset.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { parseMediaType } from "./parse_media_type.ts";
 import { type DBEntry } from "./_util.ts";
 import { db, type KeyOfDb } from "./_db.ts";

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
 
 /**

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { types } from "./_db.ts";
 
 /**

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright the Browserify authors. MIT License.
 // Ported mostly from https://github.com/browserify/path-browserify/
+// This module is browser compatible.
 
 /**
  * Utilities for working with OS-specific file paths.

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -1,5 +1,6 @@
 // Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * The semantic version parser.

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { assert } from "../_util/asserts.ts";
 import { copy } from "../bytes/copy.ts";
 

--- a/streams/byte_slice_stream.ts
+++ b/streams/byte_slice_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { assert } from "../_util/asserts.ts";
 

--- a/streams/copy.ts
+++ b/streams/copy.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
 import type { Reader, Writer } from "../types.d.ts";

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { BytesList } from "../bytes/bytes_list.ts";
 import { createLPS } from "./_common.ts";

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Merge multiple streams into a single one, taking order into account, and each stream

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
 import type { Reader, ReaderSync } from "../types.d.ts";

--- a/streams/limited_bytes_transform_stream.ts
+++ b/streams/limited_bytes_transform_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** A TransformStream that will only read & enqueue `size` amount of bytes.
  * This operation is chunk based and not BYOB based,

--- a/streams/limited_transform_stream.ts
+++ b/streams/limited_transform_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** A TransformStream that will only read & enqueue `size` amount of chunks.
  *

--- a/streams/read_all.ts
+++ b/streams/read_all.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
 import type { Reader, ReaderSync } from "../types.d.ts";

--- a/streams/readable_stream_from_iterable.ts
+++ b/streams/readable_stream_from_iterable.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** Create a `ReadableStream` from any kind of iterable.
  *

--- a/streams/readable_stream_from_reader.ts
+++ b/streams/readable_stream_from_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { DEFAULT_CHUNK_SIZE } from "./_common.ts";
 import type { Closer, Reader } from "../types.d.ts";

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
 import { writeAll } from "./write_all.ts";

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
 import { writeAll } from "./write_all.ts";

--- a/streams/text_delimiter_stream.ts
+++ b/streams/text_delimiter_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { createLPS } from "./_common.ts";
 

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 interface TextLineStreamOptions {
   /** Allow splitting by solo \r */

--- a/streams/to_transform_stream.ts
+++ b/streams/to_transform_stream.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Convert the generator function into a TransformStream.

--- a/streams/writable_stream_from_writer.ts
+++ b/streams/writable_stream_from_writer.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { writeAll } from "./write_all.ts";
 import type { Closer, Writer } from "../types.d.ts";

--- a/streams/write_all.ts
+++ b/streams/write_all.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import type { Writer, WriterSync } from "../types.d.ts";
 

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import type { Writer } from "../types.d.ts";
 

--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Merge multiple streams into a single one, taking order into account, and each stream

--- a/toml/mod.ts
+++ b/toml/mod.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 /**
  * {@linkcode parse} and {@linkcode stringify} for handling
  * [TOML](https://toml.io/en/latest) encoded data. Be sure to read the supported

--- a/toml/parse.ts
+++ b/toml/parse.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 import { ParserFactory, Toml } from "./_parser.ts";
 
 /**

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -1,4 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
 // Bare keys may only contain ASCII letters,
 // ASCII digits, underscores, and dashes (A-Za-z0-9_-).
 function joinKeys(keys: string[]): string {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /** See the Contributing > Types section in the README for an explanation of this file. */
 

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * Generators and validators for UUIDs for versions v1, v4 and v5.

--- a/yaml/example/dump.ts
+++ b/yaml/example/dump.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { stringify } from "../stringify.ts";
 

--- a/yaml/mod.ts
+++ b/yaml/mod.ts
@@ -1,5 +1,6 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 /**
  * {@linkcode parse} and {@linkcode stringify} for handling

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { CbFunction, load, loadAll } from "./_loader/loader.ts";
 import type { LoaderStateOptions } from "./_loader/loader_state.ts";

--- a/yaml/schema.ts
+++ b/yaml/schema.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { YAMLError } from "./_error.ts";
 import type { KindType, Type } from "./type.ts";

--- a/yaml/schema/core.ts
+++ b/yaml/schema/core.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Schema } from "../schema.ts";
 import { json } from "./json.ts";

--- a/yaml/schema/default.ts
+++ b/yaml/schema/default.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Schema } from "../schema.ts";
 import { binary, merge, omap, pairs, set, timestamp } from "../_type/mod.ts";

--- a/yaml/schema/extended.ts
+++ b/yaml/schema/extended.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Schema } from "../schema.ts";
 import { regexp, undefinedType } from "../_type/mod.ts";

--- a/yaml/schema/failsafe.ts
+++ b/yaml/schema/failsafe.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Schema } from "../schema.ts";
 import { map, seq, str } from "../_type/mod.ts";

--- a/yaml/schema/json.ts
+++ b/yaml/schema/json.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { Schema } from "../schema.ts";
 import { bool, float, int, nil } from "../_type/mod.ts";

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 export { core as CORE_SCHEMA } from "./core.ts";
 export { def as DEFAULT_SCHEMA } from "./default.ts";

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import { dump } from "./_dumper/dumper.ts";
 import type { DumperStateOptions } from "./_dumper/dumper_state.ts";

--- a/yaml/type.ts
+++ b/yaml/type.ts
@@ -2,6 +2,7 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
 
 import type { Any, ArrayObject } from "./_utils.ts";
 


### PR DESCRIPTION
This change:
1. Adds a new, non-compulsory tool that suggests potentially browser-compatible files.
2. Adds the browser-compatible comment to over 100 files that should have it.
3. Makes a few tiny cleanups to `test` and `test:browser` tasks.