### PR TITLE
test(datetime): make isLeap test non-sensitive to timezone

### DIFF
--- a/datetime/is_leap_test.ts
+++ b/datetime/is_leap_test.ts
@@ -9,9 +9,9 @@ Deno.test({
     assert(isLeap(2000));
     assert(!isLeap(2003));
     assert(!isLeap(2007));
-    assert(!isLeap(new Date("1970-01-01")));
-    assert(isLeap(new Date("1972-01-01")));
-    assert(isLeap(new Date("2000-01-01")));
-    assert(!isLeap(new Date("2100-01-01")));
+    assert(!isLeap(new Date("1970-01-02")));
+    assert(isLeap(new Date("1972-01-02")));
+    assert(isLeap(new Date("2000-01-02")));
+    assert(!isLeap(new Date("2100-01-02")));
   },
 });


### PR DESCRIPTION
This PR makes isLeap test cases non-sensitive to timezone.

If the timezone offset is < 0, `new Date("1970-01-01").getFullYear()` becomes `1969`, for example, and the current assertions don't pass.

<img width="778" alt="Screen Shot 2023-04-03 at 1 42 36" src="https://user-images.githubusercontent.com/613956/229413927-82f8c01c-b6fd-4a75-af96-d9751375e9fe.png">

closes #3299