### PR TITLE
feat(testing): add .skip alias to bdd test API

### DIFF
--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -439,6 +439,12 @@ export interface it {
 
   /** Registers an individual test case with ignore set to true. */
   ignore<T>(...args: ItArgs<T>): void;
+
+  /**
+   * Registers an individual test case with ignore set to true. Alias of
+   * `.ignore()`.
+   */
+  skip<T>(...args: ItArgs<T>): void;
 }
 
 /** Registers an individual test case. */
@@ -503,6 +509,8 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>) {
     ignore: true,
   });
 };
+
+it.skip = it.ignore;
 
 function addHook<T>(
   name: HookNames,
@@ -684,6 +692,9 @@ export interface describe {
 
   /** Registers a test suite with ignore set to true. */
   ignore<T>(...args: DescribeArgs<T>): TestSuite<T>;
+
+  /** Registers a test suite with ignore set to true. Alias of `.ignore()`. */
+  skip<T>(...args: ItArgs<T>): void;
 }
 
 /** Registers a test suite. */
@@ -720,3 +731,5 @@ describe.ignore = function describeIgnore<T>(
     ignore: true,
   });
 };
+
+describe.skip = describe.ignore;

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -668,6 +668,10 @@ Deno.test("global", async (t) => {
             );
           }));
       });
+
+      await t.step(".skip is an alias of .ignore", () => {
+        assertEquals(it.ignore, it.skip);
+      });
     });
   });
 
@@ -1310,6 +1314,10 @@ Deno.test("global", async (t) => {
               assertEquals(it({ suite, name: "b", fn: fns[1] }), undefined);
             }),
         );
+      });
+
+      await t.step(".skip is an alias of .ignore", () => {
+        assertEquals(describe.ignore, describe.skip);
       });
     });
 


### PR DESCRIPTION
This PR adds `.skip()` as an alias of `.ignore()`. That alias is much more common than `.ignore()` in popular bdd-style testing APIs in other test runners.

| Test runner | Skipping APIs | 
|---|---|
| [mocha](https://github.com/mochajs/mocha) | `describe.skip()`, `it.skip()` |
| [jasmine](https://github.com/jasmine/jasmine) | `xdescribe()`, `xit()` |
| [jest](https://github.com/facebook/jest) | `describe.skip()`, `it.skip()` or `xdescribe()`, `xit()` |
| [vitest](https://vitest.dev/guide/filtering.html#skipping-suites-and-tests) | `describe.skip()`, `it.skip()` |