### PR TITLE
fix(collections): redblack tree and bst not being exported from mod

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -76,3 +76,5 @@ export * from "./reduce_groups.ts";
 export * from "./sample.ts";
 export * from "./running_reduce.ts";
 export * from "./binary_heap.ts";
+export * from "./binary_search_tree.ts";
+export * from "./red_black_tree.ts";


### PR DESCRIPTION
Closes #3525 