### PR TITLE
docs(http): fix default etag algorithm

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -428,7 +428,7 @@ export interface ServeDirOptions {
    *
    * @default {"SHA-256"}
    */
-  etagAlgorithm?: DigestAlgorithm;
+  etagAlgorithm?: AlgorithmIdentifier;
   /** Headers to add to each response
    *
    * @default {[]}

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -14,7 +14,6 @@ import { parse } from "../flags/mod.ts";
 import { assert } from "../_util/asserts.ts";
 import { red } from "../fmt/colors.ts";
 import { createCommonResponse } from "./util.ts";
-import { DigestAlgorithm } from "../crypto/crypto.ts";
 import { VERSION } from "../version.ts";
 interface EntryInfo {
   mode: string;
@@ -68,9 +67,9 @@ function fileLenToString(len: number): string {
 export interface ServeFileOptions {
   /** The algorithm to use for generating the ETag.
    *
-   * @default {"fnv1a"}
+   * @default {"SHA-256"}
    */
-  etagAlgorithm?: DigestAlgorithm;
+  etagAlgorithm?: AlgorithmIdentifier;
   /** An optional FileInfo object returned by Deno.stat. It is used for optimization purposes. */
   fileInfo?: Deno.FileInfo;
 }
@@ -427,7 +426,7 @@ export interface ServeDirOptions {
   quiet?: boolean;
   /** The algorithm to use for generating the ETag.
    *
-   * @default {"fnv1a"}
+   * @default {"SHA-256"}
    */
   etagAlgorithm?: DigestAlgorithm;
   /** Headers to add to each response


### PR DESCRIPTION
Since #3245, the default etag hash algorithm is `SHA-256` instead of `fnv1a` (because `http/etag` only supports digest algorithms available for `crypto.subtle.digest`).

This PR fixes the doc for it. Also removes the reference to `DigestAlgorithm` type from `std/crypto`.

Because of the removal of the dependency to `std/crypto` this PR reduces the file_server size from 646.44KB to 389.77KB.