### PR TITLE
fix(datetime): negative months, quarters, and years

### DIFF
--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -21,9 +21,9 @@ export type DifferenceOptions = {
 };
 
 function calculateMonthsDifference(from: Date, to: Date): number {
-  let months = (from.getFullYear() - to.getFullYear()) * 12 +
-    (from.getMonth() - to.getMonth());
-  if (from.getDate() < to.getDate()) {
+  let months = (to.getFullYear() - from.getFullYear()) * 12 +
+    (to.getMonth() - from.getMonth());
+  if (to.getDate() < from.getDate()) {
     months--;
   }
   return months;
@@ -66,6 +66,7 @@ export function difference(
   to: Date,
   options?: DifferenceOptions,
 ): DifferenceFormat {
+  [from, to] = from < to ? [from, to] : [to, from];
   const uniqueUnits = options?.units ? [...new Set(options?.units)] : [
     "milliseconds",
     "seconds",

--- a/datetime/difference_test.ts
+++ b/datetime/difference_test.ts
@@ -7,6 +7,13 @@ Deno.test({
   fn() {
     const denoInit = new Date("2018/5/14");
     const denoReleaseV1 = new Date("2020/5/13");
+
+    // The order of the dates does not matter
+    assertEquals(
+      difference(denoInit, denoReleaseV1),
+      difference(denoReleaseV1, denoInit),
+    );
+
     let diff = difference(denoReleaseV1, denoInit, {
       units: ["days", "weeks", "months", "years", "quarters"],
     });


### PR DESCRIPTION
`difference` will currently return negative months, quarters, and years, when `to` < `from`, while all other units are always non-negative.

I know [we're not doing more work on `difference`](#3086), but this is just a simple bugfix, so please consider it.

```
    {
      days: 730,
      hours: 17520,
      milliseconds: 63072000000,
      minutes: 1051200,
-     months: -24,
-     quarters: -8,
+     months: 23,
+     quarters: 7,
      seconds: 63072000,
      weeks: 104,
-     years: -2,
+     years: 1,
    }
```