### PR TITLE
chore: repoint internal imports to single-export files

### DIFF
--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -863,10 +863,10 @@ Deno.test(
 
     await t.step("load", async () => {
       assertEnv(await load(optsNoEnvAccess));
-      assertRejects(
+      await assertRejects(
         () => load(optsOnlyEnvPath),
         Deno.errors.PermissionDenied,
-        `Requires env access to all, run again with the --allow-env flag`,
+        `Requires env access, run again with the --allow-env flag`,
       );
     });
 

--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// @ts-nocheck Bypass static errors for missing --unstable.
 
-import * as path from "../path/mod.ts";
+import { basename } from "../path/basename.ts";
+import { join } from "../path/join.ts";
+import { resolve } from "../path/resolve.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType, isSubdir, toPathString } from "./_util.ts";
 import { assert } from "../assert/assert.ts";
@@ -189,8 +190,8 @@ async function copyDir(
   dest = toPathString(dest);
 
   for await (const entry of Deno.readDir(src)) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, path.basename(srcPath as string));
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, basename(srcPath as string));
     if (entry.isSymlink) {
       await copySymLink(srcPath, destPath, options);
     } else if (entry.isDirectory) {
@@ -228,8 +229,8 @@ function copyDirSync(
 
   for (const entry of Deno.readDirSync(src)) {
     assert(entry.name != null, "file.name must be set");
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, path.basename(srcPath as string));
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, basename(srcPath as string));
     if (entry.isSymlink) {
       copySymlinkSync(srcPath, destPath, options);
     } else if (entry.isDirectory) {
@@ -262,8 +263,8 @@ export async function copy(
   dest: string | URL,
   options: CopyOptions = {},
 ) {
-  src = path.resolve(toPathString(src));
-  dest = path.resolve(toPathString(dest));
+  src = resolve(toPathString(src));
+  dest = resolve(toPathString(dest));
 
   if (src === dest) {
     throw new Error("Source and destination cannot be the same.");
@@ -307,8 +308,8 @@ export function copySync(
   dest: string | URL,
   options: CopyOptions = {},
 ) {
-  src = path.resolve(toPathString(src));
-  dest = path.resolve(toPathString(dest));
+  src = resolve(toPathString(src));
+  dest = resolve(toPathString(dest));
 
   if (src === dest) {
     throw new Error("Source and destination cannot be the same.");

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { join } from "../path/mod.ts";
+import { join } from "../path/join.ts";
 import { toPathString } from "./_util.ts";
 
 /**

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import * as path from "../path/mod.ts";
+import { dirname } from "../path/dirname.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType, toPathString } from "./_util.ts";
 
@@ -31,7 +31,7 @@ export async function ensureFile(filePath: string | URL) {
     // if file not exists
     if (err instanceof Deno.errors.NotFound) {
       // ensure dir exists
-      await ensureDir(path.dirname(toPathString(filePath)));
+      await ensureDir(dirname(toPathString(filePath)));
       // create file
       await Deno.writeFile(filePath, new Uint8Array());
       return;
@@ -69,7 +69,7 @@ export function ensureFileSync(filePath: string | URL) {
     // if file not exists
     if (err instanceof Deno.errors.NotFound) {
       // ensure dir exists
-      ensureDirSync(path.dirname(toPathString(filePath)));
+      ensureDirSync(dirname(toPathString(filePath)));
       // create file
       Deno.writeFileSync(filePath, new Uint8Array());
       return;

--- a/fs/ensure_link.ts
+++ b/fs/ensure_link.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import * as path from "../path/mod.ts";
+import { dirname } from "../path/dirname.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { toPathString } from "./_util.ts";
 
@@ -19,7 +19,7 @@ import { toPathString } from "./_util.ts";
  */
 export async function ensureLink(src: string | URL, dest: string | URL) {
   dest = toPathString(dest);
-  await ensureDir(path.dirname(dest));
+  await ensureDir(dirname(dest));
 
   await Deno.link(toPathString(src), dest);
 }
@@ -40,7 +40,7 @@ export async function ensureLink(src: string | URL, dest: string | URL) {
  */
 export function ensureLinkSync(src: string | URL, dest: string | URL) {
   dest = toPathString(dest);
-  ensureDirSync(path.dirname(dest));
+  ensureDirSync(dirname(dest));
 
   Deno.linkSync(toPathString(src), dest);
 }

--- a/fs/ensure_symlink.ts
+++ b/fs/ensure_symlink.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import * as path from "../path/mod.ts";
+import { dirname } from "../path/dirname.ts";
+import { resolve } from "../path/resolve.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { getFileInfoType, toPathString } from "./_util.ts";
 import { isWindows } from "../_util/os.ts";
@@ -7,7 +8,7 @@ import { isWindows } from "../_util/os.ts";
 function resolveSymlinkTarget(target: string | URL, linkName: string | URL) {
   if (typeof target != "string") return target; // URL is always absolute path
   if (typeof linkName == "string") {
-    return path.resolve(path.dirname(linkName), target);
+    return resolve(dirname(linkName), target);
   } else {
     return new URL(target, linkName);
   }
@@ -28,7 +29,7 @@ export async function ensureSymlink(
   const srcStatInfo = await Deno.lstat(targetRealPath);
   const srcFilePathType = getFileInfoType(srcStatInfo);
 
-  await ensureDir(path.dirname(toPathString(linkName)));
+  await ensureDir(dirname(toPathString(linkName)));
 
   const options: Deno.SymlinkOptions | undefined = isWindows
     ? {
@@ -60,7 +61,7 @@ export function ensureSymlinkSync(
   const srcStatInfo = Deno.lstatSync(targetRealPath);
   const srcFilePathType = getFileInfoType(srcStatInfo);
 
-  ensureDirSync(path.dirname(toPathString(linkName)));
+  ensureDirSync(dirname(toPathString(linkName)));
 
   const options: Deno.SymlinkOptions | undefined = isWindows
     ? {

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -1,13 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import {
-  GlobOptions,
-  globToRegExp,
-  isAbsolute,
-  isGlob,
-  joinGlobs,
-  resolve,
-  SEP_PATTERN,
-} from "../path/mod.ts";
+import { GlobOptions, globToRegExp, isGlob, joinGlobs } from "../path/glob.ts";
+import { isAbsolute } from "../path/is_absolute.ts";
+import { resolve } from "../path/resolve.ts";
+import { SEP_PATTERN } from "../path/separator.ts";
 import { walk, walkSync } from "./walk.ts";
 import { assert } from "../assert/assert.ts";
 import { isWindows } from "../_util/os.ts";

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -3,7 +3,8 @@
 // https://golang.org/pkg/path/filepath/#Walk
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 import { assert } from "../assert/assert.ts";
-import { join, normalize } from "../path/mod.ts";
+import { join } from "../path/join.ts";
+import { normalize } from "../path/normalize.ts";
 import {
   createWalkEntry,
   createWalkEntrySync,

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -31,14 +31,13 @@
  * @module
  */
 
-import {
-  extname,
-  join,
-  posix,
-  relative,
-  resolve,
-  SEP_PATTERN,
-} from "../path/mod.ts";
+import { posixJoin } from "../path/_join.ts";
+import { posixNormalize } from "../path/_normalize.ts";
+import { extname } from "../path/extname.ts";
+import { join } from "../path/join.ts";
+import { relative } from "../path/relative.ts";
+import { resolve } from "../path/resolve.ts";
+import { SEP_PATTERN } from "../path/separator.ts";
 import { contentType } from "../media_types/content_type.ts";
 import { calculate, ifNoneMatch } from "./etag.ts";
 import { isRedirectStatus, Status } from "./http_status.ts";
@@ -293,7 +292,7 @@ async function serveDirIndex(
       mode: modeToString(true, fileInfo.mode),
       size: "",
       name: "../",
-      url: posix.join(dirUrl, ".."),
+      url: posixJoin(dirUrl, ".."),
     }));
     listEntryPromise.push(entryInfo);
   }
@@ -304,7 +303,7 @@ async function serveDirIndex(
       continue;
     }
     const filePath = join(dirPath, entry.name);
-    const fileUrl = encodeURIComponent(posix.join(dirUrl, entry.name))
+    const fileUrl = encodeURIComponent(posixJoin(dirUrl, entry.name))
       .replaceAll("%2F", "/");
 
     listEntryPromise.push((async () => {
@@ -620,7 +619,7 @@ async function createServeDirResponse(
 
   const url = new URL(req.url);
   const decodedUrl = decodeURIComponent(url.pathname);
-  let normalizedPath = posix.normalize(decodedUrl);
+  let normalizedPath = posixNormalize(decodedUrl);
 
   if (urlRoot && !normalizedPath.startsWith("/" + urlRoot)) {
     return createCommonResponse(Status.NotFound);

--- a/http/server.ts
+++ b/http/server.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { delay } from "../async/mod.ts";
+import { delay } from "../async/delay.ts";
 
 /** Thrown by Server after it has been closed. */
 const ERROR_SERVER_CLOSED = "Server closed";

--- a/json/concatenated_json_parse_stream_test.ts
+++ b/json/concatenated_json_parse_stream_test.ts
@@ -325,7 +325,7 @@ Deno.test({
       [`{${"foo".repeat(100)}}`],
       {},
       SyntaxError,
-      `Expected property name or '}' in JSON at position 1 (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
+      `Expected property name or '}' in JSON at position 1 (line 1 column 2) (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
     );
   },
 });

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -269,12 +269,10 @@
  * @module
  */
 
-import {
-  assertEquals,
-  AssertionError,
-  assertIsError,
-  assertRejects,
-} from "./asserts.ts";
+import { assertEquals } from "../assert/assert_equals.ts";
+import { assertIsError } from "../assert/assert_is_error.ts";
+import { assertRejects } from "../assert/assert_rejects.ts";
+import { AssertionError } from "../assert/assertion_error.ts";
 
 /** An error related to spying on a function or instance method. */
 export class MockError extends Error {

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -136,10 +136,15 @@
  * @module
  */
 
-import { fromFileUrl, parse, resolve, toFileUrl } from "../path/mod.ts";
-import { ensureFile, ensureFileSync } from "../fs/mod.ts";
+import { fromFileUrl } from "../path/from_file_url.ts";
+import { parse } from "../path/parse.ts";
+import { resolve } from "../path/resolve.ts";
+import { toFileUrl } from "../path/to_file_url.ts";
+import { ensureFile, ensureFileSync } from "../fs/ensure_file.ts";
 import { bold, green, red } from "../fmt/colors.ts";
-import { assert, AssertionError, equal } from "./asserts.ts";
+import { assert } from "../assert/assert.ts";
+import { AssertionError } from "../assert/assertion_error.ts";
+import { equal } from "../assert/equal.ts";
 import { buildMessage, diff, diffstr } from "../_util/diff.ts";
 
 const CAN_NOT_DISPLAY = "[Cannot display]";

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -7,7 +7,7 @@
  */
 
 import { ascend, RedBlackTree } from "../collections/red_black_tree.ts";
-import { DelayOptions } from "../async/delay.ts";
+import type { DelayOptions } from "../async/delay.ts";
 import { _internals } from "./_time.ts";
 
 /** An error related to faking time. */

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -73,7 +73,8 @@
  * @module
  */
 
-import { relative, resolve } from "../path/mod.ts";
+import { relative } from "../path/relative.ts";
+import { resolve } from "../path/resolve.ts";
 
 const CLOCKID_REALTIME = 0;
 const CLOCKID_MONOTONIC = 1;


### PR DESCRIPTION
This PR changes a few internal imports to point to single-export files instead of their corresponding `mod.ts` files. As a result, the total size of `http/file_server.ts` and its dependencies is reduced by about 12%.

```shellsession
$ deno info https://deno.land/std@0.198.0/http/file_server.ts
…
dependencies: 57 unique
size: 367.76KB
…

$ deno info ./http/file_server.ts
…
dependencies: 34 unique
size: 323.66KB
…
```
