### PR TITLE
feat(csv): add `CsvStringifyStream`

### DIFF
--- a/csv/csv_stringify_stream.ts
+++ b/csv/csv_stringify_stream.ts
@@ -1,0 +1,67 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { stringify } from "./stringify.ts";
+
+export interface CsvStringifyStreamOptions {
+  /**
+   * Delimiter used to separate values.
+   *
+   * @default {","}
+   */
+  readonly separator?: string;
+
+  /**
+   * A list of columns to be included in the output.
+   *
+   * If you want to stream objects, this option is required.
+   */
+  readonly columns?: Array<string>;
+}
+
+/**
+ * Convert each chunk to a CSV record.
+ *
+ * @example
+ * ```ts
+ * import { CsvStringifyStream } from "https://deno.land/std@$STD_VERSION/csv/csv_stringify_stream.ts";
+ * import { readableStreamFromIterable } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_iterable.ts";
+ *
+ * const file = await Deno.open("data.csv", { create: true, write: true });
+ * const readable = readableStreamFromIterable([
+ *   { id: 1, name: "one" },
+ *   { id: 2, name: "two" },
+ *   { id: 3, name: "three" },
+ * ]);
+ *
+ * await readable
+ *   .pipeThrough(new CsvStringifyStream({ columns: ["id", "name"] }))
+ *   .pipeThrough(new TextEncoderStream())
+ *   .pipeTo(file.writable);
+ * ````
+ */
+export class CsvStringifyStream<TOptions extends CsvStringifyStreamOptions>
+  extends TransformStream<
+    TOptions["columns"] extends Array<string> ? Record<string, unknown>
+      : Array<unknown>,
+    string
+  > {
+  constructor(options?: TOptions) {
+    const {
+      separator,
+      columns = [],
+    } = options ?? {};
+
+    super(
+      {
+        transform(chunk, controller) {
+          try {
+            controller.enqueue(
+              stringify([chunk], { separator, headers: false, columns }),
+            );
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+      },
+    );
+  }
+}

--- a/csv/csv_stringify_stream_test.ts
+++ b/csv/csv_stringify_stream_test.ts
@@ -1,0 +1,114 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { CsvStringifyStream } from "./csv_stringify_stream.ts";
+import { StringifyError } from "./stringify.ts";
+import { readableStreamFromIterable } from "../streams/readable_stream_from_iterable.ts";
+import { assertEquals, assertRejects } from "../testing/asserts.ts";
+
+Deno.test({
+  name: "[csv/csv_stringify_stream] CsvStringifyStream",
+  permissions: "none",
+  fn: async (t) => {
+    await t.step("with arrays", async () => {
+      const readable = readableStreamFromIterable([
+        ["id", "name"],
+        [1, "foo"],
+        [2, "bar"],
+      ]);
+      const output: Array<string> = [];
+      for await (const r of readable.pipeThrough(new CsvStringifyStream())) {
+        output.push(r);
+      }
+      assertEquals(output, [
+        "id,name\r\n",
+        "1,foo\r\n",
+        "2,bar\r\n",
+      ]);
+    });
+
+    await t.step("with arrays, columns", async () => {
+      const readable = readableStreamFromIterable([
+        [1, "foo"],
+        [2, "bar"],
+      ]);
+      await assertRejects(async () => {
+        for await (
+          const _ of readable.pipeThrough(
+            // @ts-expect-error `columns` option is not allowed
+            new CsvStringifyStream({ columns: ["id", "name"] }),
+          )
+        );
+      }, StringifyError);
+    });
+
+    await t.step("with `separator`", async () => {
+      const readable = readableStreamFromIterable([
+        [1, "one"],
+        [2, "two"],
+        [3, "three"],
+      ]);
+      const output: Array<string> = [];
+      for await (
+        const r of readable.pipeThrough(
+          new CsvStringifyStream({ separator: "\t" }),
+        )
+      ) {
+        output.push(r);
+      }
+      assertEquals(output, [
+        "1\tone\r\n",
+        "2\ttwo\r\n",
+        "3\tthree\r\n",
+      ]);
+    });
+
+    await t.step("with invalid `separator`", async () => {
+      const readable = readableStreamFromIterable([
+        ["one", "two", "three"],
+      ]);
+      await assertRejects(async () => {
+        for await (
+          const _ of readable.pipeThrough(
+            new CsvStringifyStream({ separator: "\r\n" }),
+          )
+        );
+      }, StringifyError);
+    });
+
+    await t.step("with objects", async () => {
+      const readable = readableStreamFromIterable([
+        { id: 1, name: "foo" },
+        { id: 2, name: "bar" },
+        { id: 3, name: "baz" },
+      ]);
+      const output: Array<string> = [];
+      for await (
+        const r of readable.pipeThrough(
+          new CsvStringifyStream({ columns: ["id", "name"] }),
+        )
+      ) {
+        output.push(r);
+      }
+      assertEquals(output, [
+        "1,foo\r\n",
+        "2,bar\r\n",
+        "3,baz\r\n",
+      ]);
+    });
+
+    await t.step("with objects, no columns", async () => {
+      const readable = readableStreamFromIterable([
+        { id: 1, name: "foo" },
+        { id: 2, name: "bar" },
+        { id: 3, name: "baz" },
+      ]);
+      await assertRejects(async () => {
+        for await (
+          const _ of readable.pipeThrough(
+            // @ts-expect-error `columns` option is required
+            new CsvStringifyStream(),
+          )
+        );
+      }, StringifyError);
+    });
+  },
+});

--- a/csv/mod.ts
+++ b/csv/mod.ts
@@ -4,3 +4,4 @@
 export * from "./stringify.ts";
 export * from "./parse.ts";
 export * from "./stream.ts";
+export * from "./csv_stringify_stream.ts";


### PR DESCRIPTION
Closes #3258

This PR adds `CsvStringifyStream` (`std/csv/csv_stringify_stream`) to support streaming CSV records