### PR TITLE
Fix(streams): DelimiterStream regression

### DIFF
--- a/streams/delimiter_stream_test.ts
+++ b/streams/delimiter_stream_test.ts
@@ -78,3 +78,24 @@ Deno.test("[streams] DelimiterStream, prefix", async () => {
   ].map((s) => new TextEncoder().encode(s));
   await testTransformStream(delimStream, DELIMITER_STREAM_INPUTS, outputs);
 });
+
+Deno.test("[streams] DelimiterStream, regression 3609", async () => {
+  const delimStream = new DelimiterStream(new TextEncoder().encode(";"));
+  const inputs = [
+    ";ab;fg;hn;j",
+    "k;lr;op;rt;;",
+  ].map((s) => new TextEncoder().encode(s));
+  const outputs = [
+    "",
+    "ab",
+    "fg",
+    "hn",
+    "jk",
+    "lr",
+    "op",
+    "rt",
+    "",
+    "",
+  ].map((s) => new TextEncoder().encode(s));
+  await testTransformStream(delimStream, inputs, outputs);
+});


### PR DESCRIPTION
Two regressions appeared in the recent DelimiterStream refactoring:
1. #3609 The pushing of chunk remnants was off by one, which would mean that if an incoming chunk's last byte was the first byte to be pushed out into an outgoing chunk then that byte would accidentally be left out.
2. Unreported issue but related to the first that appeared once it was fixed was that if an incoming chunk started with a separator then the chunk starting pointer was not properly moved forward.

A regression test was added testing for these two errors.

closes #3609 