### PR TITLE
fix: Added catches for primitive/null values passed as "actual" in assertObjectMatch

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,8 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-// deno-lint-ignore-file ban-types
-
 import { filterInPlace } from "./_utils.ts";
 
 const { hasOwn } = Object;

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -62,10 +62,7 @@ export function equal(c: unknown, d: unknown): boolean {
       return true;
     }
     if (a && typeof a === "object" && b && typeof b === "object") {
-      if (
-        a && b &&
-        !constructorsEqual(a, b)
-      ) {
+      if (a && b && !constructorsEqual(a, b)) {
         return false;
       }
       if (a instanceof WeakMap || b instanceof WeakMap) {

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -545,11 +545,7 @@ export function assertObjectMatch(
         seen.set(a, b);
       } catch (err) {
         if (err instanceof TypeError) {
-          throw new TypeError(
-            `Cannot assertObjectMatch ${
-              a === null ? null : `type ${typeof a}`
-            }`,
-          );
+          return a;
         } else throw err;
       }
       // Filter keys and symbols which are present in both actual and expected

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -64,10 +64,7 @@ export function equal(c: unknown, d: unknown): boolean {
     if (a && typeof a === "object" && b && typeof b === "object") {
       if (
         a && b &&
-        !constructorsEqual(
-          a as unknown as Record<string, unknown>,
-          b as unknown as Record<string, unknown>,
-        )
+        !constructorsEqual(a, b)
       ) {
         return false;
       }
@@ -134,10 +131,7 @@ export function equal(c: unknown, d: unknown): boolean {
   })(c, d);
 }
 
-function constructorsEqual(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>,
-) {
+function constructorsEqual(a: object, b: object) {
   return a.constructor === b.constructor ||
     a.constructor === Object && !b.constructor ||
     !a.constructor && b.constructor === Object;

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -542,7 +542,17 @@ export function assertObjectMatch(
       if ((seen.has(a)) && (seen.get(a) === b)) {
         return a;
       }
-      seen.set(a, b);
+      try {
+        seen.set(a, b);
+      } catch (err) {
+        if (err instanceof TypeError) {
+          throw new TypeError(
+            `Cannot assertObjectMatch ${
+              a === null ? null : `type ${typeof a}`
+            }`,
+          );
+        } else throw err;
+      }
       // Filter keys and symbols which are present in both actual and expected
       const filtered = {} as loose;
       const entries = [
@@ -564,7 +574,7 @@ export function assertObjectMatch(
           filtered[key] = value;
           continue;
         } // On nested objects references, build a filtered object recursively
-        else if (typeof value === "object") {
+        else if (typeof value === "object" && value !== null) {
           const subset = (b as loose)[key];
           if ((typeof subset === "object") && (subset)) {
             // When both operands are maps, build a filtered map with common keys and filter nested objects inside

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -62,7 +62,13 @@ export function equal(c: unknown, d: unknown): boolean {
       return true;
     }
     if (a && typeof a === "object" && b && typeof b === "object") {
-      if (a && b && !constructorsEqual(a, b)) {
+      if (
+        a && b &&
+        !constructorsEqual(
+          a as unknown as Record<string, unknown>,
+          b as unknown as Record<string, unknown>,
+        )
+      ) {
         return false;
       }
       if (a instanceof WeakMap || b instanceof WeakMap) {
@@ -128,8 +134,10 @@ export function equal(c: unknown, d: unknown): boolean {
   })(c, d);
 }
 
-// deno-lint-ignore ban-types
-function constructorsEqual(a: object, b: object) {
+function constructorsEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+) {
   return a.constructor === b.constructor ||
     a.constructor === Object && !b.constructor ||
     !a.constructor && b.constructor === Object;

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -545,7 +545,11 @@ export function assertObjectMatch(
         seen.set(a, b);
       } catch (err) {
         if (err instanceof TypeError) {
-          return a;
+          throw new TypeError(
+            `Cannot assertObjectMatch ${
+              a === null ? null : `type ${typeof a}`
+            }`,
+          );
         } else throw err;
       }
       // Filter keys and symbols which are present in both actual and expected

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -750,7 +750,7 @@ Deno.test("AssertObjectMatching", function () {
     () => assertObjectMatch({ foo: undefined, bar: null }, { foo: null }),
     AssertionError,
   );
-  // Non mapable primative types should throw a readable type error
+  // Non mapable primative types should throw a readable assertion error
   assertThrows(
     // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(null, { foo: 42 }),

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -743,6 +743,40 @@ Deno.test("AssertObjectMatching", function () {
     () => assertObjectMatch(n, { baz: new Map([["a", { baz: true }]]) }),
     AssertionError,
   );
+  // null in the first argument throws an assertion error, rather than a TypeError: Invalid value used as weak map key
+  assertThrows(
+    () => assertObjectMatch({ foo: null }, { foo: { bar: 42 } }),
+    AssertionError,
+  );
+  assertObjectMatch({ foo: null, bar: null }, { foo: null });
+  assertObjectMatch({ foo: undefined, bar: null }, { foo: undefined });
+  assertThrows(
+    () => assertObjectMatch({ foo: undefined, bar: null }, { foo: null }),
+    AssertionError,
+  );
+  // Non mapable primative types should throw a readable type error
+  assertThrows(
+    // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
+    () => assertObjectMatch(null, { foo: 42 }),
+    TypeError,
+    "assertObjectMatch",
+  );
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
+  assertThrows(() => assertObjectMatch(null, { foo: 42 }), TypeError, "null"); // since typeof null is "object", want to make sure user knows the bad value is "null"
+  assertThrows(
+    // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'Record<PropertyKey, any>'
+    () => assertObjectMatch(undefined, { foo: 42 }),
+    TypeError,
+    "assertObjectMatch",
+  );
+  // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'Record<PropertyKey, any>'
+  assertThrows(() => assertObjectMatch(21, 42), TypeError, "assertObjectMatch");
+  assertThrows(
+    // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'Record<PropertyKey, any>'
+    () => assertObjectMatch("string", "string"),
+    TypeError,
+    "assertObjectMatch",
+  );
 });
 
 Deno.test("AssertsUnimplemented", function () {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -750,7 +750,7 @@ Deno.test("AssertObjectMatching", function () {
     () => assertObjectMatch({ foo: undefined, bar: null }, { foo: null }),
     AssertionError,
   );
-  // Non mapable primative types should throw a readable assertion error
+  // Non mapable primative types should throw a readable type error
   assertThrows(
     // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(null, { foo: 42 }),

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -227,22 +227,23 @@ Deno.test("Equal", function () {
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
-      new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
+      new (class<T extends Record<string, unknown>> extends WeakRef<T> {})({
+        hello: "world",
+      }),
     ),
   );
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
-      new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
+      new (class<T extends Record<string, unknown>> extends WeakRef<T> {})({
+        hello: "world",
+      }),
     ),
   );
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
-      new (class<T extends object> extends WeakRef<T> {
+      new (class<T extends Record<string, unknown>> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
     ),
@@ -250,8 +251,7 @@ Deno.test("Equal", function () {
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
-      new (class<T extends object> extends WeakRef<T> {
+      new (class<T extends Record<string, unknown>> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
     ),
@@ -1443,8 +1443,7 @@ Deno.test({
     assertArrayIncludes<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
-    // deno-lint-ignore ban-types
-    assertNotStrictEquals<object>(value, { x: 1 });
+    assertNotStrictEquals<Record<string, unknown>>(value, { x: 1 });
   },
 });
 

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -754,19 +754,25 @@ Deno.test("AssertObjectMatching", function () {
   assertThrows(
     // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(null, { foo: 42 }),
-    AssertionError,
+    TypeError,
+    "assertObjectMatch",
   );
   // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
-  assertThrows(() => assertObjectMatch(null, { foo: 42 }), AssertionError); // since typeof null is "object", want to make sure user knows the bad value is "null"
+  assertThrows(() => assertObjectMatch(null, { foo: 42 }), TypeError, "null"); // since typeof null is "object", want to make sure user knows the bad value is "null"
   assertThrows(
     // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(undefined, { foo: 42 }),
-    AssertionError,
+    TypeError,
+    "assertObjectMatch",
   );
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'Record<PropertyKey, any>'
-  assertThrows(() => assertObjectMatch(21, 42), AssertionError);
-  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'Record<PropertyKey, any>'
-  assertObjectMatch("string", "string");
+  assertThrows(() => assertObjectMatch(21, 42), TypeError, "assertObjectMatch");
+  assertThrows(
+    // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'Record<PropertyKey, any>'
+    () => assertObjectMatch("string", "string"),
+    TypeError,
+    "assertObjectMatch",
+  );
 });
 
 Deno.test("AssertsUnimplemented", function () {

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -227,23 +227,19 @@ Deno.test("Equal", function () {
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      new (class<T extends Record<string, unknown>> extends WeakRef<T> {})({
-        hello: "world",
-      }),
+      new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
     ),
   );
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      new (class<T extends Record<string, unknown>> extends WeakRef<T> {})({
-        hello: "world",
-      }),
+      new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
     ),
   );
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      new (class<T extends Record<string, unknown>> extends WeakRef<T> {
+      new (class<T extends object> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
     ),
@@ -251,7 +247,7 @@ Deno.test("Equal", function () {
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      new (class<T extends Record<string, unknown>> extends WeakRef<T> {
+      new (class<T extends object> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
     ),
@@ -1443,7 +1439,7 @@ Deno.test({
     assertArrayIncludes<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
-    assertNotStrictEquals<Record<string, unknown>>(value, { x: 1 });
+    assertNotStrictEquals<object>(value, { x: 1 });
   },
 });
 

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -754,25 +754,19 @@ Deno.test("AssertObjectMatching", function () {
   assertThrows(
     // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(null, { foo: 42 }),
-    TypeError,
-    "assertObjectMatch",
+    AssertionError,
   );
   // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'Record<PropertyKey, any>'
-  assertThrows(() => assertObjectMatch(null, { foo: 42 }), TypeError, "null"); // since typeof null is "object", want to make sure user knows the bad value is "null"
+  assertThrows(() => assertObjectMatch(null, { foo: 42 }), AssertionError); // since typeof null is "object", want to make sure user knows the bad value is "null"
   assertThrows(
     // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'Record<PropertyKey, any>'
     () => assertObjectMatch(undefined, { foo: 42 }),
-    TypeError,
-    "assertObjectMatch",
+    AssertionError,
   );
   // @ts-expect-error Argument of type 'number' is not assignable to parameter of type 'Record<PropertyKey, any>'
-  assertThrows(() => assertObjectMatch(21, 42), TypeError, "assertObjectMatch");
-  assertThrows(
-    // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'Record<PropertyKey, any>'
-    () => assertObjectMatch("string", "string"),
-    TypeError,
-    "assertObjectMatch",
-  );
+  assertThrows(() => assertObjectMatch(21, 42), AssertionError);
+  // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'Record<PropertyKey, any>'
+  assertObjectMatch("string", "string");
 });
 
 Deno.test("AssertsUnimplemented", function () {


### PR DESCRIPTION
Having issues when null and undefined are passed in the 'actual' argument for `assertObjectMatch`. Typeof null is 'object', so in recursion null kept being sent as a weakmap, but should have been assigned as `filtered[key] = value`.

Primitive types also could be passed in as the 'actual' value in JS, and they gave a cryptic weakmap error, but it's just a typeerror.

I slightly disagree with the AssertionError instead of the TypeError in issue #3451, but I'm open to suggestions.
