### PR TITLE
chore(_tools): update TypeScript version in doc import check

### DIFF
--- a/_tools/check_doc_imports.ts
+++ b/_tools/check_doc_imports.ts
@@ -8,7 +8,7 @@ import {
   ScriptTarget,
   StringLiteral,
   SyntaxKind,
-} from "https://esm.sh/typescript@4.9.4";
+} from "https://esm.sh/typescript@5.0.2";
 
 const EXTENSIONS = [".mjs", ".js", ".ts", ".md"];
 const EXCLUDED_PATHS = [


### PR DESCRIPTION
This PR updates the TypeScript version in the doc import checker. Now, it matches the current TypeScript version of the CLI, v5.0.2.