### PR TITLE
 ci: add spell-checking with typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,11 @@ jobs:
       - name: Check non-test assertions
         run: deno task lint:check-assertions
 
+      - name: Spell-check
+        uses: crate-ci/typos@master
+        with:
+          config: ./.github/workflows/typos.toml
+
   wasm:
     name: wasm
     runs-on: ubuntu-22.04

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,0 +1,18 @@
+[default]
+check-filename = false
+
+[default.extend-identifiers]
+# The typo also exists in https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/typenames.witx.
+ERRNO_ACCES = "ERRNO_ACCES"
+
+# variable name used by node-semver
+_fpr = "_fpr"
+
+[files]
+extend-exclude = [
+  "*.json",
+  "*_test.ts",
+  "*.generated.mjs",
+  "media_types/vendor",
+  "http/testdata",
+]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Before opening a PR make sure to:
 - `deno task test` passes.
 - `deno fmt --check` passes.
 - `deno task lint` passes.
+- (optionally) check for typos with `deno task typos` (requires
+  [typos](https://github.com/crate-ci/typos#install) to be installed)
 
 Give the PR a descriptive title.
 

--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "lint:doc-imports": "deno run --allow-env --allow-read ./_tools/check_doc_imports.ts",
     "lint:check-assertions": "deno run --allow-read --allow-net ./_tools/check_assertions.ts",
     "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:deprecations && deno task lint:doc-imports && deno task lint:check-assertions",
+    "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run --unstable -A https://deno.land/x/wasmbuild@0.10.3/main.ts --js-ext mjs --sync"
   }


### PR DESCRIPTION
This is the followup PR for #3458 to prevent accidental typos from ending up in the codebase.