### PR TITLE
refactor(_tools): update check_doc_imports.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,8 @@ jobs:
       - name: Check Deprecations
         run: "deno task lint:deprecations"
 
-      # TODO(bartlomieju): temporarily disabled, because it relies on 
-      # `Deno[Deno.internal].core`, which was removed in v1.33.0.
-      # - name: Check Import paths in Docs
-      #   run: "deno task lint:doc-imports"
+      - name: Check Import paths in Docs
+        run: "deno task lint:doc-imports"
 
       - name: Check non-test assertions
         run: deno task lint:check-assertions
@@ -137,7 +135,7 @@ jobs:
           rust-version: 1.65.0
           targets: wasm32-unknown-unknown
           components: rustfmt
-    
+
       - name: Rebuild Wasm and verify it hasn't changed
         if: success() && steps.source.outputs.modified == 'true'
         run: deno task build:${{ matrix.module }} --check

--- a/_tools/check_doc_imports.ts
+++ b/_tools/check_doc_imports.ts
@@ -2,13 +2,14 @@
 
 import { blue, red, yellow } from "../fmt/colors.ts";
 import { walk } from "../fs/walk.ts";
-import {
+import ts from "npm:typescript@5.0.2";
+const {
   createSourceFile,
   ImportDeclaration,
   ScriptTarget,
   StringLiteral,
   SyntaxKind,
-} from "https://esm.sh/typescript@5.0.2";
+} = ts;
 
 const EXTENSIONS = [".mjs", ".js", ".ts", ".md"];
 const EXCLUDED_PATHS = [

--- a/_tools/check_doc_imports.ts
+++ b/_tools/check_doc_imports.ts
@@ -5,9 +5,7 @@ import { walk } from "../fs/walk.ts";
 import ts from "npm:typescript@5.0.2";
 const {
   createSourceFile,
-  ImportDeclaration,
   ScriptTarget,
-  StringLiteral,
   SyntaxKind,
 } = ts;
 


### PR DESCRIPTION
This PR uses `npm:typescript@5.0.2` instead of `https://esm.sh/typescript@5.0.2`. This change removes the dependency to `Deno.core` (`Deno.core.runMicrotasks` are used in `std@0.177.0/node` and it's in dependnecy of `https://esm.sh/typescript@5.0.2`)

closes #3337