### PR TITLE
fix(assert): fix swapping of multiline str diff

### DIFF
--- a/assert/_diff.ts
+++ b/assert/_diff.ts
@@ -342,18 +342,21 @@ export function diffstr(A: string, B: string) {
   }
 
   // Compute word-diff
-  const aLines = added.length < removed.length ? added : removed;
-  const bLines = aLines === removed ? added : removed;
+  const hasMoreRemovedLines = added.length < removed.length;
+  const aLines = hasMoreRemovedLines ? added : removed;
+  const bLines = hasMoreRemovedLines ? removed : added;
   for (const a of aLines) {
     let tokens = [] as Array<DiffResult<string>>,
       b: undefined | DiffResult<string>;
     // Search another diff line with at least one common token
     while (bLines.length) {
       b = bLines.shift();
-      tokens = diff(
+      const tokenized = [
         tokenize(a.value, { wordDiff: true }),
         tokenize(b?.value ?? "", { wordDiff: true }),
-      );
+      ] as string[][];
+      if (hasMoreRemovedLines) tokenized.reverse();
+      tokens = diff(tokenized[0], tokenized[1]);
       if (
         tokens.some(({ type, value }) =>
           type === DiffType.common && value.trim().length

--- a/assert/_diff_test.ts
+++ b/assert/_diff_test.ts
@@ -314,3 +314,32 @@ Deno.test({
     ]);
   },
 });
+
+Deno.test({
+  name: "multiline diff with more removed lines",
+  fn() {
+    const diffResult = diffstr("a\na", "e");
+    assertEquals(diffResult, [
+      {
+        type: DiffType.removed,
+        value: "a\\n\n",
+      },
+      {
+        type: DiffType.removed,
+        value: "a\n",
+        details: [
+          { type: DiffType.removed, value: "a" },
+          { type: DiffType.common, value: "\n" },
+        ],
+      },
+      {
+        type: DiffType.added,
+        value: "e\n",
+        details: [
+          { type: DiffType.added, value: "e" },
+          { type: DiffType.common, value: "\n" },
+        ],
+      },
+    ]);
+  },
+});


### PR DESCRIPTION
This PR fixes the bug of multiline str diff when there are more diff lines in `actual` than `expected`.

The multiline diff algorithm ([`diffstr`](https://github.com/denoland/deno_std/blob/4fe9fd6d3910589a6fbae2f5063981d3510c965a/assert/_diff.ts#L250)) performs diffing in 2 different ways: First it takes diff of the entire multiple string, comparing each line. Then it takes diff of words for each line over the combination of added (`expected`) lines and removed (`actual`) lines.

When computing word diffs for each line combination, the code swaps [the main array](https://github.com/denoland/deno_std/blob/4fe9fd6d3910589a6fbae2f5063981d3510c965a/assert/_diff.ts#L345) to use for the loop (probably for optimization), but it forgot to swap [diffing target](https://github.com/denoland/deno_std/blob/4fe9fd6d3910589a6fbae2f5063981d3510c965a/assert/_diff.ts#L353-L356). It resulted in swapped diff when there are more removed (`actual`) lines.

closes #3039 
closes #3681

ref #948