### PR TITLE
feat(encoding): add encodeHex, decodeHex

### DIFF
--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -12,16 +12,16 @@
  * @example
  * ```ts
  * import {
- *   decode,
- *   encode,
+ *   decodeHex,
+ *   encodeHex,
  * } from "https://deno.land/std@$STD_VERSION/encoding/hex.ts";
  *
  * const binary = new TextEncoder().encode("abc");
- * const encoded = encode(binary);
+ * const encoded = encodeHex(binary);
  * console.log(encoded);
- * // => Uint8Array(6) [ 54, 49, 54, 50, 54, 51 ]
+ * // => "616263"
  *
- * console.log(decode(encoded));
+ * console.log(decodeHex(encoded));
  * // => Uint8Array(3) [ 97, 98, 99 ]
  * ```
  *
@@ -29,6 +29,8 @@
  */
 
 const hexTable = new TextEncoder().encode("0123456789abcdef");
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 function errInvalidByte(byte: number) {
   return new TypeError(`Invalid byte '${String.fromCharCode(byte)}'`);
@@ -61,6 +63,29 @@ export function encode(src: Uint8Array): Uint8Array {
   return dst;
 }
 
+/** Encodes the source into hex string. */
+export function encodeHex(src: string | Uint8Array | ArrayBuffer): string {
+  let u8: Uint8Array;
+
+  if (src instanceof Uint8Array) {
+    u8 = src;
+  } else if (src instanceof ArrayBuffer) {
+    u8 = new Uint8Array(src);
+  } else if (typeof src === "string") {
+    u8 = textEncoder.encode(src);
+  } else {
+    throw new TypeError(`Invalid input type: ${typeof src}`);
+  }
+
+  const dst = new Uint8Array(u8.length * 2);
+  for (let i = 0; i < dst.length; i++) {
+    const v = u8[i];
+    dst[i * 2] = hexTable[v >> 4];
+    dst[i * 2 + 1] = hexTable[v & 0x0f];
+  }
+  return textDecoder.decode(dst);
+}
+
 /**
  * Decodes `src` into `src.length / 2` bytes.
  * If the input is malformed, an error will be thrown.
@@ -77,6 +102,27 @@ export function decode(src: Uint8Array): Uint8Array {
     // Check for invalid char before reporting bad length,
     // since the invalid char (if present) is an earlier problem.
     fromHexChar(src[dst.length * 2]);
+    throw errLength();
+  }
+
+  return dst;
+}
+
+/** Decodes the given hex string to Uint8Array.
+ * If the input is malformed, an error will be thrown. */
+export function decodeHex(src: string): Uint8Array {
+  const u8 = textEncoder.encode(src);
+  const dst = new Uint8Array(u8.length / 2);
+  for (let i = 0; i < dst.length; i++) {
+    const a = fromHexChar(u8[i * 2]);
+    const b = fromHexChar(u8[i * 2 + 1]);
+    dst[i] = (a << 4) | b;
+  }
+
+  if (u8.length % 2 === 1) {
+    // Check for invalid char before reporting bad length,
+    // since the invalid char (if present) is an earlier problem.
+    fromHexChar(u8[dst.length * 2]);
     throw errLength();
   }
 

--- a/encoding/hex_test.ts
+++ b/encoding/hex_test.ts
@@ -6,7 +6,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 
-import { decode, encode } from "./hex.ts";
+import { decode, decodeHex, encode, encodeHex } from "./hex.ts";
 
 const testCases = [
   // encoded(hex) / decoded(Uint8Array)
@@ -48,6 +48,21 @@ Deno.test("[encoding.hex] encode", () => {
   }
 });
 
+Deno.test("[encoding.hex] encodeHex", () => {
+  {
+    const srcStr = "abc";
+    const dest = encodeHex(srcStr);
+    assertEquals(dest, "616263");
+  }
+
+  for (const [enc, dec] of testCases) {
+    const src = new Uint8Array(dec as number[]);
+    const dest = encodeHex(src);
+    assertEquals(dest.length, src.length * 2);
+    assertEquals(dest, enc);
+  }
+});
+
 Deno.test("[encoding.hex] decode", () => {
   // Case for decoding uppercase hex characters, since
   // Encode always uses lowercase.
@@ -64,10 +79,35 @@ Deno.test("[encoding.hex] decode", () => {
   }
 });
 
+Deno.test("[encoding.hex] decodeHex", () => {
+  // Case for decoding uppercase hex characters, since
+  // Encode always uses lowercase.
+  const extraTestcase: [string, number[]][] = [
+    ["F8F9FAFBFCFDFEFF", [0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff]],
+  ];
+
+  const cases = testCases.concat(extraTestcase);
+
+  for (const [enc, dec] of cases) {
+    const dest = decodeHex(enc as string);
+    assertEquals(dest, new Uint8Array(dec as number[]));
+  }
+});
+
 Deno.test("[encoding.hex] decode error", () => {
   for (const [input, expectedErr, msg] of errCases) {
     assertThrows(
       () => decode(new TextEncoder().encode(input)),
+      expectedErr,
+      msg,
+    );
+  }
+});
+
+Deno.test("[encoding.hex] decodeHex error", () => {
+  for (const [input, expectedErr, msg] of errCases) {
+    assertThrows(
+      () => decodeHex(input),
       expectedErr,
       msg,
     );


### PR DESCRIPTION
`encode`, `decode` of `hex` has inconvenient signatures (and also inconsistent with other `encode` `decode`).

This PR adds `encodeHex` and `decodeHex` APIs which are more aligned to other `encode`/`decode` APIs and also ergonomic for most usages.

This PR also prepares for the deprecation of `toHashString` of `std/crypto` in #3630 

closes #3605