### PR TITLE
fix(testing/time): fix FakeTime.next to return false if all timers are cleared

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -157,6 +157,16 @@ function* timerIdGen() {
   while (true) yield i++;
 }
 
+function nextDueNode(): DueNode | null {
+  for (;;) {
+    const dueNode = dueTree.min();
+    if (!dueNode) return null;
+    const hasTimer = dueNode.timers.some((timer) => dueNodes.has(timer.id));
+    if (hasTimer) return dueNode;
+    dueTree.remove(dueNode);
+  }
+}
+
 let startedAt: number;
 let now: number;
 let initializedAt: number;
@@ -375,7 +385,7 @@ export class FakeTime {
    * Returns true when there is a scheduled timer and false when there is not.
    */
   next(): boolean {
-    const next = dueTree.min();
+    const next = nextDueNode();
     if (next) this.now = next.due;
     return !!next;
   }

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -483,7 +483,7 @@ Deno.test("tickAsync runs all microtasks and runs timers if ticks past due", asy
   }
 });
 
-Deno.test("runNext runs next timer without running microtasks", async () => {
+Deno.test("next runs next timer without running microtasks", async () => {
   const time: FakeTime = new FakeTime();
   const start: number = Date.now();
   const cb = spy(fromNow());
@@ -516,7 +516,7 @@ Deno.test("runNext runs next timer without running microtasks", async () => {
   }
 });
 
-Deno.test("runNextAsync runs all microtasks and next timer", async () => {
+Deno.test("nextAsync runs all microtasks and next timer", async () => {
   const time: FakeTime = new FakeTime();
   const start: number = Date.now();
   const cb = spy(fromNow());


### PR DESCRIPTION
Fix `FakeTime.next()` and `nextAsync()` to return `false` if all timers are cleared.

## Problem

The document for `FakeTime.next()` says:
```
Advances time to when the next scheduled timer is due.
If there are no pending timers, time will not be changed.
Returns true when there is a scheduled timer and false when there is not.
```

However, if the timer is cleared before calling `next()`, it will return true even if there is no scheduled timer.

```typescript
import { FakeTime } from "https://deno.land/std@0.201.0/testing/time.ts";

const time = new FakeTime();
const start = time.now;

const id = setTimeout(() => {}, 1000);
clearTimeout(id);
const hasNext = time.next();

console.log(hasNext); // true, but expected false
console.log(time.now - start); // 1000, but expected 0
```