### PR TITLE
fix(http/file_server): fix `Range` header handling

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -79,7 +79,7 @@ function fileLenToString(len: number): string {
  *
  * ```ts ignore
  * parseRangeHeader("bytes=0-100",   500); // => { start: 0, end: 100 }
- * parseRangeHeader("bytes=0-",      500); // => { start: 0, end: 500 }
+ * parseRangeHeader("bytes=0-",      500); // => { start: 0, end: 499 }
  * parseRangeHeader("bytes=-100",    500); // => { start: 400, end: 499 }
  * parseRangeHeader("bytes=invalid", 500); // => null
  * ```

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -77,8 +77,7 @@ function fileLenToString(len: number): string {
 /**
  * parse range header.
  *
- * ```ts
- * import { parseRangeHeader } from "./file_server.ts";
+ * ```ts ignore
  * parseRangeHeader("bytes=0-100",   500); // => { start: 0, end: 100 }
  * parseRangeHeader("bytes=0-",      500); // => { start: 0, end: 500 }
  * parseRangeHeader("bytes=-100",    500); // => { start: 400, end: 499 }

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -78,6 +78,7 @@ function fileLenToString(len: number): string {
  * parse range header.
  *
  * ```ts
+ * import { parseRangeHeader } from "./file_server.ts";
  * parseRangeHeader("bytes=0-100",   500); // => { start: 0, end: 100 }
  * parseRangeHeader("bytes=0-",      500); // => { start: 0, end: 500 }
  * parseRangeHeader("bytes=-100",    500); // => { start: 400, end: 499 }
@@ -236,6 +237,7 @@ export async function serveFile(
     const contentLength = end - start + 1;
     headers.set("content-length", `${contentLength}`);
 
+    // Return 206 Partial Content
     const file = await Deno.open(filePath);
     await file.seek(start, Deno.SeekMode.Start);
     const sliced = file.readable

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -195,9 +195,13 @@ export async function serveFile(
 
   const fileSize = fileInfo.size;
 
-  // handle range request
   const rangeValue = req.headers.get("range");
-  if (rangeValue) {
+
+  // handle range request
+  // Note: Some clients add a Range header to all requests to limit the size of the response.
+  // If the file is empty, ignore the range header and respond with a 200 rather than a 416.
+  // https://github.com/golang/go/blob/0d347544cbca0f42b160424f6bc2458ebcc7b3fc/src/net/http/fs.go#L273-L276
+  if (rangeValue && 0 < fileSize) {
     const parsed = parseRangeHeader(rangeValue, fileSize);
 
     // Returns 200 OK if parsing the range header fails

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -983,7 +983,7 @@ Deno.test(
 );
 
 Deno.test(
-  "file_server should return 416 due to request for empty file",
+  "file_server should return 200 OK due to range request for empty file",
   async () => {
     await startFileServer();
     try {
@@ -994,15 +994,11 @@ Deno.test(
         "http://localhost:4507/testdata/test_empty_file.txt",
         { headers },
       );
-      await res.text();
 
-      assertEquals(
-        res.headers.get("content-range"),
-        `bytes */0`,
-      );
+      assertEquals(await res.text(), "");
 
-      assertEquals(res.status, 416);
-      assertEquals(res.statusText, "Range Not Satisfiable");
+      assertEquals(res.status, 200);
+      assertEquals(res.statusText, "OK");
     } finally {
       await killFileServer();
     }


### PR DESCRIPTION
close #3353

Current file servers' handling of the Range header is different from typical server's handling.
After verifying with google cloud storage, cloudflare, AWS cloudfront, githubusercontent.com, express lib, etc., it seems that Range requests are handled roughly in the manner shown in the table below.

These differences are causing problems like https://github.com/denoland/deploy_feedback/issues/377.
In this PR, I rewrote the handling of the Range header to behave as per spec and behave the same as a typical server.



#### When requesting a file with content-length of 100:

request header | std's implementation before this PR | typical server<br>(e.g. cloud storage, cloudfront, github...) 
-- | -- | --
`range: bytes=0-10` | `🟡206 Partial Content`<br>(`content-range: bytes 0-10/100`) | `🟡206 Partial Content`<br>(`content-range: bytes 0-10/100`)
`range: bytes=90-` | `🟡206 Partial Content`<br>(`content-range: bytes 90-99/100`) | `🟡206 Partial Content`<br>(`content-range: bytes 90-99/100`)
`range: bytes=-10` (means the last 10   bytes) | `🔴416 Range Not Satisfiable`<br>(no `content-range` header: wrong) | `🟡206 Partial Content`<br>(`content-range: bytes 90-99/100`)
`range: bytes=90-110` | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes 90-110/100`: wrong) | `🟡206 Partial Content`<br>(`content-range: bytes 90-99/100`, The range is   clamped)
`range: bytes=-110` (means the last 110   bytes) | `🔴416 Range Not Satisfiable`<br>(no `content-range` header: wrong) | `🟡206 Partial Content`<br>(`content-range: bytes 0-99/100`, The range is   clamped)
`range: bytes=110-120` (out of range) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes 110-120/100`: wrong) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes */100`)
`range: bytes=110-` (out of range) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes 110-99/100`: wrong) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes */100`)
`range: bytes=20-10` (invalid) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes 20-10/100`: wrong) | `🔴416 Range Not Satisfiable`<br>(`content-range: bytes */100`)
`range: bytes=foobar` (invalid) | `🔴416 Range Not Satisfiable`<br>(no `content-range` header: wrong) | Fallback to `🟢200 OK`
`range: bytes=0-10,20-30` | `🟡206 Partial Content`<br>(`content-range: bytes 0-10/100`, Only the first part is accepted) | Fallback to `🟢200 OK`

Note:

- `content-range: bytes */100` header is required when returning `416 Range Not Satisfiable` response.

    > A server generating a 416 (Range Not Satisfiable) response to a
    > byte-range request SHOULD send a Content-Range header field with an
    > unsatisfied-range value, as in the following example:
    >
    >   Content-Range: bytes */1234
    > https://datatracker.ietf.org/doc/html/rfc7233#section-4.2

- ~~A Range request to an empty file should always return `416 Range Not Satisfiable`.~~
  It seems reasonable to return a 200 OK for a Range request to an empty file.

    > There's no way to issue an RFC 7433-conformant request for a range of a 0-length file. A range request is a request for a non-zero-length range of bytes. A 0-length file contains no bytes. I believe that a 416 Range Not Satisfiable response is correct in this situation. There are other correct responses (we could ignore the Range header entirely for 0-length files, for example, and return a 200 response), but I don't see a reason those other possibilities are better. I don't think there's anything surprising about responding to a request for data past the end of a file with, "Sorry, the file isn't that big".
    > https://github.com/golang/go/issues/47021

    > Some clients add a Range header to all requests to
    > limit the size of the response. If the file is empty,
    > ignore the range header and respond with a 200 rather
    > than a 416.
    > https://github.com/golang/go/blob/0d347544cbca0f42b160424f6bc2458ebcc7b3fc/src/net/http/fs.go#L273-L276

- Requesting multiple Ranges like `range: bytes=0-10,20-30` is allowed by the spec, but as far as I know, few servers supports it.

Sorry for the large git diff! Thank you for your review every time.