### PR TITLE
test(dotenv): await assertRejects

### DIFF
--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -722,19 +722,19 @@ Deno.test(
       assertStrictEquals(Object.keys(await load(optsNoPaths)).length, 0);
       assertEnv(await load(optsOnlyEnvPath));
 
-      assertRejects(
+      await assertRejects(
         () => load(optsEnvPath),
         Deno.errors.PermissionDenied,
         `Requires read access to ".env.defaults"`,
       );
 
-      assertRejects(
+      await assertRejects(
         () => load({ ...optsEnvPath, defaultsPath: null }),
         Deno.errors.PermissionDenied,
         `Requires read access to ".env.example"`,
       );
 
-      assertRejects(
+      await assertRejects(
         () => load({ ...optsEnvPath, examplePath: null }),
         Deno.errors.PermissionDenied,
         `Requires read access to ".env.defaults"`,


### PR DESCRIPTION
3 assertRejects calls are not awaited in `dotenv/mod_test.ts` (This probably caused [this flaky CI failure](https://github.com/denoland/deno_std/actions/runs/6233260565/job/16918094014?pr=3649)). This PR fixes it.