### PR TITLE
test(crypto): add regression test for re-export of native crypto.getRandomValues()

### DIFF
--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "../assert/mod.ts";
+import { assert, assertEquals, assertInstanceOf } from "../assert/mod.ts";
 import { crypto as stdCrypto } from "./mod.ts";
 import { repeat } from "../bytes/repeat.ts";
 import { dirname, fromFileUrl } from "../path/mod.ts";
@@ -1417,4 +1417,13 @@ Deno.test({
     const b = new Uint8Array([212, 213]);
     assert(stdCrypto.subtle.timingSafeEqual(a.buffer, b.buffer));
   },
+});
+
+// This is one of many methods on `crypto` for which we don't have our own
+// implementation, and just pass calls through to the native implementation.
+// This test doesn't cover any cryptographic logic, but just serves to ensure
+// that (at least this one of) the native methods are indeed re-exported, and
+// that they're appropriately bound to use the required reciever.
+Deno.test("[crypto/getRandomValues] passes through to native implementation", () => {
+  assertInstanceOf(stdCrypto.getRandomValues(new Uint8Array(1)), Uint8Array);
 });

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -1419,11 +1419,13 @@ Deno.test({
   },
 });
 
-// This is one of many methods on `crypto` for which we don't have our own
-// implementation, and just pass calls through to the native implementation.
-// This test doesn't cover any cryptographic logic, but just serves to ensure
-// that (at least this one of) the native methods are indeed re-exported, and
-// that they're appropriately bound to use the required reciever.
+/**
+ * This is one of many methods of `crypto` for which we don't have our own
+ * implementation, and just pass calls through to the native implementation.
+ * This test doesn't cover any cryptographic logic but just serves to ensure
+ * that (at least this one of) the native methods are indeed re-exported, and
+ * that they're appropriately bound to use the required receiver.
+ */
 Deno.test("[crypto/getRandomValues] passes through to native implementation", () => {
   assertInstanceOf(stdCrypto.getRandomValues(new Uint8Array(1)), Uint8Array);
 });


### PR DESCRIPTION
@iuioiua proposed a change in #3687 that looked sensible, but would have broken our re-exporting of native WebCrypto methods in the `crypto` module. Unfortunately, that this regression was not caught by our existing tests, because they only cover methods where we added new logic, not cases where we were just re-exporting native methods. I explained in more detail at https://github.com/denoland/deno_std/pull/3687#issuecomment-1752240642.

This PR just adds a one-line test to ensure that we can call one such method successfully. I'm not sure whether more thorough tests for those methods would be warranted or not, but this a small addition that would have caught the regression, so it's probably worth having this at least.
