### PR TITLE
chore(_tools): fix type errors in `_tools`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,19 +83,7 @@ jobs:
         run: deno fmt --check
 
       - name: Lint
-        run: deno lint
-
-      - name: Check License headers
-        run: deno task fmt:licence-headers --check
-
-      - name: Check Deprecations
-        run: "deno task lint:deprecations"
-
-      - name: Check Import paths in Docs
-        run: "deno task lint:doc-imports"
-
-      - name: Check circular dependencies between modules
-        run: "deno task lint:circular"
+        run: deno task lint
 
       - name: Spell-check
         uses: crate-ci/typos@master

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -37,7 +37,7 @@ let shouldFail = false;
 const DEFAULT_DEPRECATED_VERSION = semver.increment(
   semver.increment(
     semver.increment(
-      VERSION,
+      semver.parse(VERSION),
       "minor",
     )!,
     "minor",

--- a/_tools/check_doc_imports.ts
+++ b/_tools/check_doc_imports.ts
@@ -38,11 +38,11 @@ function checkImportStatements(
   );
   const importDeclarations = sourceFile.statements.filter((s) =>
     s.kind === SyntaxKind.ImportDeclaration
-  ) as ImportDeclaration[];
+  ) as ts.ImportDeclaration[];
 
   for (const importDeclaration of importDeclarations) {
     const { moduleSpecifier } = importDeclaration;
-    const importPath = (moduleSpecifier as StringLiteral).text;
+    const importPath = (moduleSpecifier as ts.StringLiteral).text;
     const isRelative = importPath.startsWith(".");
     const isInternal = importPath.startsWith(
       "https://deno.land/std@$STD_VERSION/",

--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,8 @@
     "lint:deprecations": "deno run --allow-read --allow-net ./_tools/check_deprecation.ts",
     "lint:doc-imports": "deno run --allow-env --allow-read ./_tools/check_doc_imports.ts",
     "lint:circular": "deno run --allow-env --allow-read --allow-net=deno.land ./_tools/check_circular_submodule_dependencies.ts",
-    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:deprecations && deno task lint:doc-imports && deno task lint:circular",
+    "lint:tools-types": "deno check _tools/*.ts",
+    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:deprecations && deno task lint:doc-imports && deno task lint:circular && deno task lint:tools-types",
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run --unstable -A https://deno.land/x/wasmbuild@0.10.3/main.ts --js-ext mjs --sync"


### PR DESCRIPTION
This PR fixes the below type errors in `_tools`. Currently scripts in `_tools` are not type-checked because they are not imported from any test cases. This PR also adds the type check task for them and run it in CI.

- `semver.increment(ver: string)` is now type error since #3591 (`_tools/check_deprecation.ts`)
- There are type errors in `_tools/check_doc_imports.ts` introduced in https://github.com/denoland/deno_std/pull/3351