### PR TITLE
fix(http/file_server): dealing with dir listing view that contain system files

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -275,7 +275,7 @@ async function serveDirIndex(
         const fileInfo = await Deno.stat(filePath);
         return {
           mode: modeToString(entry.isDirectory, fileInfo.mode),
-          size: entry.isFile ? formatBytes(fileInfo?.size ?? 0) : "",
+          size: entry.isFile ? formatBytes(fileInfo.size ?? 0) : "",
           name: `${entry.name}${entry.isDirectory ? "/" : ""}`,
           url: `${fileUrl}${entry.isDirectory ? "/" : ""}`,
         };

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -274,7 +274,7 @@ async function serveDirIndex(
       try {
         const fileInfo = await Deno.stat(filePath);
         return {
-          mode: modeToString(entry.isDirectory, fileInfo?.mode),
+          mode: modeToString(entry.isDirectory, fileInfo.mode),
           size: entry.isFile ? formatBytes(fileInfo?.size ?? 0) : "",
           name: `${entry.name}${entry.isDirectory ? "/" : ""}`,
           url: `${fileUrl}${entry.isDirectory ? "/" : ""}`,

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -663,9 +663,7 @@ async function createServeDirResponse(
 }
 
 function logError(error: unknown) {
-  console.error(
-    red(error instanceof Error ? error.message : "[non-error thrown]"),
-  );
+  console.error(red(error instanceof Error ? error.message : `${error}`));
 }
 
 function main() {


### PR DESCRIPTION
close #3141

When I launch a file server in the Windows root directory and access http://localhost:4507/, I get a 500 Internal Server Error.
It seems that the following error occurs internally. These are Windows system files that reject `Deno.stat` calls.

```
The process cannot access the file because it is being used by another process. (os error 32): stat 'C:\/DumpStack.log.tmp'
The process cannot access the file because it is being used by another process. (os error 32): stat 'C:\/hiberfil.sys'
The process cannot access the file because it is being used by another process. (os error 32): stat 'C:\/pagefile.sys'
Access is Denied. (os error 5): stat 'C:\/PerfLogs'
Access is Denied. (os error 5): stat 'C:\/Recovery'
The process cannot access the file because it is being used by another process. (os error 32): stat 'C:\/swapfile.sys'
Access is Denied. (os error 5): stat 'C:\/System Volume Information'
```

This PR adds a try-catch around the `Deno.stat` call so that directory listing views are generated even for directories containing system files.
After this PR, the display of the root directory page looks like this:
![image](https://user-images.githubusercontent.com/40050810/236688379-b9c0ca89-4445-4318-93ef-50f4a32a23d3.png)

