### PR TITLE
fix(http/server): flaky 'address in use' error

### DIFF
--- a/http/server.ts
+++ b/http/server.ts
@@ -601,7 +601,13 @@ export async function serve(
     once: true,
   });
 
-  const s = await server.listenAndServe();
+  const listener = Deno.listen({
+    port,
+    hostname,
+    transport: "tcp",
+  });
+
+  const s = server.serve(listener);
 
   port = (server.addrs[0] as Deno.NetAddr).port;
 
@@ -611,7 +617,7 @@ export async function serve(
     console.log(`Listening on http://${hostnameForDisplay(hostname)}:${port}/`);
   }
 
-  return s;
+  return await s;
 }
 
 export interface ServeTlsInit extends ServeInit {

--- a/http/server.ts
+++ b/http/server.ts
@@ -601,7 +601,7 @@ export async function serve(
     once: true,
   });
 
-  const s = server.listenAndServe();
+  const s = await server.listenAndServe();
 
   port = (server.addrs[0] as Deno.NetAddr).port;
 
@@ -611,7 +611,7 @@ export async function serve(
     console.log(`Listening on http://${hostnameForDisplay(hostname)}:${port}/`);
   }
 
-  return await s;
+  return s;
 }
 
 export interface ServeTlsInit extends ServeInit {


### PR DESCRIPTION
Resolves #3320 

When server.addrs[0].port is assigned to a variable, it sometimes fails because the call to `server.listenAndServe` has not finished yet, resulting in a rather unhelpful error being thrown.

Awaiting the call to `server.listenAndServe` fixes the bug.