### PR TITLE
test: fix resource leaks caused by upstream change

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -16,6 +16,7 @@ import {
 } from "../path/mod.ts";
 import { VERSION } from "../version.ts";
 import { retry } from "../async/retry.ts";
+import { delay } from "../async/delay.ts";
 
 const isWindows = Deno.build.os === "windows";
 
@@ -116,6 +117,7 @@ async function killFileServer() {
     }
   });
   await child.status;
+  await delay(1);
 }
 
 /* HTTP GET request allowing arbitrary paths */

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -762,6 +762,8 @@ Deno.test(`serve should handle websocket requests`, async () => {
     abortController.abort();
     await servePromise;
   }
+  // FIXME(kt3k): op_sleep and op_ws_next_event leak without the below delay.
+  await delay(1);
 });
 
 Deno.test(`Server.listenAndServeTls should handle requests`, async () => {


### PR DESCRIPTION
`serve should handle websocket requests` test case and some of file server test cases started reporting leaked op errors recently.

This PR fixes it.

Probably https://github.com/denoland/deno/pull/20501 is related.