### PR TITLE
BREAKING(testing/snapshot): fix regression of serialization of long strings

### DIFF
--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -100,32 +100,19 @@ snapshot[`Snapshot Test - Adverse String \\ \` \${} 1`] = `"\\\\ \` \${}"`;
 
 snapshot[`Snapshot Test - Multi-Line Strings > string 1`] = `
 "
-" +
-  "<html>
-" +
-  "  <head>
-" +
-  "    <title>Snapshot Test - Multi-Line Strings</title>
-" +
-  "  </head>
-" +
-  "  <body>
-" +
-  "    <h1>
-" +
-  "      Snapshot Test - Multi-Line Strings
-" +
-  "    </h2>
-" +
-  "    <p>
-" +
-  "      This is a snapshot of a multi-line string.
-" +
-  "    </p>
-" +
-  "  </body>
-" +
-  "</html>"
+<html>
+  <head>
+    <title>Snapshot Test - Multi-Line Strings</title>
+  </head>
+  <body>
+    <h1>
+      Snapshot Test - Multi-Line Strings
+    </h2>
+    <p>
+      This is a snapshot of a multi-line string.
+    </p>
+  </body>
+</html>"
 `;
 
 snapshot[`Snapshot Test - Multi-Line Strings > string in array 1`] = `
@@ -152,48 +139,30 @@ snapshot[`Snapshot Test - Multi-Line Strings > string in object 1`] = `
 
 snapshot[`Snapshot Test - Failed Assertion > Object 1`] = `
 "Snapshot does not match:
-" +
-  "
-" +
-  "
-" +
-  "    [Diff] Actual / Expected
-" +
-  "
-" +
-  "
-" +
-  "    [
-" +
-  "      1,
-" +
-  "      2,
-" +
-  "+     3,
-" +
-  "    ]
+
+
+    [Diff] Actual / Expected
+
+
+    [
+      1,
+      2,
++     3,
+    ]
 "
 `;
 
 snapshot[`Snapshot Test - Failed Assertion > String 1`] = `
-"Snapshot does not match:
-" +
-  "
-" +
-  "
-" +
-  "    [Diff] Actual / Expected
-" +
-  "
-" +
-  "
-" +
-  '-   "Hello!"
-' +
-  '+   "Hello World!"
-' +
-  "
-"
+'Snapshot does not match:
+
+
+    [Diff] Actual / Expected
+
+
+-   "Hello!"
++   "Hello World!"
+
+'
 `;
 
 snapshot[`custom name 1`] = `
@@ -238,373 +207,230 @@ snapshot[`Snapshot Test - Options > mode 1`] = `
 
 snapshot[`Snapshot Test - Options > mode 2`] = `
 "running 1 test from <tempDir>/test.ts
-" +
-  "snapshot ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 1 snapshots updated.
-" +
-  "
-" +
-  "ok | 1 passed | 0 failed (--ms)
-" +
-  "
+snapshot ... ok (--ms)
+------- output -------
+
+ > 1 snapshots updated.
+
+ok | 1 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - New snapshot 1`] = `
 "running 1 test from <tempDir>/test.ts
-" +
-  "Snapshot Test - Update ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 1 snapshots updated.
-" +
-  "
-" +
-  "ok | 1 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Update ... ok (--ms)
+------- output -------
+
+ > 1 snapshots updated.
+
+ok | 1 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - New snapshot 2`] = `
 "export const snapshot = {};
-" +
-  "
-" +
-  "snapshot[\`Snapshot Test - Update 1\`] = \`
-" +
-  "[
-" +
-  "  1,
-" +
-  "  2,
-" +
-  "]
-" +
-  "\`;
+
+snapshot[\`Snapshot Test - Update 1\`] = \`
+[
+  1,
+  2,
+]
+\`;
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshot - no changes 1`] = `
 "running 1 test from <tempDir>/test.ts
-" +
-  "Snapshot Test - Update ... ok (--ms)
-" +
-  "
-" +
-  "ok | 1 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Update ... ok (--ms)
+
+ok | 1 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshot - no changes 2`] = `
 "export const snapshot = {};
-" +
-  "
-" +
-  "snapshot[\`Snapshot Test - Update 1\`] = \`
-" +
-  "[
-" +
-  "  1,
-" +
-  "  2,
-" +
-  "]
-" +
-  "\`;
+
+snapshot[\`Snapshot Test - Update 1\`] = \`
+[
+  1,
+  2,
+]
+\`;
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshot - updates 1`] = `
 "running 1 test from <tempDir>/test.ts
-" +
-  "Snapshot Test - Update ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 1 snapshots updated.
-" +
-  "
-" +
-  "ok | 1 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Update ... ok (--ms)
+------- output -------
+
+ > 1 snapshots updated.
+
+ok | 1 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshot - updates 2`] = `
 "export const snapshot = {};
-" +
-  "
-" +
-  "snapshot[\`Snapshot Test - Update 1\`] = \`
-" +
-  "[
-" +
-  "  1,
-" +
-  "  2,
-" +
-  "  3,
-" +
-  "  5,
-" +
-  "]
-" +
-  "\`;
+
+snapshot[\`Snapshot Test - Update 1\`] = \`
+[
+  1,
+  2,
+  3,
+  5,
+]
+\`;
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshots - reverse order 1 1`] = `
 "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 2 snapshots updated.
-" +
-  "
-" +
-  " > 1 snapshots removed.
-" +
-  "   • Snapshot Test - Update 1
-" +
-  "
-" +
-  "ok | 2 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - First ... ok (--ms)
+Snapshot Test - Second ... ok (--ms)
+------- output -------
+
+ > 2 snapshots updated.
+
+ > 1 snapshots removed.
+   • Snapshot Test - Update 1
+
+ok | 2 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshots - reverse order 1 2`] = `
-"export const snapshot = {};
-" +
-  "
-" +
-  'snapshot[\`Snapshot Test - First 1\`] = \`"FIRST"\`;
-' +
-  "
-" +
-  'snapshot[\`Snapshot Test - Second 1\`] = \`"SECOND"\`;
+'export const snapshot = {};
+
+snapshot[\`Snapshot Test - First 1\`] = \`"FIRST"\`;
+
+snapshot[\`Snapshot Test - Second 1\`] = \`"SECOND"\`;
 '
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshots - reverse order 2 1`] = `
 "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "
-" +
-  "ok | 2 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Second ... ok (--ms)
+Snapshot Test - First ... ok (--ms)
+
+ok | 2 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Update - Existing snapshots - reverse order 2 2`] = `
-"export const snapshot = {};
-" +
-  "
-" +
-  'snapshot[\`Snapshot Test - Second 1\`] = \`"SECOND"\`;
-' +
-  "
-" +
-  'snapshot[\`Snapshot Test - First 1\`] = \`"FIRST"\`;
+'export const snapshot = {};
+
+snapshot[\`Snapshot Test - Second 1\`] = \`"SECOND"\`;
+
+snapshot[\`Snapshot Test - First 1\`] = \`"FIRST"\`;
 '
 `;
 
 snapshot[`Snapshot Test - Remove - New snapshot 1`] = `
 "running 5 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - Remove - First ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Second ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Third ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Fourth ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Fifth ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 5 snapshots updated.
-" +
-  "
-" +
-  "ok | 5 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Remove - First ... ok (--ms)
+Snapshot Test - Remove - Second ... ok (--ms)
+Snapshot Test - Remove - Third ... ok (--ms)
+Snapshot Test - Remove - Fourth ... ok (--ms)
+Snapshot Test - Remove - Fifth ... ok (--ms)
+------- output -------
+
+ > 5 snapshots updated.
+
+ok | 5 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Remove - Existing snapshot - removed one 1`] = `
 "running 4 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - Remove - First ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Second ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Fourth ... ok (--ms)
-" +
-  "Snapshot Test - Remove - Fifth ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 1 snapshots removed.
-" +
-  "   • Snapshot Test - Remove - Third 1
-" +
-  "
-" +
-  "ok | 4 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Remove - First ... ok (--ms)
+Snapshot Test - Remove - Second ... ok (--ms)
+Snapshot Test - Remove - Fourth ... ok (--ms)
+Snapshot Test - Remove - Fifth ... ok (--ms)
+------- output -------
+
+ > 1 snapshots removed.
+   • Snapshot Test - Remove - Third 1
+
+ok | 4 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Remove - Existing snapshot - removed several 1`] = `
 "running 1 test from <tempDir>/test.ts
-" +
-  "Snapshot Test - Remove - First ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 3 snapshots removed.
-" +
-  "   • Snapshot Test - Remove - Second 1
-" +
-  "   • Snapshot Test - Remove - Fourth 1
-" +
-  "   • Snapshot Test - Remove - Fifth 1
-" +
-  "
-" +
-  "ok | 1 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - Remove - First ... ok (--ms)
+------- output -------
+
+ > 3 snapshots removed.
+   • Snapshot Test - Remove - Second 1
+   • Snapshot Test - Remove - Fourth 1
+   • Snapshot Test - Remove - Fifth 1
+
+ok | 1 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Different Dir - New snapshot 1`] = `
 "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 2 snapshots updated.
-" +
-  "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - First ...----- output end -----
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 2 snapshots updated.
-" +
-  "
-" +
-  "ok | 4 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - First ... ok (--ms)
+Snapshot Test - Second ... ok (--ms)
+------- output -------
+
+ > 2 snapshots updated.
+running 2 tests from <tempDir>/test.ts
+Snapshot Test - First ...----- output end -----
+Snapshot Test - First ... ok (--ms)
+Snapshot Test - Second ... ok (--ms)
+------- output -------
+
+ > 2 snapshots updated.
+
+ok | 4 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Different Dir - Existing snapshot - update 1`] = `
 "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 1 snapshots updated.
-" +
-  "running 2 tests from <tempDir>/test.ts
-" +
-  "Snapshot Test - First ...----- output end -----
-" +
-  "Snapshot Test - First ... ok (--ms)
-" +
-  "Snapshot Test - Second ... ok (--ms)
-" +
-  "------- output -------
-" +
-  "
-" +
-  " > 2 snapshots updated.
-" +
-  "
-" +
-  "ok | 4 passed | 0 failed (--ms)
-" +
-  "
+Snapshot Test - First ... ok (--ms)
+Snapshot Test - Second ... ok (--ms)
+------- output -------
+
+ > 1 snapshots updated.
+running 2 tests from <tempDir>/test.ts
+Snapshot Test - First ...----- output end -----
+Snapshot Test - First ... ok (--ms)
+Snapshot Test - Second ... ok (--ms)
+------- output -------
+
+ > 2 snapshots updated.
+
+ok | 4 passed | 0 failed (--ms)
+
 "
 `;
 
 snapshot[`Snapshot Test - Regression #2140 1`] = `
 {
   content: "
-" +
-    "      <h1>Testing a page</h1>
-" +
-    "      <p>This is a test</p>
-" +
-    "      <ul>
-" +
-    "        <li>1</li>
-" +
-    "        <li>2</li>
-" +
-    "        <li>3</li>
-" +
-    "        <li>4</li>
-" +
-    "      </ul>
-" +
-    "      ",
+      <h1>Testing a page</h1>
+      <p>This is a test</p>
+      <ul>
+        <li>1</li>
+        <li>2</li>
+        <li>3</li>
+        <li>4</li>
+      </ul>
+      ",
   title: "Testing a page",
 }
 `;

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -204,6 +204,7 @@ export function serialize(actual: unknown): string {
     compact: false,
     iterableLimit: Infinity,
     strAbbreviateSize: Infinity,
+    breakLength: Infinity,
   }).replace(/\\n/g, "\n");
 }
 


### PR DESCRIPTION
Now the snapshots of long strings are split into additions of smaller string, and those are very hard to read as pointed in #3404. This behavior is unintentionally introduced by the merge of `Deno.inspect` and `util.inspect` (Node compat). ref: https://github.com/denoland/deno/pull/18691

 This PR uses `breakLength: Infinity` option of `Deno.inspect` (which was added in https://github.com/denoland/deno/pull/19337), and restores the original behavior.

fixes #3404 

cc @oscarotero