### PR TITLE
BREAKING(datetime): deprecate to_imf.ts

### DIFF
--- a/datetime/to_imf.ts
+++ b/datetime/to_imf.ts
@@ -2,6 +2,8 @@
 // This module is browser compatible.
 
 /**
+ * @deprecated (will be removed in 0.209.0) Use `date.toUTCString()` instead.
+ *
  * Formats the given date to IMF date time format. (Reference:
  * https://tools.ietf.org/html/rfc7231#section-7.1.1.1).
  * IMF is the time format to use when generating times in HTTP


### PR DESCRIPTION
I know we're planning on deprecating the whole module but this one is especially not useful.