### PR TITLE
chore: fix typos

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -156,7 +156,7 @@
 ### 0.176.0 / 2023.02.02
 
 - fix(node): disable worker_threads (#3151)
-- fix(node): throw permisison error instead of unknown error (#3133)
+- fix(node): throw permission error instead of unknown error (#3133)
 - fix(node/util): stricter runtime type checking (#3122)
 - fix: make encoding/front_matter work in a browser (#3154)
 
@@ -903,7 +903,7 @@ new feature added setNoDelay.
 - feat(node): allow require with 'node:' prefix (#1438)
 - feat(node/url): add `url.urlToHttpOptions(url)` (#1426)
 - feat(testing): add assertIsError (#1376)
-- fix(async): fix async/tee concurent .next calls error (#1425)
+- fix(async): fix async/tee concurrent .next calls error (#1425)
 - fix(crypto): support length option in crypto.subtle.digest (#1386)
 - fix(http/file_server): fix encoded url in dir html (#1442)
 - fix(http/file_server): fix leak file resource (#1443)
@@ -1183,7 +1183,7 @@ new feature added setNoDelay.
 ### 0.92.0 / 2021.04.02
 
 - feat: make bufio compatible to Deno Deploy (#831)
-- feat: add symlink adn symlinkSync to node/fs (#825)
+- feat: add symlink and symlinkSync to node/fs (#825)
 - feat: add format and improve deprecate in node/util (#693)
 - feat: add io/buffer and io/util module (#808) …
 - fix: handle upstream type changes (#834)

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -18,7 +18,7 @@ export interface RetryOptions {
   maxTimeout?: number;
   /** The maximum amount of attempts until failure. This is `5` by default. */
   maxAttempts?: number;
-  /** The inital and minimum amount of milliseconds between attempts. This is `1000` by default. */
+  /** The initial and minimum amount of milliseconds between attempts. This is `1000` by default. */
   minTimeout?: number;
   /** Amount of jitter to introduce to the time between attempts. This is `1` for full jitter by default. */
   jitter?: number;

--- a/async/tee_test.ts
+++ b/async/tee_test.ts
@@ -61,7 +61,7 @@ Deno.test("async/tee - 3 branches - delayed consumption", async () => {
   );
 });
 
-Deno.test("async/tee - concurent .next calls", async () => {
+Deno.test("async/tee - concurrent .next calls", async () => {
   const [left] = tee(gen());
   const l = left[Symbol.asyncIterator]();
   assertEquals(await Promise.all([l.next(), l.next(), l.next(), l.next()]), [{

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -20,10 +20,10 @@ function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
  */
 function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   const len = a.length;
-  const compressable = Math.floor(len / 4);
-  const compressedA = new Uint32Array(a.buffer, 0, compressable);
-  const compressedB = new Uint32Array(b.buffer, 0, compressable);
-  for (let i = compressable * 4; i < len; i++) {
+  const compressible = Math.floor(len / 4);
+  const compressedA = new Uint32Array(a.buffer, 0, compressible);
+  const compressedB = new Uint32Array(b.buffer, 0, compressible);
+  for (let i = compressible * 4; i < len; i++) {
     if (a[i] !== b[i]) return false;
   }
   for (let i = 0; i < compressedA.length; i++) {

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -7,7 +7,7 @@
  * A start index can be specified as the third argument that begins the search
  * at that given index. The start index defaults to the start of the array.
  *
- * The complexity of this function is O(source.lenth * needle.length).
+ * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
  * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/index_of_needle.ts";

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -7,7 +7,7 @@
  * A start index can be specified as the third argument that begins the search
  * at that given index. The start index defaults to the end of the array.
  *
- * The complexity of this function is O(source.lenth * needle.length).
+ * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
  * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/last_index_of_needle.ts";

--- a/csv/csv_parse_stream_test.ts
+++ b/csv/csv_parse_stream_test.ts
@@ -401,7 +401,7 @@ Deno.test({
     }
     {
       // `skipFirstRow` may be `true` or `false`.
-      // `coloums` may be `undefined` or `string[]`.
+      // `columns` may be `undefined` or `string[]`.
       // If you don't know exactly what the value of the option is,
       // the return type is ReadableStream<string[] | Record<string, string | undefined>>
       const options: CsvParseStreamOptions = {};

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -323,7 +323,7 @@ export interface ParseOptions extends ReadOptions {
  * @param input Input to parse.
  * @param opt options of the parser.
  * @returns If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns `string[][]`.
- *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unkown>[]`.
+ *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unknown>[]`.
  */
 export function parse(input: string, opt?: undefined): string[][];
 export function parse<const T extends ParseOptions>(

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -830,7 +830,7 @@ Deno.test({
     }
     {
       // `skipFirstRow` may be `true` or `false`.
-      // `coloums` may be `undefined` or `string[]`.
+      // `columns` may be `undefined` or `string[]`.
       // If you don't know exactly what the value of the option is,
       // the return type is string[][] | Record<string, string|undefined>[]
       const options: ParseOptions = {};

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -116,7 +116,7 @@ export interface LoadOptions {
 
   /**
    * Set to `true` to export all `.env` variables to the current processes
-   * environment. Variables are then accessable via `Deno.env.get(<key>)`.
+   * environment. Variables are then accessible via `Deno.env.get(<key>)`.
    *
    * @default {false}
    */

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -92,19 +92,19 @@ export function encode(data: ArrayBuffer | string): string {
  * @returns Decoded value
  */
 export function decode(b58: string): Uint8Array {
-  const splittedInput = b58.trim().split("");
+  const splitInput = b58.trim().split("");
 
   let length = 0;
   let ones = 0;
 
   // Counting leading ones
   let index = 0;
-  while (splittedInput[index] === "1") {
+  while (splitInput[index] === "1") {
     ones++;
     index++;
   }
 
-  const notZeroData = splittedInput.slice(index);
+  const notZeroData = splitInput.slice(index);
 
   const size = Math.round((b58.length * 733) / 1000 + 1);
   const output: number[] = [];

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -96,7 +96,7 @@
  * | `#`   |           | alternate format                                                           |
  * | `#`   | `b o x X` | prefix with `0b 0 0x`                                                      |
  * | `#`   | `g G`     | don't remove trailing zeros                                                |
- * | `#`   | `v`       | ues output of `inspect` instead of `toString`                              |
+ * | `#`   | `v`       | use output of `inspect` instead of `toString`                              |
  * | `' '` |           | space character                                                            |
  * | `' '` | `x X`     | leave spaces between bytes when printing string                            |
  * | `' '` | `d`       | insert space for missing `+` sign character                                |

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -83,7 +83,7 @@ testWalk(
   async (d: string) => {
     await touch(d + "/x");
   },
-  async function iteratable() {
+  async function iterable() {
     let count = 0;
     for (const _ of walkSync(".")) {
       count += 1;

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -188,7 +188,7 @@ for (const [key, value] of Object.entries(ERROR_STATUS_MAP)) {
 /**
  * A factory function which provides a way to create errors. It takes up to 3
  * arguments, the error `Status`, an message, which defaults to the status text
- * and error options, which incudes the `expose` property to set the `.expose`
+ * and error options, which includes the `expose` property to set the `.expose`
  * value on the error.
  */
 export function createHttpError(

--- a/io/read_range_test.ts
+++ b/io/read_range_test.ts
@@ -70,7 +70,7 @@ class MockFile
   seek(offset: number, whence: Deno.SeekMode): Promise<number> {
     assert(whence === Deno.SeekMode.Start);
     if (offset >= this.#buf.length) {
-      return Promise.reject(new RangeError("seeked pass end"));
+      return Promise.reject(new RangeError("attempted to seek past end"));
     }
     this.#offset = offset;
     return Promise.resolve(this.#offset);
@@ -79,7 +79,7 @@ class MockFile
   seekSync(offset: number, whence: Deno.SeekMode): number {
     assert(whence === Deno.SeekMode.Start);
     if (offset >= this.#buf.length) {
-      throw new RangeError("seeked pass end");
+      throw new RangeError("attempted to seek past end");
     }
     this.#offset = offset;
     return this.#offset;

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-0-1.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-0-1.js
@@ -4,7 +4,7 @@
 
 /*---
 es5id: 15.12.1.1-0-1
-description: The JSON lexical grammar treats whitespace as a token seperator
+description: The JSON lexical grammar treats whitespace as a token separator
 ---*/
 
 assert.throws(SyntaxError, function() {

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-0-9.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-0-9.js
@@ -11,4 +11,4 @@ JSON.parse('\t\r \n{\t\r \n' +
   '"property"\t\r \n:\t\r \n{\t\r \n}\t\r \n,\t\r \n' +
   '"prop2"\t\r \n:\t\r \n' +
   '[\t\r \ntrue\t\r \n,\t\r \nnull\t\r \n,123.456\t\r \n]' +
-  '\t\r \n}\t\r \n'); // should JOSN parse without error
+  '\t\r \n}\t\r \n'); // should JSON parse without error

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-1.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-1.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-1
 description: >
-    The JSON lexical grammer allows '/' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows '/' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-2.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-2.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-2
 description: >
-    The JSON lexical grammer allows '' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows '' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-3.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-3.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-3
 description: >
-    The JSON lexical grammer allows 'b' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows 'b' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-4.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-4.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-4
 description: >
-    The JSON lexical grammer allows 'f' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows 'f' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-5.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-5.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-5
 description: >
-    The JSON lexical grammer allows 'n' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows 'n' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-6.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-6.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-6
 description: >
-    The JSON lexical grammer allows 'r' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows 'r' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-7.js
+++ b/jsonc/testdata/test262/JSON/parse/15.12.1.1-g6-7.js
@@ -5,7 +5,7 @@
 /*---
 es5id: 15.12.1.1-g6-7
 description: >
-    The JSON lexical grammer allows 't' as a JSONEscapeCharacter after
+    The JSON lexical grammar allows 't' as a JSONEscapeCharacter after
     '' in a JSONString
 ---*/
 

--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -144,7 +144,7 @@ const GTLT: number = R++;
 src[GTLT] = "((?:<|>)?=?)";
 
 // Something like "2.*" or "1.2.x".
-// Note that "x.x" is a valid xRange identifer, meaning "any version"
+// Note that "x.x" is a valid xRange identifier, meaning "any version"
 // Only the first item is strictly required.
 const XRANGEIDENTIFIER: number = R++;
 src[XRANGEIDENTIFIER] = src[NUMERICIDENTIFIER] + "|x|X|\\*";

--- a/semver/is_semver.ts
+++ b/semver/is_semver.ts
@@ -7,8 +7,8 @@ import { isValidNumber, isValidString } from "./_shared.ts";
  * Checks to see if value is a valid SemVer object. It does a check
  * into each field including prerelease and build.
  *
- * Some invalid SemVer sentinals can still return true such as ANY and INVALID.
- * An object which has the same value as a sentinal but isn't reference equal
+ * Some invalid SemVer sentinels can still return true such as ANY and INVALID.
+ * An object which has the same value as a sentinel but isn't reference equal
  * will still fail.
  *
  * Objects which are valid SemVer objects but have _extra_ fields are still

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -61,7 +61,7 @@
  *
  * ## Permissions option
  *
- * Like `Deno.TestDefinition`, the `DescribeDefintion` and `ItDefinition` have a
+ * Like `Deno.TestDefinition`, the `DescribeDefinition` and `ItDefinition` have a
  * `permissions` option. They specify the permissions that should be used to run an
  * individual test case or test suite. Set this to `"inherit"` to keep the calling
  * thread's permissions. Set this to `"none"` to revoke all permissions.

--- a/testing/fast_check_example.ts
+++ b/testing/fast_check_example.ts
@@ -337,7 +337,7 @@ Deno.test("Can use fast-check to property test sort function", async (t) => {
     );
   });
   await t.step(
-    "should have exactly the same number of occurences as source for each item",
+    "should have exactly the same number of occurrences as source for each item",
     () => {
       fc.assert(
         fc.property(fc.array(fc.integer()), (data: Array<number>) => {

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -93,7 +93,7 @@
  * When configuring default options like this, the resulting `assertSnapshot`
  * function will function the same as the default function exported from the
  * snapshot module. If passed an optional options object, this will take precedence
- * over the default options, where the value provded for an option differs.
+ * over the default options, where the value provided for an option differs.
  *
  * It is possible to "extend" an `assertSnapshot` function which has been
  * configured with default options.
@@ -127,7 +127,7 @@
  *
  * ## Version Control:
  *
- * Snapshot testing works best when changes to snapshot files are comitted
+ * Snapshot testing works best when changes to snapshot files are committed
  * alongside other code changes. This allows for changes to reference snapshots to
  * be reviewed along side the code changes that caused them, and ensures that when
  * others pull your changes, their tests will pass without needing to update
@@ -174,7 +174,7 @@ export type SnapshotOptions<T = unknown> = {
    */
   name?: string;
   /**
-   * Snapshot output path. The shapshot will be written to this file. This can be
+   * Snapshot output path. The snapshot will be written to this file. This can be
    * a path relative to the test directory or an absolute path.
    *
    * If both `dir` and `path` are specified, the `dir` option will be ignored and

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -55,7 +55,7 @@ export interface FakeTimeOptions {
   /**
    * The rate relative to real time at which fake time is updated.
    * By default time only moves forward through calling tick or setting now.
-   * Set to 1 to have the fake time automatically tick foward at the same rate in milliseconds as real time.
+   * Set to 1 to have the fake time automatically tick forward at the same rate in milliseconds as real time.
    */
   advanceRate: number;
   /**

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -398,7 +398,7 @@ Deno.test({
       foo: { bar: "deno" },
       this: { is: { nested: "denonono" } },
       "https://deno.land/std": {
-        $: "doller",
+        $: "dollar",
       },
       "##": {
         deno: {
@@ -491,7 +491,7 @@ bar = "deno"
 nested = "denonono"
 
 ["https://deno.land/std"]
-"$" = "doller"
+"$" = "dollar"
 
 ["##".deno."https://deno.land"]
 proto = "https"

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -1740,14 +1740,14 @@ export default class Context {
     const { _start, _initialize, memory } = instance.exports;
 
     if (!(memory instanceof WebAssembly.Memory)) {
-      throw new TypeError("WebAsembly.instance must provide a memory export");
+      throw new TypeError("WebAssembly.instance must provide a memory export");
     }
 
     this.#memory = memory;
 
     if (typeof _initialize == "function") {
       throw new TypeError(
-        "WebAsembly.instance export _initialize must not be a function",
+        "WebAssembly.instance export _initialize must not be a function",
       );
     }
 
@@ -1789,7 +1789,7 @@ export default class Context {
     const { _start, _initialize, memory } = instance.exports;
 
     if (!(memory instanceof WebAssembly.Memory)) {
-      throw new TypeError("WebAsembly.instance must provide a memory export");
+      throw new TypeError("WebAssembly.instance must provide a memory export");
     }
 
     this.#memory = memory;


### PR DESCRIPTION
The typos were found with the typos[1] spell checker.  That spell checker will be incorporated into the CI in a followup PR.

[1]: https://github.com/crate-ci/typos