### PR TITLE
test(fs/walk): clean up socket file after testing

### DIFF
--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -92,14 +92,16 @@ Deno.test({
   name: "[fs/walk] unix socket",
   ignore: Deno.build.os === "windows",
   async fn() {
-    const listener = Deno.listen({
-      path: resolve(testdataDir, "socket", "a.sock"),
-      transport: "unix",
-    });
-    await assertWalkPaths("socket", [".", "a.sock", ".gitignore"], {
-      followSymlinks: true,
-    });
-    listener.close();
+    const path = resolve(testdataDir, "socket", "a.sock");
+    try {
+      const listener = Deno.listen({ path, transport: "unix" });
+      await assertWalkPaths("socket", [".", "a.sock", ".gitignore"], {
+        followSymlinks: true,
+      });
+      listener.close();
+    } finally {
+      await Deno.remove(path);
+    }
   },
 });
 


### PR DESCRIPTION
A unix socket file is not cleaned up after testing, and it causes test failure after the 2nd run of the same test case (The issue seems introduced in #3446)

This PR adds the clean up of it, and fixes the issue.