### PR TITLE
doc: improve dotenv config option description

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -102,7 +102,7 @@
  * |examplePath|./.env.example|Path and filename of the `.env.example` file
  * |export|false|This will export all environment variables in the `.env` and `.env.default` files to the process environment (e.g. for use by `Deno.env.get()`) but only if they are not already set.  If a variable is already in the process, the `.env` value is ignored.
  * |allowEmptyValues|false|Allows empty values for specified env variables (throws otherwise)
- * |restrictEnvAccessTo||List of Env variables to read from process. By default, the complete Env is looked up. This allows to permit access to only specific Env variables with `--allow-env=ENV_VAR_NAME`
+ * |restrictEnvAccessTo||Restrict which process env variables are accessible in the .env or .env.default files
  *
  * ### Example configuration
  * ```ts

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -102,7 +102,7 @@
  * |examplePath|./.env.example|Path and filename of the `.env.example` file
  * |export|false|This will export all environment variables in the `.env` and `.env.default` files to the process environment (e.g. for use by `Deno.env.get()`) but only if they are not already set.  If a variable is already in the process, the `.env` value is ignored.
  * |allowEmptyValues|false|Allows empty values for specified env variables (throws otherwise)
- * |restrictEnvAccessTo||Restrict which process env variables are accessible in the .env or .env.default files
+ * |restrictEnvAccessTo||Restrict which process environment variables are accessible in the `.env` or `.env.default` files
  *
  * ### Example configuration
  * ```ts


### PR DESCRIPTION
The current description of the `restrictEnvAccessTo` is confusing and potentially misleading.  This PR attempts to simplify the description.

Example of behaviour:
```sh
#.env
HELLO=world
SOME=${A}
THING=${B}
```

```ts
//main.ts
import {load} from https://deno.land/std@0.199.0/dotenv/mod.ts
const env1 = await load({ restrictEnvAccessTo: ['A'] });  //.env only has access to A
console.log(env1);
const env2 = await load(); //.env has access to both A and B
console.log(env2);
```
and invoke with:
```sh
A=1 B=2 deno run -A main.ts
```

the output is:
```sh
{ HELLO: "world", SOME: "1", THING: "undefined" }
{ HELLO: "world", SOME: "1", THING: "2" }
```