### PR TITLE
chore(csv): remove internal dead code

### DIFF
--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -55,27 +55,13 @@ export const defaultReadOptions: ReadOptions = {
 
 export interface LineReader {
   readLine(): Promise<string | null>;
-  isEOF(): Promise<boolean>;
-}
-
-export async function readRecord(
-  startLine: number,
-  reader: LineReader,
-  opt: ReadOptions = defaultReadOptions,
-): Promise<string[] | null> {
-  const line = await reader.readLine();
-  if (line === null) return null;
-  if (line.length === 0) {
-    return [];
-  }
-
-  return parseRecord(line, reader, opt, startLine, startLine + 1);
+  isEOF(): boolean;
 }
 
 export async function parseRecord(
   line: string,
   reader: LineReader,
-  opt: ReadOptions = defaultReadOptions,
+  opt: ReadOptions,
   startLine: number,
   lineIndex: number = startLine,
 ): Promise<Array<string> | null> {
@@ -167,7 +153,7 @@ export async function parseRecord(
             );
             break parseField;
           }
-        } else if (line.length > 0 || !(await reader.isEOF())) {
+        } else if (line.length > 0 || !reader.isEOF()) {
           // Hit end of line (copy all data so far).
           recordBuffer += line;
           const r = await reader.readLine();

--- a/csv/csv_parse_stream.ts
+++ b/csv/csv_parse_stream.ts
@@ -41,8 +41,8 @@ class StreamLineReader implements LineReader {
     }
   }
 
-  isEOF(): Promise<boolean> {
-    return Promise.resolve(this.#done);
+  isEOF(): boolean {
+    return this.#done;
   }
 
   cancel() {
@@ -87,7 +87,7 @@ export class CsvParseStream<
 
   #headers: readonly string[] = [];
 
-  constructor(options: T = defaultReadOptions as T) {
+  constructor(options?: T) {
     this.#options = {
       ...defaultReadOptions,
       ...options,


### PR DESCRIPTION
I removed the `readRecord()` in `csv/_io.ts` as it is not used anywhere.

