### PR TITLE
Avoid internally using strings for numbers

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -23,7 +23,7 @@ let child: Deno.ChildProcess;
 let stdout: ReadableStream<string>;
 
 interface FileServerCfg {
-  port?: string;
+  port?: number;
   cors?: boolean;
   "dir-listing"?: boolean;
   dotfiles?: boolean;
@@ -40,7 +40,7 @@ const testdataDir = resolve(moduleDir, "testdata");
 
 async function startFileServer({
   target = ".",
-  port = "4507",
+  port = 4507,
   "dir-listing": dirListing = true,
   dotfiles = true,
   headers = [],
@@ -489,7 +489,7 @@ Deno.test("file_server should ignore query params", async () => {
 
 async function startTlsFileServer({
   target = ".",
-  port = "4577",
+  port = 4577,
 }: FileServerCfg = {}) {
   const fileServer = new Deno.Command(Deno.execPath(), {
     args: [
@@ -528,7 +528,7 @@ async function startTlsFileServer({
   await retry(async () => {
     const conn = await Deno.connectTls({
       hostname: "localhost",
-      port: +port,
+      port,
       certFile: join(testdataDir, "tls/RootCA.pem"),
     });
     conn.close();

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -22,7 +22,7 @@ export function mergeReadableStreams<T>(
           mustClose = true;
           controller.error(error);
         });
-      for (const [key, stream] of Object.entries(streams)) {
+      for (const [index, stream] of streams.entries()) {
         (async () => {
           try {
             for await (const data of stream) {
@@ -31,9 +31,9 @@ export function mergeReadableStreams<T>(
               }
               controller.enqueue(data);
             }
-            resolvePromises[+key].resolve();
+            resolvePromises[index].resolve();
           } catch (error) {
-            resolvePromises[+key].reject(error);
+            resolvePromises[index].reject(error);
           }
         })();
       }

--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -10,19 +10,19 @@
 export function zipReadableStreams<T>(
   ...streams: ReadableStream<T>[]
 ): ReadableStream<T> {
-  const readers = streams.map((s) => s.getReader());
+  const readers = new Set(streams.map((s) => s.getReader()));
   return new ReadableStream<T>({
     async start(controller) {
       try {
         let resolved = 0;
         while (resolved !== streams.length) {
-          for (const [key, reader] of Object.entries(readers)) {
+          for (const reader of readers) {
             const { value, done } = await reader.read();
             if (!done) {
               controller.enqueue(value!);
             } else {
               resolved++;
-              readers.splice(+key, 1);
+              readers.delete(reader);
             }
           }
         }


### PR DESCRIPTION
Small change to avoid using numbers that are converted to strings then converted back to numbers.

`mergeReadableStreams` and `zipReadableStreams` both used `Object.entries(array)`, which turned the array indexes into strings. Using `array.entries()` instead lets us stick with numbers the whole time. `zipReadableStreams` can additionally just use a set instead of working with indexes at all.

file_server_test used `port?: string` as its config type instead of `port?: number`, which also required coersion.