### PR TITLE
fix(http/cookie_map): Add maxAge to set/delete options

### DIFF
--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -106,6 +106,8 @@ export interface CookieMapSetDeleteOptions {
   domain?: string;
   /** When the cookie expires. */
   expires?: Date;
+  /** Number of seconds until the cookie expires */
+  maxAge?: number;
   /** A flag that indicates if the cookie is valid over HTTP only. */
   httpOnly?: boolean;
   /** Do not error when signing and validating cookies over an insecure
@@ -165,6 +167,8 @@ export interface SecureCookieMapSetDeleteOptions {
   domain?: string;
   /** When the cookie expires. */
   expires?: Date;
+  /** Number of seconds until the cookie expires */
+  maxAge?: number;
   /** A flag that indicates if the cookie is valid over HTTP only. */
   httpOnly?: boolean;
   /** Do not error when signing and validating cookies over an insecure

--- a/http/cookie_map_test.ts
+++ b/http/cookie_map_test.ts
@@ -6,6 +6,7 @@ import {
   assertRejects,
   assertThrows,
 } from "../assert/mod.ts";
+import { FakeTime } from "../testing/time.ts";
 import { KeyStack } from "../crypto/keystack.ts";
 
 import {
@@ -115,6 +116,24 @@ Deno.test({
     assertEquals(
       response.get("set-cookie"),
       "foo=bar; path=/foo; expires=Wed, 01 Jan 2020 00:00:00 GMT; domain=*.example.com; samesite=strict",
+    );
+  },
+});
+
+Deno.test({
+  name: "CookieMap - set cookie with maxAge instead of expires",
+  fn() {
+    const time = new FakeTime(0);
+    const request = createHeaders();
+    const response = createHeaders();
+    const cookies = new CookieMap(request, { response });
+    cookies.set("foo", "bar", {
+      maxAge: 1,
+    });
+    time.restore();
+    assertEquals(
+      response.get("set-cookie"),
+      "foo=bar; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; httponly",
     );
   },
 });


### PR DESCRIPTION
Adds `maxAge` to the `CookieMapSetDeleteOptions` and `SecureCookieMapSetDeleteOptions`, so the interface matches the implementation. Closes #3523.

I added a test to make sure `maxAge` keeps working, since there wasn't one. The option gets converted to `expires`, so I needed to mock the time with `FakeTime`.