### PR TITLE
feat(async): support `signal` on `deadline()` like `delay()`

### DIFF
--- a/async/deadline_test.ts
+++ b/async/deadline_test.ts
@@ -1,28 +1,37 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertRejects } from "../testing/asserts.ts";
-import { deferred } from "./deferred.ts";
+import { delay } from "./delay.ts";
 import { deadline, DeadlineError } from "./deadline.ts";
 
 Deno.test("[async] deadline: return fulfilled promise", async () => {
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const controller = new AbortController();
+  const { signal } = controller;
+  const p = delay(100, { signal })
+    .catch(() => {})
+    .then(() => "Hello");
   const result = await deadline(p, 1000);
   assertEquals(result, "Hello");
-  clearTimeout(t);
+  controller.abort();
 });
 
 Deno.test("[async] deadline: throws DeadlineError", async () => {
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 1000);
+  const controller = new AbortController();
+  const { signal } = controller;
+  const p = delay(1000, { signal })
+    .catch(() => {})
+    .then(() => "Hello");
   await assertRejects(async () => {
     await deadline(p, 100);
   }, DeadlineError);
-  clearTimeout(t);
+  controller.abort();
 });
 
 Deno.test("[async] deadline: thrown when promise is rejected", async () => {
-  const p = deferred();
-  const t = setTimeout(() => p.reject(new Error("booom")), 100);
+  const controller = new AbortController();
+  const { signal } = controller;
+  const p = delay(100, { signal })
+    .catch(() => {})
+    .then(() => Promise.reject(new Error("booom")));
   await assertRejects(
     async () => {
       await deadline(p, 1000);
@@ -30,5 +39,5 @@ Deno.test("[async] deadline: thrown when promise is rejected", async () => {
     Error,
     "booom",
   );
-  clearTimeout(t);
+  controller.abort();
 });


### PR DESCRIPTION
As the subject suggests, I have added support for the signal parameter in the `deadline()` function. This change is useful to clean up dangling promises for tests like:

```ts
Deno.test("...", async () => {
  const controller = new AbortController();
  const { signal } = controller;
  assertEquals(await Promise.race([
    deadline(new Promise(() => {}), 100, { signal }),
    Promise.resolve("Hello"),
  ], "Hello");
  controller.abort();
});
```

Without the signal parameter, the above test fails with the following error:

```
error: Leaking async ops:
  - 1 async operation to sleep for a duration was started in this test, but never completed. This is often caus
ed by not cancelling a `setTimeout` or `setInterval` call.
To get more details where ops were leaked, run again with --trace-ops flag.
```

Note that the comment on `deadline` suggests using `AbortSignal.timeout(...)` instead. However, the signal itself cannot be manually aborted ([yet](https://github.com/w3ctag/design-reviews/issues/737)), so `deadline()` is still useful in such cases.