### PR TITLE
feat(http): add HTTP_METHODS, HttpMethods, and isHttpMethod

### DIFF
--- a/http/method.ts
+++ b/http/method.ts
@@ -3,27 +3,57 @@
 
 /**
  * Contains the constant {@linkcode HTTP_METHODS} and the type
- * {@linkcode HttpMethods} and the type guard {@linkcode isHttpMethod} for
+ * {@linkcode HttpMethod} and the type guard {@linkcode isHttpMethod} for
  * working with HTTP methods with type safety.
  *
  * @module
  */
 
-/** A constant array of common HTTP methods. */
+/** A constant array of common HTTP methods.
+ *
+ * This list is compatible with Node.js `http` module.
+ */
 export const HTTP_METHODS = [
-  "HEAD",
-  "OPTIONS",
+  "ACL",
+  "BIND",
+  "CHECKOUT",
+  "CONNECT",
+  "COPY",
+  "DELETE",
   "GET",
-  "PUT",
+  "HEAD",
+  "LINK",
+  "LOCK",
+  "M-SEARCH",
+  "MERGE",
+  "MKACTIVITY",
+  "MKCALENDAR",
+  "MKCOL",
+  "MOVE",
+  "NOTIFY",
+  "OPTIONS",
   "PATCH",
   "POST",
-  "DELETE",
+  "PROPFIND",
+  "PROPPATCH",
+  "PURGE",
+  "PUT",
+  "REBIND",
+  "REPORT",
+  "SEARCH",
+  "SOURCE",
+  "SUBSCRIBE",
+  "TRACE",
+  "UNBIND",
+  "UNLINK",
+  "UNLOCK",
+  "UNSUBSCRIBE",
 ] as const;
 
 /** A type representing string literals of each of the common HTTP method. */
-export type HttpMethods = typeof HTTP_METHODS[number];
+export type HttpMethod = typeof HTTP_METHODS[number];
 
 /** A type guard that determines if a value is a valid HTTP method. */
-export function isHttpMethod(value: unknown): value is HttpMethods {
-  return HTTP_METHODS.includes(value as HttpMethods);
+export function isHttpMethod(value: unknown): value is HttpMethod {
+  return HTTP_METHODS.includes(value as HttpMethod);
 }

--- a/http/method.ts
+++ b/http/method.ts
@@ -1,0 +1,29 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+/**
+ * Contains the constant {@linkcode HTTP_METHODS} and the type
+ * {@linkcode HttpMethods} and the type guard {@linkcode isHttpMethod} for
+ * working with HTTP methods with type safety.
+ *
+ * @module
+ */
+
+/** A constant array of common HTTP methods. */
+export const HTTP_METHODS = [
+  "HEAD",
+  "OPTIONS",
+  "GET",
+  "PUT",
+  "PATCH",
+  "POST",
+  "DELETE",
+] as const;
+
+/** A type representing string literals of each of the common HTTP method. */
+export type HttpMethods = typeof HTTP_METHODS[number];
+
+/** A type guard that determines if a value is a valid HTTP method. */
+export function isHttpMethod(value: unknown): value is HttpMethods {
+  return HTTP_METHODS.includes(value as HttpMethods);
+}

--- a/http/method_test.ts
+++ b/http/method_test.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { assert, assertEquals } from "../testing/asserts.ts";
+
+import { HTTP_METHODS, isHttpMethod } from "./method.ts";
+
+Deno.test({
+  name: "HTTP_METHODS",
+  fn() {
+    const methods = [
+      "HEAD",
+      "OPTIONS",
+      "GET",
+      "PUT",
+      "PATCH",
+      "POST",
+      "DELETE",
+    ] as const;
+    for (const method of methods) {
+      assert(HTTP_METHODS.includes(method));
+    }
+    assertEquals(HTTP_METHODS.length, methods.length);
+  },
+});
+
+Deno.test({
+  name: "isHttpMethod",
+  fn() {
+    assert(isHttpMethod("GET"));
+    assert(!isHttpMethod("PUSH"));
+  },
+});

--- a/http/method_test.ts
+++ b/http/method_test.ts
@@ -8,13 +8,40 @@ Deno.test({
   name: "HTTP_METHODS",
   fn() {
     const methods = [
-      "HEAD",
-      "OPTIONS",
+      "ACL",
+      "BIND",
+      "CHECKOUT",
+      "CONNECT",
+      "COPY",
+      "DELETE",
       "GET",
-      "PUT",
+      "HEAD",
+      "LINK",
+      "LOCK",
+      "M-SEARCH",
+      "MERGE",
+      "MKACTIVITY",
+      "MKCALENDAR",
+      "MKCOL",
+      "MOVE",
+      "NOTIFY",
+      "OPTIONS",
       "PATCH",
       "POST",
-      "DELETE",
+      "PROPFIND",
+      "PROPPATCH",
+      "PURGE",
+      "PUT",
+      "REBIND",
+      "REPORT",
+      "SEARCH",
+      "SOURCE",
+      "SUBSCRIBE",
+      "TRACE",
+      "UNBIND",
+      "UNLINK",
+      "UNLOCK",
+      "UNSUBSCRIBE",
     ] as const;
     for (const method of methods) {
       assert(HTTP_METHODS.includes(method));
@@ -28,5 +55,6 @@ Deno.test({
   fn() {
     assert(isHttpMethod("GET"));
     assert(!isHttpMethod("PUSH"));
+    assert(isHttpMethod("M-SEARCH"));
   },
 });

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -34,6 +34,10 @@
  * Provides error classes for each HTTP error status code as well as utility
  * functions for handling HTTP errors in a structured way.
  *
+ * ## Methods
+ *
+ * Provides helper functions and types to work with HTTP method strings safely.
+ *
  * ## Negotiation
  *
  * A set of functions which can be used to negotiate content types, encodings and

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -58,6 +58,7 @@ export * from "./cookie_map.ts";
 export * from "./etag.ts";
 export * from "./http_errors.ts";
 export * from "./http_status.ts";
+export * from "./method.ts";
 export * from "./negotiation.ts";
 export * from "./server.ts";
 export * from "./server_sent_event.ts";


### PR DESCRIPTION
This provides a couple of utilities to be able to safely handle common HTTP methods.

This comes from oak/oak_commons.
