### PR TITLE
chore(http/file_server): remove unnecessary Date header generation

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -150,7 +150,7 @@ export async function serveFile(
     return createCommonResponse(Status.NotFound);
   }
 
-  const headers = setBaseHeaders();
+  const headers = createBaseHeaders();
 
   // Set date header if access timestamp is available
   if (fileInfo.atime) {
@@ -300,8 +300,8 @@ async function serveDirIndex(
   const formattedDirUrl = `${dirUrl.replace(/\/$/, "")}/`;
   const page = encoder.encode(dirViewerTemplate(formattedDirUrl, listEntry));
 
-  const headers = setBaseHeaders();
-  headers.set("content-type", "text/html");
+  const headers = createBaseHeaders();
+  headers.set("content-type", "text/html; charset=UTF-8");
 
   return createCommonResponse(Status.OK, page, { headers });
 }
@@ -325,15 +325,12 @@ function serverLog(req: Request, status: number) {
   console.debug(s);
 }
 
-function setBaseHeaders(): Headers {
-  const headers = new Headers();
-  headers.set("server", "deno");
-
-  // Set "accept-ranges" so that the client knows it can make range requests on future requests
-  headers.set("accept-ranges", "bytes");
-  headers.set("date", new Date().toUTCString());
-
-  return headers;
+function createBaseHeaders(): Headers {
+  return new Headers({
+    server: "deno",
+    // Set "accept-ranges" so that the client knows it can make range requests on future requests
+    "accept-ranges": "bytes",
+  });
 }
 
 function dirViewerTemplate(dirname: string, entries: EntryInfo[]): string {


### PR DESCRIPTION
part of #3361

As far as I know, when this code was first introduced we had to manually set the Date header. The CLI now automatically sets the Date header, so we no longer need to manually set the Date header.

There is one more place to set the Date header ([link](https://github.com/denoland/deno_std/blob/699ba98572f28e6dfb423abe959502ba6a96c551/http/file_server.ts#L157)), but I left it that way because it seemed meaningful.

Also renamed `setBaseHeader` to `createBaseHeader` as I thought it would be more appropriate.

---

I apologize for submitting the PR all at once. Feel free to close these PRs if you don't think you need them.