### PR TITLE
chore(fs): remove redundant await

### DIFF
--- a/fs/exists_test.ts
+++ b/fs/exists_test.ts
@@ -11,7 +11,7 @@ Deno.test("[fs] existsFile", async function () {
     await exists(path.join(testdataDir, "not_exist_file.ts")),
     false,
   );
-  assertEquals(await existsSync(path.join(testdataDir, "0.ts")), true);
+  assertEquals(existsSync(path.join(testdataDir, "0.ts")), true);
 });
 
 Deno.test("[fs] existsFileSync", function () {


### PR DESCRIPTION
I don't know how this has happened, but it basically slipped through, an unnecessary `await` in my `exists_tests.ts`.

This PR cleans it up, just a tiny minor adjustment