### PR TITLE
BREAKING(front_matter): deprecate default exports

### DIFF
--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -12,4 +12,5 @@ export const extract = createExtractor({
   [Format.TOML]: parseTOML as Parser,
   [Format.JSON]: JSON.parse as Parser,
 });
+/** @deprecated (will be removed after 0.210.0) import `extract` (named export) instead. */
 export default extract;

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -11,4 +11,5 @@ export function test(str: string): boolean {
 }
 
 export const extract = createExtractor({ [Format.JSON]: JSON.parse as Parser });
+/** @deprecated (will be removed after 0.210.0) import `extract` (named export) instead. */
 export default extract;

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -12,4 +12,5 @@ export function test(str: string): boolean {
 }
 
 export const extract = createExtractor({ [Format.TOML]: parse as Parser });
+/** @deprecated (will be removed after 0.210.0) import `extract` (named export) instead. */
 export default extract;

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -12,4 +12,5 @@ export function test(str: string): boolean {
 }
 
 export const extract = createExtractor({ [Format.YAML]: parse as Parser });
+/** @deprecated (will be removed after 0.210.0) import `extract` (named export) instead. */
 export default extract;


### PR DESCRIPTION
This PR deprecates default export items from `front_matter`. In deno std, we usually don't use default exports except these 4 (and also `wasi/snapshot_preview1.ts`).

This aligns `front_matter` design to other modules.

part of #3601 #3489 