### PR TITLE
BREAKING(yaml): change binary handling

### DIFF
--- a/yaml/_type/binary.ts
+++ b/yaml/_type/binary.ts
@@ -4,7 +4,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { Type } from "../type.ts";
 import type { Any } from "../_utils.ts";
-import { Buffer } from "../../io/buffer.ts";
 
 // [ 64, 65, 66 ] -> [ padding, CR, LF ]
 const BASE64_MAP =
@@ -35,7 +34,7 @@ function resolveYamlBinary(data: Any): boolean {
   return bitlen % 8 === 0;
 }
 
-function constructYamlBinary(data: string): Buffer {
+function constructYamlBinary(data: string): Uint8Array {
   // remove CR/LF & padding to simplify scan
   const input = data.replace(/[\r\n=]/g, "");
   const max = input.length;
@@ -70,7 +69,7 @@ function constructYamlBinary(data: string): Buffer {
     result.push((bits >> 4) & 0xff);
   }
 
-  return new Buffer(new Uint8Array(result));
+  return new Uint8Array(result);
 }
 
 function representYamlBinary(object: Uint8Array): string {
@@ -116,19 +115,8 @@ function representYamlBinary(object: Uint8Array): string {
   return result;
 }
 
-function isBinary(obj: Any): obj is Buffer {
-  if (typeof obj?.readSync !== "function") {
-    return false;
-  }
-  const buf = new Buffer();
-  try {
-    if (0 > buf.readFromSync(obj as Buffer)) return true;
-    return false;
-  } catch {
-    return false;
-  } finally {
-    buf.reset();
-  }
+function isBinary(obj: Any): obj is Uint8Array {
+  return obj instanceof Uint8Array;
 }
 
 export const binary = new Type("tag:yaml.org,2002:binary", {

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -230,3 +230,13 @@ Deno.test({
     assertEquals(parse(yaml3), expected);
   },
 });
+
+Deno.test({
+  name: "parse bianry type",
+  fn() {
+    const yaml = `message: !!binary "SGVsbG8="`;
+    assertEquals(parse(yaml), {
+      message: new Uint8Array([72, 101, 108, 108, 111]),
+    });
+  },
+});

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -232,7 +232,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "parse bianry type",
+  name: "parse binary type",
   fn() {
     const yaml = `message: !!binary "SGVsbG8="`;
     assertEquals(parse(yaml), {

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -27,6 +27,7 @@ Deno.test({
         ],
       },
       test: "foobar",
+      binary: new Uint8Array([72, 101, 108, 108, 111]),
     };
 
     const ASSERTS = `foo:
@@ -37,6 +38,7 @@ Deno.test({
     - a: false
     - a: false
 test: foobar
+binary: !<tag:yaml.org,2002:binary> SGVsbG8=
 `;
 
     assertEquals(stringify(FIXTURE), ASSERTS);


### PR DESCRIPTION
Currently `yaml` module parses `!!binary "..BASE64.."` notation to `Buffer` class, and serializes `Buffer` (or any object with `readSync` method) to `!!binary "..BASE64.."` notation.

This PR replaces `Buffer` in the above usage with `Uint8Array`. I think this makes more sense in JavaScript.

Also this change is necessary to remove the dependency to `std/io` from `std/yaml`. We're going to deprecate `std/io` soon. This change is necessary for stabilizing `yaml` in the future.

closes #3585 