### PR TITLE
BREAKING(front_matter): deprecate language-specific `test` functions

### DIFF
--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -6,6 +6,7 @@ import { parse as parseYAML } from "../yaml/parse.ts";
 import { parse as parseTOML } from "../toml/parse.ts";
 
 export { Format } from "./_formats.ts";
+/* @deprecated (will be removed after 0.210.0) Import test from test.ts. */
 export { test } from "./test.ts";
 export const extract = createExtractor({
   [Format.YAML]: parseYAML as Parser,

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -6,6 +6,7 @@ import { test as _test } from "./test.ts";
 
 export { Format } from "./_formats.ts";
 
+/* @deprecated (will be removed after 0.210.0) Import test from test.ts and use `test(str, ["json"])`. */
 export function test(str: string): boolean {
   return _test(str, [Format.JSON]);
 }

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -7,6 +7,7 @@ import { parse } from "../toml/parse.ts";
 
 export { Format } from "./_formats.ts";
 
+/* @deprecated (will be removed after 0.210.0) Import test from test.ts and use `test(str, ["toml"])`. */
 export function test(str: string): boolean {
   return _test(str, [Format.TOML]);
 }

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -7,6 +7,7 @@ import { parse } from "../yaml/parse.ts";
 
 export { Format } from "./_formats.ts";
 
+/* @deprecated (will be removed after 0.210.0) Import test from test.ts and use `test(str, ["yaml"])`. */
 export function test(str: string): boolean {
   return _test(str, [Format.YAML]);
 }


### PR DESCRIPTION
This PR deprecates language specific `test` functions. This PR makes front_matter module aligned to single-export pattern together with #3653 #3641 

part of #3601 #3489 