### PR TITLE
test(testing): use assert/mod.ts instead of testing/asserts.ts

### DIFF
--- a/testing/bdd_examples/user_flat_test.ts
+++ b/testing/bdd_examples/user_flat_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals, assertThrows } from "../asserts.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "../../assert/mod.ts";
 import { describe, it } from "../bdd.ts";
 import { User } from "./user.ts";
 

--- a/testing/bdd_examples/user_mixed_test.ts
+++ b/testing/bdd_examples/user_mixed_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals, assertThrows } from "../asserts.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "../../assert/mod.ts";
 import { describe, it } from "../bdd.ts";
 import { User } from "./user.ts";
 

--- a/testing/bdd_examples/user_nested_test.ts
+++ b/testing/bdd_examples/user_nested_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals, assertThrows } from "../asserts.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "../../assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "../bdd.ts";
 import { User } from "./user.ts";
 

--- a/testing/bdd_examples/user_test.ts
+++ b/testing/bdd_examples/user_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals, assertThrows } from "../asserts.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "../../assert/mod.ts";
 import { User } from "./user.ts";
 
 Deno.test("User.users initially empty", () => {

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertObjectMatch,
   assertStrictEquals,
-} from "./asserts.ts";
+} from "../assert/mod.ts";
 import {
   afterAll,
   afterEach,

--- a/testing/mock_examples/internals_injection_test.ts
+++ b/testing/mock_examples/internals_injection_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertSpyCall, assertSpyCalls, spy } from "../mock.ts";
-import { assertEquals } from "../asserts.ts";
+import { assertEquals } from "../../assert/mod.ts";
 import { _internals, square } from "./internals_injection.ts";
 
 Deno.test("square calls multiply and returns results", () => {

--- a/testing/mock_examples/parameter_injection_test.ts
+++ b/testing/mock_examples/parameter_injection_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertSpyCall, assertSpyCalls, spy } from "../mock.ts";
-import { assertEquals } from "../asserts.ts";
+import { assertEquals } from "../../assert/mod.ts";
 import { multiply, square } from "./parameter_injection.ts";
 
 Deno.test("square calls multiply and returns results", () => {

--- a/testing/mock_examples/random_test.ts
+++ b/testing/mock_examples/random_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertSpyCall, assertSpyCalls, returnsNext, stub } from "../mock.ts";
-import { assertEquals } from "../asserts.ts";
+import { assertEquals } from "../../assert/mod.ts";
 import { _internals, randomMultiple } from "./random.ts";
 
 Deno.test("randomMultiple uses randomInt to generate random multiples between -10 and 10 times the value", () => {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -6,7 +6,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertThrows,
-} from "./asserts.ts";
+} from "../assert/mod.ts";
 import {
   assertSpyCall,
   assertSpyCallArg,

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -7,7 +7,7 @@ import {
   AssertionError,
   assertRejects,
   fail,
-} from "./asserts.ts";
+} from "../assert/mod.ts";
 import { assertSnapshot, createAssertSnapshot, serialize } from "./snapshot.ts";
 
 const SNAPSHOT_MODULE_URL = toFileUrl(join(

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -6,7 +6,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertStrictEquals,
-} from "./asserts.ts";
+} from "../assert/mod.ts";
 import { FakeTime, TimeError } from "./time.ts";
 import { _internals } from "./_time.ts";
 import { assertSpyCall, spy, SpyCall } from "./mock.ts";


### PR DESCRIPTION
The test files under `testing/` still use deprecated `testing/asserts.ts`. This PR fixes it.