### PR TITLE
fix(log): fix serializing BigInt value in object

### DIFF
--- a/log/logger.ts
+++ b/log/logger.ts
@@ -123,8 +123,9 @@ export class Logger {
     return msg instanceof Function ? fnResult : msg;
   }
 
-  asString(data: unknown): string {
+  asString(data: unknown, isProperty = false): string {
     if (typeof data === "string") {
+      if (isProperty) return `"${data}"`;
       return data;
     } else if (
       data === null ||
@@ -138,7 +139,11 @@ export class Logger {
     } else if (data instanceof Error) {
       return data.stack!;
     } else if (typeof data === "object") {
-      return JSON.stringify(data);
+      return `{${
+        Object.entries(data)
+          .map(([k, v]) => `"${k}":${this.asString(v, true)}`)
+          .join(",")
+      }}`;
     }
     return "undefined";
   }

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -241,15 +241,33 @@ Deno.test(
       payload: "data",
       other: 123,
     });
+    const data19: { payload: string; other: bigint } = logger.error({
+      payload: "data",
+      other: 123n,
+    });
+    assertEquals(data19, {
+      payload: "data",
+      other: 123n,
+    });
+    const data20: { payload: string; other: bigint } = logger.error(
+      { payload: "data", other: 123n },
+      1,
+    );
+    assertEquals(data20, {
+      payload: "data",
+      other: 123n,
+    });
     assertEquals(handler.messages[16], 'ERROR {"payload":"data","other":123}');
     assertEquals(handler.messages[17], 'ERROR {"payload":"data","other":123}');
+    assertEquals(handler.messages[18], 'ERROR {"payload":"data","other":123}');
+    assertEquals(handler.messages[19], 'ERROR {"payload":"data","other":123}');
 
     // error
     const error = new RangeError("Uh-oh!");
-    const data19: RangeError = logger.error(error);
-    assertEquals(data19, error);
-    const messages19 = handler.messages[18].split("\n");
-    assertEquals(messages19[0], `ERROR ${error.name}: ${error.message}`);
-    assertMatch(messages19[1], /^\s+at file:.*\d+:\d+$/);
+    const data21: RangeError = logger.error(error);
+    assertEquals(data21, error);
+    const messages21 = handler.messages[20].split("\n");
+    assertEquals(messages21[0], `ERROR ${error.name}: ${error.message}`);
+    assertMatch(messages21[1], /^\s+at file:.*\d+:\d+$/);
   },
 );


### PR DESCRIPTION
Another approach to fix #3547

While my brief implementation in original issue and #3548 represent bigint value as quoted string, this PR serializes value without quotes.

Since this is my first PR submitting to deno, I hope I'm doing right to follow community guidelines😅