### PR TITLE
feat: add Pull Request auto labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,66 +1,66 @@
 archive:
-- archive/**
+  - archive/**
 async:
-- async/**
+  - async/**
 bytes:
-- bytes/**
+  - bytes/**
 collections:
-- collections/**
+  - collections/**
 console:
-- console/**
+  - console/**
 crypto:
-- crypto/**
+  - crypto/**
 csv:
-- csv/**
+  - csv/**
 datetime:
-- datetime/**
+  - datetime/**
 dotenv:
-- dotenv/**
+  - dotenv/**
 encoding:
-- encoding/**
+  - encoding/**
 examples:
-- examples/**
+  - examples/**
 flags:
-- flags/**
+  - flags/**
 fmt:
-- fmt/**
+  - fmt/**
 front_matter:
-- front_matter/**
+  - front_matter/**
 fs:
-- fs/**
+  - fs/**
 html:
-- html/**
+  - html/**
 http:
-- http/**
+  - http/**
 io:
-- io/**
+  - io/**
 json:
-- json/**
+  - json/**
 jsonc:
-- jsonc/**
+  - jsonc/**
 log:
-- log/**
+  - log/**
 media_types:
-- media_types/**
+  - media_types/**
 path:
-- path/**
+  - path/**
 permission:
-- permission/**
+  - permission/**
 regexp:
-- regexp/**
+  - regexp/**
 semver:
-- semver/**
+  - semver/**
 signal:
-- signal/**
+  - signal/**
 streams:
-- streams/**
+  - streams/**
 testing:
-- testing/**
+  - testing/**
 toml:
-- toml/**
+  - toml/**
 uuid:
-- uuid/**
+  - uuid/**
 wasi:
-- wasi/**
+  - wasi/**
 yaml:
-- yaml/**
+  - yaml/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+archive:
+- archive/**
+async:
+- async/**
+bytes:
+- bytes/**
+collections:
+- collections/**
+console:
+- console/**
+crypto:
+- crypto/**
+csv:
+- csv/**
+datetime:
+- datetime/**
+dotenv:
+- dotenv/**
+encoding:
+- encoding/**
+examples:
+- examples/**
+flags:
+- flags/**
+fmt:
+- fmt/**
+front_matter:
+- front_matter/**
+fs:
+- fs/**
+html:
+- html/**
+http:
+- http/**
+io:
+- io/**
+json:
+- json/**
+jsonc:
+- jsonc/**
+log:
+- log/**
+media_types:
+- media_types/**
+path:
+- path/**
+permission:
+- permission/**
+regexp:
+- regexp/**
+semver:
+- semver/**
+signal:
+- signal/**
+streams:
+- streams/**
+testing:
+- testing/**
+toml:
+- toml/**
+uuid:
+- uuid/**
+wasi:
+- wasi/**
+yaml:
+- yaml/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        sync-labels: true


### PR DESCRIPTION
Add a GitHub action that automatically labels the PR with the names of the modules changed. Currently, it seems that PRs don't always follow the conventional commit naming convention, resulting in PR names that are not directly associated with the changed modules/code.

The action used is maintained in GitHub's actions repository and is used by ~47k repositories. The action takes ~14s and automatically sets the configured labels. You can see that it needs [`pull-requests: write`](https://github.com/actions/labeler/#permissions) permissions. There is also an option to include dot directories like `.github` if desired.

Information about other options and configurations can be found [here](https://github.com/actions/labeler/#match-object).

Recent:
- Added the labels of the `std` library modules only.

Idea:
- Add the `tests` label when tests have been added in a PR.

## How does this help?
Get a quicker and easier overview of the changed code in the PRs without having to check each PR individually.

If there are more labels that could be helpful, let me know or push the PR branch :)