### PR TITLE
docs(fs/walk): add descriptions to `WalkOptions`'s properties

### DIFF
--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -49,18 +49,49 @@ function wrapErrorWithPath(err: unknown, root: string) {
 }
 
 export interface WalkOptions {
-  /** @default {Infinity} */
+  /**
+   * The maximum depth of the file tree to be walked recursively.
+   * @default {Infinity}
+   */
   maxDepth?: number;
-  /** @default {true} */
+  /**
+   * Indicates whether file entries should be included or not.
+   * @default {true}
+   */
   includeFiles?: boolean;
-  /** @default {true} */
+  /**
+   * Indicates whether directory entries should be included or not.
+   * @default {true}
+   */
   includeDirs?: boolean;
-  /** @default {true} */
+  /**
+   * Indicates whether symlink entries should be included or not.
+   * This option is meaningful only if `followSymlinks` is set to `false`.
+   * @default {true}
+   */
   includeSymlinks?: boolean;
-  /** @default {false} */
+  /**
+   * Indicates whether symlinks should be resolved or not.
+   * @default {false}
+   */
   followSymlinks?: boolean;
+  /**
+   * List of file extensions used to filter entries.
+   * If specified, entries without the file extension specified by this option are excluded.
+   * @default {undefined}
+   */
   exts?: string[];
+  /**
+   * List of regular expression patterns used to filter entries.
+   * If specified, entries that do not match the patterns specified by this option are excluded.
+   * @default {undefined}
+   */
   match?: RegExp[];
+  /**
+   * List of regular expression patterns used to filter entries.
+   * If specified, entries matching the patterns specified by this option are excluded.
+   * @default {undefined}
+   */
   skip?: RegExp[];
 }
 export type { WalkEntry };


### PR DESCRIPTION
When I looked at the [WalkOptions](https://deno.land/std@0.198.0/fs/walk.ts?s=WalkOptions) documentation, I noticed that there is no description of each property. So, this PR adds JSDoc comments to each property of `WalkOptions`.