### PR TITLE
chore(fmt): fix spelling of 'milliseconds'

### DIFF
--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -45,7 +45,7 @@ const keyList: Record<keyof DurationObject, string> = {
   ns: "nanoseconds",
 };
 
-/** Parse milleseconds into a duration. */
+/** Parse milliseconds into a duration. */
 function millisecondsToDurationObject(ms: number): DurationObject {
   // Duration cannot be negative
   const absolute_ms = Math.abs(ms);


### PR DESCRIPTION
Fix spelling error in `millisecondsToDurationObject()` function JSDoc.