### PR TITLE
BREAKING(crypto): deprecate crypto.subtle.timingSafeEqual()

### DIFF
--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -72,58 +72,6 @@
  * ] as const;
  * ```
  *
- * ## Timing safe comparison
- *
- * When checking the values of cryptographic hashes are equal, default
- * comparisons can be susceptible to timing based attacks, where attacker is
- * able to find out information about the host system by repeatedly checking
- * response times to equality comparisons of values.
- *
- * It is likely some form of timing safe equality will make its way to the
- * WebCrypto standard (see:
- * [w3c/webcrypto#270](https://github.com/w3c/webcrypto/issues/270)), but until
- * that time, `timingSafeEqual()` is provided:
- *
- * ```ts
- * import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
- *
- * const a = await crypto.subtle.digest(
- *   "SHA-384",
- *   new TextEncoder().encode("hello world"),
- * );
- * const b = await crypto.subtle.digest(
- *   "SHA-384",
- *   new TextEncoder().encode("hello world"),
- * );
- * const c = await crypto.subtle.digest(
- *   "SHA-384",
- *   new TextEncoder().encode("hello deno"),
- * );
- *
- * assert(crypto.subtle.timingSafeEqual(a, b));
- * assert(!crypto.subtle.timingSafeEqual(a, c));
- * ```
- *
- * In addition to the method being part of the `crypto.subtle` interface, it is
- * also loadable directly:
- *
- * ```ts
- * import { timingSafeEqual } from "https://deno.land/std@$STD_VERSION/crypto/timing_safe_equal.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
- *
- * const a = await crypto.subtle.digest(
- *   "SHA-384",
- *   new TextEncoder().encode("hello world"),
- * );
- * const b = await crypto.subtle.digest(
- *   "SHA-384",
- *   new TextEncoder().encode("hello world"),
- * );
- *
- * assert(timingSafeEqual(a, b));
- * ```
- *
  * @example
  * ```ts
  * import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
@@ -235,7 +183,10 @@ export interface StdSubtleCrypto extends SubtleCrypto {
     data: BufferSource | Iterable<BufferSource>,
   ): ArrayBuffer;
 
-  /** Compare to array buffers or data views in a way that timing based attacks
+  /**
+   * @deprecated (will be removed in 0.207.0) Import from `std/crypto/timing_safe_equal.ts` instead
+   *
+   * Compare to array buffers or data views in a way that timing based attacks
    * cannot gain information about the platform. */
   timingSafeEqual(
     a: ArrayBufferLike | DataView,

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -3,8 +3,33 @@
 
 import { assert } from "../assert/assert.ts";
 
-/** Compare to array buffers or data views in a way that timing based attacks
- * cannot gain information about the platform. */
+/**
+ * When checking the values of cryptographic hashes are equal, default
+ * comparisons can be susceptible to timing based attacks, where attacker is
+ * able to find out information about the host system by repeatedly checking
+ * response times to equality comparisons of values.
+ *
+ * It is likely some form of timing safe equality will make its way to the
+ * WebCrypto standard (see:
+ * [w3c/webcrypto#270](https://github.com/w3c/webcrypto/issues/270)), but until
+ * that time, `timingSafeEqual()` is provided:
+ *
+ * ```ts
+ * import { timingSafeEqual } from "https://deno.land/std@$STD_VERSION/crypto/timing_safe_equal.ts";
+ * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+ *
+ * const a = await crypto.subtle.digest(
+ *   "SHA-384",
+ *   new TextEncoder().encode("hello world"),
+ * );
+ * const b = await crypto.subtle.digest(
+ *   "SHA-384",
+ *   new TextEncoder().encode("hello world"),
+ * );
+ *
+ * assert(timingSafeEqual(a, b));
+ * ```
+ */
 export function timingSafeEqual(
   a: ArrayBufferView | ArrayBufferLike | DataView,
   b: ArrayBufferView | ArrayBufferLike | DataView,


### PR DESCRIPTION
Closes #3541