### PR TITLE
fix(msgpack): encode huge objects #3696

### DIFF
--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -9,17 +9,30 @@
  * const b = new Uint8Array([3, 4, 5]);
  * console.log(concat(a, b)); // [0, 1, 2, 3, 4, 5]
  */
-export function concat(...buf: Uint8Array[]): Uint8Array {
+export function concat(...buf: Uint8Array[] | Uint8Array[][]): Uint8Array {
   let length = 0;
   for (const b of buf) {
-    length += b.length;
+    if (Array.isArray(b)) {
+      for (const b1 of b) {
+        length += b1.length;
+      }
+    } else {
+      length += b.length;
+    }
   }
 
   const output = new Uint8Array(length);
   let index = 0;
   for (const b of buf) {
-    output.set(b, index);
-    index += b.length;
+    if (Array.isArray(b)) {
+      for (const b1 of b) {
+        output.set(b1, index);
+        index += b1.length;
+      }
+    } else {
+      output.set(b, index);
+      index += b.length;
+    }
   }
 
   return output;

--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -8,6 +8,7 @@
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);
  * console.log(concat(a, b)); // [0, 1, 2, 3, 4, 5]
+ * ```
  */
 export function concat(...buf: Uint8Array[] | Uint8Array[][]): Uint8Array {
   let length = 0;

--- a/msgpack/encode.ts
+++ b/msgpack/encode.ts
@@ -50,7 +50,7 @@ const encoder = new TextEncoder();
 export function encode(object: ValueType) {
   const byteParts: Uint8Array[] = [];
   encodeSlice(object, byteParts);
-  return concat(...byteParts);
+  return concat(byteParts);
 }
 
 function encodeFloat64(num: number) {

--- a/msgpack/encode_test.ts
+++ b/msgpack/encode_test.ts
@@ -162,3 +162,25 @@ Deno.test("maps", () => {
   const nestedMap = { "a": -1, "b": 2, "c": "three", "d": null, "e": map1 };
   assertEquals(decode(encode(nestedMap)), nestedMap);
 });
+
+Deno.test("huge array with 100k objects", () => {
+  const bigArray = [];
+  for (let i = 0; i < 100000; i++) {
+    bigArray.push({ a: { i: `${i}` }, i: i });
+  }
+  const bigObject = { a: bigArray }
+
+  assertEquals(decode(encode(bigObject)), bigObject);
+});
+
+Deno.test("huge object with 100k properties", () => {
+  const bigObject = {};
+  for (let i = 0; i < 100000; i++) {
+    const _ = Object.defineProperty(bigObject, `prop_${i}`, {
+      value: i,
+      enumerable: true
+    });
+  }
+  assertEquals(decode(encode(bigObject)), bigObject);
+}
+);


### PR DESCRIPTION
This PR resolves #3696.

Also required to adjust `concat` function so that it also supports `Uint8Array[][]`. 