### PR TITLE
fix(std/path) duplicate export sep/SEP and naming conventions

### DIFF
--- a/path/_separator.ts
+++ b/path/_separator.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+// NOTE: This file exists to break circular referencecs; it should NOT be
+// imported directly, outside of the "std/path" module.
+
+import { isWindows } from "../_util/os.ts";
+import { sep as win32Sep } from "./win32.ts";
+import { sep as posixSep } from "./posix.ts";
+
+export const SEP = isWindows ? win32Sep : posixSep;
+export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;

--- a/path/common.ts
+++ b/path/common.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { SEP } from "./separator.ts";
+import { SEP } from "./_separator.ts";
 
 /** Determines the common path from a set of paths, using an optional separator,
  * which defaults to the OS default separator.

--- a/path/glob.ts
+++ b/path/glob.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { isWindows, osType } from "../_util/os.ts";
-import { SEP, SEP_PATTERN } from "./separator.ts";
+import { SEP, SEP_PATTERN } from "./_separator.ts";
 import * as _win32 from "./win32.ts";
 import * as _posix from "./posix.ts";
 import type { OSType } from "../_util/os.ts";

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -49,6 +49,6 @@ export const {
 } = path;
 
 export * from "./common.ts";
-export { SEP, SEP_PATTERN } from "./separator.ts";
+export * from "./_separator.ts";
 export * from "./_interface.ts";
 export * from "./glob.ts";

--- a/path/separator.ts
+++ b/path/separator.ts
@@ -1,7 +1,0 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
-
-import { isWindows } from "../_util/os.ts";
-
-export const SEP = isWindows ? "\\" : "/";
-export const SEP_PATTERN = isWindows ? /[\\/]+/ : /\/+/;


### PR DESCRIPTION
issue: #3194

**Summary**

  1. Created new variable names to align with the - current, published - naming convention
  2. Kept the non-standard - to be deprecated - variables as alias to the standard versions
  3. Added `@deprecated` tags to each variable that will be removed in a future version
  4. Moved the `separators.ts` file to `_separators.ts` to align with the naming convention for [files that should not be linked to directly](https://deno.com/manual@v1.32.5/references/contributing/style_guide#if-a-filename-starts-with-an-underscore-_foots-do-not-link-to-it)
  5. Added comment to `_separators.ts` to detail why the file is necessary

I am completely open to suggestion/debate on anything proposed herein.