### PR TITLE
Accept readonly arrays in aggregateGroups, reduceGroups, zip

### DIFF
--- a/collections/aggregate_groups.ts
+++ b/collections/aggregate_groups.ts
@@ -7,6 +7,8 @@ import { mapEntries } from "./map_entries.ts";
  * Applies the given aggregator to each group in the given grouping, returning the
  * results together with the respective group keys
  *
+ * @template T input type of an item in a group in the given grouping.
+ * @template A type of the accumulator value, which will match the returned record's values.
  * @example
  * ```ts
  * import { aggregateGroups } from "https://deno.land/std@$STD_VERSION/collections/aggregate_groups.ts";
@@ -34,7 +36,7 @@ import { mapEntries } from "./map_entries.ts";
  * ```
  */
 export function aggregateGroups<T, A>(
-  record: Readonly<Record<string, Array<T>>>,
+  record: Readonly<Record<string, ReadonlyArray<T>>>,
   aggregator: (current: T, key: string, first: boolean, accumulator?: A) => A,
 ): Record<string, A> {
   return mapEntries(

--- a/collections/aggregate_groups_test.ts
+++ b/collections/aggregate_groups_test.ts
@@ -5,7 +5,7 @@ import { aggregateGroups } from "./aggregate_groups.ts";
 
 function aggregateGroupsTest<T, A>(
   input: [
-    Record<string, Array<T>>,
+    Record<string, ReadonlyArray<T>>,
     (current: T, key: string, first: boolean, accumulator?: A) => A,
   ],
   expected: Record<string, A>,

--- a/collections/reduce_groups.ts
+++ b/collections/reduce_groups.ts
@@ -4,9 +4,11 @@
 import { mapValues } from "./map_values.ts";
 
 /**
- * Applies the given reducer to each group in the given Grouping, returning the
+ * Applies the given reducer to each group in the given grouping, returning the
  * results together with the respective group keys.
  *
+ * @template T input type of an item in a group in the given grouping.
+ * @template A type of the accumulator value, which will match the returned record's values.
  * @example
  * ```ts
  * import { reduceGroups } from "https://deno.land/std@$STD_VERSION/collections/reduce_groups.ts";
@@ -26,7 +28,7 @@ import { mapValues } from "./map_values.ts";
  * ```
  */
 export function reduceGroups<T, A>(
-  record: Readonly<Record<string, Array<T>>>,
+  record: Readonly<Record<string, ReadonlyArray<T>>>,
   reducer: (accumulator: A, current: T) => A,
   initialValue: A,
 ): Record<string, A> {

--- a/collections/reduce_groups_test.ts
+++ b/collections/reduce_groups_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { reduceGroups } from "./reduce_groups.ts";
 
 function reduceGroupsTest<T, A>(
-  input: [Record<string, Array<T>>, (accumulator: A, current: T) => A, A],
+  input: [Record<string, ReadonlyArray<T>>, (accumulator: A, current: T) => A, A],
   expected: Record<string, A>,
   message?: string,
 ) {

--- a/collections/reduce_groups_test.ts
+++ b/collections/reduce_groups_test.ts
@@ -4,7 +4,11 @@ import { assertEquals } from "../assert/mod.ts";
 import { reduceGroups } from "./reduce_groups.ts";
 
 function reduceGroupsTest<T, A>(
-  input: [Record<string, ReadonlyArray<T>>, (accumulator: A, current: T) => A, A],
+  input: [
+    record: Record<string, ReadonlyArray<T>>,
+    reducer: (accumulator: A, current: T) => A,
+    initialValue: A,
+  ],
   expected: Record<string, A>,
   message?: string,
 ) {

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -5,6 +5,7 @@
  * Builds N-tuples of elements from the given N arrays with matching indices,
  * stopping when the smallest array's end is reached.
  *
+ * @template T the type of the tuples produced by this function.
  * @example
  * ```ts
  * import { zip } from "https://deno.land/std@$STD_VERSION/collections/zip.ts";
@@ -29,7 +30,7 @@
 import { minOf } from "./min_of.ts";
 
 export function zip<T extends unknown[]>(
-  ...arrays: { [K in keyof T]: T[K][] }
+  ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
 ): T[] {
   const minLength = minOf(arrays, (it) => it.length) ?? 0;
 

--- a/collections/zip_test.ts
+++ b/collections/zip_test.ts
@@ -24,7 +24,7 @@ Deno.test({
 });
 
 function zipTest<T, U>(
-  input: [Array<T>, Array<U>],
+  input: [ReadonlyArray<T>, ReadonlyArray<U>],
   expected: Array<[T, U]>,
   message?: string,
 ) {


### PR DESCRIPTION
Most methods in std/collections accept readonly arrays (as none of the methods mutate the input), but these 3 were the exception. Updated types to allow readonly arrays as input.

Additionally added docs for the generic types, since the single letter names can be difficult to read.