### PR TITLE
doc(testing): update fast-check integer method

### DIFF
--- a/testing/fast_check_example.ts
+++ b/testing/fast_check_example.ts
@@ -92,8 +92,8 @@ Deno.test("Can use fast-check to property test decomposePrime function", async (
   await t.step("should be able to decompose a product of two numbers", () => {
     fc.assert(
       fc.property(
-        fc.integer(2, MAX_INPUT),
-        fc.integer(2, MAX_INPUT),
+        fc.integer({ min: 2, max: MAX_INPUT }),
+        fc.integer({ min: 2, max: MAX_INPUT }),
         (a: number, b: number) => {
           const n = a * b;
           const factors = decomposePrime(n);
@@ -107,8 +107,8 @@ Deno.test("Can use fast-check to property test decomposePrime function", async (
     () => {
       fc.assert(
         fc.property(
-          fc.integer(2, MAX_INPUT),
-          fc.integer(2, MAX_INPUT),
+          fc.integer({ min: 2, max: MAX_INPUT }),
+          fc.integer({ min: 2, max: MAX_INPUT }),
           (a: number, b: number) => {
             const factorsA = decomposePrime(a);
             const factorsB = decomposePrime(b);
@@ -185,7 +185,7 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
     "should be equal to the sum of fibonacci(n-1) and fibonacci(n-2)",
     () => {
       fc.assert(
-        fc.property(fc.integer(2, MaxN), (n: number) => {
+        fc.property(fc.integer({ min: 2, max: MaxN }), (n: number) => {
           assert(fibonacci(n) === (fibonacci(n - 1) + fibonacci(n - 2)));
         }),
       );
@@ -198,8 +198,8 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
     () => {
       fc.assert(
         fc.property(
-          fc.integer(1, MaxN),
-          fc.integer(0, MaxN),
+          fc.integer({ min: 1, max: MaxN }),
+          fc.integer({ min: 0, max: MaxN }),
           (p: number, q: number) => {
             assertEquals(
               fibonacci(p + q),
@@ -213,7 +213,7 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
   await t.step("should fulfill fibonacci(2p-1) = fibo²(p-1)+fibo²(p)", () => {
     // Special case of the property above
     fc.assert(
-      fc.property(fc.integer(1, MaxN), (p: number) => {
+      fc.property(fc.integer({ min: 1, max: MaxN }), (p: number) => {
         assertEquals(
           fibonacci(2 * p - 1),
           fibonacci(p - 1) * fibonacci(p - 1) + fibonacci(p) * fibonacci(p),
@@ -224,8 +224,8 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
   await t.step("should fulfill Catalan identity", () => {
     fc.assert(
       fc.property(
-        fc.integer(0, MaxN),
-        fc.integer(0, MaxN),
+        fc.integer({ min: 0, max: MaxN }),
+        fc.integer({ min: 0, max: MaxN }),
         (a: number, b: number) => {
           const [p, q] = a < b ? [b, a] : [a, b];
           const sign = (p - q) % 2 === 0 ? 1n : -1n; // (-1)^(p-q)
@@ -239,7 +239,7 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
   });
   await t.step("should fulfill Cassini identity", () => {
     fc.assert(
-      fc.property(fc.integer(1, MaxN), fc.integer(0, MaxN), (p: number) => {
+      fc.property(fc.integer({ min: 1, max: MaxN }), fc.integer({ min: 0, max: MaxN }), (p: number) => {
         const sign = p % 2 === 0 ? 1n : -1n; // (-1)^p
         assert(
           fibonacci(p + 1) * fibonacci(p - 1) - fibonacci(p) * fibonacci(p) ===
@@ -251,8 +251,8 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
   await t.step("should fibonacci(nk) divisible by fibonacci(n)", () => {
     fc.assert(
       fc.property(
-        fc.integer(1, MaxN),
-        fc.integer(0, 100),
+        fc.integer({ min: 1, max: MaxN }),
+        fc.integer({ min: 0, max: 100 }),
         (n: number, k: number) => {
           assert(fibonacci(n * k) % fibonacci(n) === 0n);
         },
@@ -264,8 +264,8 @@ Deno.test("Can use fast-check to property test fibronacci function", async (t) =
     () => {
       fc.assert(
         fc.property(
-          fc.integer(1, MaxN),
-          fc.integer(1, MaxN),
+          fc.integer({ min: 1, max: MaxN }),
+          fc.integer({ min: 1, max: MaxN }),
           (a: number, b: number) => {
             const gcd = <T extends bigint | number>(a: T, b: T, zero: T): T => {
               a = a < zero ? (-a as T) : a;
@@ -415,8 +415,8 @@ Deno.test("Can use fast-check to property test add and absoluteAddition function
     () => {
       fc.assert(
         fc.property(
-          fc.integer(-99, 99),
-          fc.integer(-99, 99),
+          fc.integer({ min: -99, max: 99 }),
+          fc.integer({ min: -99, max: 99 }),
           (a: number, b: number) => add(a, b) <= absoluteAddition(a, b),
         ),
       );


### PR DESCRIPTION
Since this commit https://github.com/dubzzz/fast-check/issues/992 the lower and upper bounds is now a single object parameter

fix denoland/deno_std#3081