### PR TITLE
chore(fmt): attribute contributor of original source

### DIFF
--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -1,5 +1,6 @@
 // Copyright 2014-2021 Sindre Sorhus. All rights reserved. MIT license.
 // Copyright 2021 Yoshiya Hinosawa. All rights reserved. MIT license.
+// Copyright 2021 Giuseppe Eletto. All rights reserved. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 


### PR DESCRIPTION
Attribution to the contributor of original source was missing. ref. https://github.com/kt3k/pretty_bytes/commit/2cc05376ff87c0d374ef7073754740b6f1530a16