### PR TITLE
perf(collections/includes_value): support objects with non-enumerable properties

### DIFF
--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -23,7 +23,9 @@ export function includesValue<T>(
   record: Readonly<Record<string, T>>,
   value: T,
 ): boolean {
-  for (const i in record) {
+  const keys = getAllKeys(record);
+
+  for (const i of keys) {
     if (
       Object.hasOwn(record, i) &&
       (record[i] === value || Number.isNaN(value) && Number.isNaN(record[i]))
@@ -33,4 +35,22 @@ export function includesValue<T>(
   }
 
   return false;
+}
+
+/** Get all properties of an object (including non-enumerable properties) */
+function getAllKeys<T>(record: Readonly<Record<string, T>>) {
+  const keys: string[] = [];
+  let obj = record;
+
+  while (obj) {
+    Object.getOwnPropertyNames(obj).forEach((key) => {
+      if (keys.indexOf(key) === -1) {
+        keys.push(key);
+      }
+    });
+
+    obj = Object.getPrototypeOf(obj);
+  }
+
+  return keys;
 }

--- a/collections/includes_value_test.ts
+++ b/collections/includes_value_test.ts
@@ -45,7 +45,6 @@ Deno.test("[collections/includesValue] Returns false when it doesn't include the
 });
 
 Deno.test("[collections/includesValue] Non-enumerable properties", () => {
-  // FAIL is expected, TODO: Figure out how to make it work on
   const input = {};
 
   Object.defineProperty(input, "nep", {
@@ -67,9 +66,9 @@ Deno.test("[collections/includesValue] Non-enumerable properties", () => {
   const actual2 = includesValue(input, "hello");
   const actual3 = includesValue(input, true);
 
-  assert(!actual1);
-  assert(!actual2);
-  assert(!actual3);
+  assert(actual1);
+  assert(actual2);
+  assert(actual3);
 });
 
 Deno.test("[collections/includesValue] Non-primitive values", () => {


### PR DESCRIPTION
Since [`for...in` loop can only visit enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties#traversing_object_properties), this PR updates `includesValue` function to work with non-enumerable properties.