### PR TITLE
fix(archive/tar): implement clean function correctly

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -74,7 +74,6 @@ class FileReader implements Reader {
  */
 function clean(length: number): Uint8Array {
   const buffer = new Uint8Array(length);
-  buffer.fill(0, 0, length - 1);
   return buffer;
 }
 


### PR DESCRIPTION
According to this line https://github.com/denoland/deno_std/blob/0783b5a32243262cd56dcb82db6e2a546448636c/archive/tar.ts#L72 and this line https://github.com/denoland/deno_std/blob/0783b5a32243262cd56dcb82db6e2a546448636c/archive/tar.ts#L77, I find there exists a bug.
Firstly, the third argument (end index) of Uint8Array.fill is not included. See more information on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill.
Secondly, when calling Uint8Array constructor function with length argument, the contents of Uint8Array are initialized to 0.