### PR TITLE
Properly quote/escape strings in assertIsError

### DIFF
--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -22,18 +22,18 @@ export function assertIsError<E extends Error = Error>(
     );
   }
   if (ErrorClass && !(error instanceof ErrorClass)) {
-    msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
-      typeof error === "object" ? error?.constructor?.name : "[not an object]"
-    }"${msgSuffix}`;
+    msg = `Expected error to be instance of ${JSON.stringify(ErrorClass.name)}, but was ${
+      typeof error === "object" ? JSON.stringify(error?.constructor?.name) : "[not an object]"
+    }${msgSuffix}`;
     throw new AssertionError(msg);
   }
   if (
     msgIncludes && (!(error instanceof Error) ||
       !stripColor(error.message).includes(stripColor(msgIncludes)))
   ) {
-    msg = `Expected error message to include "${msgIncludes}", but got "${
-      error instanceof Error ? error.message : "[not an Error]"
-    }"${msgSuffix}`;
+    msg = `Expected error message to include ${JSON.stringify(msgIncludes)}, but got ${
+      error instanceof Error ? JSON.stringify(error.message) : "[not an Error]"
+    }${msgSuffix}`;
     throw new AssertionError(msg);
   }
 }

--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -22,17 +22,21 @@ export function assertIsError<E extends Error = Error>(
     );
   }
   if (ErrorClass && !(error instanceof ErrorClass)) {
-    msg = `Expected error to be instance of ${JSON.stringify(ErrorClass.name)}, but was ${
-      typeof error === "object" ? JSON.stringify(error?.constructor?.name) : "[not an object]"
-    }${msgSuffix}`;
+    msg = `Expected error to be instance of "${ErrorClass.name}", but was "${
+      typeof error === "object" ? error?.constructor?.name : "[not an object]"
+    }"${msgSuffix}`;
     throw new AssertionError(msg);
   }
   if (
     msgIncludes && (!(error instanceof Error) ||
       !stripColor(error.message).includes(stripColor(msgIncludes)))
   ) {
-    msg = `Expected error message to include ${JSON.stringify(msgIncludes)}, but got ${
-      error instanceof Error ? JSON.stringify(error.message) : "[not an Error]"
+    msg = `Expected error message to include ${
+      JSON.stringify(msgIncludes)
+    }, but got ${
+      error instanceof Error
+        ? JSON.stringify(error.message)
+        : '"[not an Error]"' // TODO(kt3k): show more useful information
     }${msgSuffix}`;
     throw new AssertionError(msg);
   }

--- a/assert/assert_is_error_test.ts
+++ b/assert/assert_is_error_test.ts
@@ -35,3 +35,17 @@ Deno.test("Assert Is Error with custom Error", () => {
     'Expected error to be instance of "CustomError", but was "AnotherCustomError".',
   );
 });
+
+Deno.test("assertIsError throws with message diff, where messages contain double quotes", () => {
+  class CustomError extends Error {}
+  assertThrows(
+    () =>
+      assertIsError(
+        new CustomError('error with "double quotes"'),
+        CustomError,
+        'doesn\'t include "this message"',
+      ),
+    AssertionError,
+    `Expected error message to include "doesn't include \\"this message\\"", but got "error with \\"double quotes\\"".`,
+  );
+});


### PR DESCRIPTION
Currently messages will look like
- `expected X but got "["howdy", 2]"` instead of
- `expected X but got "[\"howdy\", 2]"`

Its misleading, but also inconvenient since often its nice to copy out the `instead got` and use it to fix the test case.