### PR TITLE
fix(fs/walk): return symbolic links (#1359)

### DIFF
--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -51,6 +51,7 @@ Deno.test("expandGlobWildcard", async function () {
     "abc",
     "abcdef",
     "abcdefghi",
+    "link",
     "subdir",
   ]);
 });
@@ -70,6 +71,7 @@ Deno.test("expandGlobParent", async function () {
     "abc",
     "abcdef",
     "abcdefghi",
+    "link",
     "subdir",
   ]);
 });
@@ -118,6 +120,7 @@ Deno.test("expandGlobGlobstarFalseWithGlob", async function () {
     "abc",
     "abcdef",
     "abcdefghi",
+    "link",
     "subdir",
   ]);
 });

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -108,7 +108,10 @@ export async function* walk(
       let { isSymlink, isDirectory } = entry;
 
       if (isSymlink) {
-        if (!followSymlinks) continue;
+        if (!followSymlinks) {
+          yield { path, ...entry };
+          continue;
+        }
         path = await Deno.realPath(path);
         // Caveat emptor: don't assume |path| is not a symlink. realpath()
         // resolves symlinks but another process can replace the file system
@@ -171,7 +174,10 @@ export function* walkSync(
     let { isSymlink, isDirectory } = entry;
 
     if (isSymlink) {
-      if (!followSymlinks) continue;
+      if (!followSymlinks) {
+        yield { path, ...entry };
+        continue;
+      }
       path = Deno.realPathSync(path);
       // Caveat emptor: don't assume |path| is not a symlink. realpath()
       // resolves symlinks but another process can replace the file system


### PR DESCRIPTION
Symbolic links were not returned. This means that `walk()` is not listing all the contents of a directory.

Some use cases for this is are:

- Copying a directory recursively.
- Finding invalid symbolic links.
- Modify link targets without resolving them.

Other changes:

- walk_test.ts: Rename `walkArray()` to `collectPaths()` because it is more descriptive.
- walk_test.ts: Add `collectEntries()`

closes #1359