### PR TITLE
test(json): fix expectation of ConcatenatedJsonParseStream test

### DIFF
--- a/json/concatenated_json_parse_stream_test.ts
+++ b/json/concatenated_json_parse_stream_test.ts
@@ -325,7 +325,7 @@ Deno.test({
       [`{${"foo".repeat(100)}}`],
       {},
       SyntaxError,
-      `Expected property name or '}' in JSON at position 1 (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
+      `Expected property name or '}' in JSON at position 1 (line 1 column 2) (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
     );
   },
 });


### PR DESCRIPTION
This PR updates the expectation error message in ConcatenatedJsonParseStream test to pass the CI. This message seems produced by builtin `JSON.parse`. Probably this has been affected by v8 upgrade in https://github.com/denoland/deno_core/pull/145 and https://github.com/denoland/deno/pull/20135