### PR TITLE
perf(http/file_server): read fileinfo in parallel

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -23,8 +23,6 @@ interface EntryInfo {
   name: string;
 }
 
-const encoder = new TextEncoder();
-
 const ENV_PERM_STATUS =
   Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
     .state ?? "granted"; // for deno deploy
@@ -255,7 +253,6 @@ export async function serveFile(
   return createCommonResponse(Status.OK, file.readable, { headers });
 }
 
-// TODO(bartlomieju): simplify this after deno.stat and deno.readDir are fixed
 async function serveDirIndex(
   dirPath: string,
   options: {
@@ -265,20 +262,21 @@ async function serveDirIndex(
 ): Promise<Response> {
   const showDotfiles = options.dotfiles;
   const dirUrl = `/${posix.relative(options.target, dirPath)}`;
-  const listEntry: EntryInfo[] = [];
+  const listEntryPromise: Promise<EntryInfo>[] = [];
 
   // if ".." makes sense
   if (dirUrl !== "/") {
     const prevPath = posix.join(dirPath, "..");
-    const fileInfo = await Deno.stat(prevPath);
-    listEntry.push({
+    const entryInfo = Deno.stat(prevPath).then((fileInfo): EntryInfo => ({
       mode: modeToString(true, fileInfo.mode),
       size: "",
       name: "../",
       url: posix.join(dirUrl, ".."),
-    });
+    }));
+    listEntryPromise.push(entryInfo);
   }
 
+  // Read fileInfo in parallel
   for await (const entry of Deno.readDir(dirPath)) {
     if (!showDotfiles && entry.name[0] === ".") {
       continue;
@@ -286,19 +284,21 @@ async function serveDirIndex(
     const filePath = posix.join(dirPath, entry.name);
     const fileUrl = encodeURIComponent(posix.join(dirUrl, entry.name))
       .replaceAll("%2F", "/");
-    const fileInfo = await Deno.stat(filePath);
-    listEntry.push({
+    const entryInfo = Deno.stat(filePath).then((fileInfo): EntryInfo => ({
       mode: modeToString(entry.isDirectory, fileInfo.mode),
       size: entry.isFile ? fileLenToString(fileInfo.size ?? 0) : "",
       name: `${entry.name}${entry.isDirectory ? "/" : ""}`,
       url: `${fileUrl}${entry.isDirectory ? "/" : ""}`,
-    });
+    }));
+    listEntryPromise.push(entryInfo);
   }
+
+  const listEntry = await Promise.all(listEntryPromise);
   listEntry.sort((a, b) =>
     a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1
   );
   const formattedDirUrl = `${dirUrl.replace(/\/$/, "")}/`;
-  const page = encoder.encode(dirViewerTemplate(formattedDirUrl, listEntry));
+  const page = dirViewerTemplate(formattedDirUrl, listEntry);
 
   const headers = setBaseHeaders();
   headers.set("content-type", "text/html");


### PR DESCRIPTION
part of #3361

Previously, fileInfo was read serially when generating directory listing pages. Change this to read in parallel.
After this PR, the display of the directory listing (page below) is tens of milliseconds faster.

![image](https://user-images.githubusercontent.com/40050810/236527912-9cc11ed5-a593-49e8-8e68-e05a4ce05851.png)

```
// When there are 100 files in the directory:
benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
before     29.6 ms/iter (20.56 ms … 34.89 ms) 31.05 ms 34.89 ms 34.89 ms
after      4.27 ms/iter   (3.51 ms … 6.63 ms)  4.44 ms  5.27 ms  6.63 ms

// When there are 1000 files in the directory:
benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
before     310.22 ms/iter (295.08 ms … 331.81 ms) 317.34 ms 331.81 ms 331.81 ms
after       30.35 ms/iter   (28.24 ms … 32.86 ms)  31.65 ms  32.86 ms  32.86 ms
```

<details>
<summary>benchmark code:</summary>

```ts
// I created 100 files in the testdata/bench directory and run the `deno bench` command.

import { serveDir } from "./file_server.ts";
import { serveDir as serveDirOld } from "./file_server_old.ts";

Deno.bench(async function after() {
  const res = await serveDir(
    new Request("http://localhost:4507/http/testdata/bench/"),
    { quiet: true, showDirListing: true },
  );
  await res.text();
});

Deno.bench(async function before() {
  const res = await serveDirOld(
    new Request("http://localhost:4507/http/testdata/bench/"),
    { quiet: true, showDirListing: true },
  );
  await res.text();
});
```
</details>
