### PR TITLE
BREAKING(testing/snapshot): change tab char serialization

### DIFF
--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -98,6 +98,11 @@ snapshot[`Snapshot Test - step 2`] = `"hello world"`;
 
 snapshot[`Snapshot Test - Adverse String \\ \` \${} 1`] = `"\\\\ \` \${}"`;
 
+snapshot[`Snapshot Test - Default serializer 1`] = `
+"a
+b	c"
+`;
+
 snapshot[`Snapshot Test - Multi-Line Strings > string 1`] = `
 "
 " +

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -204,7 +204,7 @@ export function serialize(actual: unknown): string {
     compact: false,
     iterableLimit: Infinity,
     strAbbreviateSize: Infinity,
-  }).replace(/\\n/g, "\n");
+  }).replace(/\\n/g, "\n").replace(/\\t/g, "\t");
 }
 
 /**

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -204,7 +204,8 @@ export function serialize(actual: unknown): string {
     compact: false,
     iterableLimit: Infinity,
     strAbbreviateSize: Infinity,
-  }).replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+    escapeSequences: false,
+  });
 }
 
 /**

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -108,6 +108,10 @@ Deno.test("Snapshot Test - Adverse String \\ ` ${}", async (t) => {
   await assertSnapshot(t, "\\ ` ${}");
 });
 
+Deno.test("Snapshot Test - Default serializer", async (t) => {
+  await assertSnapshot(t, "a\nb\tc");
+});
+
 Deno.test("Snapshot Test - Multi-Line Strings", async (t) => {
   await t.step("string", async (t) => {
     await assertSnapshot(


### PR DESCRIPTION
Example test
```ts
Deno.test("Snapshot Test - Default serializer", async (t) => {
  await assertSnapshot(t, "a\nb\tc");
});
```

Before
```
snapshot[`Snapshot Test - Default serializer 1`] = `
"a
b\\tc"
`;
```

After
```
snapshot[`Snapshot Test - Default serializer 1`] = `
"a
b	c"
`;
```