### PR TITLE
test(examples/xeval): re-enable `xevalCliSyntaxError` test case

### DIFF
--- a/examples/xeval_test.ts
+++ b/examples/xeval_test.ts
@@ -62,8 +62,7 @@ Deno.test({
   },
 });
 
-// TODO(kt3k): Enable this test
-Deno.test("xevalCliSyntaxError", { ignore: true }, async function () {
+Deno.test("xevalCliSyntaxError", async function () {
   const command = new Deno.Command(Deno.execPath(), {
     args: ["run", "--quiet", xevalPath, "("],
     cwd: moduleDir,


### PR DESCRIPTION
Close #3343