### PR TITLE
docs(http): add missing default values for `ServeDir` options of `file_server`

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -408,9 +408,15 @@ function dirViewerTemplate(dirname: string, entries: EntryInfo[]): string {
 
 /** Interface for serveDir options. */
 export interface ServeDirOptions {
-  /** Serves the files under the given directory root. Defaults to your current directory. */
+  /** Serves the files under the given directory root. Defaults to your current directory.
+   *
+   * @default {"."}
+   */
   fsRoot?: string;
-  /** Specified that part is stripped from the beginning of the requested pathname. */
+  /** Specified that part is stripped from the beginning of the requested pathname.
+   *
+   * @default {undefined}
+   */
   urlRoot?: string;
   /** Enable directory listing.
    *
@@ -422,7 +428,10 @@ export interface ServeDirOptions {
    * @default {false}
    */
   showDotfiles?: boolean;
-  /** Serves index.html as the index file of the directory. */
+  /** Serves index.html as the index file of the directory.
+   *
+   * @default {true}
+   */
   showIndex?: boolean;
   /** Enable CORS via the "Access-Control-Allow-Origin" header.
    *


### PR DESCRIPTION
Documents the default values for the `fsRoot`, `urlRoot` and `showIndex` options of `file_server`'s `serveDir` function which are currently missing in the [documentation](https://deno.land/std@0.185.0/http/file_server.ts?s=ServeDirOptions).