### PR TITLE
feat(fmt): add significantParts option to duration format

### DIFF
--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -102,29 +102,21 @@ export function format(
   switch (opt.style) {
     case "narrow": {
       if (opt.ignoreZero) {
-        return `${
-          durationArr.filter((x) => x.value).map((x) =>
-            `${x.value}${x.type === "us" ? "µs" : x.type}`
-          )
-            .join(" ")
-        }`;
+        return durationArr.filter((x) => x.value).map((x) =>
+          `${x.value}${x.type === "us" ? "µs" : x.type}`
+        ).join(" ");
       }
-      return `${
-        durationArr.map((x) => `${x.value}${x.type === "us" ? "µs" : x.type}`)
-          .join(" ")
-      }`;
+      return durationArr.map((x) =>
+        `${x.value}${x.type === "us" ? "µs" : x.type}`
+      ).join(" ");
     }
     case "full": {
       if (opt.ignoreZero) {
-        return `${
-          durationArr.filter((x) => x.value).map((x) =>
-            `${x.value} ${keyList[x.type]}`
-          ).join(", ")
-        }`;
+        return durationArr.filter((x) => x.value).map((x) =>
+          `${x.value} ${keyList[x.type]}`
+        ).join(", ");
       }
-      return `${
-        durationArr.map((x) => `${x.value} ${keyList[x.type]}`).join(", ")
-      }`;
+      return durationArr.map((x) => `${x.value} ${keyList[x.type]}`).join(", ");
     }
     case "digital": {
       const arr = durationArr.map((x) =>

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -87,6 +87,11 @@ export interface PrettyDurationOptions {
    * With style="digital", only values in the ends are ignored.
    */
   ignoreZero: boolean;
+  /**
+   * Number of significant parts to display.
+   * e.g. 1h 10m 30s 500ms with significantParts=2 will be displayed as 1h 10m.
+   */
+  significantParts?: number;
 }
 
 export function format(
@@ -94,11 +99,25 @@ export function format(
   options: Partial<PrettyDurationOptions> = {},
 ): string {
   const opt = Object.assign(
-    { style: "narrow", ignoreZero: false },
+    { style: "narrow", ignoreZero: false, significantParts: -1 },
     options,
   );
   const duration = millisecondsToDurationObject(ms);
   const durationArr = durationArray(duration);
+  let significantParts = opt.significantParts ?? durationArr.length;
+  if (opt.significantParts > 0) {
+    let hitFirstSignificant = false;
+    for (let i = 0; i < durationArr.length; i++) {
+      if (durationArr[i].value) hitFirstSignificant = true;
+      if (hitFirstSignificant) {
+        if (significantParts > 0) significantParts--;
+        else {
+          durationArr.splice(i);
+          break;
+        }
+      }
+    }
+  }
   switch (opt.style) {
     case "narrow": {
       if (opt.ignoreZero) {

--- a/fmt/duration_test.ts
+++ b/fmt/duration_test.ts
@@ -47,6 +47,26 @@ Deno.test({
 });
 
 Deno.test({
+  name: "format negative duration ignore zero",
+  fn() {
+    assertEquals(
+      format(-99674, { style: "digital", ignoreZero: true }),
+      "00:00:01:39:674",
+    );
+  },
+});
+
+Deno.test({
+  name: "format negative duration 3 significant parts",
+  fn() {
+    assertEquals(
+      format(-99674, { style: "digital", significantParts: 3 }),
+      "00:00:01:39:674",
+    );
+  },
+});
+
+Deno.test({
   name: "format full duration ignore zero",
   fn() {
     assertEquals(
@@ -57,8 +77,28 @@ Deno.test({
 });
 
 Deno.test({
+  name: "format full duration ignore zero 2 significant parts",
+  fn() {
+    assertEquals(
+      format(99674, { style: "full", ignoreZero: true, significantParts: 2 }),
+      "1 minutes, 39 seconds",
+    );
+  },
+});
+
+Deno.test({
   name: "format narrow duration ignore zero",
   fn() {
     assertEquals(format(99674, { ignoreZero: true }), "1m 39s 674ms");
+  },
+});
+
+Deno.test({
+  name: "format narrow duration ignore zero 2 significant parts",
+  fn() {
+    assertEquals(
+      format(99674, { ignoreZero: true, significantParts: 2 }),
+      "1m 39s",
+    );
   },
 });

--- a/fmt/duration_test.ts
+++ b/fmt/duration_test.ts
@@ -102,3 +102,13 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "format narrow duration ignore zero 3 significant parts",
+  fn() {
+    assertEquals(
+      format(7_205_000.5, { ignoreZero: true, significantParts: 3 }),
+      "2h 0m 5s",
+    );
+  },
+});


### PR DESCRIPTION
Added the `significantParts` option to the std/fmt/duration `format()` function. This can reduce the number of date parts returned, showing only the first N signficant parts. Added 4 test cases for this new option. 

## Example
```js
format(10_000_000)

"0d 2h 46m 40s 0ms 0µs 0ns"
```

With `significantParts: 2`
```js
format(10_000_000, {
  significantParts: 2
})

"0d 2h 46m"
```

With `ignoreZero: true`
```js
format(10_000_000, {
  ignoreZero: true,
  significantParts: 2
})

"2h 46m"
```

### Notes
No rounding is performed, only truncation. Perhaps rounding may be desirable as mathematically "significant figures" does round.

Removed seemingly redundant template literal strings surrounding `.join(" ")` functions. If anyone can explain why it was used then please leave a reply.

In my opinion, the `ignoreZero` option should be `true` by default. It makes the duration easier to read. This may be considered a breaking change though.