### PR TITLE
test(http): update cert error assertions

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -548,7 +548,7 @@ Deno.test(`Server.listenAndServeTls should handle requests`, async () => {
     await assertRejects(
       () => badConn.read(new Uint8Array(1)),
       Deno.errors.InvalidData,
-      "invalid peer certificate contents: invalid peer certificate: UnknownIssuer",
+      "invalid peer certificate: UnknownIssuer",
       "Read with missing certFile didn't throw an InvalidData error when it should have.",
     );
 
@@ -793,7 +793,7 @@ Deno.test(`Server.listenAndServeTls should handle requests`, async () => {
     await assertRejects(
       () => badConn.read(new Uint8Array(1)),
       Deno.errors.InvalidData,
-      "invalid peer certificate contents: invalid peer certificate: UnknownIssuer",
+      "invalid peer certificate: UnknownIssuer",
       "Read with missing certFile didn't throw an InvalidData error when it should have.",
     );
 


### PR DESCRIPTION
This PR fixes the CI on main.

The cert error message of http client seems a bit changed by this change ( https://github.com/denoland/deno/pull/18499 ) in CLI repo.