### PR TITLE
chore(encoding/yaml): restore deprecated exports

### DIFF
--- a/encoding/_yaml/loader/loader.ts
+++ b/encoding/_yaml/loader/loader.ts
@@ -1,0 +1,8 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+export {
+  /** @deprecated (will be removed after 0.182.0) use `parse` from std/yaml/mod.ts instead */
+  load,
+  /** @deprecated (will be removed after 0.182.0) use `parseAll` from std/yaml/mod.ts instead */
+  loadAll,
+} from "../../../yaml/_loader/loader.ts";


### PR DESCRIPTION
`x/markdown@v2.0.0` depends on this file with non-versioned std url.

https://github.com/ubersl0th/markdown/blob/v2.0.0/src/block-lexer.ts#L25