### PR TITLE
Draft: dotenv: don't crash when permission is not granted to an env file

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -315,6 +315,7 @@ function parseFileSync(
     return parse(Deno.readTextFileSync(filepath), restrictEnvAccessTo);
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) return {};
+    if (e instanceof Deno.errors.PermissionDenied && Deno.permissions.querySync({ name: "read", path: filepath }).state !== "granted") return {};
     throw e;
   }
 }
@@ -327,6 +328,7 @@ async function parseFile(
     return parse(await Deno.readTextFile(filepath), restrictEnvAccessTo);
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) return {};
+    if (e instanceof Deno.errors.PermissionDenied && (await Deno.permissions.query({ name: "read", path: filepath })).state !== "granted") return {};
     throw e;
   }
 }


### PR DESCRIPTION
I'm having a problem with using `--allow-read=.env`

It wants to read `.env.defaults` and `.env.example`, which I don't care about.

I think if you don't grant permission to those files, the application should not crash. It should continue on without them. For now, the only way around it is with `--allow-read=.env,.env.defaults,.env.example` (too verbose), or to call `loadSync({ export: true, examplePath: null, defaultsPath: null })` (also too verbose)

So I have made it not crash when the files are denied permission.

But there's another problem. `Deno.errors.PermissionDenied` can occur both for Deno permissions AND for OS file permissions.

That seems like a flaw in Deno itself. You should be able to tell whether `PermissionDenied` is due to OS permissions or Deno permissions.

The only way around that is a verbose check of the file against the permissions API.

It seems wrong. I wouldn't merge this code as-is. But I'm wondering if someone has ideas about what to do.