### PR TITLE
fix(toml/parse): Fix edge cases

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -354,7 +354,7 @@ function character(str: string) {
 const Patterns = {
   BARE_KEY: /[A-Za-z0-9_-]/,
   FLOAT: /[0-9_\.e+\-]/i,
-  END_OF_VALUE: /[ \t\r\n#,}]/,
+  END_OF_VALUE: /[ \t\r\n#,}\]]/,
 };
 
 export function BareKey(scanner: Scanner): ParseResult<string> {

--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -741,6 +741,10 @@ export function InlineTable(
   scanner: Scanner,
 ): ParseResult<Record<string, unknown>> {
   scanner.nextUntilChar();
+  if (scanner.char(1) === "}") {
+    scanner.next(2);
+    return success({});
+  }
   const pairs = surround(
     "{",
     join(Pair, ","),

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -301,6 +301,7 @@ Deno.test({
             ],
           },
         },
+        empty: {},
       },
     };
     const actual = parseFile(path.join(testdataDir, "inlineTable.toml"));

--- a/toml/test.ts
+++ b/toml/test.ts
@@ -132,6 +132,10 @@ Deno.test({
           ["gamma", "delta"],
           [1, 2],
         ],
+        floats: [
+          0.1,
+          -1.25,
+        ],
         hosts: ["alpha", "omega"],
         profiles: [
           {

--- a/toml/testdata/arrays.toml
+++ b/toml/testdata/arrays.toml
@@ -8,3 +8,5 @@ hosts = [
 ] # comment
 
 profiles = [ { name = "John", "john@example.com" = true }, { name = "Doe", "doe@example.com" = true }, ]
+
+floats = [ 0.1, -1.25 ]

--- a/toml/testdata/inlineTable.toml
+++ b/toml/testdata/inlineTable.toml
@@ -8,3 +8,4 @@ nile = { derek.roddy = "drummer", also = { malevolant.creation = { drum.kit = "T
 annotation_filter = { "kubernetes.io/ingress.class" = "nginx" }
 literal_key = { 'foo\nbar' = 'foo\nbar' }
 nested = { parent = { children = ["{", "}"], "child.ren" = ["[", "]"] } } # comment
+empty = {}


### PR DESCRIPTION
This PR fixes the two remaining cases described in #3402.

Specifically:

`toml.parse("a = [0.1]")`:

Previously:
`Uncaught Error: Parse error on line 1, column 6: Array is not closed`

Now:
`{"a":[0.1]}`

And...

`toml.parse("a = {}")`:

Previously:
`Uncaught Error: Parse error on line 1, column 5: Invalid token after "{"`

Expected:
`{"a": {}}`

Tests have been added for both fixes.

Closes #3402.