### PR TITLE
fix(assert/assert_false): Fix incorrect JSDoc placement

### DIFF
--- a/assert/assert_false.ts
+++ b/assert/assert_false.ts
@@ -1,8 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { AssertionError } from "./assertion_error.ts";
 
-/** Make an assertion, error will be thrown if `expr` have truthy value. */
 type Falsy = false | 0 | 0n | "" | null | undefined;
+
+/** Make an assertion, error will be thrown if `expr` have truthy value. */
 export function assertFalse(expr: unknown, msg = ""): asserts expr is Falsy {
   if (expr) {
     throw new AssertionError(msg);


### PR DESCRIPTION
That JSDoc should belong to `function assertFalse` but not `type Falsy`.
