### PR TITLE
feat(jsonc): annotate return types

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -97,7 +97,7 @@ class JSONCParser {
   }
   parse(): JsonValue {
     const token = this.#getNext();
-    const res = this.#parseJSONValue(token);
+    const res = this.#parseJsonValue(token);
 
     // make sure all characters have been read
     const { done, value } = this.#tokenized.next();
@@ -209,7 +209,7 @@ class JSONCParser {
       }
     }
   }
-  #parseJSONValue(value: Token): JsonValue {
+  #parseJsonValue(value: Token): JsonValue {
     switch (value.type) {
       case TokenType.BeginObject:
         return this.#parseObject();
@@ -267,7 +267,7 @@ class JSONCParser {
 
       const token3 = this.#getNext();
       Object.defineProperty(target, key, {
-        value: this.#parseJSONValue(token3),
+        value: this.#parseJsonValue(token3),
         writable: true,
         enumerable: true,
         configurable: true,
@@ -306,7 +306,7 @@ class JSONCParser {
       ) {
         return target;
       }
-      target.push(this.#parseJSONValue(token1));
+      target.push(this.#parseJsonValue(token1));
 
       const token2 = this.#getNext();
       if (token2.type === TokenType.EndArray) {

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -41,11 +41,11 @@ export interface ParseOptions {
 export function parse(
   text: string,
   { allowTrailingComma = true }: ParseOptions = {},
-) {
+): JSONValue {
   if (new.target) {
     throw new TypeError("parse is not a constructor");
   }
-  return new JSONCParser(text, { allowTrailingComma }).parse() as JSONValue;
+  return new JSONCParser(text, { allowTrailingComma }).parse();
 }
 
 /** Valid types as a result of JSON parsing */
@@ -101,7 +101,7 @@ class JSONCParser {
     this.#tokenized = this.#tokenize();
     this.#options = options;
   }
-  parse() {
+  parse(): JSONValue {
     const token = this.#getNext();
     const res = this.#parseJSONValue(token);
 
@@ -114,7 +114,7 @@ class JSONCParser {
     return res;
   }
   /** Read the next token. If the token is read to the end, it throws a SyntaxError. */
-  #getNext() {
+  #getNext(): Token {
     const { done, value } = this.#tokenized.next();
     if (done) {
       throw new SyntaxError("Unexpected end of JSONC input");
@@ -215,7 +215,7 @@ class JSONCParser {
       }
     }
   }
-  #parseJSONValue(value: Token) {
+  #parseJSONValue(value: Token): JSONValue {
     switch (value.type) {
       case tokenType.beginObject:
         return this.#parseObject();
@@ -229,8 +229,8 @@ class JSONCParser {
         throw new SyntaxError(buildErrorMessage(value));
     }
   }
-  #parseObject() {
-    const target: Record<string, unknown> = {};
+  #parseObject(): { [key: string]: JSONValue | undefined } {
+    const target: { [key: string]: JSONValue | undefined } = {};
     //   ┌─token1
     // { }
     //      ┌─────────────token1
@@ -288,8 +288,8 @@ class JSONCParser {
       }
     }
   }
-  #parseArray() {
-    const target: unknown[] = [];
+  #parseArray(): JSONValue[] {
+    const target: JSONValue[] = [];
     //   ┌─token1
     // [ ]
     //      ┌─────────────token1
@@ -342,7 +342,7 @@ class JSONCParser {
     type: tokenType.nullOrTrueOrFalseOrNumber;
     sourceText: string;
     position: number;
-  }) {
+  }): null | boolean | number {
     if (value.sourceText === "null") {
       return null;
     }
@@ -364,7 +364,7 @@ class JSONCParser {
   }
 }
 
-function buildErrorMessage({ type, sourceText, position }: Token) {
+function buildErrorMessage({ type, sourceText, position }: Token): string {
   let token = "";
   switch (type) {
     case tokenType.beginObject:

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -153,22 +153,22 @@ class JSONCParser {
 
       switch (this.#text[i]) {
         case "{":
-          yield { type: TokenType.BeginObject, position: i } as const;
+          yield { type: TokenType.BeginObject, position: i };
           break;
         case "}":
-          yield { type: TokenType.EndObject, position: i } as const;
+          yield { type: TokenType.EndObject, position: i };
           break;
         case "[":
-          yield { type: TokenType.BeginArray, position: i } as const;
+          yield { type: TokenType.BeginArray, position: i };
           break;
         case "]":
-          yield { type: TokenType.EndArray, position: i } as const;
+          yield { type: TokenType.EndArray, position: i };
           break;
         case ":":
-          yield { type: TokenType.NameSeparator, position: i } as const;
+          yield { type: TokenType.NameSeparator, position: i };
           break;
         case ",":
-          yield { type: TokenType.ValueSeparator, position: i } as const;
+          yield { type: TokenType.ValueSeparator, position: i };
           break;
         case '"': { // parse string token
           const startIndex = i;
@@ -189,7 +189,7 @@ class JSONCParser {
             type: TokenType.String,
             sourceText: this.#text.substring(startIndex, i + 1),
             position: startIndex,
-          } as const;
+          };
           break;
         }
         default: { // parse null, true, false or number token
@@ -204,7 +204,7 @@ class JSONCParser {
             type: TokenType.NullOrTrueOrFalseOrNumber,
             sourceText: this.#text.substring(startIndex, i + 1),
             position: startIndex,
-          } as const;
+          };
         }
       }
     }

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -12,6 +12,9 @@
 
 import { assert } from "../_util/asserts.ts";
 
+import type { JsonValue } from "../json/common.ts";
+export type { JsonValue } from "../json/common.ts";
+
 export interface ParseOptions {
   /** Allow trailing commas at the end of arrays and objects.
    *
@@ -41,21 +44,12 @@ export interface ParseOptions {
 export function parse(
   text: string,
   { allowTrailingComma = true }: ParseOptions = {},
-): JSONValue {
+): JsonValue {
   if (new.target) {
     throw new TypeError("parse is not a constructor");
   }
   return new JSONCParser(text, { allowTrailingComma }).parse();
 }
-
-/** Valid types as a result of JSON parsing */
-export type JSONValue =
-  | { [key: string]: JSONValue | undefined }
-  | JSONValue[]
-  | string
-  | number
-  | boolean
-  | null;
 
 enum tokenType {
   beginObject,
@@ -101,7 +95,7 @@ class JSONCParser {
     this.#tokenized = this.#tokenize();
     this.#options = options;
   }
-  parse(): JSONValue {
+  parse(): JsonValue {
     const token = this.#getNext();
     const res = this.#parseJSONValue(token);
 
@@ -215,7 +209,7 @@ class JSONCParser {
       }
     }
   }
-  #parseJSONValue(value: Token): JSONValue {
+  #parseJSONValue(value: Token): JsonValue {
     switch (value.type) {
       case tokenType.beginObject:
         return this.#parseObject();
@@ -229,8 +223,8 @@ class JSONCParser {
         throw new SyntaxError(buildErrorMessage(value));
     }
   }
-  #parseObject(): { [key: string]: JSONValue | undefined } {
-    const target: { [key: string]: JSONValue | undefined } = {};
+  #parseObject(): { [key: string]: JsonValue | undefined } {
+    const target: { [key: string]: JsonValue | undefined } = {};
     //   ┌─token1
     // { }
     //      ┌─────────────token1
@@ -288,8 +282,8 @@ class JSONCParser {
       }
     }
   }
-  #parseArray(): JSONValue[] {
-    const target: JSONValue[] = [];
+  #parseArray(): JsonValue[] {
+    const target: JsonValue[] = [];
     //   ┌─token1
     // [ ]
     //      ┌─────────────token1


### PR DESCRIPTION
Previously, return type annotations were missing and the type `JsonValue` was duplicated.