### PR TITLE
feat(collections): add `partitionEntries`

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -50,6 +50,7 @@ export * from "./map_keys.ts";
 export * from "./map_not_nullish.ts";
 export * from "./map_values.ts";
 export * from "./partition.ts";
+export * from "./partition_entries.ts";
 export * from "./permutations.ts";
 export * from "./find_single.ts";
 export * from "./sliding_windows.ts";

--- a/collections/partition_entries.ts
+++ b/collections/partition_entries.ts
@@ -1,0 +1,50 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+/**
+ * Returns a tuple of two records with the first one containing all entries of
+ * the given record that match the given predicate and the second one containing
+ * all that do not.
+ *
+ * @example
+ * ```ts
+ * import { partitionEntries } from "https://deno.land/std@$STD_VERSION/collections/partition_entries.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+ *
+ * const menu = {
+ *   "Salad": 11,
+ *   "Soup": 8,
+ *   "Pasta": 13,
+ * } as const;
+ * const myOptions = partitionEntries(
+ *   menu,
+ *   ([item, price]) => item !== "Pasta" && price < 10,
+ * );
+ *
+ * assertEquals(
+ *   myOptions,
+ *   [
+ *     { "Soup": 8 },
+ *     { "Salad": 11, "Pasta": 13 },
+ *   ],
+ * );
+ * ```
+ */
+export function partitionEntries<T>(
+  record: Readonly<Record<string, T>>,
+  predicate: (entry: [string, T]) => boolean,
+): [match: Record<string, T>, rest: Record<string, T>] {
+  const match: Record<string, T> = {};
+  const rest: Record<string, T> = {};
+  const entries = Object.entries(record);
+
+  for (const [key, value] of entries) {
+    if (predicate([key, value])) {
+      match[key] = value;
+    } else {
+      rest[key] = value;
+    }
+  }
+
+  return [match, rest];
+}

--- a/collections/partition_entries_test.ts
+++ b/collections/partition_entries_test.ts
@@ -1,0 +1,119 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../testing/asserts.ts";
+import { partitionEntries } from "./partition_entries.ts";
+
+function partitionEntriesTest<T>(
+  input: [Record<string, T>, (entry: [string, T]) => boolean],
+  expected: [match: Record<string, T>, rest: Record<string, T>],
+  message?: string,
+) {
+  const actual = partitionEntries(...input);
+  assertEquals(actual, expected, message);
+}
+
+Deno.test({
+  name: "[collections/partitionEntries] no mutation",
+  fn() {
+    const object = { a: 5, b: true };
+    partitionEntries(object, ([key]) => key !== "a");
+
+    assertEquals(object, { a: 5, b: true });
+  },
+});
+
+Deno.test({
+  name: "[collections/partitionEntries] empty input",
+  fn() {
+    partitionEntriesTest(
+      [{}, () => true],
+      [{}, {}],
+    );
+  },
+});
+
+Deno.test({
+  name: "[collections/partitionEntries] identity",
+  fn() {
+    partitionEntriesTest(
+      [
+        {
+          foo: true,
+          bar: "lorem",
+          1: -5,
+        },
+        () => true,
+      ],
+      [{
+        foo: true,
+        bar: "lorem",
+        1: -5,
+      }, {}],
+    );
+  },
+});
+
+Deno.test({
+  name: "[collections/partitionEntries] clean object",
+  fn() {
+    partitionEntriesTest(
+      [
+        { test: "foo", "": [] },
+        () => false,
+      ],
+      [{}, { test: "foo", "": [] }],
+    );
+  },
+});
+
+Deno.test({
+  name: "[collections/partitionEntries] filters",
+  fn() {
+    partitionEntriesTest(
+      [
+        {
+          "Anna": 22,
+          "Kim": 24,
+          "Karen": 33,
+          "Claudio": 11,
+          "Karl": 45,
+        },
+        ([name, age]) => name.startsWith("K") && age > 30,
+      ],
+      [
+        {
+          "Karen": 33,
+          "Karl": 45,
+        },
+        {
+          "Anna": 22,
+          "Kim": 24,
+          "Claudio": 11,
+        },
+      ],
+    );
+    partitionEntriesTest(
+      [
+        {
+          "A": true,
+          "b": "foo",
+          "C": 5,
+          "d": -2,
+          "": false,
+        },
+        ([key]) => key.toUpperCase() === key,
+      ],
+      [
+        {
+          "A": true,
+          "C": 5,
+          "": false,
+        },
+        {
+          "b": "foo",
+          "d": -2,
+        },
+      ],
+    );
+  },
+});


### PR DESCRIPTION
## Rationale

The collection functions for arrays and objects are mostly in parity, such as `filter{keys,values,entries}`. However, [partition][partition] is available only for arrays.

[partition]: https://github.com/denoland/deno_std/blob/9dd2253e591d4bf2f66a4d38d75a7e60b1cb7c74/collections/partition.ts

## Implementaion and testing
bulk of the [code][code] and [test][test] are modified from `filterEntries`, as the only difference was not discarding entries that does not match given predicate.

[code]: https://github.com/denoland/deno_std/blob/9dd2253e591d4bf2f66a4d38d75a7e60b1cb7c74/collections/filter_entries.ts
[test]: https://github.com/denoland/deno_std/blob/9dd2253e591d4bf2f66a4d38d75a7e60b1cb7c74/collections/filter_entries_test.ts

## Example usage

<details><summary>Example usages</summary>

```ts
const args = {
  "armor_bullet": 30,
  "id": "item_id1",
  "name": "item1",
  "armor_bash": 46,
  "material": "nanite",
  "armor_cut": 30,
  "weight": "460 g",
  "volume": "430 ml",
  "armor_acid": 80,
  "armor_foo": 123,
  "armor_bar": 456,
  "armor_baz": 789,
  "flags": ["foo", "bar", "baz"],
}
```
before:
```ts
import { partition } from "https://deno.land/std/collections/partition.ts"

const [armors, notArmors] = partition(Object.entries(args), ([key]) => key.startsWith("armor_"))
const armorskeys = armors.map(([key, value]) => [key.replace("armor_", ""), value])

const result = {
  armor: Object.fromEntries(armorskeys),
  ...Object.fromEntries(notArmors),
}
```
after:
```ts
import { partitionEntries } from "https://deno.land/std/collections/partition_entries.ts"

const [armors, notArmors] = partitionEntries(args, ([key]) => key.startsWith("armor_"))
const armorskeys = mapKeys(armors, (key) => key.replace("armor_", ""))
  
const result = {
  armor: armorskeys,
  ...notArmors,
}
```

</details> 
