### PR TITLE
fix(csv/csv_stringify_stream): output headers based on `columns` option

### DIFF
--- a/csv/csv_stringify_stream.ts
+++ b/csv/csv_stringify_stream.ts
@@ -52,6 +52,17 @@ export class CsvStringifyStream<TOptions extends CsvStringifyStreamOptions>
 
     super(
       {
+        start(controller) {
+          if (columns && columns.length > 0) {
+            try {
+              controller.enqueue(
+                stringify([columns], { separator, headers: false }),
+              );
+            } catch (error) {
+              controller.error(error);
+            }
+          }
+        },
         transform(chunk, controller) {
           try {
             controller.enqueue(

--- a/csv/csv_stringify_stream_test.ts
+++ b/csv/csv_stringify_stream_test.ts
@@ -89,6 +89,7 @@ Deno.test({
         output.push(r);
       }
       assertEquals(output, [
+        "id,name\r\n",
         "1,foo\r\n",
         "2,bar\r\n",
         "3,baz\r\n",


### PR DESCRIPTION
## Example

```javascript
// test.js
import { CsvStringifyStream } from "./csv/csv_stringify_stream.ts";
import { readableStreamFromIterable } from "./streams/readable_stream_from_iterable.ts";

const file = await Deno.open("data.csv", { create: true, write: true });
const readable = readableStreamFromIterable([
  { id: 1, name: "one" },
  { id: 2, name: "two" },
  { id: 3, name: "three" },
]);

await readable
  .pipeThrough(new CsvStringifyStream({ columns: ["id", "name"] }))
  .pipeThrough(new TextEncoderStream())
  .pipeTo(file.writable);
```

**Before:**

```
$ deno run --allow-write main.js
$ cat data.csv
1,one
2,two
3,three
```

**After:**

```
$ deno run --allow-write main.js
$ cat data.csv
id,name
1,one
2,two
3,three
```