### PR TITLE
fix: typo in parse_media_type.ts example

### DIFF
--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -33,7 +33,7 @@ import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
  * assertEquals(
  *   parseMediaType("text/html; charset=UTF-8"),
  *   [
- *     "application/json",
+ *     "text/html",
  *     { charset: "UTF-8" },
  *   ]
  * );


### PR DESCRIPTION
In the `parseMediaType` example from `std/media_types/parse_media_type.ts`, the example code asserts (erroneously) that an input of `text/html; charset=utf-8` will return `["application/json", { charset: "utf-8" }]`. 

This has been corrected to `["text/html", { charset: "utf-8" }]`.

Thanks!