### PR TITLE
fix(testing/time): fix FakeTime.restoreFor accuracy for sync callbacks

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -258,7 +258,7 @@ export class FakeTime {
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<T> {
-    if (!time) throw new TimeError("no fake time");
+    if (!time) return Promise.reject(new TimeError("no fake time"));
     restoreGlobals();
     try {
       const result = callback.apply(null, args);

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -252,21 +252,26 @@ export class FakeTime {
   /**
    * Restores real time temporarily until callback returns and resolves.
    */
-  static async restoreFor<T>(
+  static restoreFor<T>(
     // deno-lint-ignore no-explicit-any
     callback: (...args: any[]) => Promise<T> | T,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<T> {
     if (!time) throw new TimeError("no fake time");
-    let result: T;
     restoreGlobals();
     try {
-      result = await callback.apply(null, args);
-    } finally {
+      const result = callback.apply(null, args);
+      if (result instanceof Promise) {
+        return result.finally(() => overrideGlobals());
+      } else {
+        overrideGlobals();
+        return Promise.resolve(result);
+      }
+    } catch (e) {
       overrideGlobals();
+      return Promise.reject(e);
     }
-    return result;
   }
 
   /**

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -304,6 +304,70 @@ Deno.test("FakeTime restoreFor restores real time temporarily", async () => {
   }
 });
 
+Deno.test("FakeTime restoreFor restores real time and re-overridden atomically", async () => {
+  const time: FakeTime = new FakeTime();
+  const fakeSetTimeout = setTimeout;
+  const actualSetTimeouts: (typeof setTimeout)[] = [];
+
+  try {
+    const asyncFn = async () => {
+      actualSetTimeouts.push(setTimeout);
+      await Promise.resolve();
+      actualSetTimeouts.push(setTimeout);
+      await Promise.resolve();
+      actualSetTimeouts.push(setTimeout);
+    };
+    const promise = asyncFn();
+    await new Promise((resolve) => {
+      FakeTime.restoreFor(() => setTimeout(resolve, 0));
+    });
+    await promise;
+    assertEquals(actualSetTimeouts, [
+      fakeSetTimeout,
+      fakeSetTimeout,
+      fakeSetTimeout,
+    ]);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("FakeTime restoreFor returns promise that resolved to result of callback", async () => {
+  const time: FakeTime = new FakeTime();
+
+  try {
+    const resultSync = await FakeTime.restoreFor(() => "a");
+    assertEquals(resultSync, "a");
+    const resultAsync = await FakeTime.restoreFor(() => Promise.resolve("b"));
+    assertEquals(resultAsync, "b");
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("FakeTime restoreFor returns promise that rejected to error in callback", async () => {
+  const time: FakeTime = new FakeTime();
+
+  try {
+    await assertRejects(
+      () => FakeTime.restoreFor(() => {
+        throw new Error("Error in sync callback");
+      }),
+      Error,
+      "Error in sync callback",
+    );
+    await assertRejects(
+      () => FakeTime.restoreFor(() => {
+        return Promise.reject(new Error("Error in async callback"));
+      }),
+      Error,
+      "Error in async callback",
+    );
+  } finally {
+    time.restore();
+  }
+});
+
 Deno.test("delay uses real time", async () => {
   const time: FakeTime = new FakeTime();
   const start: number = Date.now();

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -350,16 +350,18 @@ Deno.test("FakeTime restoreFor returns promise that rejected to error in callbac
 
   try {
     await assertRejects(
-      () => FakeTime.restoreFor(() => {
-        throw new Error("Error in sync callback");
-      }),
+      () =>
+        FakeTime.restoreFor(() => {
+          throw new Error("Error in sync callback");
+        }),
       Error,
       "Error in sync callback",
     );
     await assertRejects(
-      () => FakeTime.restoreFor(() => {
-        return Promise.reject(new Error("Error in async callback"));
-      }),
+      () =>
+        FakeTime.restoreFor(() => {
+          return Promise.reject(new Error("Error in async callback"));
+        }),
       Error,
       "Error in async callback",
     );

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -7,7 +7,7 @@ import {
   assertRejects,
   assertStrictEquals,
 } from "./asserts.ts";
-import { FakeTime } from "./time.ts";
+import { FakeTime, TimeError } from "./time.ts";
 import { _internals } from "./_time.ts";
 import { assertSpyCall, spy, SpyCall } from "./mock.ts";
 
@@ -368,6 +368,14 @@ Deno.test("FakeTime restoreFor returns promise that rejected to error in callbac
   } finally {
     time.restore();
   }
+});
+
+Deno.test("FakeTime restoreFor returns promise that rejected to TimeError if FakeTime is uninitialized", async () => {
+  await assertRejects(
+    () => FakeTime.restoreFor(() => {}),
+    TimeError,
+    "no fake time",
+  );
 });
 
 Deno.test("delay uses real time", async () => {


### PR DESCRIPTION
Fixed `FakeTime.restoreFor` to atomically restore and re-override `globalThis.setTimeout` etc.
This also fixes `FakeTime.prototype.delay` and `FakeTime.prototype.runMicrotasks` and others.

Of course, we don't get atomicity when an async function is specified to `restoreFor`.
However, `FakeTime.prototype.delay` that uses an non-async function will be fixed.

Example of `runMicrotasks` (that calls `delay` that calls `restoreFor`):
```ts
import { FakeTime } from "./testing/time.ts";

const testTarget = async() => {
   console.log(1, setTimeout);
   await Promise.resolve();
   console.log(2, setTimeout);
   await Promise.resolve();
   console.log(3, setTimeout);
};

const time = new FakeTime();
const promise = testTarget(); // no await, microtask is queued
time.runMicrotasks();
await promise; // already resolved
time.restore();

// Outputs before PR:
// 1 [Function: fakeSetTimeout]
// 2 [Function: setTimeout]
// 3 [Function: fakeSetTimeout]

// Outputs this PR:
// 1 [Function: fakeSetTimeout]
// 2 [Function: fakeSetTimeout]
// 3 [Function: fakeSetTimeout]
```