### PR TITLE
feat(dotenv): allow reading from `.env` files without granting env access

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -178,7 +178,7 @@ const RE_ExpandValue =
 
 export function parse(
   rawDotenv: string,
-  restrictEnvAccessTo: StringList = [],
+  restrictEnvAccessTo?: StringList,
 ): Record<string, string> {
   const env: Record<string, string> = {};
 
@@ -224,7 +224,7 @@ export function loadSync(
     defaultsPath = ".env.defaults",
     export: _export = false,
     allowEmptyValues = false,
-    restrictEnvAccessTo = [],
+    restrictEnvAccessTo,
   }: LoadOptions = {},
 ): Record<string, string> {
   const conf = envPath ? parseFileSync(envPath, restrictEnvAccessTo) : {};
@@ -268,7 +268,7 @@ export async function load(
     defaultsPath = ".env.defaults",
     export: _export = false,
     allowEmptyValues = false,
-    restrictEnvAccessTo = [],
+    restrictEnvAccessTo,
   }: LoadOptions = {},
 ): Promise<Record<string, string>> {
   const conf = envPath ? await parseFile(envPath, restrictEnvAccessTo) : {};
@@ -305,7 +305,7 @@ export async function load(
 
 function parseFileSync(
   filepath: string,
-  restrictEnvAccessTo: StringList = [],
+  restrictEnvAccessTo?: StringList,
 ): Record<string, string> {
   try {
     return parse(Deno.readTextFileSync(filepath), restrictEnvAccessTo);
@@ -317,7 +317,7 @@ function parseFileSync(
 
 async function parseFile(
   filepath: string,
-  restrictEnvAccessTo: StringList = [],
+  restrictEnvAccessTo?: StringList,
 ): Promise<Record<string, string>> {
   try {
     return parse(await Deno.readTextFile(filepath), restrictEnvAccessTo);
@@ -344,7 +344,7 @@ function assertSafe(
   conf: Record<string, string>,
   confExample: Record<string, string>,
   allowEmptyValues: boolean,
-  restrictEnvAccessTo: StringList = [],
+  restrictEnvAccessTo?: StringList,
 ) {
   const currentEnv = readEnv(restrictEnvAccessTo);
 
@@ -381,10 +381,7 @@ function assertSafe(
 // a guarded env access, that reads only a subset from the Deno.env object,
 // if `restrictEnvAccessTo` property is passed.
 function readEnv(restrictEnvAccessTo: StringList) {
-  if (
-    restrictEnvAccessTo && Array.isArray(restrictEnvAccessTo) &&
-    restrictEnvAccessTo.length > 0
-  ) {
+  if (restrictEnvAccessTo && Array.isArray(restrictEnvAccessTo)) {
     return restrictEnvAccessTo.reduce(
       (
         accessedEnvVars: Record<string, string>,

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -581,6 +581,7 @@ Deno.test("expand variables", () => {
     "variables within and without brackets expanded",
   );
 });
+
 Deno.test("stringify", async (t) => {
   await t.step(
     "basic",
@@ -758,7 +759,7 @@ Deno.test("type inference based on restrictEnvAccessTo", async (t) => {
 });
 
 Deno.test(
-  "prevent file systems reads of default path parameter values by using explicit null",
+  "prevent file system reads of default path parameter values by using explicit null",
   {
     permissions: {
       env: ["GREETING", "DO_NOT_OVERRIDE"],


### PR DESCRIPTION
This PR improves security/privacy by allowing the user to read env data from `.env` files without granting actual environment permissions.

Continuation of [#3221 (comment)](https://github.com/denoland/deno_std/pull/3221#issuecomment-1444784865):

> Note to self and for a potential follow up PR: After refactoring the new test to be stricter, I realized that there doesn't seem to be a way to load environment variables purely from a file: without granting access to at least some actual environment variables. In my view, this seems like an oversight and could be fixed rather easily by:
> 
> * not using an empty array `[]` as the default parameter for `restrictEnvAccessTo` in most of the functions in this module, and
> * refactoring `readEnv` to interpret the case of an empty array as "allow access to no variables" (a no-op), and just return `{}` without attempting to use the `Deno.env` API at all

Technically, I think this is a breaking change — but if I'm wrong about that, please feel free to change the title. There are no tests to support my hypothesis that it's a breaking change, but I think that it could break existing code if a consumer previously provided an explicit empty array and expected for variables to be read from the environment.