### PR TITLE
Various edge case fixes for `toml.stringify`

### DIFF
--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -223,8 +223,11 @@ class Dumper {
       const l = this.output[i];
       // we keep empty entry for array of objects
       if (l[0] === "[" && l[1] !== "[") {
-        // empty object
-        if (this.output[i + 1] === "") {
+        // non-empty object with only subobjects as properties
+        if (
+          this.output[i + 1] === "" &&
+          this.output[i + 2]?.slice(0, l.length) === l.slice(0, -1) + "."
+        ) {
           i += 1;
           continue;
         }

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -8,7 +8,9 @@ function joinKeys(keys: string[]): string {
   // This allows for grouping similar properties together:
   return keys
     .map((str: string): string => {
-      return str.match(/[^A-Za-z0-9_-]/) ? JSON.stringify(str) : str;
+      return str.length === 0 || str.match(/[^A-Za-z0-9_-]/)
+        ? JSON.stringify(str)
+        : str;
     })
     .join(".");
 }

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -147,8 +147,9 @@ class Dumper {
         throw new Error("should never reach");
       }
       const str = Object.keys(value).map((key) => {
-        // deno-lint-ignore no-explicit-any
-        return `${key} = ${this.#printAsInlineValue((value as any)[key])}`;
+        return `${joinKeys([key])} = ${
+          // deno-lint-ignore no-explicit-any
+          this.#printAsInlineValue((value as any)[key])}`;
       }).join(",");
       return `{${str}}`;
     }

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -711,3 +711,15 @@ aaaaa = 1
     assertEquals(actual, expected);
   },
 });
+
+Deno.test({
+  name: "[TOML] stringify empty key",
+  fn() {
+    const src = {
+      "": "a",
+      "b": { "": "c" },
+    };
+    const roundTrip = parse(stringify(src));
+    assertEquals(src, roundTrip);
+  },
+});

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -735,3 +735,14 @@ Deno.test({
     assertEquals(src, roundTrip);
   },
 });
+
+Deno.test({
+  name: "[TOML] stringify special keys in inline object",
+  fn() {
+    const src = {
+      "a": [{ "/": "b" }, "c"],
+    };
+    const roundTrip = parse(stringify(src));
+    assertEquals(src, roundTrip);
+  },
+});

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -719,8 +719,13 @@ Deno.test({
       "": "a",
       "b": { "": "c" },
     };
-    const roundTrip = parse(stringify(src));
-    assertEquals(src, roundTrip);
+    const actual = stringify(src);
+    const expected = `"" = "a"
+
+[b]
+"" = "c"
+`;
+    assertEquals(actual, expected);
   },
 });
 
@@ -731,8 +736,13 @@ Deno.test({
       "a": {},
       "b": { "c": {} },
     };
-    const roundTrip = parse(stringify(src));
-    assertEquals(src, roundTrip);
+    const actual = stringify(src);
+    const expected = `
+[a]
+
+[b.c]
+`;
+    assertEquals(actual, expected);
   },
 });
 
@@ -742,7 +752,8 @@ Deno.test({
     const src = {
       "a": [{ "/": "b" }, "c"],
     };
-    const roundTrip = parse(stringify(src));
-    assertEquals(src, roundTrip);
+    const actual = stringify(src);
+    const expected = 'a = [{"/" = "b"},"c"]\n';
+    assertEquals(actual, expected);
   },
 });

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -723,3 +723,15 @@ Deno.test({
     assertEquals(src, roundTrip);
   },
 });
+
+Deno.test({
+  name: "[TOML] stringify empty object",
+  fn() {
+    const src = {
+      "a": {},
+      "b": { "c": {} },
+    };
+    const roundTrip = parse(stringify(src));
+    assertEquals(src, roundTrip);
+  },
+});


### PR DESCRIPTION
Fixes the `stringify` errors in #3402