### PR TITLE
feat(stripAnsiCode): escape erase character

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -556,7 +556,7 @@ export function bgRgb24(str: string, color: number | Rgb): string {
 const ANSI_PATTERN = new RegExp(
   [
     "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
-    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TXZcf-nq-uy=><~]))",
   ].join("|"),
   "g",
 );


### PR DESCRIPTION
I run into this while debugging a windows terminal app

A quick search on github shows that it seems to be the erase character sequence https://github.com/search?q=ESC%5B%23X&type=code