### PR TITLE
docs(dotenv): Add documentation about default .env values

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -47,6 +47,10 @@
  * hello world
  * ```
  *
+ * Default values can be placed in a local `.env.defaults` file. If present,
+ * `load.ts` will automatically fallback to default values if a value is not
+ * present in the local `.env` file.
+ *
  * ## Parsing Rules
  *
  * The parsing engine currently supports the following rules:


### PR DESCRIPTION
Closes #3492 

Add documentation about default .env values