### PR TITLE
fix(streams/mergeReadableStreams): better error handling

### DIFF
--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -16,17 +16,17 @@ export function mergeReadableStreams<T>(
       Promise.all(resolvePromises).then(() => {
         controller.close();
       });
-      try {
-        for (const [key, stream] of Object.entries(streams)) {
-          (async () => {
+      for (const [key, stream] of Object.entries(streams)) {
+        (async () => {
+          try {
             for await (const data of stream) {
               controller.enqueue(data);
             }
             resolvePromises[+key].resolve();
-          })();
-        }
-      } catch (e) {
-        controller.error(e);
+          } catch (error) {
+            controller.error(error);
+          }
+        })();
       }
     },
   });

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -33,7 +33,6 @@ export function mergeReadableStreams<T>(
             }
             resolvePromises[+key].resolve();
           } catch (error) {
-            mustClose = true;
             resolvePromises[+key].reject(error);
           }
         })();

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -13,18 +13,28 @@ export function mergeReadableStreams<T>(
   const resolvePromises = streams.map(() => deferred<void>());
   return new ReadableStream<T>({
     start(controller) {
-      Promise.all(resolvePromises).then(() => {
-        controller.close();
-      });
+      let mustClose = false;
+      Promise.all(resolvePromises)
+        .then(() => {
+          controller.close();
+        })
+        .catch((error) => {
+          mustClose = true;
+          controller.error(error);
+        });
       for (const [key, stream] of Object.entries(streams)) {
         (async () => {
           try {
             for await (const data of stream) {
+              if (mustClose) {
+                break;
+              }
               controller.enqueue(data);
             }
             resolvePromises[+key].resolve();
           } catch (error) {
-            controller.error(error);
+            mustClose = true;
+            resolvePromises[+key].reject(error);
           }
         })();
       }


### PR DESCRIPTION
'try catch' must be wrapping the inner body of the async function in order to be effective. In this way not unhandle errors will be thrown