### PR TITLE
fix(datetime): fix dayOfYear when the timezone has DST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Run tests canary
         run: deno task test
 
+      - name: Run timezone-dependent tests
+        run: |
+          TZ=Australia/Sydney deno test datetime
+          TZ=Europe/London deno test datetime
+          TZ=America/Toronto deno test datetime
+        if: matrix.os == 'ubuntu-22.04'
+
       - name: Type check browser compatible modules
         shell: bash
         run: deno task test:browser

--- a/datetime/day_of_year.ts
+++ b/datetime/day_of_year.ts
@@ -22,7 +22,8 @@ export function dayOfYear(date: Date): number {
   const yearStart = new Date(date);
 
   yearStart.setFullYear(date.getFullYear(), 0, 0);
-  const diff = date.getTime() - yearStart.getTime();
+  const diff = (date.getTime() - date.getTimezoneOffset() * 60 * 1000) -
+    (yearStart.getTime() - yearStart.getTimezoneOffset() * 60 * 1000);
 
   return Math.floor(diff / DAY);
 }


### PR DESCRIPTION
`dayOfYear` result looks wrong when the timezone has the daylight saving time, and the start of year and the given date have different timezone offsets.

This PR fixes the issue by adjusting the diff calculation using timezone offset values.

closes #3659 
closes #3571 