### PR TITLE
feat(fmt): enable `setColorEnabled` in browsers

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -76,10 +76,6 @@ let enabled = !noColor;
  * @param value
  */
 export function setColorEnabled(value: boolean) {
-  if (noColor) {
-    return;
-  }
-
   enabled = value;
 }
 

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -76,6 +76,10 @@ let enabled = !noColor;
  * @param value
  */
 export function setColorEnabled(value: boolean) {
+  if (Deno?.noColor) {
+    return;
+  }
+
   enabled = value;
 }
 

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -54,7 +54,7 @@
 const { Deno } = globalThis as any;
 const noColor = typeof Deno?.noColor === "boolean"
   ? Deno.noColor as boolean
-  : true;
+  : false;
 
 interface Code {
   open: string;


### PR DESCRIPTION
Allowed for programmatic override of enable color.

When Deno is not available in global this, and we want to use the colors library in e.g. browsers without shiming (dnt), it is not possible to view colors in the console, or set it to enabled. This pr changes this behavior so that it is possible to programmatically override the enable variable.