### PR TITLE
fix(yaml): parse always return null when file is empty, whitespace or only comments

### DIFF
--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -1788,7 +1788,7 @@ export function load(input: string, options?: LoaderStateOptions): unknown {
   const documents = loadDocuments(input, options);
 
   if (documents.length === 0) {
-    return;
+    return null;
   }
   if (documents.length === 1) {
     return documents[0];

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -216,3 +216,17 @@ merge_test:
     assert(success);
   },
 });
+
+Deno.test({
+  name: "parse returns `null` when yaml is empty or only comments",
+  fn() {
+    const expected = null;
+
+    const yaml1 = ``;
+    assertEquals(parse(yaml1), expected);
+    const yaml2 = ` \n\n `;
+    assertEquals(parse(yaml2), expected);
+    const yaml3 = `# just a bunch of comments \n # in this file`;
+    assertEquals(parse(yaml3), expected);
+  },
+});


### PR DESCRIPTION
In issue #3426 there's differences with how YAML parse is treating empty YAML files. Sometimes they're undefined, but if you have extra lines, you can get back null. I don't really care what value we want to put in (null, undefined, ""), but the null was already being triggered when adding a yaml file with `\n`, so that's the value I rolled with. It also makes sense to me if loadDocuments returns something, either a parsed document, empty string or null - `undefined` gives the vibe that sometimes this function returns something and sometimes nothing. At least null or "" looks intentional.