### PR TITLE
test(http): re-enable 'serveDirIndex TLS' test on mac

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -526,10 +526,8 @@ async function startTlsFileServer({
   reader.releaseLock();
 }
 
-// TODO(bartlomieju): Somehow this test started failing on macOS for 0.192.0
 Deno.test(
   "serveDirIndex TLS",
-  { ignore: Deno.build.os === "darwin" },
   async function () {
     await startTlsFileServer();
     try {

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -524,6 +524,16 @@ async function startTlsFileServer({
   const res = await reader.read();
   assert(!res.done && res.value.includes("Listening"));
   reader.releaseLock();
+
+  // Wait for fileServer to be ready.
+  await retry(async () => {
+    const conn = await Deno.connectTls({
+      hostname: "localhost",
+      port: +port,
+      certFile: join(testdataDir, "tls/RootCA.pem"),
+    });
+    conn.close();
+  });
 }
 
 Deno.test(


### PR DESCRIPTION
closes #3450 