### PR TITLE
feat(collections): switch functions to take iterables when possible

### DIFF
--- a/collections/associate_by.ts
+++ b/collections/associate_by.ts
@@ -26,7 +26,7 @@
  * ```
  */
 export function associateBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => string,
 ): Record<string, T> {
   const ret: Record<string, T> = {};

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -22,7 +22,7 @@
  * ```
  */
 export function associateWith<T>(
-  array: readonly string[],
+  array: Iterable<string>,
   selector: (key: string) => T,
 ): Record<string, T> {
   const ret: Record<string, T> = {};

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -16,7 +16,7 @@
  * assertEquals(distinctNumbers, [3, 2, 5]);
  * ```
  */
-export function distinct<T>(array: readonly T[]): T[] {
+export function distinct<T>(array: Iterable<T>): T[] {
   const set = new Set(array);
 
   return Array.from(set);

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -17,7 +17,7 @@
  * ```
  */
 export function distinctBy<T, D>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => D,
 ): T[] {
   const selectedValues = new Set<D>();

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -23,7 +23,7 @@
  * ```
  */
 export function findSingle<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   predicate: (el: T) => boolean,
 ): T | undefined {
   let match: T | undefined = undefined;

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -22,7 +22,7 @@
  * ```
  */
 export function firstNotNullishOf<T, O>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (item: T) => O | undefined | null,
 ): NonNullable<O> | undefined {
   for (const current of array) {

--- a/collections/join_to_string.ts
+++ b/collections/join_to_string.ts
@@ -43,7 +43,7 @@ export type JoinToStringOptions = {
  * ```
  */
 export function joinToString<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => string,
   {
     separator = ",",
@@ -56,8 +56,8 @@ export function joinToString<T>(
   let result = "";
 
   let index = -1;
-  while (++index < array.length) {
-    const el = array[index];
+  for (const el of array) {
+    index++;
 
     if (index > 0) {
       result += separator;

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -23,7 +23,7 @@
  * ```
  */
 export function mapNotNullish<T, O>(
-  array: readonly T[],
+  array: Iterable<T>,
   transformer: (el: T) => O,
 ): NonNullable<O>[] {
   const ret: NonNullable<O>[] = [];

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -22,23 +22,23 @@
  * ```
  */
 export function maxBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => number,
 ): T | undefined;
 export function maxBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => string,
 ): T | undefined;
 export function maxBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => bigint,
 ): T | undefined;
 export function maxBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => Date,
 ): T | undefined;
 export function maxBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector:
     | ((el: T) => number)
     | ((el: T) => string)

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -23,17 +23,17 @@
  * ```
  */
 export function maxOf<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => number,
 ): number | undefined;
 
 export function maxOf<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => bigint,
 ): bigint | undefined;
 
 export function maxOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {
   let maximumValue: ReturnType<S> | undefined = undefined;

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -21,7 +21,7 @@
  * ```
  */
 export function maxWith<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   comparator: (a: T, b: T) => number,
 ): T | undefined {
   let max: T | undefined = undefined;

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -22,23 +22,23 @@
  * ```
  */
 export function minBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => number,
 ): T | undefined;
 export function minBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => string,
 ): T | undefined;
 export function minBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => bigint,
 ): T | undefined;
 export function minBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => Date,
 ): T | undefined;
 export function minBy<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector:
     | ((el: T) => number)
     | ((el: T) => string)

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -22,17 +22,17 @@
  * ```
  */
 export function minOf<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => number,
 ): number | undefined;
 
 export function minOf<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => bigint,
 ): bigint | undefined;
 
 export function minOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {
   let minimumValue: ReturnType<S> | undefined = undefined;

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -17,7 +17,7 @@
  * ```
  */
 export function minWith<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   comparator: (a: T, b: T) => number,
 ): T | undefined {
   let min: T | undefined = undefined;

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -19,15 +19,15 @@
  * ```
  */
 export function partition<T, U extends T>(
-  array: readonly T[],
+  array: Iterable<T>,
   predicate: (el: T) => el is U,
 ): [U[], Exclude<T, U>[]];
 export function partition<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   predicate: (el: T) => boolean,
 ): [T[], T[]];
 export function partition(
-  array: readonly unknown[],
+  array: Iterable<unknown>,
   predicate: (el: unknown) => boolean,
 ): [unknown[], unknown[]] {
   const matches: Array<unknown> = [];

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -20,16 +20,18 @@
  * ]);
  * ```
  */
-export function permutations<T>(inputArray: readonly T[]): T[][] {
+export function permutations<T>(inputArray: Iterable<T>): T[][] {
   const ret: T[][] = [];
-  const k = inputArray.length;
+
+  // Heap's Algorithm
+  const array = [...inputArray];
+
+  const k = array.length;
 
   if (k === 0) {
     return ret;
   }
 
-  // Heap's Algorithm
-  const array = [...inputArray];
   const c = new Array<number>(k).fill(0);
 
   ret.push([...array]);

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -23,7 +23,6 @@
 export function permutations<T>(inputArray: Iterable<T>): T[][] {
   const ret: T[][] = [];
 
-  // Heap's Algorithm
   const array = [...inputArray];
 
   const k = array.length;
@@ -32,6 +31,7 @@ export function permutations<T>(inputArray: Iterable<T>): T[][] {
     return ret;
   }
 
+  // Heap's Algorithm
   const c = new Array<number>(k).fill(0);
 
   ret.push([...array]);

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -21,7 +21,7 @@
  * ```
  */
 export function sumOf<T>(
-  array: readonly T[],
+  array: Iterable<T>,
   selector: (el: T) => number,
 ): number {
   let sum = 0;

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -16,7 +16,7 @@
  * assertEquals(shoppingList, ["Pepper", "Carrots", "Leek", "Radicchio"]);
  * ```
  */
-export function union<T>(...arrays: (readonly T[])[]): T[] {
+export function union<T>(...arrays: Iterable<T>[]): T[] {
   const set = new Set<T>();
 
   for (const array of arrays) {

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -25,8 +25,8 @@
 export function unzip<T, U>(pairs: readonly [T, U][]): [T[], U[]] {
   const { length } = pairs;
   const ret: [T[], U[]] = [
-    Array.from({ length }),
-    Array.from({ length }),
+    Array<T>(length),
+    Array<U>(length),
   ];
 
   pairs.forEach(([first, second], index) => {


### PR DESCRIPTION
Many functions in the standard library already work with all iterables, so the argument types should be updated to reflect that. I also made small changes with negligible performance implications to `joinToString` and `permutations` to make them support iterables.

Unrelated to the rest of the PR, I also changed `unzip` to use the `Array` length constructor instead of `Array.from` since `Array.from` is for some reason much, much slower.