### PR TITLE
fix(datetime): Correctly format midnight in 12-hour time

### DIFF
--- a/datetime/_common.ts
+++ b/datetime/_common.ts
@@ -318,7 +318,10 @@ export class DateTimeFormatter {
         }
         case "hour": {
           let value = utc ? date.getUTCHours() : date.getHours();
-          value -= token.hour12 && date.getHours() > 12 ? 12 : 0;
+          if (token.hour12) {
+            if (value === 0) value = 12;
+            else if (value > 12) value -= 12;
+          }
           switch (token.value) {
             case "numeric": {
               string += value;

--- a/datetime/format_test.ts
+++ b/datetime/format_test.ts
@@ -7,6 +7,10 @@ Deno.test({
   fn: () => {
     // 00 hours
     assertEquals(
+      "00:00:00",
+      format(new Date("2019-01-01T00:00:00"), "HH:mm:ss"),
+    );
+    assertEquals(
       "01:00:00",
       format(new Date("2019-01-01T01:00:00"), "HH:mm:ss"),
     );
@@ -16,6 +20,10 @@ Deno.test({
     );
 
     // 12 hours
+    assertEquals(
+      "12:00:00",
+      format(new Date("2019-01-01T00:00:00"), "hh:mm:ss"),
+    );
     assertEquals(
       "01:00:00",
       format(new Date("2019-01-01T01:00:00"), "hh:mm:ss"),
@@ -40,6 +48,14 @@ Deno.test({
     );
 
     // day period
+    assertEquals(
+      "00:00:00 AM",
+      format(new Date("2019-01-01T00:00:00"), "HH:mm:ss a"),
+    );
+    assertEquals(
+      "12:00:00 AM",
+      format(new Date("2019-01-01T00:00:00"), "hh:mm:ss a"),
+    );
     assertEquals(
       "01:00:00 AM",
       format(new Date("2019-01-01T01:00:00"), "HH:mm:ss a"),


### PR DESCRIPTION
I found that a Date object in the midnight hour will be formatted as `0:xx` in a `hmm` date time format.

Deno's [datetime.format documentation](https://deno.land/std@0.202.0/datetime/mod.ts) for `h`/`hh` says this should be from 1-12, as does the underlying [Unicode specification](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-hour).