### PR TITLE
fix(encoding/ascii85): fix `encode()` returns a wrong result with a 4-byte subarray

### DIFF
--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -65,6 +65,9 @@ const Z85 =
  * @param [options.delimiter] whether to use a delimiter, if supported by encoding standard
  */
 export function encode(uint8: Uint8Array, options?: Ascii85Options): string {
+  // Create a new Uint8Array from the given uint8 instead of using it
+  uint8 = new Uint8Array(uint8);
+
   const standard = options?.standard ?? "Adobe";
   let output: string[] = [],
     v: number,

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -67,7 +67,6 @@ const Z85 =
 export function encode(uint8: Uint8Array, options?: Ascii85Options): string {
   // Create a new Uint8Array from the given uint8 instead of using it
   uint8 = new Uint8Array(uint8);
-
   const standard = options?.standard ?? "Adobe";
   let output: string[] = [],
     v: number,

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -65,8 +65,6 @@ const Z85 =
  * @param [options.delimiter] whether to use a delimiter, if supported by encoding standard
  */
 export function encode(uint8: Uint8Array, options?: Ascii85Options): string {
-  // Create a new Uint8Array from the given uint8 instead of using it
-  uint8 = new Uint8Array(uint8);
   const standard = options?.standard ?? "Adobe";
   let output: string[] = [],
     v: number,
@@ -78,7 +76,7 @@ export function encode(uint8: Uint8Array, options?: Ascii85Options): string {
     uint8 = new Uint8Array(tmp.length + difference);
     uint8.set(tmp);
   }
-  const view = new DataView(uint8.buffer);
+  const view = new DataView(uint8.buffer, uint8.byteOffset, uint8.byteLength);
   for (let i = 0, len = uint8.length; i < len; i += 4) {
     v = view.getUint32(i);
     // Adobe and btoa standards compress 4 zeroes to single "z" character

--- a/encoding/ascii85_test.ts
+++ b/encoding/ascii85_test.ts
@@ -176,3 +176,19 @@ for (const [standard, tests] of Object.entries(testCasesDelimiter)) {
     },
   });
 }
+
+Deno.test({
+  name: `[encoding/ascii85] encode subarray of an Uint8Array`,
+  fn() {
+    const data1 = new Uint8Array([0x73, 0x70, 0x61, 0x6d]);
+    const data2 = new Uint8Array(
+      [0x01, 0x02, 0x03, 0x04, 0x73, 0x70, 0x61, 0x6d],
+    );
+
+    const encoded1 = encode(data1);
+    const encoded2 = encode(data2.subarray(4));
+
+    assertEquals(encoded1, "F)YQ)");
+    assertEquals(encoded2, "F)YQ)");
+  },
+});


### PR DESCRIPTION
Fixes: #3223