### PR TITLE
chore: fix fmt error

### DIFF
--- a/assert/assert_object_match.ts
+++ b/assert/assert_object_match.ts
@@ -56,7 +56,7 @@ export function assertObjectMatch(
         } // On nested objects references, build a filtered object recursively
         else if (typeof value === "object" && value !== null) {
           const subset = (b as loose)[key];
-          if ((typeof subset === "object") && (subset)) {
+          if ((typeof subset === "object") && subset) {
             // When both operands are maps, build a filtered map with common keys and filter nested objects inside
             if ((value instanceof Map) && (subset instanceof Map)) {
               filtered[key] = new Map(


### PR DESCRIPTION
Seems like a new version of canary caught this. I'm a fan of the change.