### PR TITLE
fix(lint): remove unused lint ignore

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,8 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-// deno-lint-ignore-file ban-types
-
 import { filterInPlace } from "./_utils.ts";
 
 const { hasOwn } = Object;

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -128,7 +128,6 @@ export function equal(c: unknown, d: unknown): boolean {
   })(c, d);
 }
 
-// deno-lint-ignore ban-types
 function constructorsEqual(a: object, b: object) {
   return a.constructor === b.constructor ||
     a.constructor === Object && !b.constructor ||

--- a/testing/asserts_test.ts
+++ b/testing/asserts_test.ts
@@ -227,21 +227,18 @@ Deno.test("Equal", function () {
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
       new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
     ),
   );
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
       new (class<T extends object> extends WeakRef<T> {})({ hello: "world" }),
     ),
   );
   assert(
     !equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
       new (class<T extends object> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
@@ -250,7 +247,6 @@ Deno.test("Equal", function () {
   assertFalse(
     equal(
       new WeakRef({ hello: "world" }),
-      // deno-lint-ignore ban-types
       new (class<T extends object> extends WeakRef<T> {
         foo = "bar";
       })({ hello: "world" }),
@@ -1409,7 +1405,6 @@ Deno.test({
     assertArrayIncludes<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
-    // deno-lint-ignore ban-types
     assertNotStrictEquals<object>(value, { x: 1 });
   },
 });


### PR DESCRIPTION
Since [0.48.0](https://github.com/denoland/deno_lint/releases/tag/0.48.0), `deno_lint` has been suggesting `object` for "any object type" and removed it from `ban-types`. This PR fixes the linting issue.