### PR TITLE
chore(msgpack): get rid of testing/asserts usage

### DIFF
--- a/msgpack/decode_test.ts
+++ b/msgpack/decode_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../assert/mod.ts";
 import { decode } from "./decode.ts";
 
 Deno.test("positive fixint", () => {

--- a/msgpack/encode_test.ts
+++ b/msgpack/encode_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertThrows } from "../testing/asserts.ts";
+import { assertEquals, assertThrows } from "../assert/mod.ts";
 import * as path from "../path/mod.ts";
 import { decode, encode } from "./mod.ts";
 


### PR DESCRIPTION
Not sure how these slipped through the last removal PR. Maybe `msgpack` was originally written before deprecation and merged right after these were removed from the rest of std?