### PR TITLE
docs: remove `@$STD_VERSION` references

### DIFF
--- a/_tools/check_doc_imports.ts
+++ b/_tools/check_doc_imports.ts
@@ -45,7 +45,7 @@ function checkImportStatements(
     const importPath = (moduleSpecifier as ts.StringLiteral).text;
     const isRelative = importPath.startsWith(".");
     const isInternal = importPath.startsWith(
-      "https://deno.land/std@$STD_VERSION/",
+      "https://deno.land/std/",
     );
     const { line } = sourceFile.getLineAndCharacterOfPosition(
       moduleSpecifier.pos,

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -149,9 +149,9 @@ export interface TarDataWithSource extends TarData {
  *
  * @example
  * ```ts
- * import { Tar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { Tar } from "https://deno.land/std/archive/tar.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
  *
  * const tar = new Tar();
  *

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -181,10 +181,10 @@ export class TarEntry implements Reader {
  *
  * @example
  * ```ts
- * import { Untar } from "https://deno.land/std@$STD_VERSION/archive/untar.ts";
- * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/ensure_file.ts";
- * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { Untar } from "https://deno.land/std/archive/untar.ts";
+ * import { ensureFile } from "https://deno.land/std/fs/ensure_file.ts";
+ * import { ensureDir } from "https://deno.land/std/fs/ensure_dir.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
  *
  * const reader = await Deno.open("./out.tar", { read: true });
  * const untar = new Untar(reader);

--- a/assert/assert_almost_equals.ts
+++ b/assert/assert_almost_equals.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example
  * ```ts
- * import { assertAlmostEquals, assertThrows } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
+ * import { assertAlmostEquals, assertThrows } from "https://deno.land/std/assert/mod.ts";
  *
  * assertAlmostEquals(0.1, 0.2);
  *

--- a/assert/assert_array_includes.ts
+++ b/assert/assert_array_includes.ts
@@ -11,7 +11,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example
  * ```ts
- * import { assertArrayIncludes } from "https://deno.land/std@$STD_VERSION/assert/assert_array_includes.ts";
+ * import { assertArrayIncludes } from "https://deno.land/std/assert/assert_array_includes.ts";
  *
  * assertArrayIncludes<number>([1, 2], [2])
  * ```

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -14,7 +14,7 @@ import { CAN_NOT_DISPLAY } from "./_constants.ts";
  *
  * @example
  * ```ts
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * Deno.test("example", function (): void {
  *   assertEquals("world", "world");

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -10,7 +10,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example
  * ```ts
- * import { assertNotEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_not_equals.ts";
+ * import { assertNotEquals } from "https://deno.land/std/assert/assert_not_equals.ts";
  *
  * assertNotEquals<number>(1, 2)
  * ```

--- a/assert/assert_not_strict_equals.ts
+++ b/assert/assert_not_strict_equals.ts
@@ -7,7 +7,7 @@ import { format } from "./_format.ts";
  * If the values are strictly equal then throw.
  *
  * ```ts
- * import { assertNotStrictEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_not_strict_equals.ts";
+ * import { assertNotStrictEquals } from "https://deno.land/std/assert/assert_not_strict_equals.ts";
  *
  * assertNotStrictEquals(1, 1)
  * ```

--- a/assert/assert_rejects.ts
+++ b/assert/assert_rejects.ts
@@ -7,7 +7,7 @@ import { assertIsError } from "./assert_is_error.ts";
  *
  * @example
  * ```ts
- * import { assertRejects } from "https://deno.land/std@$STD_VERSION/assert/assert_rejects.ts";
+ * import { assertRejects } from "https://deno.land/std/assert/assert_rejects.ts";
  *
  * Deno.test("doesThrow", async function () {
  *   await assertRejects(
@@ -43,7 +43,7 @@ export function assertRejects(
  *
  * @example
  * ```ts
- * import { assertRejects } from "https://deno.land/std@$STD_VERSION/assert/assert_rejects.ts";
+ * import { assertRejects } from "https://deno.land/std/assert/assert_rejects.ts";
  *
  * Deno.test("doesThrow", async function () {
  *   await assertRejects(async () => {

--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -11,7 +11,7 @@ import { red } from "../fmt/colors.ts";
  *
  * @example
  * ```ts
- * import { assertStrictEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_strict_equals.ts";
+ * import { assertStrictEquals } from "https://deno.land/std/assert/assert_strict_equals.ts";
  *
  * Deno.test("isStrictlyEqual", function (): void {
  *   const a = {};

--- a/assert/assert_throws.ts
+++ b/assert/assert_throws.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example
  * ```ts
- * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ * import { assertThrows } from "https://deno.land/std/assert/assert_throws.ts";
  *
  * Deno.test("doesThrow", function (): void {
  *   assertThrows((): void => {
@@ -35,7 +35,7 @@ export function assertThrows(
  *
  * @example
  * ```ts
- * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ * import { assertThrows } from "https://deno.land/std/assert/assert_throws.ts";
  *
  * Deno.test("doesThrow", function (): void {
  *   assertThrows((): void => {

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -8,8 +8,8 @@ import { deferred } from "./deferred.ts";
  *
  * @example
  * ```typescript
- * import { abortable } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { abortable } from "https://deno.land/std/async/mod.ts";
+ * import { delay } from "https://deno.land/std/async/mod.ts";
  *
  * const p = delay(1000);
  * const c = new AbortController();
@@ -25,8 +25,8 @@ export function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T>;
  *
  * @example
  * ```typescript
- * import { abortable } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { abortable } from "https://deno.land/std/async/mod.ts";
+ * import { delay } from "https://deno.land/std/async/mod.ts";
  *
  * const p = async function* () {
  *   yield "Hello";
@@ -64,7 +64,7 @@ export function abortable<T>(
  *
  * @example
  * ```typescript
- * import { abortablePromise } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { abortablePromise } from "https://deno.land/std/async/mod.ts";
  *
  * const request = fetch("https://example.com");
  *
@@ -100,8 +100,8 @@ export function abortablePromise<T>(
  *
  * @example
  * ```typescript
- * import { abortableAsyncIterable } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { abortableAsyncIterable } from "https://deno.land/std/async/mod.ts";
+ * import { delay } from "https://deno.land/std/async/mod.ts";
  *
  * const p = async function* () {
  *   yield "Hello";

--- a/async/deadline.ts
+++ b/async/deadline.ts
@@ -22,8 +22,8 @@ export class DeadlineError extends Error {
  *
  * @example
  * ```typescript
- * import { deadline } from "https://deno.land/std@$STD_VERSION/async/deadline.ts";
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/delay.ts";
+ * import { deadline } from "https://deno.land/std/async/deadline.ts";
+ * import { delay } from "https://deno.land/std/async/delay.ts";
  *
  * const delayedPromise = delay(1000);
  * // Below throws `DeadlineError` after 10 ms

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -24,7 +24,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  *
  * @example
  * ```
- * import { debounce } from "https://deno.land/std@$STD_VERSION/async/debounce.ts";
+ * import { debounce } from "https://deno.land/std/async/debounce.ts";
  *
  * const log = debounce(
  *   (event: Deno.FsEvent) =>

--- a/async/deferred.ts
+++ b/async/deferred.ts
@@ -19,7 +19,7 @@ export interface Deferred<T> extends Promise<T> {
  *
  * @example
  * ```typescript
- * import { deferred } from "https://deno.land/std@$STD_VERSION/async/deferred.ts";
+ * import { deferred } from "https://deno.land/std/async/deferred.ts";
  *
  * const p = deferred<number>();
  * // ...

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -17,7 +17,7 @@ export interface DelayOptions {
  * @example
  *
  * ```typescript
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/delay.ts";
+ * import { delay } from "https://deno.land/std/async/delay.ts";
  *
  * // ...
  * const delayedPromise = delay(100);
@@ -29,7 +29,7 @@ export interface DelayOptions {
  * `--unstable` flag.
  *
  * ```typescript
- * import { delay } from "https://deno.land/std@$STD_VERSION/async/delay.ts";
+ * import { delay } from "https://deno.land/std/async/delay.ts";
  *
  * // ...
  * await delay(100, { persistent: false });

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -16,7 +16,7 @@ interface TaggedYieldedValue<T> {
  *
  * @example
  * ```typescript
- * import { MuxAsyncIterator } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { MuxAsyncIterator } from "https://deno.land/std/async/mod.ts";
  *
  * async function* gen123(): AsyncIterableIterator<number> {
  *   yield 1;

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -15,7 +15,7 @@ export const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
  *
  * @example
  * ```typescript
- * import { pooledMap } from "https://deno.land/std@$STD_VERSION/async/pool.ts";
+ * import { pooledMap } from "https://deno.land/std/async/pool.ts";
  *
  * const results = pooledMap(
  *   2,

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -47,7 +47,7 @@ const defaultRetryOptions: Required<RetryOptions> = {
  *
  * @example
  * ```typescript
- * import { retry } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { retry } from "https://deno.land/std/async/mod.ts";
  * const req = async () => {
  *  // some function that throws sometimes
  * };
@@ -64,7 +64,7 @@ const defaultRetryOptions: Required<RetryOptions> = {
  *
  * @example
  * ```typescript
- * import { retry } from "https://deno.land/std@$STD_VERSION/async/mod.ts";
+ * import { retry } from "https://deno.land/std/async/mod.ts";
  * const req = async () => {
  *  // some function that throws sometimes
  * };

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -51,7 +51,7 @@ class Queue<T> {
  *
  * @example
  * ```ts
- * import { tee } from "https://deno.land/std@$STD_VERSION/async/tee.ts";
+ * import { tee } from "https://deno.land/std/async/tee.ts";
  *
  * const gen = async function* gen() {
  *   yield 1;

--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -4,7 +4,7 @@
 /** Concatenate the given arrays into a new Uint8Array.
  *
  * ```ts
- * import { concat } from "https://deno.land/std@$STD_VERSION/bytes/concat.ts";
+ * import { concat } from "https://deno.land/std/bytes/concat.ts";
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);
  * console.log(concat(a, b)); // [0, 1, 2, 3, 4, 5]

--- a/bytes/copy.ts
+++ b/bytes/copy.ts
@@ -12,7 +12,7 @@
  * the array.
  *
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
+ * import { copy } from "https://deno.land/std/bytes/copy.ts";
  * const src = new Uint8Array([9, 8, 7]);
  * const dst = new Uint8Array([0, 1, 2, 3, 4, 5]);
  * console.log(copy(src, dst)); // 3
@@ -20,7 +20,7 @@
  * ```
  *
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/bytes/copy.ts";
+ * import { copy } from "https://deno.land/std/bytes/copy.ts";
  * const src = new Uint8Array([1, 1, 1, 1]);
  * const dst = new Uint8Array([0, 0, 0, 0]);
  * console.log(copy(src, dst, 1)); // 3

--- a/bytes/ends_with.ts
+++ b/bytes/ends_with.ts
@@ -7,7 +7,7 @@
  * The complexity of this function is O(suffix.length).
  *
  * ```ts
- * import { endsWith } from "https://deno.land/std@$STD_VERSION/bytes/ends_with.ts";
+ * import { endsWith } from "https://deno.land/std/bytes/ends_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const suffix = new Uint8Array([1, 2, 3]);
  * console.log(endsWith(source, suffix)); // true

--- a/bytes/includes_needle.ts
+++ b/bytes/includes_needle.ts
@@ -11,7 +11,7 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
- * import { includesNeedle } from "https://deno.land/std@$STD_VERSION/bytes/includes_needle.ts";
+ * import { includesNeedle } from "https://deno.land/std/bytes/includes_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(includesNeedle(source, needle)); // true

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -10,7 +10,7 @@
  * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
- * import { indexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/index_of_needle.ts";
+ * import { indexOfNeedle } from "https://deno.land/std/bytes/index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(indexOfNeedle(source, needle)); // 1

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -10,7 +10,7 @@
  * The complexity of this function is O(source.length * needle.length).
  *
  * ```ts
- * import { lastIndexOfNeedle } from "https://deno.land/std@$STD_VERSION/bytes/last_index_of_needle.ts";
+ * import { lastIndexOfNeedle } from "https://deno.land/std/bytes/last_index_of_needle.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
  * console.log(lastIndexOfNeedle(source, needle)); // 5

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -8,7 +8,7 @@ import { copy } from "./copy.ts";
  * If `count` is negative, a `RangeError` is thrown.
  *
  * ```ts
- * import { repeat } from "https://deno.land/std@$STD_VERSION/bytes/repeat.ts";
+ * import { repeat } from "https://deno.land/std/bytes/repeat.ts";
  * const source = new Uint8Array([0, 1, 2]);
  * console.log(repeat(source, 3)); // [0, 1, 2, 0, 1, 2, 0, 1, 2]
  * console.log(repeat(source, 0)); // []

--- a/bytes/starts_with.ts
+++ b/bytes/starts_with.ts
@@ -7,7 +7,7 @@
  * The complexity of this function is O(prefix.length).
  *
  * ```ts
- * import { startsWith } from "https://deno.land/std@$STD_VERSION/bytes/starts_with.ts";
+ * import { startsWith } from "https://deno.land/std/bytes/starts_with.ts";
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const prefix = new Uint8Array([0, 1, 2]);
  * console.log(startsWith(source, prefix)); // true

--- a/collections/aggregate_groups.ts
+++ b/collections/aggregate_groups.ts
@@ -11,8 +11,8 @@ import { mapEntries } from "./map_entries.ts";
  * @template A type of the accumulator value, which will match the returned record's values.
  * @example
  * ```ts
- * import { aggregateGroups } from "https://deno.land/std@$STD_VERSION/collections/aggregate_groups.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { aggregateGroups } from "https://deno.land/std/collections/aggregate_groups.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const foodProperties = {
  *   "Curry": ["spicy", "vegan"],

--- a/collections/associate_by.ts
+++ b/collections/associate_by.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { associateBy } from "https://deno.land/std@$STD_VERSION/collections/associate_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { associateBy } from "https://deno.land/std/collections/associate_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const users = [
  *   { id: "a2e", userName: "Anna" },

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { associateWith } from "https://deno.land/std@$STD_VERSION/collections/associate_with.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { associateWith } from "https://deno.land/std/collections/associate_with.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const names = ["Kim", "Lara", "Jonathan"];
  * const namesToLength = associateWith(names, (it) => it.length);

--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -6,8 +6,8 @@
  *
  * @example
  * ```ts
- * import { chunk } from "https://deno.land/std@$STD_VERSION/collections/chunk.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { chunk } from "https://deno.land/std/collections/chunk.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const words = [
  *   "lorem",

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -15,8 +15,8 @@ const { hasOwn } = Object;
  *
  * @example
  * ```ts
- * import { deepMerge } from "https://deno.land/std@$STD_VERSION/collections/deep_merge.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { deepMerge } from "https://deno.land/std/collections/deep_merge.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const a = { foo: true };
  * const b = { foo: { bar: true } };

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { distinct } from "https://deno.land/std@$STD_VERSION/collections/distinct.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { distinct } from "https://deno.land/std/collections/distinct.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [3, 2, 5, 2, 5];
  * const distinctNumbers = distinct(numbers);

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { distinctBy } from "https://deno.land/std@$STD_VERSION/collections/distinct_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { distinctBy } from "https://deno.land/std/collections/distinct_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const names = ["Anna", "Kim", "Arnold", "Kate"];
  * const exampleNamesByFirstLetter = distinctBy(names, (it) => it.charAt(0));

--- a/collections/drop_last_while.ts
+++ b/collections/drop_last_while.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { dropLastWhile } from "https://deno.land/std@$STD_VERSION/collections/drop_last_while.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { dropLastWhile } from "https://deno.land/std/collections/drop_last_while.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [22, 30, 44];
  *

--- a/collections/drop_while.ts
+++ b/collections/drop_while.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { dropWhile } from "https://deno.land/std@$STD_VERSION/collections/drop_while.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { dropWhile } from "https://deno.land/std/collections/drop_while.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [3, 2, 5, 2, 5];
  * const dropWhileNumbers = dropWhile(numbers, (i) => i !== 2);

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { filterEntries } from "https://deno.land/std@$STD_VERSION/collections/filter_entries.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { filterEntries } from "https://deno.land/std/collections/filter_entries.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const menu = {
  *   "Salad": 11,

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { filterKeys } from "https://deno.land/std@$STD_VERSION/collections/filter_keys.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { filterKeys } from "https://deno.land/std/collections/filter_keys.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const menu = {
  *   "Salad": 11,

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { filterValues } from "https://deno.land/std@$STD_VERSION/collections/filter_values.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { filterValues } from "https://deno.land/std/collections/filter_values.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = {
  *   "Arnold": 37,

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { findSingle } from "https://deno.land/std@$STD_VERSION/collections/find_single.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { findSingle } from "https://deno.land/std/collections/find_single.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const bookings = [
  *   { month: "January", active: false },

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { firstNotNullishOf } from "https://deno.land/std@$STD_VERSION/collections/first_not_nullish_of.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { firstNotNullishOf } from "https://deno.land/std/collections/first_not_nullish_of.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const tables = [
  *   { number: 11, order: null },

--- a/collections/group_by.ts
+++ b/collections/group_by.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { groupBy } from "https://deno.land/std@$STD_VERSION/collections/group_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { groupBy } from "https://deno.land/std/collections/group_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { name: "Anna" },

--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { includesValue } from "https://deno.land/std@$STD_VERSION/collections/includes_value.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { includesValue } from "https://deno.land/std/collections/includes_value.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const input = {
  *   first: 33,

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -9,8 +9,8 @@ import { filterInPlace } from "./_utils.ts";
  *
  * @example
  * ```ts
- * import { intersect } from "https://deno.land/std@$STD_VERSION/collections/intersect.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { intersect } from "https://deno.land/std/collections/intersect.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const lisaInterests = ["Cooking", "Music", "Hiking"];
  * const kimInterests = ["Music", "Tennis", "Cooking"];

--- a/collections/join_to_string.ts
+++ b/collections/join_to_string.ts
@@ -22,8 +22,8 @@ export type JoinToStringOptions = {
  *
  * @example
  * ```ts
- * import { joinToString } from "https://deno.land/std@$STD_VERSION/collections/join_to_string.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { joinToString } from "https://deno.land/std/collections/join_to_string.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const users = [
  *   { name: "Kim" },

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { mapEntries } from "https://deno.land/std@$STD_VERSION/collections/map_entries.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { mapEntries } from "https://deno.land/std/collections/map_entries.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const usersById = {
  *   "a2e": { name: "Kim", age: 22 },

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -10,8 +10,8 @@
  *
  * @example
  * ```ts
- * import { mapKeys } from "https://deno.land/std@$STD_VERSION/collections/map_keys.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { mapKeys } from "https://deno.land/std/collections/map_keys.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const counts = { a: 5, b: 3, c: 8 };
  *

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { mapNotNullish } from "https://deno.land/std@$STD_VERSION/collections/map_not_nullish.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { mapNotNullish } from "https://deno.land/std/collections/map_not_nullish.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { middleName: null },

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { mapValues } from "https://deno.land/std@$STD_VERSION/collections/map_values.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { mapValues } from "https://deno.land/std/collections/map_values.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const usersById = {
  *   "a5ec": { name: "Mischa" },

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { maxBy } from "https://deno.land/std@$STD_VERSION/collections/max_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { maxBy } from "https://deno.land/std/collections/max_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { name: "Anna", age: 34 },

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { maxOf } from "https://deno.land/std@$STD_VERSION/collections/max_of.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { maxOf } from "https://deno.land/std/collections/max_of.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const inventory = [
  *   { name: "mustard", count: 2 },

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -11,8 +11,8 @@
  *
  * @example
  * ```ts
- * import { maxWith } from "https://deno.land/std@$STD_VERSION/collections/max_with.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { maxWith } from "https://deno.land/std/collections/max_with.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = ["Kim", "Anna", "John", "Arthur"];
  * const largestName = maxWith(people, (a, b) => a.length - b.length);

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { minBy } from "https://deno.land/std@$STD_VERSION/collections/min_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { minBy } from "https://deno.land/std/collections/min_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { name: "Anna", age: 34 },

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { minOf } from "https://deno.land/std@$STD_VERSION/collections/min_of.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { minOf } from "https://deno.land/std/collections/min_of.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const inventory = [
  *   { name: "mustard", count: 2 },

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { minWith } from "https://deno.land/std@$STD_VERSION/collections/min_with.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { minWith } from "https://deno.land/std/collections/min_with.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = ["Kim", "Anna", "John"];
  * const smallestName = minWith(people, (a, b) => a.length - b.length);

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -17,7 +17,7 @@
  * module:
  *
  * ```ts
- * import { groupBy } from "https://deno.land/std@$STD_VERSION/collections/group_by.ts";
+ * import { groupBy } from "https://deno.land/std/collections/group_by.ts";
  * ```
  *
  * @module

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { partition } from "https://deno.land/std@$STD_VERSION/collections/partition.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { partition } from "https://deno.land/std/collections/partition.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [5, 6, 7, 8, 9];
  * const [even, odd] = partition(numbers, (it) => it % 2 === 0);

--- a/collections/partition_entries.ts
+++ b/collections/partition_entries.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { partitionEntries } from "https://deno.land/std@$STD_VERSION/collections/partition_entries.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { partitionEntries } from "https://deno.land/std/collections/partition_entries.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const menu = {
  *   "Salad": 11,

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { permutations } from "https://deno.land/std@$STD_VERSION/collections/permutations.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { permutations } from "https://deno.land/std/collections/permutations.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [ 1, 2 ];
  * const windows = permutations(numbers);

--- a/collections/reduce_groups.ts
+++ b/collections/reduce_groups.ts
@@ -11,8 +11,8 @@ import { mapValues } from "./map_values.ts";
  * @template A type of the accumulator value, which will match the returned record's values.
  * @example
  * ```ts
- * import { reduceGroups } from "https://deno.land/std@$STD_VERSION/collections/reduce_groups.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { reduceGroups } from "https://deno.land/std/collections/reduce_groups.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const votes = {
  *   "Woody": [2, 3, 1, 4],

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -8,8 +8,8 @@
  *
  * @example
  * ```ts
- * import { runningReduce } from "https://deno.land/std@$STD_VERSION/collections/running_reduce.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { runningReduce } from "https://deno.land/std/collections/running_reduce.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [1, 2, 3, 4, 5];
  * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -8,8 +8,8 @@ import { randomInteger } from "./_utils.ts";
  *
  * @example
  * ```ts
- * import { sample } from "https://deno.land/std@$STD_VERSION/collections/sample.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+ * import { sample } from "https://deno.land/std/collections/sample.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts";
  *
  * const numbers = [1, 2, 3, 4];
  * const random = sample(numbers);

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -13,8 +13,8 @@
  *
  * @example
  * ```ts
- * import { slidingWindows } from "https://deno.land/std@$STD_VERSION/collections/sliding_windows.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { slidingWindows } from "https://deno.land/std/collections/sliding_windows.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  * const numbers = [1, 2, 3, 4, 5];
  *
  * const windows = slidingWindows(numbers, 3);

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -16,8 +16,8 @@ export type SortByOptions = {
  *
  * @example
  * ```ts
- * import { sortBy } from "https://deno.land/std@$STD_VERSION/collections/sort_by.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { sortBy } from "https://deno.land/std/collections/sort_by.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { name: "Anna", age: 34 },

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { sumOf } from "https://deno.land/std@$STD_VERSION/collections/sum_of.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { sumOf } from "https://deno.land/std/collections/sum_of.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const people = [
  *   { name: "Anna", age: 34 },

--- a/collections/take_last_while.ts
+++ b/collections/take_last_while.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { takeLastWhile } from "https://deno.land/std@$STD_VERSION/collections/take_last_while.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { takeLastWhile } from "https://deno.land/std/collections/take_last_while.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const arr = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/take_while.ts
+++ b/collections/take_while.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { takeWhile } from "https://deno.land/std@$STD_VERSION/collections/take_while.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { takeWhile } from "https://deno.land/std/collections/take_while.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const arr = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -6,8 +6,8 @@
  *
  * @example
  * ```ts
- * import { union } from "https://deno.land/std@$STD_VERSION/collections/union.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { union } from "https://deno.land/std/collections/union.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const soupIngredients = ["Pepper", "Carrots", "Leek"];
  * const saladIngredients = ["Carrots", "Radicchio", "Pepper"];

--- a/collections/unstable/binary_heap.ts
+++ b/collections/unstable/binary_heap.ts
@@ -32,8 +32,8 @@ function getParentIndex(index: number) {
  *   ascend,
  *   BinaryHeap,
  *   descend,
- * } from "https://deno.land/std@$STD_VERSION/collections/binary_heap.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/collections/binary_heap.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const maxHeap = new BinaryHeap<number>();
  * maxHeap.push(4, 1, 3, 5, 2);

--- a/collections/unstable/binary_search_tree.ts
+++ b/collections/unstable/binary_search_tree.ts
@@ -27,9 +27,9 @@ type Direction = "left" | "right";
  * ```ts
  * import {
  *   BinarySearchTree,
- * } from "https://deno.land/std@$STD_VERSION/collections/unstable/binary_search_tree.ts";
- * import { ascend, descend } from "https://deno.land/std@$STD_VERSION/collections/unstable/comparators.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/collections/unstable/binary_search_tree.ts";
+ * import { ascend, descend } from "https://deno.land/std/collections/unstable/comparators.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const values = [3, 10, 13, 4, 6, 7, 1, 14];
  * const tree = new BinarySearchTree<number>();

--- a/collections/unstable/red_black_tree.ts
+++ b/collections/unstable/red_black_tree.ts
@@ -29,8 +29,8 @@ import { Direction, RedBlackNode } from "./_red_black_node.ts";
  *   ascend,
  *   descend,
  *   RedBlackTree,
- * } from "https://deno.land/std@$STD_VERSION/collections/red_black_tree.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/collections/red_black_tree.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const values = [3, 10, 13, 4, 6, 7, 1, 14];
  * const tree = new RedBlackTree<number>();

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -7,8 +7,8 @@
  * all the second elements.
  *
  * ```ts
- * import { unzip } from "https://deno.land/std@$STD_VERSION/collections/unzip.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { unzip } from "https://deno.land/std/collections/unzip.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const parents = [
  *   ["Maria", "Jeff"],

--- a/collections/without_all.ts
+++ b/collections/without_all.ts
@@ -6,8 +6,8 @@
  *
  * @example
  * ```ts
- * import { withoutAll } from "https://deno.land/std@$STD_VERSION/collections/without_all.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { withoutAll } from "https://deno.land/std/collections/without_all.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const withoutList = withoutAll([2, 1, 2, 3], [1, 2]);
  *

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -8,8 +8,8 @@
  * @template T the type of the tuples produced by this function.
  * @example
  * ```ts
- * import { zip } from "https://deno.land/std@$STD_VERSION/collections/zip.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { zip } from "https://deno.land/std/collections/zip.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * const numbers = [1, 2, 3, 4];
  * const letters = ["a", "b", "c", "d"];

--- a/console/unicode_width.ts
+++ b/console/unicode_width.ts
@@ -45,9 +45,9 @@ function charWidth(ch: string) {
  *
  * @example
  * ```ts
- * import { unicodeWidth } from "https://deno.land/std@$STD_VERSION/console/unicode_width.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
- * import { stripColor } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * import { unicodeWidth } from "https://deno.land/std/console/unicode_width.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
+ * import { stripColor } from "https://deno.land/std/fmt/colors.ts";
  *
  * assertEquals(unicodeWidth("hello world"), 11);
  * assertEquals(unicodeWidth("天地玄黃宇宙洪荒"), 16);

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -75,7 +75,7 @@
  *
  * @example
  * ```ts
- * import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
+ * import { crypto } from "https://deno.land/std/crypto/mod.ts";
  *
  * // This will delegate to the runtime's WebCrypto implementation.
  * console.log(
@@ -104,7 +104,7 @@
  * import {
  *   crypto,
  *   toHashString,
- * } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
+ * } from "https://deno.land/std/crypto/mod.ts";
  *
  * const hash = await crypto.subtle.digest(
  *   "SHA-384",

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -15,8 +15,8 @@ import { assert } from "../assert/assert.ts";
  * that time, `timingSafeEqual()` is provided:
  *
  * ```ts
- * import { timingSafeEqual } from "https://deno.land/std@$STD_VERSION/crypto/timing_safe_equal.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+ * import { timingSafeEqual } from "https://deno.land/std/crypto/timing_safe_equal.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts";
  *
  * const a = await crypto.subtle.digest(
  *   "SHA-384",

--- a/crypto/to_hash_string.ts
+++ b/crypto/to_hash_string.ts
@@ -12,8 +12,8 @@ const decoder = new TextDecoder();
  * Converts a hash to a string with a given encoding.
  * @example
  * ```ts
- * import { crypto } from "https://deno.land/std@$STD_VERSION/crypto/crypto.ts";
- * import { toHashString } from "https://deno.land/std@$STD_VERSION/crypto/to_hash_string.ts"
+ * import { crypto } from "https://deno.land/std/crypto/crypto.ts";
+ * import { toHashString } from "https://deno.land/std/crypto/to_hash_string.ts"
  *
  * const hash = await crypto.subtle.digest("SHA-384", new TextEncoder().encode("You hear that Mr. Anderson?"));
  *

--- a/crypto/unstable/keystack.ts
+++ b/crypto/unstable/keystack.ts
@@ -74,7 +74,7 @@ async function compare(a: Data, b: Data): Promise<boolean> {
  *
  * @example
  * ```ts
- * import { KeyStack } from "https://deno.land/std@$STD_VERSION/crypto/keystack.ts";
+ * import { KeyStack } from "https://deno.land/std/crypto/keystack.ts";
  *
  * const keyStack = new KeyStack(["hello", "world"]);
  * const digest = await keyStack.sign("some data");

--- a/csv/csv_parse_stream.ts
+++ b/csv/csv_parse_stream.ts
@@ -66,7 +66,7 @@ type RowType<T> = T extends undefined ? string[]
  *
  * @example
  * ```ts
- * import { CsvParseStream } from "https://deno.land/std@$STD_VERSION/csv/csv_parse_stream.ts";
+ * import { CsvParseStream } from "https://deno.land/std/csv/csv_parse_stream.ts";
  * const res = await fetch("https://example.com/data.csv");
  * const parts = res.body!
  *   .pipeThrough(new TextDecoderStream())

--- a/csv/csv_stringify_stream.ts
+++ b/csv/csv_stringify_stream.ts
@@ -22,7 +22,7 @@ export interface CsvStringifyStreamOptions {
  *
  * @example
  * ```ts
- * import { CsvStringifyStream } from "https://deno.land/std@$STD_VERSION/csv/csv_stringify_stream.ts";
+ * import { CsvStringifyStream } from "https://deno.land/std/csv/csv_stringify_stream.ts";
  *
  * const file = await Deno.open("data.csv", { create: true, write: true });
  * const readable = ReadableStream.from([

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -310,7 +310,7 @@ export interface ParseOptions extends ReadOptions {
  *
  * @example
  * ```ts
- * import { parse } from "https://deno.land/std@$STD_VERSION/csv/parse.ts";
+ * import { parse } from "https://deno.land/std/csv/parse.ts";
  * const string = "a,b,c\nd,e,f";
  *
  * console.log(

--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -236,7 +236,7 @@ function getValuesFromItem(
  * import {
  *   Column,
  *   stringify,
- * } from "https://deno.land/std@$STD_VERSION/csv/stringify.ts";
+ * } from "https://deno.land/std/csv/stringify.ts";
  *
  * type Character = {
  *   age: number;

--- a/datetime/constants.ts
+++ b/datetime/constants.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { SECOND } from "https://deno.land/std@$STD_VERSION/datetime/constants.ts";
+ * import { SECOND } from "https://deno.land/std/datetime/constants.ts";
  *
  * console.log(SECOND); // => 1000
  * ```
@@ -17,7 +17,7 @@ export const SECOND = 1e3;
  *
  * @example
  * ```ts
- * import { MINUTE } from "https://deno.land/std@$STD_VERSION/datetime/constants.ts";
+ * import { MINUTE } from "https://deno.land/std/datetime/constants.ts";
  *
  * console.log(MINUTE); // => 60000 (60 * 1000)
  * ```
@@ -28,7 +28,7 @@ export const MINUTE = SECOND * 60;
  *
  * @example
  * ```ts
- * import { HOUR } from "https://deno.land/std@$STD_VERSION/datetime/constants.ts";
+ * import { HOUR } from "https://deno.land/std/datetime/constants.ts";
  *
  * console.log(HOUR); // => 3600000 (60 * 60 * 1000)
  * ```
@@ -39,7 +39,7 @@ export const HOUR = MINUTE * 60;
  *
  * @example
  * ```ts
- * import { DAY } from "https://deno.land/std@$STD_VERSION/datetime/constants.ts";
+ * import { DAY } from "https://deno.land/std/datetime/constants.ts";
  *
  * console.log(DAY); // => 86400000 (24 * 60 * 60 * 1000)
  * ```
@@ -50,7 +50,7 @@ export const DAY = HOUR * 24;
  *
  * @example
  * ```ts
- * import { WEEK } from "https://deno.land/std@$STD_VERSION/datetime/constants.ts";
+ * import { WEEK } from "https://deno.land/std/datetime/constants.ts";
  *
  * console.log(WEEK); // => 604800000 (7 * 24 * 60 * 60 * 1000)
  * ```

--- a/datetime/day_of_year.ts
+++ b/datetime/day_of_year.ts
@@ -8,7 +8,7 @@ import { DAY } from "./constants.ts";
  *
  * @example
  * ```ts
- * import { dayOfYear } from "https://deno.land/std@$STD_VERSION/datetime/mod.ts";
+ * import { dayOfYear } from "https://deno.land/std/datetime/mod.ts";
  *
  * dayOfYear(new Date("2019-03-11T03:24:00")); // output: 70
  * ```
@@ -33,7 +33,7 @@ export function dayOfYear(date: Date): number {
  *
  * @example
  * ```ts
- * import { dayOfYearUtc } from "https://deno.land/std@$STD_VERSION/datetime/mod.ts";
+ * import { dayOfYearUtc } from "https://deno.land/std/datetime/mod.ts";
  *
  * dayOfYearUtc(new Date("2019-03-11T03:24:00.000Z")) // output 70
  * ```

--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -35,7 +35,7 @@ function calculateMonthsDifference(from: Date, to: Date): number {
  *
  * @example
  * ```ts
- * import { difference } from "https://deno.land/std@$STD_VERSION/datetime/difference.ts";
+ * import { difference } from "https://deno.land/std/datetime/difference.ts";
  *
  * const date0 = new Date("2018-05-14");
  * const date1 = new Date("2020-05-13");

--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -8,7 +8,7 @@ import { DateTimeFormatter } from "./_common.ts";
  *
  * @example
  * ```ts
- * import { format } from "https://deno.land/std@$STD_VERSION/datetime/format.ts";
+ * import { format } from "https://deno.land/std/datetime/format.ts";
  *
  * format(new Date(2019, 0, 20), "dd-MM-yyyy"); // output : "20-01-2019"
  * format(new Date(2019, 0, 20), "yyyy-MM-dd"); // output : "2019-01-20"

--- a/datetime/is_leap.ts
+++ b/datetime/is_leap.ts
@@ -7,7 +7,7 @@
  *
  * @example
  * ```ts
- * import { isLeap } from "https://deno.land/std@$STD_VERSION/datetime/is_leap.ts";
+ * import { isLeap } from "https://deno.land/std/datetime/is_leap.ts";
  *
  * isLeap(new Date("1970-01-02")); // => returns false
  * isLeap(new Date("1972-01-02")); // => returns true
@@ -20,7 +20,7 @@
  *
  * @example
  * ```ts
- * import { isLeap } from "https://deno.land/std@$STD_VERSION/datetime/is_leap.ts";
+ * import { isLeap } from "https://deno.land/std/datetime/is_leap.ts";
  *
  * isLeap(new Date("2000-01-01")); // => returns true if the local timezone is GMT+0, returns false if the local timezone is GMT-1
  * isLeap(2000); // => returns true regardless of the local timezone
@@ -39,7 +39,7 @@ export function isLeap(year: Date | number): boolean {
  *
  * @example
  * ```ts
- * import { isUtcLeap } from "https://deno.land/std@$STD_VERSION/datetime/is_leap.ts";
+ * import { isUtcLeap } from "https://deno.land/std/datetime/is_leap.ts";
  *
  * isUtcLeap(2000); // => returns true regardless of the local timezone
  * isUtcLeap(new Date("2000-01-01")); // => returns true regardless of the local timezone

--- a/datetime/parse.ts
+++ b/datetime/parse.ts
@@ -8,7 +8,7 @@ import { DateTimeFormatter } from "./_common.ts";
  *
  * @example
  * ```ts
- * import { parse } from "https://deno.land/std@$STD_VERSION/datetime/parse.ts";
+ * import { parse } from "https://deno.land/std/datetime/parse.ts";
  *
  * parse("20-01-2019", "dd-MM-yyyy"); // output : new Date(2019, 0, 20)
  * parse("2019-01-20", "yyyy-MM-dd"); // output : new Date(2019, 0, 20)

--- a/datetime/to_imf.ts
+++ b/datetime/to_imf.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```ts
- * import { toIMF } from "https://deno.land/std@$STD_VERSION/datetime/to_imf.ts";
+ * import { toIMF } from "https://deno.land/std/datetime/to_imf.ts";
  *
  * toIMF(new Date(0)); // => returns "Thu, 01 Jan 1970 00:00:00 GMT"
  * ```

--- a/datetime/week_of_year.ts
+++ b/datetime/week_of_year.ts
@@ -20,7 +20,7 @@ enum Day {
  *
  * @example
  * ```ts
- * import { weekOfYear } from "https://deno.land/std@$STD_VERSION/datetime/week_of_year.ts";
+ * import { weekOfYear } from "https://deno.land/std/datetime/week_of_year.ts";
  *
  * weekOfYear(new Date("2020-12-28T03:24:00")); // Returns 53
  * ```

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "noImplicitOverride": true
   },
   "imports": {
-    "https://deno.land/std@$STD_VERSION/": "./"
+    "https://deno.land/std/": "./"
   },
   "tasks": {
     "test": "deno test --doc --unstable --allow-all --parallel --coverage=./cov",

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -17,7 +17,7 @@
  *
  * ```ts
  * // app.ts
- * import { load } from "https://deno.land/std@$STD_VERSION/dotenv/mod.ts";
+ * import { load } from "https://deno.land/std/dotenv/mod.ts";
  *
  * console.log(await load({export: true})); // { GREETING: "hello world" }
  * console.log(Deno.env.get("GREETING")); // hello world
@@ -34,7 +34,7 @@
  *
  * ```ts
  * // app.ts
- * import "https://deno.land/std@$STD_VERSION/dotenv/load.ts";
+ * import "https://deno.land/std/dotenv/load.ts";
  *
  * console.log(Deno.env.get("GREETING")); // hello world
  * ```
@@ -111,7 +111,7 @@
  *
  * ### Example configuration
  * ```ts
- * import { load } from "https://deno.land/std@$STD_VERSION/dotenv/mod.ts";
+ * import { load } from "https://deno.land/std/dotenv/mod.ts";
  *
  * const conf = await load({
  *     envPath: "./.env_prod",
@@ -460,7 +460,7 @@ function expand(str: string, variablesMap: { [key: string]: string }): string {
 /**
  * @example
  * ```ts
- * import { stringify } from "https://deno.land/std@$STD_VERSION/dotenv/mod.ts";
+ * import { stringify } from "https://deno.land/std/dotenv/mod.ts";
  *
  * const object = { GREETING: "hello world" };
  * const string = stringify(object); // GREETING='hello world'

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -28,7 +28,7 @@ import { validateBinaryLike } from "./_util.ts";
  * import {
  *   decode,
  *   encode,
- * } from "https://deno.land/std@$STD_VERSION/encoding/ascii85.ts";
+ * } from "https://deno.land/std/encoding/ascii85.ts";
  *
  * const a85Repr = "LpTqp";
  *

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -17,7 +17,7 @@ import { validateBinaryLike } from "./_util.ts";
  * import {
  *   decodeBase32,
  *   encodeBase32,
- * } from "https://deno.land/std@$STD_VERSION/encoding/base32.ts";
+ * } from "https://deno.land/std/encoding/base32.ts";
  *
  * const b32Repr = "RC2E6GA=";
  *

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -14,7 +14,7 @@ import { validateBinaryLike } from "./_util.ts";
  * import {
  *   decodeBase64,
  *   encodeBase64,
- * } from "https://deno.land/std@$STD_VERSION/encoding/base64.ts";
+ * } from "https://deno.land/std/encoding/base64.ts";
  *
  * const b64Repr = "Zm9vYg==";
  *

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -12,7 +12,7 @@
  * import {
  *   decodeBase64Url,
  *   encodeBase64Url,
- * } from "https://deno.land/std@$STD_VERSION/encoding/base64url.ts";
+ * } from "https://deno.land/std/encoding/base64url.ts";
  *
  * const binary = new TextEncoder().encode("foobar");
  * const encoded = encodeBase64Url(binary);

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -16,7 +16,7 @@ import { validateBinaryLike } from "./_util.ts";
  * import {
  *   decodeHex,
  *   encodeHex,
- * } from "https://deno.land/std@$STD_VERSION/encoding/hex.ts";
+ * } from "https://deno.land/std/encoding/hex.ts";
  *
  * const binary = new TextEncoder().encode("abc");
  * const encoded = encodeHex(binary);

--- a/flags/mod.ts
+++ b/flags/mod.ts
@@ -9,7 +9,7 @@
  *
  * @example
  * ```ts
- * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
+ * import { parse } from "https://deno.land/std/flags/mod.ts";
  *
  * console.dir(parse(Deno.args));
  * ```
@@ -288,7 +288,7 @@ export interface ParseOptions<
    *  @example
    * ```ts
    * // $ deno run example.ts -- a arg1
-   * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
+   * import { parse } from "https://deno.land/std/flags/mod.ts";
    * console.dir(parse(Deno.args, { "--": false }));
    * // output: { _: [ "a", "arg1" ] }
    * console.dir(parse(Deno.args, { "--": true }));
@@ -415,13 +415,13 @@ function hasKey(obj: NestedMapping, keys: string[]): boolean {
  *
  * @example
  * ```ts
- * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
+ * import { parse } from "https://deno.land/std/flags/mod.ts";
  * const parsedArgs = parse(Deno.args);
  * ```
  *
  * @example
  * ```ts
- * import { parse } from "https://deno.land/std@$STD_VERSION/flags/mod.ts";
+ * import { parse } from "https://deno.land/std/flags/mod.ts";
  * const parsedArgs = parse(["--foo", "--bar=baz", "./quux.txt"]);
  * // parsedArgs: { foo: true, bar: "baz", _: ["./quux.txt"] }
  * ```

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -13,7 +13,7 @@
  *
  * @example
  * ```ts
- * import { format } from "https://deno.land/std@$STD_VERSION/fmt/bytes.ts";
+ * import { format } from "https://deno.land/std/fmt/bytes.ts";
  *
  * format(1337);
  * //=> '1.34 kB'

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -22,7 +22,7 @@
  *   red,
  *   rgb24,
  *   rgb8,
- * } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * } from "https://deno.land/std/fmt/colors.ts";
  *
  * console.log(bgBlue(italic(red(bold("Hello, World!")))));
  *
@@ -480,7 +480,7 @@ export function bgRgb8(str: string, color: number): string {
  * To produce the color magenta:
  *
  * ```ts
- *      import { rgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ *      import { rgb24 } from "https://deno.land/std/fmt/colors.ts";
  *      rgb24("foo", 0xff00ff);
  *      rgb24("foo", {r: 255, g: 0, b: 255});
  * ```
@@ -520,7 +520,7 @@ export function rgb24(str: string, color: number | Rgb): string {
  * To produce the color magenta:
  *
  * ```ts
- *      import { bgRgb24 } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ *      import { bgRgb24 } from "https://deno.land/std/fmt/colors.ts";
  *      bgRgb24("foo", 0xff00ff);
  *      bgRgb24("foo", {r: 255, g: 0, b: 255});
  * ```

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -5,7 +5,7 @@
  * Format milliseconds to time duration.
  *
  * ```ts
- * import { format } from "https://deno.land/std@$STD_VERSION/fmt/duration.ts";
+ * import { format } from "https://deno.land/std/fmt/duration.ts";
  *
  * // "00:00:01:39:674:000:000"
  * format(99674, { style: "digital" });

--- a/front_matter/create_extractor.ts
+++ b/front_matter/create_extractor.ts
@@ -41,8 +41,8 @@ function _extract<T>(
  * @param formats A list of formats to recognize. Defaults to all supported formats.
  *
  * ```ts
- * import { recognize } from "https://deno.land/std@$STD_VERSION/front_matter/mod.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { recognize } from "https://deno.land/std/front_matter/mod.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * assertEquals(recognize("---\ntitle: Three dashes marks the spot\n---\n"), "yaml");
  * assertEquals(recognize("---toml\ntitle = 'Three dashes followed by format marks the spot'\n---\n"), "toml");
@@ -79,10 +79,10 @@ function recognize(str: string, formats?: Format[]): Format {
  * @returns A function that extracts front matter from a string with the given parsers.
  *
  * ```ts
- * import { createExtractor, Parser } from "https://deno.land/std@$STD_VERSION/front_matter/mod.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
- * import { parse as parseYAML } from "https://deno.land/std@$STD_VERSION/yaml/parse.ts";
- * import { parse as parseTOML } from "https://deno.land/std@$STD_VERSION/toml/parse.ts";
+ * import { createExtractor, Parser } from "https://deno.land/std/front_matter/mod.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
+ * import { parse as parseYAML } from "https://deno.land/std/yaml/parse.ts";
+ * import { parse as parseTOML } from "https://deno.land/std/toml/parse.ts";
  * const extractYAML = createExtractor({ yaml: parseYAML as Parser });
  * const extractTOML = createExtractor({ toml: parseTOML as Parser });
  * const extractJSON = createExtractor({ json: JSON.parse as Parser });

--- a/front_matter/mod.ts
+++ b/front_matter/mod.ts
@@ -40,7 +40,7 @@
  * import {
  *   extract,
  *   test,
- * } from "https://deno.land/std@$STD_VERSION/front_matter/any.ts";
+ * } from "https://deno.land/std/front_matter/any.ts";
  *
  * const str = await Deno.readTextFile("./example.md");
  *
@@ -75,8 +75,8 @@
  *   Format,
  *   Parser,
  *   test as _test,
- * } from "https://deno.land/std@$STD_VERSION/front_matter/mod.ts";
- * import { parse } from "https://deno.land/std@$STD_VERSION/toml/parse.ts";
+ * } from "https://deno.land/std/front_matter/mod.ts";
+ * import { parse } from "https://deno.land/std/toml/parse.ts";
  *
  * const extract = createExtractor({
  *   [Format.TOML]: parse as Parser,

--- a/front_matter/test.ts
+++ b/front_matter/test.ts
@@ -11,8 +11,8 @@ type Format = "yaml" | "toml" | "json" | "unknown";
  * @param formats A list of formats to test for. Defaults to all supported formats.
  *
  * ```ts
- * import { test, Format } from "https://deno.land/std@$STD_VERSION/front_matter/mod.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+ * import { test, Format } from "https://deno.land/std/front_matter/mod.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts";
  *
  * assert(test("---\ntitle: Three dashes marks the spot\n---\n"));
  * assert(test("---toml\ntitle = 'Three dashes followed by format marks the spot'\n---\n"));

--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -251,7 +251,7 @@ function copyDirSync(
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/fs/copy.ts";
+ * import { copy } from "https://deno.land/std/fs/copy.ts";
  * copy("./foo", "./bar"); // returns a promise
  * ```
  *
@@ -297,7 +297,7 @@ export async function copy(
  *
  * @example
  * ```ts
- * import { copySync } from "https://deno.land/std@$STD_VERSION/fs/copy.ts";
+ * import { copySync } from "https://deno.land/std/fs/copy.ts";
  * copySync("./foo", "./bar"); // void
  * ```
  * @param src the file/directory path.

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -11,7 +11,7 @@ import { toPathString } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { emptyDir } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { emptyDir } from "https://deno.land/std/fs/mod.ts";
  *
  * emptyDir("./foo"); // returns a promise
  * ```
@@ -48,7 +48,7 @@ export async function emptyDir(dir: string | URL) {
  *
  * @example
  * ```ts
- * import { emptyDirSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { emptyDirSync } from "https://deno.land/std/fs/mod.ts";
  *
  * emptyDirSync("./foo"); // void
  * ```

--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -8,7 +8,7 @@ import { getFileInfoType } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureDir } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureDir("./bar"); // returns a promise
  * ```
@@ -39,7 +39,7 @@ export async function ensureDir(dir: string | URL) {
  *
  * @example
  * ```ts
- * import { ensureDirSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureDirSync } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureDirSync("./ensureDirSync"); // void
  * ```

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -13,7 +13,7 @@ import { getFileInfoType, toPathString } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureFile } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureFile("./folder/targetFile.dat"); // returns promise
  * ```
@@ -51,7 +51,7 @@ export async function ensureFile(filePath: string | URL) {
  *
  * @example
  * ```ts
- * import { ensureFileSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureFileSync } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureFileSync("./folder/targetFile.dat"); // void
  * ```

--- a/fs/ensure_link.ts
+++ b/fs/ensure_link.ts
@@ -9,7 +9,7 @@ import { toPathString } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { ensureSymlink } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureSymlink } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureSymlink("./folder/targetFile.dat", "./folder/targetFile.link.dat"); // returns promise
  * ```
@@ -30,7 +30,7 @@ export async function ensureLink(src: string | URL, dest: string | URL) {
  *
  * @example
  * ```ts
- * import { ensureSymlinkSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { ensureSymlinkSync } from "https://deno.land/std/fs/mod.ts";
  *
  * ensureSymlinkSync("./folder/targetFile.dat", "./folder/targetFile.link.dat"); // void
  * ```

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -17,7 +17,7 @@ const regDetect = /(?:\r?\n)/g;
  *
  * @example
  * ```ts
- * import { detect, EOL } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { detect, EOL } from "https://deno.land/std/fs/mod.ts";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";
  * const Mixedinput = "deno\nis not\r\nnode";
@@ -45,7 +45,7 @@ export function detect(content: string): EOL | null {
  *
  * @example
  * ```ts
- * import { EOL, format } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { EOL, format } from "https://deno.land/std/fs/mod.ts";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";
  *

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -24,7 +24,7 @@ export interface ExistsOptions {
  * Test whether or not the given path exists by checking with the file system. Please consider to check if the path is readable and either a file or a directory by providing additional `options`:
  *
  * ```ts
- * import { exists } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { exists } from "https://deno.land/std/fs/mod.ts";
  * const isReadableDir = await exists("./foo", {
  *   isReadable: true,
  *   isDirectory: true
@@ -39,7 +39,7 @@ export interface ExistsOptions {
  *
  * Bad:
  * ```ts
- * import { exists } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { exists } from "https://deno.land/std/fs/mod.ts";
  *
  * if (await exists("./foo")) {
  *   await Deno.remove("./foo");
@@ -115,7 +115,7 @@ export async function exists(
  * Test whether or not the given path exists by checking with the file system. Please consider to check if the path is readable and either a file or a directory by providing additional `options`:
  *
  * ```ts
- * import { existsSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { existsSync } from "https://deno.land/std/fs/mod.ts";
  * const isReadableDir = existsSync("./foo", {
  *   isReadable: true,
  *   isDirectory: true
@@ -130,7 +130,7 @@ export async function exists(
  *
  * Bad:
  * ```ts
- * import { existsSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { existsSync } from "https://deno.land/std/fs/mod.ts";
  *
  * if (existsSync("./foo")) {
  *   Deno.removeSync("./foo");

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -64,7 +64,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  *
  * @example
  * ```ts
- * import { expandGlob } from "https://deno.land/std@$STD_VERSION/fs/expand_glob.ts";
+ * import { expandGlob } from "https://deno.land/std/fs/expand_glob.ts";
  * for await (const file of expandGlob("**\/*.ts")) {
  *   console.log(file);
  * }
@@ -186,7 +186,7 @@ export async function* expandGlob(
  *
  * @example
  * ```ts
- * import { expandGlobSync } from "https://deno.land/std@$STD_VERSION/fs/expand_glob.ts";
+ * import { expandGlobSync } from "https://deno.land/std/fs/expand_glob.ts";
  * for (const file of expandGlobSync("**\/*.ts")) {
  *   console.log(file);
  * }

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -20,7 +20,7 @@ interface MoveOptions {
  *
  * @example
  * ```ts
- * import { move } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { move } from "https://deno.land/std/fs/mod.ts";
  *
  * move("./foo", "./bar"); // returns a promise
  * ```
@@ -64,7 +64,7 @@ export async function move(
  * Moves a file or directory synchronously.
  * @example
  * ```ts
- * import { moveSync } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { moveSync } from "https://deno.land/std/fs/mod.ts";
  *
  * moveSync("./foo", "./bar"); // void
  * ```

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -102,8 +102,8 @@ export type { WalkEntry };
  *
  * @example
  * ```ts
- * import { walk } from "https://deno.land/std@$STD_VERSION/fs/walk.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+ * import { walk } from "https://deno.land/std/fs/walk.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts";
  *
  * for await (const entry of walk(".")) {
  *   console.log(entry.path);

--- a/html/entities.ts
+++ b/html/entities.ts
@@ -26,8 +26,8 @@ const rawRe = new RegExp(`[${[...rawToEntity.keys()].join("")}]`, "g");
  *
  * @example
  * ```ts
- * import { escape } from "https://deno.land/std@$STD_VERSION/html/entities.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { escape } from "https://deno.land/std/html/entities.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * assertEquals(escape("<>'&AA"), "&lt;&gt;&#39;&amp;AA");
  *
@@ -58,15 +58,15 @@ const entityListRegexCache = new WeakMap<EntityList, RegExp>();
  *
  * @example
  * ```ts
- * import { unescape } from "https://deno.land/std@$STD_VERSION/html/entities.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { unescape } from "https://deno.land/std/html/entities.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * // default options (only handles &<>'" and numeric entities)
  * assertEquals(unescape("&lt;&gt;&apos;&amp;&#65;&#x41;"), "<>'&AA");
  * assertEquals(unescape("&thorn;&eth;"), "&thorn;&eth;");
  *
  * // using the full named entity list from the HTML spec (~47K unminified)
- * import entityList from "https://deno.land/std@$STD_VERSION/html/named_entity_list.json" assert { type: "json" };
+ * import entityList from "https://deno.land/std/html/named_entity_list.json" assert { type: "json" };
  * assertEquals(unescape("&thorn;&eth;", { entityList }), "þð");
  * ```
  */

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -14,7 +14,7 @@ export interface Cookie {
    * @example <caption>Explicit date:</caption>
    *
    * ```ts
-   * import { Cookie } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+   * import { Cookie } from "https://deno.land/std/http/cookie.ts";
    * const cookie: Cookie = {
    *   name: 'name',
    *   value: 'value',
@@ -26,7 +26,7 @@ export interface Cookie {
    * @example <caption>UTC milliseconds</caption>
    *
    * ```ts
-   * import { Cookie } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+   * import { Cookie } from "https://deno.land/std/http/cookie.ts";
    * const cookie: Cookie = {
    *   name: 'name',
    *   value: 'value',
@@ -191,7 +191,7 @@ function validateDomain(domain: string) {
  *
  * @example
  * ```ts
- * import { getCookies } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+ * import { getCookies } from "https://deno.land/std/http/cookie.ts";
  *
  * const headers = new Headers();
  * headers.set("Cookie", "full=of; tasty=chocolate");
@@ -227,7 +227,7 @@ export function getCookies(headers: Headers): Record<string, string> {
  * import {
  *   Cookie,
  *   setCookie,
- * } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+ * } from "https://deno.land/std/http/cookie.ts";
  *
  * const headers = new Headers();
  * const cookie: Cookie = { name: "Space", value: "Cat" };
@@ -257,7 +257,7 @@ export function setCookie(headers: Headers, cookie: Cookie) {
  *
  * @example
  * ```ts
- * import { deleteCookie } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+ * import { deleteCookie } from "https://deno.land/std/http/cookie.ts";
  *
  * const headers = new Headers();
  * deleteCookie(headers, "deno");
@@ -368,7 +368,7 @@ function parseSetCookie(value: string): Cookie | null {
  *
  * @example
  * ```ts
- * import { getSetCookies } from "https://deno.land/std@$STD_VERSION/http/cookie.ts";
+ * import { getSetCookies } from "https://deno.land/std/http/cookie.ts";
  *
  * const headers = new Headers([
  *   ["Set-Cookie", "lulu=meow; Secure; Max-Age=3600"],

--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -14,7 +14,7 @@
  * import {
  *   CookieMap,
  *   mergeHeaders
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}
@@ -42,7 +42,7 @@
  *   SecureCookieMap,
  *   mergeHeaders,
  *   type KeyRing,
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}
@@ -68,7 +68,7 @@
  * set cookies will be added directly to those headers:
  *
  * ```ts
- * import { CookieMap } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * import { CookieMap } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -82,8 +82,8 @@ async function calcFileInfo(
  * information, it will be calculated as a weak tag.
  *
  * ```ts
- * import { calculate } from "https://deno.land/std@$STD_VERSION/http/etag.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts"
+ * import { calculate } from "https://deno.land/std/http/etag.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts"
  *
  * const body = "hello deno!";
  *
@@ -117,8 +117,8 @@ export async function calculate(
  * import {
  *   calculate,
  *   ifMatch,
- * } from "https://deno.land/std@$STD_VERSION/http/etag.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts"
+ * } from "https://deno.land/std/http/etag.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts"
  *
  * const body = "hello deno!";
  *
@@ -160,8 +160,8 @@ export function ifMatch(
  * import {
  *   calculate,
  *   ifNoneMatch,
- * } from "https://deno.land/std@$STD_VERSION/http/etag.ts";
- * import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts"
+ * } from "https://deno.land/std/http/etag.ts";
+ * import { assert } from "https://deno.land/std/assert/assert.ts"
  *
  * const body = "hello deno!";
  *

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -12,16 +12,16 @@
  *
  * ```shell
  * > # start server
- * > deno run --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts
+ * > deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts
  * > # show help
- * > deno run --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts --help
+ * > deno run --allow-net --allow-read https://deno.land/std/http/file_server.ts --help
  * ```
  *
  * If you want to install and run:
  *
  * ```shell
  * > # install
- * > deno install --allow-net --allow-read https://deno.land/std@$STD_VERSION/http/file_server.ts
+ * > deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts
  * > # start server
  * > file_server
  * > # show help
@@ -561,7 +561,7 @@ export interface ServeDirOptions {
  * Serves the files under the given directory root (opts.fsRoot).
  *
  * ```ts
- * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
+ * import { serveDir } from "https://deno.land/std/http/file_server.ts";
  *
  * Deno.serve((req) => {
  *   const pathname = new URL(req.url).pathname;
@@ -578,7 +578,7 @@ export interface ServeDirOptions {
  * Optionally you can pass `urlRoot` option. If it's specified that part is stripped from the beginning of the requested pathname.
  *
  * ```ts
- * import { serveDir } from "https://deno.land/std@$STD_VERSION/http/file_server.ts";
+ * import { serveDir } from "https://deno.land/std/http/file_server.ts";
  *
  * // ...
  * serveDir(new Request("http://localhost/static/path/to/file"), {

--- a/http/http_errors.ts
+++ b/http/http_errors.ts
@@ -17,7 +17,7 @@
  *
  * @example
  * ```ts
- * import { errors, isHttpError } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
+ * import { errors, isHttpError } from "https://deno.land/std/http/unstable_errors.ts";
  *
  * try {
  *   throw new errors.NotFound();
@@ -32,8 +32,8 @@
  *
  * @example
  * ```ts
- * import { createHttpError } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
- * import { Status } from "https://deno.land/std@$STD_VERSION/http/status.ts";
+ * import { createHttpError } from "https://deno.land/std/http/unstable_errors.ts";
+ * import { Status } from "https://deno.land/std/http/status.ts";
  *
  * try {
  *   throw createHttpError(
@@ -89,7 +89,7 @@ export const HttpError = HttpError_;
  *
  * @example
  * ```ts
- * import { errors } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
+ * import { errors } from "https://deno.land/std/http/unstable_errors.ts";
  *
  * throw new errors.InternalServerError("Ooops!");
  * ```

--- a/http/http_status.ts
+++ b/http/http_status.ts
@@ -13,14 +13,14 @@
  * import {
  *   Status,
  *   STATUS_TEXT,
- * } from "https://deno.land/std@$STD_VERSION/http/http_status.ts";
+ * } from "https://deno.land/std/http/http_status.ts";
  *
  * console.log(Status.NotFound); //=> 404
  * console.log(STATUS_TEXT[Status.NotFound]); //=> "Not Found"
  * ```
  *
  * ```ts
- * import { isErrorStatus } from "https://deno.land/std@$STD_VERSION/http/http_status.ts";
+ * import { isErrorStatus } from "https://deno.land/std/http/http_status.ts";
  *
  * const res = await fetch("https://example.com/");
  *

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -50,7 +50,7 @@
  * in an http request would look like this:
  *
  * ```ts
- * import { UserAgent } from "https://deno.land/std@$STD_VERSION/http/user_agent.ts";
+ * import { UserAgent } from "https://deno.land/std/http/user_agent.ts";
  *
  * Deno.serve((req) => {
  *   const userAgent = new UserAgent(req.headers.get("user-agent") ?? "");

--- a/http/negotiation.ts
+++ b/http/negotiation.ts
@@ -25,7 +25,7 @@ export type Request = {
  *
  * @example
  * ```ts
- * import { accepts } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { accepts } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: {
@@ -51,7 +51,7 @@ export function accepts(request: Request): string[];
  *
  *  @example
  * ```ts
- * import { accepts } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { accepts } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: {
@@ -86,7 +86,7 @@ export function accepts(
  *
  * @example
  * ```ts
- * import { acceptsEncodings } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { acceptsEncodings } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: { "accept-encoding": "deflate, gzip;q=1.0, *;q=0.5" },
@@ -107,7 +107,7 @@ export function acceptsEncodings(request: Request): string[];
  *
  * @example
  * ```ts
- * import { acceptsEncodings } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { acceptsEncodings } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: { "accept-encoding": "deflate, gzip;q=1.0, *;q=0.5" },
@@ -141,7 +141,7 @@ export function acceptsEncodings(
  *
  * @example
  * ```ts
- * import { acceptsLanguages } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { acceptsLanguages } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: {
@@ -159,7 +159,7 @@ export function acceptsLanguages(request: Request): string[];
  *
  * @example
  * ```ts
- * import { acceptsLanguages } from "https://deno.land/std@$STD_VERSION/http/negotiation.ts";
+ * import { acceptsLanguages } from "https://deno.land/std/http/negotiation.ts";
  *
  * const req = new Request("https://example.com/", {
  *   headers: {

--- a/http/server.ts
+++ b/http/server.ts
@@ -79,7 +79,7 @@ export class Server {
    * Constructs a new HTTP Server instance.
    *
    * ```ts
-   * import { Server } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+   * import { Server } from "https://deno.land/std/http/server.ts";
    *
    * const port = 4505;
    * const handler = (request: Request) => {
@@ -118,7 +118,7 @@ export class Server {
    * Will always close the created listener.
    *
    * ```ts
-   * import { Server } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+   * import { Server } from "https://deno.land/std/http/server.ts";
    *
    * const handler = (request: Request) => {
    *   const body = `Your user-agent is:\n\n${request.headers.get(
@@ -170,7 +170,7 @@ export class Server {
    * Throws a server closed error if the server has been closed.
    *
    * ```ts
-   * import { Server } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+   * import { Server } from "https://deno.land/std/http/server.ts";
    *
    * const port = 4505;
    * const handler = (request: Request) => {
@@ -214,7 +214,7 @@ export class Server {
    * Throws a server closed error if the server has been closed.
    *
    * ```ts
-   * import { Server } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+   * import { Server } from "https://deno.land/std/http/server.ts";
    *
    * const port = 4505;
    * const handler = (request: Request) => {
@@ -536,7 +536,7 @@ export interface ServeListenerOptions {
  * handles requests on these connections with the given handler.
  *
  * ```ts
- * import { serveListener } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serveListener } from "https://deno.land/std/http/server.ts";
  *
  * const listener = Deno.listen({ port: 4505 });
  *
@@ -587,7 +587,7 @@ function hostnameForDisplay(hostname: string) {
  * The below example serves with the port 8000.
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serve } from "https://deno.land/std/http/server.ts";
  * serve((_req) => new Response("Hello, world"));
  * ```
  *
@@ -595,7 +595,7 @@ function hostnameForDisplay(hostname: string) {
  * The below example serves with the port 3000.
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serve } from "https://deno.land/std/http/server.ts";
  * serve((_req) => new Response("Hello, world"), { port: 3000 });
  * ```
  *
@@ -604,7 +604,7 @@ function hostnameForDisplay(hostname: string) {
  * `onListen` option to override it.
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serve } from "https://deno.land/std/http/server.ts";
  * serve((_req) => new Response("Hello, world"), {
  *   onListen({ port, hostname }) {
  *     console.log(`Server started at http://${hostname}:${port}`);
@@ -616,7 +616,7 @@ function hostnameForDisplay(hostname: string) {
  * You can also specify `undefined` or `null` to stop the logging behavior.
  *
  * ```ts
- * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serve } from "https://deno.land/std/http/server.ts";
  * serve((_req) => new Response("Hello, world"), { onListen: undefined });
  * ```
  *
@@ -693,7 +693,7 @@ export interface ServeTlsInit extends ServeInit {
  * The below example serves with the default port 8443.
  *
  * ```ts
- * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serveTls } from "https://deno.land/std/http/server.ts";
  *
  * const cert = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n";
  * const key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n";
@@ -711,7 +711,7 @@ export interface ServeTlsInit extends ServeInit {
  * `onListen` option to override it.
  *
  * ```ts
- * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serveTls } from "https://deno.land/std/http/server.ts";
  * const certFile = "/path/to/certFile.crt";
  * const keyFile = "/path/to/keyFile.key";
  * serveTls((_req) => new Response("Hello, world"), {
@@ -727,7 +727,7 @@ export interface ServeTlsInit extends ServeInit {
  * You can also specify `undefined` or `null` to stop the logging behavior.
  *
  * ```ts
- * import { serveTls } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+ * import { serveTls } from "https://deno.land/std/http/server.ts";
  * const certFile = "/path/to/certFile.crt";
  * const keyFile = "/path/to/keyFile.key";
  * serveTls((_req) => new Response("Hello, world"), {

--- a/http/server_sent_event.ts
+++ b/http/server_sent_event.ts
@@ -22,7 +22,7 @@
  * import {
  *   ServerSentEvent,
  *   ServerSentEventStreamTarget,
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_server_sent_event.ts";
+ * } from "https://deno.land/std/http/unstable_server_sent_event.ts";
  *
  * Deno.serve({ port: 8000 }, (request) => {
  *   const target = new ServerSentEventStreamTarget();
@@ -85,7 +85,7 @@ export type ServerSentEventTargetOptions = ServerSentEventTargetOptions_;
  * import {
  *   ServerSentEvent,
  *   ServerSentEventStreamTarget,
- * } from "https://deno.land/std@$STD_VERSION/http/server_sent_event.ts";
+ * } from "https://deno.land/std/http/server_sent_event.ts";
  *
  * Deno.serve({ port: 8000 }, (request) => {
  *   const target = new ServerSentEventStreamTarget();

--- a/http/status.ts
+++ b/http/status.ts
@@ -11,14 +11,14 @@
  * import {
  *   Status,
  *   STATUS_TEXT,
- * } from "https://deno.land/std@$STD_VERSION/http/status.ts";
+ * } from "https://deno.land/std/http/status.ts";
  *
  * console.log(Status.NotFound); //=> 404
  * console.log(STATUS_TEXT[Status.NotFound]); //=> "Not Found"
  * ```
  *
  * ```ts
- * import { isErrorStatus } from "https://deno.land/std@$STD_VERSION/http/status.ts";
+ * import { isErrorStatus } from "https://deno.land/std/http/status.ts";
  *
  * const res = await fetch("https://example.com/");
  *

--- a/http/unstable_cookie_map.ts
+++ b/http/unstable_cookie_map.ts
@@ -11,7 +11,7 @@
  * import {
  *   CookieMap,
  *   mergeHeaders
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}
@@ -39,7 +39,7 @@
  *   SecureCookieMap,
  *   mergeHeaders,
  *   type KeyRing,
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}
@@ -65,7 +65,7 @@
  * set cookies will be added directly to those headers:
  *
  * ```ts
- * import { CookieMap } from "https://deno.land/std@$STD_VERSION/http/unstable_cookie_map.ts";
+ * import { CookieMap } from "https://deno.land/std/http/unstable_cookie_map.ts";
  *
  * const request = new Request("https://localhost/", {
  *   headers: { "cookie": "foo=bar; bar=baz;"}

--- a/http/unstable_errors.ts
+++ b/http/unstable_errors.ts
@@ -14,7 +14,7 @@
  *
  * @example
  * ```ts
- * import { errors, isHttpError } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
+ * import { errors, isHttpError } from "https://deno.land/std/http/unstable_errors.ts";
  *
  * try {
  *   throw new errors.NotFound();
@@ -29,8 +29,8 @@
  *
  * @example
  * ```ts
- * import { createHttpError } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
- * import { Status } from "https://deno.land/std@$STD_VERSION/http/status.ts";
+ * import { createHttpError } from "https://deno.land/std/http/unstable_errors.ts";
+ * import { Status } from "https://deno.land/std/http/status.ts";
  *
  * try {
  *   throw createHttpError(
@@ -171,7 +171,7 @@ function createHttpErrorConstructor(status: ErrorStatus): typeof HttpError {
  *
  * @example
  * ```ts
- * import { errors } from "https://deno.land/std@$STD_VERSION/http/unstable_errors.ts";
+ * import { errors } from "https://deno.land/std/http/unstable_errors.ts";
  *
  * throw new errors.InternalServerError("Ooops!");
  * ```

--- a/http/unstable_server_sent_event.ts
+++ b/http/unstable_server_sent_event.ts
@@ -20,7 +20,7 @@
  * import {
  *   ServerSentEvent,
  *   ServerSentEventStreamTarget,
- * } from "https://deno.land/std@$STD_VERSION/http/unstable_server_sent_event.ts";
+ * } from "https://deno.land/std/http/unstable_server_sent_event.ts";
  *
  * Deno.serve({ port: 8000 }, (request) => {
  *   const target = new ServerSentEventStreamTarget();
@@ -99,7 +99,7 @@ class CloseEvent extends Event {
  * import {
  *   ServerSentEvent,
  *   ServerSentEventStreamTarget,
- * } from "https://deno.land/std@$STD_VERSION/http/server_sent_event.ts";
+ * } from "https://deno.land/std/http/server_sent_event.ts";
  *
  * Deno.serve({ port: 8000 }, (request) => {
  *   const target = new ServerSentEventStreamTarget();
@@ -186,7 +186,7 @@ export interface ServerSentEventTarget extends EventTarget {
    * connection is kept alive.
    *
    * ```ts
-   * import { ServerSentEventStreamTarget } from "https://deno.land/std@$STD_VERSION/http/server_sent_event.ts";
+   * import { ServerSentEventStreamTarget } from "https://deno.land/std/http/server_sent_event.ts";
    *
    * Deno.serve({ port: 8000 }, (request) => {
    *   const target = new ServerSentEventStreamTarget();
@@ -213,7 +213,7 @@ export interface ServerSentEventTarget extends EventTarget {
    * import {
    *   ServerSentEvent,
    *   ServerSentEventStreamTarget,
-   * } from "https://deno.land/std@$STD_VERSION/http/server_sent_event.ts";
+   * } from "https://deno.land/std/http/server_sent_event.ts";
    *
    * Deno.serve({ port: 8000 }, (request) => {
    *   const target = new ServerSentEventStreamTarget();
@@ -236,7 +236,7 @@ export interface ServerSentEventTarget extends EventTarget {
    * import {
    *   ServerSentEvent,
    *   ServerSentEventStreamTarget,
-   * } from "https://deno.land/std@$STD_VERSION/http/server_sent_event.ts";
+   * } from "https://deno.land/std/http/server_sent_event.ts";
    *
    * Deno.serve({ port: 8000 }, (request) => {
    *   const target = new ServerSentEventStreamTarget();

--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -982,7 +982,7 @@ export class UserAgent {
    * determined lazily.
    *
    * ```ts
-   * import { UserAgent } from "https://deno.land/std@$STD_VERSION/http/user_agent.ts";
+   * import { UserAgent } from "https://deno.land/std/http/user_agent.ts";
    *
    * Deno.serve((req) => {
    *   const userAgent = new UserAgent(req.headers.get("user-agent") ?? "");

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -10,8 +10,8 @@ import { concat } from "../bytes/concat.ts";
  *
  *  @example
  * ```ts
- * import { readLines } from "https://deno.land/std@$STD_VERSION/io/read_lines.ts";
- * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ * import { readLines } from "https://deno.land/std/io/read_lines.ts";
+ * import * as path from "https://deno.land/std/path/mod.ts";
  *
  * const filename = path.join(Deno.cwd(), "std/io/README.md");
  * let fileReader = await Deno.open(filename);

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -23,8 +23,8 @@ export interface ByteRange {
  * range.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
- * import { readRange } from "https://deno.land/std@$STD_VERSION/io/read_range.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
+ * import { readRange } from "https://deno.land/std/io/read_range.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = await Deno.open("example.txt", { read: true });
@@ -63,8 +63,8 @@ export async function readRange(
  * within that range.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
- * import { readRangeSync } from "https://deno.land/std@$STD_VERSION/io/read_range.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
+ * import { readRangeSync } from "https://deno.land/std/io/read_range.ts";
  *
  * // Read the first 10 bytes of a file
  * const file = Deno.openSync("example.txt", { read: true });

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -9,8 +9,8 @@ import { readDelim } from "./read_delim.ts";
  *
  * @example
  * ```ts
- * import { readStringDelim } from "https://deno.land/std@$STD_VERSION/io/read_string_delim.ts";
- * import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ * import { readStringDelim } from "https://deno.land/std/io/read_string_delim.ts";
+ * import * as path from "https://deno.land/std/path/mod.ts";
  *
  * const filename = path.join(Deno.cwd(), "std/io/README.md");
  * let fileReader = await Deno.open(filename);

--- a/io/string_reader.ts
+++ b/io/string_reader.ts
@@ -8,7 +8,7 @@ import { Buffer } from "./buffer.ts";
  *
  * @example
  * ```ts
- * import { StringReader } from "https://deno.land/std@$STD_VERSION/io/string_reader.ts";
+ * import { StringReader } from "https://deno.land/std/io/string_reader.ts";
  *
  * const data = new Uint8Array(6);
  * const r = new StringReader("abcdef");

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -14,8 +14,8 @@ const decoder = new TextDecoder();
  *   copyN,
  *   StringReader,
  *   StringWriter,
- * } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * } from "https://deno.land/std/io/mod.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
  *
  * const w = new StringWriter("base");
  * const r = new StringReader("0123456789");

--- a/json/concatenated_json_parse_stream.ts
+++ b/json/concatenated_json_parse_stream.ts
@@ -17,9 +17,9 @@ const primitives = new Map(
  *
  * @example
  * ```ts
- * import { ConcatenatedJsonParseStream } from "https://deno.land/std@$STD_VERSION/json/concatenated_json_parse_stream.ts";
+ * import { ConcatenatedJsonParseStream } from "https://deno.land/std/json/concatenated_json_parse_stream.ts";
  *
- * const url = "https://deno.land/std@$STD_VERSION/json/testdata/test.concatenated-json";
+ * const url = "https://deno.land/std/json/testdata/test.concatenated-json";
  * const { body } = await fetch(url);
  *
  * const readable = body!

--- a/json/json_parse_stream.ts
+++ b/json/json_parse_stream.ts
@@ -18,10 +18,10 @@ function isBrankString(str: string) {
  * @example
  * parse JSON lines or NDJSON
  * ```ts
- * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/text_line_stream.ts";
- * import { JsonParseStream } from "https://deno.land/std@$STD_VERSION/json/json_parse_stream.ts";
+ * import { TextLineStream } from "https://deno.land/std/streams/text_line_stream.ts";
+ * import { JsonParseStream } from "https://deno.land/std/json/json_parse_stream.ts";
  *
- * const url = "https://deno.land/std@$STD_VERSION/json/testdata/test.jsonl";
+ * const url = "https://deno.land/std/json/testdata/test.jsonl";
  * const { body } = await fetch(url);
  *
  * const readable = body!
@@ -37,11 +37,11 @@ function isBrankString(str: string) {
  * @example
  * parse JSON Text Sequences
  * ```ts
- * import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/text_delimiter_stream.ts";
- * import { JsonParseStream } from "https://deno.land/std@$STD_VERSION/json/json_parse_stream.ts";
+ * import { TextDelimiterStream } from "https://deno.land/std/streams/text_delimiter_stream.ts";
+ * import { JsonParseStream } from "https://deno.land/std/json/json_parse_stream.ts";
  *
  * const url =
- *   "https://deno.land/std@$STD_VERSION/json/testdata/test.json-seq";
+ *   "https://deno.land/std/json/testdata/test.json-seq";
  * const { body } = await fetch(url);
  *
  * const delimiter = "\x1E";

--- a/json/json_stringify_stream.ts
+++ b/json/json_stringify_stream.ts
@@ -27,7 +27,7 @@ export interface StringifyStreamOptions {
  *
  * @example
  * ```ts
- * import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/json/json_stringify_stream.ts";
+ * import { JsonStringifyStream } from "https://deno.land/std/json/json_stringify_stream.ts";
  *
  * const file = await Deno.open("./tmp.jsonl", { create: true, write: true });
  *
@@ -42,7 +42,7 @@ export interface StringifyStreamOptions {
  * To convert to [JSON Text Sequences](https://datatracker.ietf.org/doc/html/rfc7464), set the
  * prefix to the delimiter "\x1E" as options.
  * ```ts
- * import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/json/json_stringify_stream.ts";
+ * import { JsonStringifyStream } from "https://deno.land/std/json/json_stringify_stream.ts";
  *
  * const file = await Deno.open("./tmp.jsonl", { create: true, write: true });
  *
@@ -56,7 +56,7 @@ export interface StringifyStreamOptions {
  * @example
  * If you want to stream [JSON lines](https://jsonlines.org/) from the server:
  * ```ts
- * import { JsonStringifyStream } from "https://deno.land/std@$STD_VERSION/json/json_stringify_stream.ts";
+ * import { JsonStringifyStream } from "https://deno.land/std/json/json_stringify_stream.ts";
  *
  * // A server that streams one line of JSON every second
  * Deno.serve(() => {

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -30,7 +30,7 @@ export interface ParseOptions {
  * @example
  *
  * ```ts
- * import * as JSONC from "https://deno.land/std@$STD_VERSION/jsonc/mod.ts";
+ * import * as JSONC from "https://deno.land/std/jsonc/mod.ts";
  *
  * console.log(JSONC.parse('{"foo": "bar", } // comment')); //=> { foo: "bar" }
  * console.log(JSONC.parse('{"foo": "bar", } /* comment *\/')); //=> { foo: "bar" }

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -41,7 +41,7 @@
  * module by using a custom logger:
  *
  * ```ts
- * import { getLogger } from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import { getLogger } from "https://deno.land/std/log/mod.ts";
  *
  * function logger() {
  *   return getLogger("my-awesome-module");
@@ -61,7 +61,7 @@
  * The user of the module can then display the internal logs with:
  *
  * ```ts, ignore
- * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import * as log from "https://deno.land/std/log/mod.ts";
  * import { sum } from "<the-awesome-module>/mod.ts";
  *
  * log.setup({
@@ -84,7 +84,7 @@
  * following won't work:
  *
  * ```ts
- * import { getLogger } from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import { getLogger } from "https://deno.land/std/log/mod.ts";
  *
  * const logger = getLogger("my-awesome-module");
  *
@@ -96,7 +96,7 @@
  *
  * @example
  * ```ts
- * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import * as log from "https://deno.land/std/log/mod.ts";
  *
  * // Simple default logger out of the box. You can customize it
  * // by overriding logger and handler named "default", or providing
@@ -155,7 +155,7 @@
  * @example
  * Custom message format example
  * ```ts
- * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import * as log from "https://deno.land/std/log/mod.ts";
  *
  * log.setup({
  *   handlers: {
@@ -207,7 +207,7 @@
  * @example
  * Inline Logging
  * ```ts
- * import * as logger from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import * as logger from "https://deno.land/std/log/mod.ts";
  *
  * const stringData: string = logger.debug("hello world");
  * const booleanData: boolean = logger.debug(true, 1, "abc");
@@ -223,7 +223,7 @@
  * @example
  * Lazy Log Evaluation
  * ```ts
- * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ * import * as log from "https://deno.land/std/log/mod.ts";
  *
  * log.setup({
  *   handlers: {

--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -37,7 +37,7 @@ type KnownExtensionOrType =
  *
  * @example
  * ```ts
- * import { contentType } from "https://deno.land/std@$STD_VERSION/media_types/content_type.ts";
+ * import { contentType } from "https://deno.land/std/media_types/content_type.ts";
  *
  * contentType(".json"); // `application/json; charset=UTF-8`
  * contentType("text/html"); // `text/html; charset=UTF-8`

--- a/media_types/extension.ts
+++ b/media_types/extension.ts
@@ -11,7 +11,7 @@ import { extensionsByType } from "./extensions_by_type.ts";
  *
  * @example
  * ```ts
- * import { extension } from "https://deno.land/std@$STD_VERSION/media_types/extension.ts";
+ * import { extension } from "https://deno.land/std/media_types/extension.ts";
  *
  * extension("text/plain"); // `txt`
  * extension("application/json"); // `json`

--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -16,7 +16,7 @@ export { extensions };
  *
  * @example
  * ```ts
- * import { extensionsByType } from "https://deno.land/std@$STD_VERSION/media_types/extensions_by_type.ts";
+ * import { extensionsByType } from "https://deno.land/std/media_types/extensions_by_type.ts";
  *
  * extensionsByType("application/json"); // ["json", "map"]
  * extensionsByType("text/html; charset=UTF-8"); // ["html", "htm", "shtml"]

--- a/media_types/format_media_type.ts
+++ b/media_types/format_media_type.ts
@@ -13,7 +13,7 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { formatMediaType } from "https://deno.land/std@$STD_VERSION/media_types/format_media_type.ts";
+ * import { formatMediaType } from "https://deno.land/std/media_types/format_media_type.ts";
  *
  * formatMediaType("text/plain", { charset: "UTF-8" }); // `text/plain; charset=UTF-8`
  * ```

--- a/media_types/get_charset.ts
+++ b/media_types/get_charset.ts
@@ -11,7 +11,7 @@ import { db, type KeyOfDb } from "./_db.ts";
  *
  * @example
  * ```ts
- * import { getCharset } from "https://deno.land/std@$STD_VERSION/media_types/get_charset.ts";
+ * import { getCharset } from "https://deno.land/std/media_types/get_charset.ts";
  *
  * getCharset("text/plain"); // `UTF-8`
  * getCharset("application/foo"); // undefined

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -19,8 +19,8 @@ import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
  *
  * @example
  * ```ts
- * import { parseMediaType } from "https://deno.land/std@$STD_VERSION/media_types/parse_media_type.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * import { parseMediaType } from "https://deno.land/std/media_types/parse_media_type.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  *
  * assertEquals(
  *   parseMediaType("application/JSON"),

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -13,7 +13,7 @@ import { types } from "./_db.ts";
  *
  * @example
  * ```ts
- * import { typeByExtension } from "https://deno.land/std@$STD_VERSION/media_types/type_by_extension.ts";
+ * import { typeByExtension } from "https://deno.land/std/media_types/type_by_extension.ts";
  *
  * typeByExtension("js"); // `application/json`
  * typeByExtension(".HTML"); // `text/html`

--- a/msgpack/decode.ts
+++ b/msgpack/decode.ts
@@ -7,7 +7,7 @@ import { ValueType } from "./encode.ts";
  *
  * @example
  * ```ts
- * import { decode } from "https://deno.land/std@$STD_VERSION/msgpack/decode.ts";
+ * import { decode } from "https://deno.land/std/msgpack/decode.ts";
  *
  * const encoded = Uint8Array.of(1, 2, 3)
  *

--- a/msgpack/encode.ts
+++ b/msgpack/encode.ts
@@ -34,7 +34,7 @@ const encoder = new TextEncoder();
  *
  * @example
  * ```ts
- * import { encode } from "https://deno.land/std@$STD_VERSION/msgpack/encode.ts";
+ * import { encode } from "https://deno.land/std/msgpack/encode.ts";
  *
  * const obj = {
  *   str: "deno",

--- a/path/README.md
+++ b/path/README.md
@@ -5,7 +5,7 @@ path module is made to provide helpers to manipulate the path.
 ## Usage
 
 ```ts
-import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import * as path from "https://deno.land/std/path/mod.ts";
 ```
 
 Codes in the following example uses POSIX path but it automatically use Windows
@@ -13,7 +13,7 @@ path on Windows. Use methods under `posix` or `win32` object instead to handle
 non platform specific path like:
 
 ```ts
-import { posix, win32 } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { posix, win32 } from "https://deno.land/std/path/mod.ts";
 const p1 = posix.fromFileUrl("file:///home/foo");
 const p2 = win32.fromFileUrl("file:///home/foo");
 console.log(p1); // "/home/foo"
@@ -25,7 +25,7 @@ console.log(p2); // "\\home\\foo"
 Return the last portion of a `path`. Trailing directory separators are ignored.
 
 ```ts
-import { basename } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { basename } from "https://deno.land/std/path/mod.ts";
 const p = basename("./deno/std/path/mod.ts");
 console.log(p); // "mod.ts"
 ```
@@ -35,7 +35,7 @@ console.log(p); // "mod.ts"
 Return the directory name of a `path`.
 
 ```ts
-import { dirname } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { dirname } from "https://deno.land/std/path/mod.ts";
 const p = dirname("./deno/std/path/mod.ts");
 console.log(p); // "./deno/std/path"
 ```
@@ -45,7 +45,7 @@ console.log(p); // "./deno/std/path"
 Return the extension of the `path`.
 
 ```ts
-import { extname } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { extname } from "https://deno.land/std/path/mod.ts";
 const p = extname("./deno/std/path/mod.ts");
 console.log(p); // ".ts"
 ```
@@ -55,7 +55,7 @@ console.log(p); // ".ts"
 Generate a path from `FormatInputPathObject` object.
 
 ```ts
-import { format } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { format } from "https://deno.land/std/path/mod.ts";
 const p = format({
   root: "/",
   dir: "/home/user/dir",
@@ -70,7 +70,7 @@ console.log(p); // "/home/user/dir/index.html"
 Converts a file URL to a path string.
 
 ```ts
-import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { fromFileUrl } from "https://deno.land/std/path/mod.ts";
 const p = fromFileUrl("file:///home/foo");
 console.log(p); // "/home/foo"
 ```
@@ -80,7 +80,7 @@ console.log(p); // "/home/foo"
 Verifies whether provided path is absolute
 
 ```ts
-import { isAbsolute } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { isAbsolute } from "https://deno.land/std/path/mod.ts";
 console.log(isAbsolute("/home/foo")); // true
 console.log(isAbsolute("foo")); // false
 ```
@@ -90,7 +90,7 @@ console.log(isAbsolute("foo")); // false
 Join all given a sequence of `paths`,then normalizes the resulting path.
 
 ```ts
-import { join } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { join } from "https://deno.land/std/path/mod.ts";
 const p = join("foo", "bar");
 console.log(p); // "foo/bar"
 ```
@@ -100,7 +100,7 @@ console.log(p); // "foo/bar"
 Normalize the `path`, resolving `'..'` and `'.'` segments.
 
 ```ts
-import { normalize } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { normalize } from "https://deno.land/std/path/mod.ts";
 const p = normalize("/home/foo/bar/../hoge/./piyo");
 console.log(p); // "/home/foo/hoge/piyo"
 ```
@@ -110,7 +110,7 @@ console.log(p); // "/home/foo/hoge/piyo"
 Return a `ParsedPath` object of the `path`.
 
 ```ts
-import { parse } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { parse } from "https://deno.land/std/path/mod.ts";
 const p = parse("/home/user/dir/index.html");
 console.log(p);
 /*
@@ -129,7 +129,7 @@ console.log(p);
 Return the relative path from `from` to `to` based on current working directory.
 
 ```ts
-import { relative } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { relative } from "https://deno.land/std/path/mod.ts";
 const p = relative("/var/lib", "/var/apache");
 console.log(p); // "../apache"
 ```
@@ -139,7 +139,7 @@ console.log(p); // "../apache"
 Resolves `pathSegments` into an absolute path.
 
 ```ts
-import { resolve } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { resolve } from "https://deno.land/std/path/mod.ts";
 const p = resolve("/var/lib", "../", "file/");
 console.log(p); // "/var/file"
 ```
@@ -149,7 +149,7 @@ console.log(p); // "/var/file"
 Converts a path string to a file URL.
 
 ```ts
-import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { toFileUrl } from "https://deno.land/std/path/mod.ts";
 const p = toFileUrl("/home/foo");
 console.log(p);
 /*
@@ -174,7 +174,7 @@ console.log(p);
 Resolves path to a namespace path
 
 ```ts
-import { toNamespacedPath } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { toNamespacedPath } from "https://deno.land/std/path/mod.ts";
 const p = toNamespacedPath("/home/foo");
 console.log(p); // "/home/foo"
 ```
@@ -185,7 +185,7 @@ Determines the common path from a set of paths, using an optional separator,
 which defaults to the OS default separator.
 
 ```ts
-import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+import { common } from "https://deno.land/std/path/mod.ts";
 const p = common([
   "./deno/std/path/mod.ts",
   "./deno/std/fs/mod.ts",
@@ -199,7 +199,7 @@ Generate a regex based on glob pattern and options This was meant to be using
 the `fs.walk` function but can be used anywhere else.
 
 ```ts
-import { globToRegExp } from "https://deno.land/std@$STD_VERSION/path/glob.ts";
+import { globToRegExp } from "https://deno.land/std/path/glob.ts";
 
 globToRegExp("foo/**/*.json", {
   extended: true,

--- a/path/common.ts
+++ b/path/common.ts
@@ -8,7 +8,7 @@ import { SEP } from "./separator.ts";
  * which defaults to the OS default separator.
  *
  * ```ts
- *       import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ *       import { common } from "https://deno.land/std/path/mod.ts";
  *       const p = common([
  *         "./deno/std/path/mod.ts",
  *         "./deno/std/fs/mod.ts",

--- a/path/from_file_url.ts
+++ b/path/from_file_url.ts
@@ -9,7 +9,7 @@ import { fromFileUrl as windowsFromFileUrl } from "./windows/from_file_url.ts";
  * Converts a file URL to a path string.
  *
  * ```ts
- * import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/from_file_url.ts";
+ * import { fromFileUrl } from "https://deno.land/std/path/from_file_url.ts";
  *
  * // posix
  * fromFileUrl("file:///home/foo"); // "/home/foo"

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -16,7 +16,7 @@
  * Example, for `posix`:
  *
  * ```ts
- * import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix/from_file_url.ts";
+ * import { fromFileUrl } from "https://deno.land/std/path/posix/from_file_url.ts";
  * const p = fromFileUrl("file:///home/foo");
  * console.log(p); // "/home/foo"
  * ```
@@ -24,7 +24,7 @@
  * or, for `windows`:
  *
  * ```ts
- * import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/windows/from_file_url.ts";
+ * import { fromFileUrl } from "https://deno.land/std/path/windows/from_file_url.ts";
  * const p = fromFileUrl("file:///home/foo");
  * console.log(p); // "\\home\\foo"
  * ```

--- a/path/posix/common.ts
+++ b/path/posix/common.ts
@@ -8,7 +8,7 @@ import { SEP } from "./separator.ts";
  * which defaults to the OS default separator.
  *
  * ```ts
- *       import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ *       import { common } from "https://deno.land/std/path/mod.ts";
  *       const p = common([
  *         "./deno/std/path/mod.ts",
  *         "./deno/std/fs/mod.ts",

--- a/path/posix/from_file_url.ts
+++ b/path/posix/from_file_url.ts
@@ -7,7 +7,7 @@ import { assertArg } from "../_common/from_file_url.ts";
  * Converts a file URL to a path string.
  *
  * ```ts
- * import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
+ * import { fromFileUrl } from "https://deno.land/std/path/posix.ts";
  *
  * fromFileUrl("file:///home/foo"); // "/home/foo"
  * ```

--- a/path/posix/mod.ts
+++ b/path/posix/mod.ts
@@ -10,7 +10,7 @@
  * on Windows. Use methods under `posix` or `win32` object instead to handle non
  * platform specific path like:
  * ```ts
- * import { posix, win32 } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ * import { posix, win32 } from "https://deno.land/std/path/mod.ts";
  * const p1 = posix.fromFileUrl("file:///home/foo");
  * const p2 = win32.fromFileUrl("file:///home/foo");
  * console.log(p1); // "/home/foo"

--- a/path/posix/to_file_url.ts
+++ b/path/posix/to_file_url.ts
@@ -8,7 +8,7 @@ import { isAbsolute } from "./is_absolute.ts";
  * Converts a path string to a file URL.
  *
  * ```ts
- * import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/posix.ts";
+ * import { toFileUrl } from "https://deno.land/std/path/posix.ts";
  *
  * toFileUrl("/home/foo"); // new URL("file:///home/foo")
  * ```

--- a/path/to_file_url.ts
+++ b/path/to_file_url.ts
@@ -9,7 +9,7 @@ import { toFileUrl as windowsToFileUrl } from "./windows/to_file_url.ts";
  * Converts a path string to a file URL.
  *
  * ```ts
- * import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/to_file_url.ts";
+ * import { toFileUrl } from "https://deno.land/std/path/to_file_url.ts";
  *
  * // posix
  * toFileUrl("/home/foo"); // new URL("file:///home/foo")

--- a/path/windows/common.ts
+++ b/path/windows/common.ts
@@ -8,7 +8,7 @@ import { SEP } from "./separator.ts";
  * which defaults to the OS default separator.
  *
  * ```ts
- *       import { common } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ *       import { common } from "https://deno.land/std/path/mod.ts";
  *       const p = common([
  *         "./deno/std/path/mod.ts",
  *         "./deno/std/fs/mod.ts",

--- a/path/windows/from_file_url.ts
+++ b/path/windows/from_file_url.ts
@@ -7,7 +7,7 @@ import { assertArg } from "../_common/from_file_url.ts";
  * Converts a file URL to a path string.
  *
  * ```ts
- * import { fromFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
+ * import { fromFileUrl } from "https://deno.land/std/path/win32.ts";
  *
  * fromFileUrl("file:///home/foo"); // "\\home\\foo"
  * fromFileUrl("file:///C:/Users/foo"); // "C:\\Users\\foo"

--- a/path/windows/mod.ts
+++ b/path/windows/mod.ts
@@ -10,7 +10,7 @@
  * on Windows. Use methods under `posix` or `win32` object instead to handle non
  * platform specific path like:
  * ```ts
- * import { posix, win32 } from "https://deno.land/std@$STD_VERSION/path/mod.ts";
+ * import { posix, win32 } from "https://deno.land/std/path/mod.ts";
  * const p1 = posix.fromFileUrl("file:///home/foo");
  * const p2 = win32.fromFileUrl("file:///home/foo");
  * console.log(p1); // "/home/foo"

--- a/path/windows/to_file_url.ts
+++ b/path/windows/to_file_url.ts
@@ -8,7 +8,7 @@ import { isAbsolute } from "./is_absolute.ts";
  * Converts a path string to a file URL.
  *
  * ```ts
- * import { toFileUrl } from "https://deno.land/std@$STD_VERSION/path/win32.ts";
+ * import { toFileUrl } from "https://deno.land/std/path/win32.ts";
  *
  * toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
  * toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -35,7 +35,7 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
  * the permissions that are granted.
  *
  * ```ts
- *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
+ *      import { grant } from "https://deno.land/std/permissions/mod.ts";
  *      const perms = await grant({ name: "net" }, { name: "read" });
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
@@ -56,7 +56,7 @@ export async function grant(
  * the permissions that are granted.
  *
  * ```ts
- *      import { grant } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
+ *      import { grant } from "https://deno.land/std/permissions/mod.ts";
  *      const perms = await grant([{ name: "net" }, { name: "read" }]);
  *      if (perms && perms.length === 2) {
  *        // do something cool that connects to the net and reads files
@@ -96,7 +96,7 @@ export async function grant(
 /** Attempts to grant a set of permissions or rejects.
  *
  * ```ts
- *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
+ *      import { grantOrThrow } from "https://deno.land/std/permissions/mod.ts";
  *      await grantOrThrow({ name: "env" }, { name: "net" });
  * ```
  *
@@ -113,7 +113,7 @@ export async function grantOrThrow(
 /** Attempts to grant a set of permissions or rejects.
  *
  * ```ts
- *      import { grantOrThrow } from "https://deno.land/std@$STD_VERSION/permissions/mod.ts";
+ *      import { grantOrThrow } from "https://deno.land/std/permissions/mod.ts";
  *      await grantOrThrow([{ name: "env" }, { name: "net" }]);
  * ```
  *

--- a/regexp/escape.ts
+++ b/regexp/escape.ts
@@ -65,8 +65,8 @@ const RX_REGEXP_ESCAPE = new RegExp(
  *
  * @example
  * ```ts
- * import { escape } from "https://deno.land/std@$STD_VERSION/regexp/mod.ts";
- * import { assertEquals, assertMatch, assertNotMatch } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
+ * import { escape } from "https://deno.land/std/regexp/mod.ts";
+ * import { assertEquals, assertMatch, assertNotMatch } from "https://deno.land/std/assert/mod.ts";
  *
  * const re = new RegExp(`^${escape(".")}$`, "u");
  *

--- a/semver/constants.ts
+++ b/semver/constants.ts
@@ -29,9 +29,9 @@ export const MIN: SemVer = {
  * which may be the result of impossible ranges or comparator operations.
  * @example
  * ```ts
- * import { eq } from "https://deno.land/std@$STD_VERSION/semver/eq.ts";
- * import { parse } from "https://deno.land/std@$STD_VERSION/semver/parse.ts";
- * import { INVALID } from "https://deno.land/std@$STD_VERSION/semver/constants.ts"
+ * import { eq } from "https://deno.land/std/semver/eq.ts";
+ * import { parse } from "https://deno.land/std/semver/parse.ts";
+ * import { INVALID } from "https://deno.land/std/semver/constants.ts"
  * eq(parse("1.2.3"), INVALID);
  * ```
  */
@@ -48,9 +48,9 @@ export const INVALID: SemVer = {
  * SemVer object and should not be used directly.
  * @example
  * ```ts
- * import { eq } from "https://deno.land/std@$STD_VERSION/semver/eq.ts";
- * import { parse } from "https://deno.land/std@$STD_VERSION/semver/parse.ts";
- * import { ANY } from "https://deno.land/std@$STD_VERSION/semver/constants.ts"
+ * import { eq } from "https://deno.land/std/semver/eq.ts";
+ * import { parse } from "https://deno.land/std/semver/parse.ts";
+ * import { ANY } from "https://deno.land/std/semver/constants.ts"
  * eq(parse("1.2.3"), ANY); // false
  * ```
  */

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -256,7 +256,7 @@
  *   gt,
  *   lt,
  *   format
- * } from "https://deno.land/std@$STD_VERSION/semver/mod.ts";
+ * } from "https://deno.land/std/semver/mod.ts";
  *
  * const semver = parse("1.2.3");
  * const range = parseRange("1.x || >=2.5.0 || 5.0.0 - 7.2.3");

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -18,7 +18,7 @@ export type Disposable = { dispose: () => void };
  * Example:
  *
  * ```ts
- * import { signal } from "https://deno.land/std@$STD_VERSION/signal/mod.ts";
+ * import { signal } from "https://deno.land/std/signal/mod.ts";
  *
  * const sig = signal("SIGUSR1", "SIGINT");
  * setTimeout(() => {}, 5000); // Prevents exiting immediately

--- a/streams/byte_slice_stream.ts
+++ b/streams/byte_slice_stream.ts
@@ -8,7 +8,7 @@ import { assert } from "../assert/assert.ts";
  *
  * @example
  * ```ts
- * import { ByteSliceStream } from "https://deno.land/std@$STD_VERSION/streams/byte_slice_stream.ts";
+ * import { ByteSliceStream } from "https://deno.land/std/streams/byte_slice_stream.ts";
  * const response = await fetch("https://example.com");
  * const rangedStream = response.body!
  *   .pipeThrough(new ByteSliceStream(3, 8));

--- a/streams/copy.ts
+++ b/streams/copy.ts
@@ -12,7 +12,7 @@ import type { Reader, Writer } from "../types.d.ts";
  * the first error encountered while copying.
  *
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
  *
  * const source = await Deno.open("my_file.txt");
  * const bytesCopied1 = await copy(source, Deno.stdout);

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -25,7 +25,7 @@ export interface DelimiterStreamOptions {
  * @example
  * Divide a CSV stream by commas, discarding the commas:
  * ```ts
- * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
+ * import { DelimiterStream } from "https://deno.land/std/streams/delimiter_stream.ts";
  * const res = await fetch("https://example.com/data.csv");
  * const parts = res.body!
  *   .pipeThrough(new DelimiterStream(new TextEncoder().encode(",")))
@@ -35,7 +35,7 @@ export interface DelimiterStreamOptions {
  * @example
  * Divide a stream after semi-colons, keeping the semi-colons in the output:
  * ```ts
- * import { DelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/delimiter_stream.ts";
+ * import { DelimiterStream } from "https://deno.land/std/streams/delimiter_stream.ts";
  * const res = await fetch("https://example.com/file.js");
  * const parts = res.body!
  *   .pipeThrough(

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -10,7 +10,7 @@ import type { Reader, ReaderSync } from "../types.d.ts";
  * Turns a Reader, `r`, into an async iterator.
  *
  * ```ts
- * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
+ * import { iterateReader } from "https://deno.land/std/streams/iterate_reader.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * for await (const chunk of iterateReader(f)) {
@@ -23,7 +23,7 @@ import type { Reader, ReaderSync } from "../types.d.ts";
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iterateReader } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
+ * import { iterateReader } from "https://deno.land/std/streams/iterate_reader.ts";
  *
  * let f = await Deno.open("/etc/passwd");
  * const it = iterateReader(f, {
@@ -59,7 +59,7 @@ export async function* iterateReader(
  * Turns a ReaderSync, `r`, into an iterator.
  *
  * ```ts
- * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
+ * import { iterateReaderSync } from "https://deno.land/std/streams/iterate_reader.ts";
  *
  * let f = Deno.openSync("/etc/passwd");
  * for (const chunk of iterateReaderSync(f)) {
@@ -72,7 +72,7 @@ export async function* iterateReader(
  * Default size of the buffer is 32kB.
  *
  * ```ts
- * import { iterateReaderSync } from "https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts";
+ * import { iterateReaderSync } from "https://deno.land/std/streams/iterate_reader.ts";
 
  * let f = await Deno.open("/etc/passwd");
  * const iter = iterateReaderSync(f, {

--- a/streams/limited_bytes_transform_stream.ts
+++ b/streams/limited_bytes_transform_stream.ts
@@ -9,7 +9,7 @@
  * an error will be thrown.
  *
  * ```ts
- * import { LimitedBytesTransformStream } from "https://deno.land/std@$STD_VERSION/streams/limited_bytes_transform_stream.ts";
+ * import { LimitedBytesTransformStream } from "https://deno.land/std/streams/limited_bytes_transform_stream.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!
  *   .pipeThrough(new LimitedBytesTransformStream(512 * 1024));

--- a/streams/limited_transform_stream.ts
+++ b/streams/limited_transform_stream.ts
@@ -7,7 +7,7 @@
  * an error will be thrown.
  *
  * ```ts
- * import { LimitedTransformStream } from "https://deno.land/std@$STD_VERSION/streams/limited_transform_stream.ts";
+ * import { LimitedTransformStream } from "https://deno.land/std/streams/limited_transform_stream.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!.pipeThrough(new LimitedTransformStream(50));
  * ```

--- a/streams/read_all.ts
+++ b/streams/read_all.ts
@@ -11,8 +11,8 @@ import type { Reader, ReaderSync } from "../types.d.ts";
  * Uint8Array`.
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { readAll } from "https://deno.land/std@$STD_VERSION/streams/read_all.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { readAll } from "https://deno.land/std/streams/read_all.ts";
  *
  * // Example from stdin
  * const stdinContent = await readAll(Deno.stdin);
@@ -42,8 +42,8 @@ export async function readAll(r: Reader): Promise<Uint8Array> {
  * as `Uint8Array`.
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { readAllSync } from "https://deno.land/std@$STD_VERSION/streams/read_all.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { readAllSync } from "https://deno.land/std/streams/read_all.ts";
  *
  * // Example from stdin
  * const stdinContent = readAllSync(Deno.stdin);

--- a/streams/readable_stream_from_reader.ts
+++ b/streams/readable_stream_from_reader.ts
@@ -40,7 +40,7 @@ export interface ReadableStreamFromReaderOptions {
  * An example converting a `Deno.FsFile` into a readable stream:
  *
  * ```ts
- * import { readableStreamFromReader } from "https://deno.land/std@$STD_VERSION/streams/readable_stream_from_reader.ts";
+ * import { readableStreamFromReader } from "https://deno.land/std/streams/readable_stream_from_reader.ts";
  *
  * const file = await Deno.open("./file.txt", { read: true });
  * const fileStream = readableStreamFromReader(file);

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -11,8 +11,8 @@ import { Reader } from "../types.d.ts";
  * Create a `Reader` from an iterable of `Uint8Array`s.
  *
  * ```ts
- *      import { readerFromIterable } from "https://deno.land/std@$STD_VERSION/streams/reader_from_iterable.ts";
- *      import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ *      import { readerFromIterable } from "https://deno.land/std/streams/reader_from_iterable.ts";
+ *      import { copy } from "https://deno.land/std/streams/copy.ts";
  *
  *      const file = await Deno.open("metrics.txt", { write: true });
  *      const reader = readerFromIterable((async function* () {

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -12,8 +12,8 @@ import type { Reader } from "../types.d.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
- * import { readerFromStreamReader } from "https://deno.land/std@$STD_VERSION/streams/reader_from_stream_reader.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
+ * import { readerFromStreamReader } from "https://deno.land/std/streams/reader_from_stream_reader.ts";
  *
  * const res = await fetch("https://deno.land");
  * const file = await Deno.open("./deno.land.html", { create: true, write: true });

--- a/streams/text_delimiter_stream.ts
+++ b/streams/text_delimiter_stream.ts
@@ -11,7 +11,7 @@ import type {
 /** Transform a stream into a stream where each chunk is divided by a given delimiter.
  *
  * ```ts
- * import { TextDelimiterStream } from "https://deno.land/std@$STD_VERSION/streams/text_delimiter_stream.ts";
+ * import { TextDelimiterStream } from "https://deno.land/std/streams/text_delimiter_stream.ts";
  * const res = await fetch("https://example.com");
  * const parts = res.body!
  *   .pipeThrough(new TextDecoderStream())

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -10,7 +10,7 @@ interface TextLineStreamOptions {
  * be it `\n` or `\r\n`. `\r` can be enabled via the `allowCR` option.
  *
  * ```ts
- * import { TextLineStream } from "https://deno.land/std@$STD_VERSION/streams/text_line_stream.ts";
+ * import { TextLineStream } from "https://deno.land/std/streams/text_line_stream.ts";
  * const res = await fetch("https://example.com");
  * const lines = res.body!
  *   .pipeThrough(new TextDecoderStream())

--- a/streams/to_transform_stream.ts
+++ b/streams/to_transform_stream.ts
@@ -5,7 +5,7 @@
  * Convert the generator function into a TransformStream.
  *
  * ```ts
- * import { toTransformStream } from "https://deno.land/std@$STD_VERSION/streams/to_transform_stream.ts";
+ * import { toTransformStream } from "https://deno.land/std/streams/to_transform_stream.ts";
  *
  * const readable = ReadableStream.from([0, 1, 2])
  *   .pipeThrough(toTransformStream(async function* (src) {

--- a/streams/write_all.ts
+++ b/streams/write_all.ts
@@ -9,8 +9,8 @@ import type { Writer, WriterSync } from "../types.d.ts";
  * Write all the content of the array buffer (`arr`) to the writer (`w`).
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { writeAll } from "https://deno.land/std@$STD_VERSION/streams/write_all.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { writeAll } from "https://deno.land/std/streams/write_all.ts";
 
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");
@@ -43,8 +43,8 @@ export async function writeAll(w: Writer, arr: Uint8Array) {
  * writer (`w`).
  *
  * ```ts
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { writeAllSync } from "https://deno.land/std@$STD_VERSION/streams/write_all.ts";
+ * import { Buffer } from "https://deno.land/std/io/buffer.ts";
+ * import { writeAllSync } from "https://deno.land/std/streams/write_all.ts";
  *
  * // Example writing to stdout
  * let contentBytes = new TextEncoder().encode("Hello World");

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -10,8 +10,8 @@ import type { Writer } from "../types.d.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
- * import { writerFromStreamWriter } from "https://deno.land/std@$STD_VERSION/streams/writer_from_stream_writer.ts";
+ * import { copy } from "https://deno.land/std/streams/copy.ts";
+ * import { writerFromStreamWriter } from "https://deno.land/std/streams/writer_from_stream_writer.ts";
  *
  * const file = await Deno.open("./deno.land.html", { read: true });
  *

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -30,7 +30,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertAlmostEquals, assertThrows } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertAlmostEquals, assertThrows } from "https://deno.land/std/testing/asserts.ts";
    *
    * assertAlmostEquals(0.1, 0.2);
    *
@@ -50,7 +50,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertArrayIncludes } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertArrayIncludes } from "https://deno.land/std/testing/asserts.ts";
    *
    * assertArrayIncludes<number>([1, 2], [2])
    * ```
@@ -66,7 +66,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("example", function (): void {
    *   assertEquals("world", "world");
@@ -123,7 +123,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertNotEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertNotEquals } from "https://deno.land/std/testing/asserts.ts";
    *
    * assertNotEquals<number>(1, 2)
    * ```
@@ -150,7 +150,7 @@ export {
    * If the values are strictly equal then throw.
    *
    * ```ts
-   * import { assertNotStrictEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertNotStrictEquals } from "https://deno.land/std/testing/asserts.ts";
    *
    * assertNotStrictEquals(1, 1)
    * ```
@@ -168,7 +168,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertRejects } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertRejects } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("doesThrow", async function () {
    *   await assertRejects(async () => {
@@ -195,7 +195,7 @@ export {
    *
    *  * @example
    * ```ts
-   * import { assertRejects } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertRejects } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("doesThrow", async function () {
    *   await assertRejects(
@@ -229,7 +229,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertStrictEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertStrictEquals } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("isStrictlyEqual", function (): void {
    *   const a = {};
@@ -262,7 +262,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertThrows } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertThrows } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("doesThrow", function (): void {
    *   assertThrows((): void => {
@@ -287,7 +287,7 @@ export {
    *
    * @example
    * ```ts
-   * import { assertThrows } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+   * import { assertThrows } from "https://deno.land/std/testing/asserts.ts";
    *
    * Deno.test("doesThrow", function (): void {
    *   assertThrows((): void => {

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -87,13 +87,13 @@
  * both styles.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_test.ts
+ * // https://deno.land/std/testing/bdd_examples/user_test.ts
  * import {
  *   assertEquals,
  *   assertStrictEquals,
  *   assertThrows,
- * } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
- * import { User } from "https://deno.land/std@$STD_VERSION/testing/bdd_examples/user.ts";
+ * } from "https://deno.land/std/assert/mod.ts";
+ * import { User } from "https://deno.land/std/testing/bdd_examples/user.ts";
  *
  * Deno.test("User.users initially empty", () => {
  *   assertEquals(User.users.size, 0);
@@ -132,19 +132,19 @@
  * the options argument for describe.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_nested_test.ts
+ * // https://deno.land/std/testing/bdd_examples/user_nested_test.ts
  * import {
  *   assertEquals,
  *   assertStrictEquals,
  *   assertThrows,
- * } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
+ * } from "https://deno.land/std/assert/mod.ts";
  * import {
  *   afterEach,
  *   beforeEach,
  *   describe,
  *   it,
- * } from "https://deno.land/std@$STD_VERSION/testing/bdd.ts";
- * import { User } from "https://deno.land/std@$STD_VERSION/testing/bdd_examples/user.ts";
+ * } from "https://deno.land/std/testing/bdd.ts";
+ * import { User } from "https://deno.land/std/testing/bdd_examples/user.ts";
  *
  * describe("User", () => {
  *   it("users initially empty", () => {
@@ -194,17 +194,17 @@
  * indentation in front of the grouped tests.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_flat_test.ts
+ * // https://deno.land/std/testing/bdd_examples/user_flat_test.ts
  * import {
  *   assertEquals,
  *   assertStrictEquals,
  *   assertThrows,
- * } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
+ * } from "https://deno.land/std/assert/mod.ts";
  * import {
  *   describe,
  *   it,
- * } from "https://deno.land/std@$STD_VERSION/testing/bdd.ts";
- * import { User } from "https://deno.land/std@$STD_VERSION/testing/bdd_examples/user.ts";
+ * } from "https://deno.land/std/testing/bdd.ts";
+ * import { User } from "https://deno.land/std/testing/bdd_examples/user.ts";
  *
  * const userTests = describe("User");
  *
@@ -254,17 +254,17 @@
  * indentation in front of each line.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/bdd_examples/user_mixed_test.ts
+ * // https://deno.land/std/testing/bdd_examples/user_mixed_test.ts
  * import {
  *   assertEquals,
  *   assertStrictEquals,
  *   assertThrows,
- * } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
+ * } from "https://deno.land/std/assert/mod.ts";
  * import {
  *   describe,
  *   it,
- * } from "https://deno.land/std@$STD_VERSION/testing/bdd.ts";
- * import { User } from "https://deno.land/std@$STD_VERSION/testing/bdd_examples/user.ts";
+ * } from "https://deno.land/std/testing/bdd.ts";
+ * import { User } from "https://deno.land/std/testing/bdd_examples/user.ts";
  *
  * describe("User", () => {
  *   it("users initially empty", () => {

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -17,7 +17,7 @@
  * multiply as a parameter.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/parameter_injection.ts
+ * // https://deno.land/std/testing/mock_examples/parameter_injection.ts
  * export function multiply(a: number, b: number): number {
  *   return a * b;
  * }
@@ -35,17 +35,17 @@
  * `square(multiplySpy, value)` in the testing code.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/parameter_injection_test.ts
+ * // https://deno.land/std/testing/mock_examples/parameter_injection_test.ts
  * import {
  *   assertSpyCall,
  *   assertSpyCalls,
  *   spy,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/testing/mock.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  * import {
  *   multiply,
  *   square,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock_examples/parameter_injection.ts";
+ * } from "https://deno.land/std/testing/mock_examples/parameter_injection.ts";
  *
  * Deno.test("square calls multiply and returns results", () => {
  *   const multiplySpy = spy(multiply);
@@ -70,7 +70,7 @@
  * `multiply`.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/internals_injection.ts
+ * // https://deno.land/std/testing/mock_examples/internals_injection.ts
  * export function multiply(a: number, b: number): number {
  *   return a * b;
  * }
@@ -88,17 +88,17 @@
  * function.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/internals_injection_test.ts
+ * // https://deno.land/std/testing/mock_examples/internals_injection_test.ts
  * import {
  *   assertSpyCall,
  *   assertSpyCalls,
  *   spy,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/testing/mock.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  * import {
  *   _internals,
  *   square,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock_examples/internals_injection.ts";
+ * } from "https://deno.land/std/testing/mock_examples/internals_injection.ts";
  *
  * Deno.test("square calls multiply and returns results", () => {
  *   const multiplySpy = spy(_internals, "multiply");
@@ -154,7 +154,7 @@
  * `randomInt` with a function that returns pre-defined values.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/random.ts
+ * // https://deno.land/std/testing/mock_examples/random.ts
  * export function randomInt(lowerBound: number, upperBound: number): number {
  *   return lowerBound + Math.floor(Math.random() * (upperBound - lowerBound));
  * }
@@ -171,18 +171,18 @@
  * on consecutive calls.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/random_test.ts
+ * // https://deno.land/std/testing/mock_examples/random_test.ts
  * import {
  *   assertSpyCall,
  *   assertSpyCalls,
  *   returnsNext,
  *   stub,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
- * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ * } from "https://deno.land/std/testing/mock.ts";
+ * import { assertEquals } from "https://deno.land/std/assert/assert_equals.ts";
  * import {
  *   _internals,
  *   randomMultiple,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock_examples/random.ts";
+ * } from "https://deno.land/std/testing/mock_examples/random.ts";
  *
  * Deno.test("randomMultiple uses randomInt to generate random multiples between -10 and 10 times the value", () => {
  *   const randomIntStub = stub(_internals, "randomInt", returnsNext([-3, 3]));
@@ -220,7 +220,7 @@
  * the callback is called every second.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval.ts
+ * // https://deno.land/std/testing/mock_examples/interval.ts
  * export function secondInterval(cb: () => void): number {
  *   return setInterval(cb, 1000);
  * }
@@ -233,13 +233,13 @@
  * `tick` method on the `FakeTime` instance.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval_test.ts
+ * // https://deno.land/std/testing/mock_examples/interval_test.ts
  * import {
  *   assertSpyCalls,
  *   spy,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
- * import { FakeTime } from "https://deno.land/std@$STD_VERSION/testing/time.ts";
- * import { secondInterval } from "https://deno.land/std@$STD_VERSION/testing/mock_examples/interval.ts";
+ * } from "https://deno.land/std/testing/mock.ts";
+ * import { FakeTime } from "https://deno.land/std/testing/time.ts";
+ * import { secondInterval } from "https://deno.land/std/testing/mock_examples/interval.ts";
  *
  * Deno.test("secondInterval calls callback every second and stops after being cleared", () => {
  *   const time = new FakeTime();

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -8,7 +8,7 @@
  *
  * ```ts
  * // example_test.ts
- * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
+ * import { assertSnapshot } from "https://deno.land/std/testing/snapshot.ts";
  *
  * Deno.test("isSnapshotMatch", async function (t): Promise<void> {
  *   const a = {
@@ -66,7 +66,7 @@
  *
  * ```ts
  * // example_test.ts
- * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
+ * import { assertSnapshot } from "https://deno.land/std/testing/snapshot.ts";
  *
  * Deno.test("isSnapshotMatch", async function (t): Promise<void> {
  *   const a = {
@@ -83,7 +83,7 @@
  *
  * ```ts
  * // example_test.ts
- * import { createAssertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
+ * import { createAssertSnapshot } from "https://deno.land/std/testing/snapshot.ts";
  *
  * const assertSnapshot = createAssertSnapshot({
  *   // options
@@ -100,8 +100,8 @@
  *
  * ```ts
  * // example_test.ts
- * import { createAssertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
- * import { stripColor } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * import { createAssertSnapshot } from "https://deno.land/std/testing/snapshot.ts";
+ * import { stripColor } from "https://deno.land/std/fmt/colors.ts";
  *
  * const assertSnapshot = createAssertSnapshot({
  *   dir: ".snaps",
@@ -515,7 +515,7 @@ class AssertSnapshotContext {
  *
  * @example
  * ```ts
- * import { assertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
+ * import { assertSnapshot } from "https://deno.land/std/testing/snapshot.ts";
  *
  * Deno.test("snapshot", async (test) => {
  *  await assertSnapshot<number>(test, 2);

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -182,13 +182,13 @@ let dueTree: RedBlackTree<DueNode>;
  * controlled through the fake time instance.
  *
  * ```ts
- * // https://deno.land/std@$STD_VERSION/testing/mock_examples/interval_test.ts
+ * // https://deno.land/std/testing/mock_examples/interval_test.ts
  * import {
  *   assertSpyCalls,
  *   spy,
- * } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
- * import { FakeTime } from "https://deno.land/std@$STD_VERSION/testing/time.ts";
- * import { secondInterval } from "https://deno.land/std@$STD_VERSION/testing/mock_examples/interval.ts";
+ * } from "https://deno.land/std/testing/mock.ts";
+ * import { FakeTime } from "https://deno.land/std/testing/time.ts";
+ * import { secondInterval } from "https://deno.land/std/testing/mock_examples/interval.ts";
  *
  * Deno.test("secondInterval calls callback every second and stops after being cleared", () => {
  *   const time = new FakeTime();

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -6,7 +6,7 @@
  * @param expectTrue - True if the passed in type argument resolved to true.
  * @example
  * ```typescript, ignore
- * import { assertType, IsExact, IsNullable } from "https://deno.land/std@$STD_VERSION/testing/types.ts";
+ * import { assertType, IsExact, IsNullable } from "https://deno.land/std/testing/types.ts";
  *
  * const result = "some result" as string | number;
  *
@@ -25,7 +25,7 @@ export function assertType<T extends true | false>(_expectTrue: T) {
  *
  * @example
  * ```typescript
- * import { AssertTrue, Has, IsNullable } from "https://deno.land/std@$STD_VERSION/testing/types.ts";
+ * import { AssertTrue, Has, IsNullable } from "https://deno.land/std/testing/types.ts";
  *
  * const result = 1 as string | number | null;
  *
@@ -38,7 +38,7 @@ export type AssertTrue<T extends true> = never;
  * Asserts at compile time that the provided type argument's type resolves to false.
  * @example
  * ```typescript
- * import { AssertFalse, IsNever } from "https://deno.land/std@$STD_VERSION/testing/types.ts";
+ * import { AssertFalse, IsNever } from "https://deno.land/std/testing/types.ts";
  *
  * const result = 1 as string | number | null;
  *
@@ -51,7 +51,7 @@ export type AssertFalse<T extends false> = never;
  * Asserts at compile time that the provided type argument's type resolves to the expected boolean literal type.
  * @example
  * ```typescript
- * import { Assert, Has } from "https://deno.land/std@$STD_VERSION/testing/types.ts";
+ * import { Assert, Has } from "https://deno.land/std/testing/types.ts";
  *
  * const result = 1 as string | number | null;
  *

--- a/toml/mod.ts
+++ b/toml/mod.ts
@@ -97,7 +97,7 @@
  * import {
  *   parse,
  *   stringify,
- * } from "https://deno.land/std@$STD_VERSION/toml/mod.ts";
+ * } from "https://deno.land/std/toml/mod.ts";
  * const obj = {
  *   bin: [
  *     { name: "deno", path: "cli/main.rs" },

--- a/types.d.ts
+++ b/types.d.ts
@@ -24,7 +24,7 @@ export interface Reader {
    *
    * Implementations should not retain a reference to `p`.
    *
-   * Use iterateReader() from https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts to turn a Reader into an
+   * Use iterateReader() from https://deno.land/std/streams/iterate_reader.ts to turn a Reader into an
    * AsyncIterator.
    */
   read(p: Uint8Array): Promise<number | null>;
@@ -50,7 +50,7 @@ export interface ReaderSync {
    *
    * Implementations should not retain a reference to `p`.
    *
-   * Use iterateReaderSync() from https://deno.land/std@$STD_VERSION/streams/iterate_reader.ts to turn a ReaderSync
+   * Use iterateReaderSync() from https://deno.land/std/streams/iterate_reader.ts to turn a ReaderSync
    * into an Iterator.
    */
   readSync(p: Uint8Array): number | null;

--- a/ulid/_util.ts
+++ b/ulid/_util.ts
@@ -63,7 +63,7 @@ export function incrementBase32(str: string): string {
  *
  * @example To generate monotonically increasing ULIDs, create a monotonic counter.
  * ```ts
- * import { monotonicFactory } from "https://deno.land/std@$STD_VERSION/ulid/_util.ts";
+ * import { monotonicFactory } from "https://deno.land/std/ulid/_util.ts";
  *
  * const ulid = monotonicFactory();
  * // Strict ordering for the same timestamp, by incrementing the least-significant random bit by 1

--- a/ulid/mod.ts
+++ b/ulid/mod.ts
@@ -7,7 +7,7 @@
  * @module
  * @example
  * ```ts
- * import { ulid } from "https://deno.land/std@$STD_VERSION/ulid/mod.ts";
+ * import { ulid } from "https://deno.land/std/ulid/mod.ts";
  * ulid(); // 01ARZ3NDEKTSV4RRFFQ69G5FAV
  * ```
  */
@@ -50,7 +50,7 @@ export function decodeTime(id: string): number {
 /**
  * @example
  * ```ts
- * import { monotonicUlid } from "https://deno.land/std@$STD_VERSION/ulid/mod.ts";
+ * import { monotonicUlid } from "https://deno.land/std/ulid/mod.ts";
  *
  * // Strict ordering for the same timestamp, by incrementing the least-significant random bit by 1
  * monotonicUlid(150000); // 000XAL6S41ACTAV9WEVGEMMVR8
@@ -68,7 +68,7 @@ export const monotonicUlid = monotonicFactory();
 /**
  * @example
  * ```ts
- * import { ulid } from "https://deno.land/std@$STD_VERSION/ulid/mod.ts";
+ * import { ulid } from "https://deno.land/std/ulid/mod.ts";
  * ulid(); // 01ARZ3NDEKTSV4RRFFQ69G5FAV
  *
  * // You can also input a seed time which will consistently give you the same string for the time component

--- a/url/basename.ts
+++ b/url/basename.ts
@@ -10,7 +10,7 @@ import { strip } from "./_strip.ts";
  *
  * @example
  * ```ts
- * import { basename } from "https://deno.land/std@$STD_VERSION/url/basename.ts";
+ * import { basename } from "https://deno.land/std/url/basename.ts";
  *
  * // basename accepts a string or URL
  * console.log(basename("https://deno.land/std/assert/mod.ts"));  // "mod.ts"

--- a/url/dirname.ts
+++ b/url/dirname.ts
@@ -14,7 +14,7 @@ import { strip } from "./_strip.ts";
  *
  * @example
  * ```ts
- * import { dirname } from "https://deno.land/std@$STD_VERSION/url/dirname.ts";
+ * import { dirname } from "https://deno.land/std/url/dirname.ts";
  *
  * console.log(dirname("https://deno.land/std/path/mod.ts?a=b").href); // "https://deno.land/std/path"
  * console.log(dirname("https://deno.land/").href); // "https://deno.land"

--- a/url/extname.ts
+++ b/url/extname.ts
@@ -11,7 +11,7 @@ import { strip } from "./_strip.ts";
  *
  * @example
  * ```ts
- * import { extname } from "https://deno.land/std@$STD_VERSION/url/extname.ts";
+ * import { extname } from "https://deno.land/std/url/extname.ts";
  *
  * console.log(extname("https://deno.land/std/path/mod.ts")); // ".ts"
  * console.log(extname("https://deno.land/std/path/mod")); // ""

--- a/url/join.ts
+++ b/url/join.ts
@@ -8,7 +8,7 @@ import { join as posixJoin } from "../path/posix/join.ts";
  *
  * @example
  * ```ts
- * import { join } from "https://deno.land/std@$STD_VERSION/url/join.ts";
+ * import { join } from "https://deno.land/std/url/join.ts";
  *
  * console.log(join("https://deno.land/", "std", "path", "mod.ts").href);
  * // Outputs: "https://deno.land/std/path/mod.ts"

--- a/url/normalize.ts
+++ b/url/normalize.ts
@@ -9,7 +9,7 @@ import { normalize as posixNormalize } from "../path/posix/normalize.ts";
  *
  * @example
  * ```ts
- * import { normalize } from "https://deno.land/std@$STD_VERSION/url/normalize.ts";
+ * import { normalize } from "https://deno.land/std/url/normalize.ts";
  *
  * console.log(normalize("https:///deno.land///std//assert//.//mod.ts").href);
  * // Outputs: "https://deno.land/std/path/mod.ts"

--- a/uuid/constants.ts
+++ b/uuid/constants.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { NAMESPACE_DNS } from "https://deno.land/std@$STD_VERSION/uuid/constants.ts";
+ * import { NAMESPACE_DNS } from "https://deno.land/std/uuid/constants.ts";
  *
  * console.log(NAMESPACE_DNS); // => 6ba7b810-9dad-11d1-80b4-00c04fd430c8
  * ```
@@ -17,7 +17,7 @@ export const NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
  *
  * @example
  * ```ts
- * import { NAMESPACE_URL } from "https://deno.land/std@$STD_VERSION/uuid/constants.ts";
+ * import { NAMESPACE_URL } from "https://deno.land/std/uuid/constants.ts";
  *
  * console.log(NAMESPACE_URL); // => 6ba7b811-9dad-11d1-80b4-00c04fd430c8
  * ```
@@ -28,7 +28,7 @@ export const NAMESPACE_URL = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
  *
  * @example
  * ```ts
- * import { NAMESPACE_OID } from "https://deno.land/std@$STD_VERSION/uuid/constants.ts";
+ * import { NAMESPACE_OID } from "https://deno.land/std/uuid/constants.ts";
  *
  * console.log(NAMESPACE_OID); // => 6ba7b812-9dad-11d1-80b4-00c04fd430c8
  * ```
@@ -39,7 +39,7 @@ export const NAMESPACE_OID = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
  *
  * @example
  * ```ts
- * import { NAMESPACE_X500 } from "https://deno.land/std@$STD_VERSION/uuid/constants.ts";
+ * import { NAMESPACE_X500 } from "https://deno.land/std/uuid/constants.ts";
  *
  * console.log(NAMESPACE_X500); // => 6ba7b814-9dad-11d1-80b4-00c04fd430c8
  * ```

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -30,7 +30,7 @@ export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
  * Check if the passed UUID is the nil UUID.
  *
  * ```js
- * import { isNil } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts";
+ * import { isNil } from "https://deno.land/std/uuid/mod.ts";
  *
  * isNil("00000000-0000-0000-0000-000000000000") // true
  * isNil(crypto.randomUUID()) // false
@@ -44,7 +44,7 @@ export function isNil(id: string): boolean {
  * Test a string to see if it is a valid UUID.
  *
  * ```js
- * import { validate } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
+ * import { validate } from "https://deno.land/std/uuid/mod.ts"
  *
  * validate("not a UUID") // false
  * validate("6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b") // true
@@ -61,7 +61,7 @@ export function validate(uuid: string): boolean {
  * Detect RFC version of a UUID.
  *
  * ```js
- * import { version } from "https://deno.land/std@$STD_VERSION/uuid/mod.ts"
+ * import { version } from "https://deno.land/std/uuid/mod.ts"
  *
  * version("d9428888-122b-11e1-b85c-61cd3cbb3210") // 1
  * version("109156be-c4fb-41ea-b1b4-efe1671c5836") // 4

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -14,7 +14,7 @@ const UUID_RE =
  *
  * @example
  * ```ts
- * import { generate as generateV3, validate } from "https://deno.land/std@$STD_VERSION/uuid/v3.ts";
+ * import { generate as generateV3, validate } from "https://deno.land/std/uuid/v3.ts";
  *
  * validate(await generateV3("6ba7b811-9dad-11d1-80b4-00c04fd430c8", new Uint8Array())); // true
  * validate(crypto.randomUUID()); // false
@@ -30,7 +30,7 @@ export function validate(id: string): boolean {
  *
  * @example
  * ```js
- * import { generate } from "https://deno.land/std@$STD_VERSION/uuid/v3.ts";
+ * import { generate } from "https://deno.land/std/uuid/v3.ts";
  *
  * const NAMESPACE_URL = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
  *

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -9,8 +9,8 @@ const UUID_RE =
  *
  * @example
  * ```ts
- * import { validate } from "https://deno.land/std@$STD_VERSION/uuid/v4.ts";
- * import { generate as generateV1 } from "https://deno.land/std@$STD_VERSION/uuid/v1.ts";
+ * import { validate } from "https://deno.land/std/uuid/v4.ts";
+ * import { generate as generateV1 } from "https://deno.land/std/uuid/v1.ts";
  *
  * validate(crypto.randomUUID()); // true
  * validate(generateV1() as string); // false

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -13,7 +13,7 @@ const UUID_RE =
  *
  * @example
  * ```ts
- * import { generate as generateV5, validate } from "https://deno.land/std@$STD_VERSION/uuid/v5.ts";
+ * import { generate as generateV5, validate } from "https://deno.land/std/uuid/v5.ts";
  *
  * validate(await generateV5("6ba7b811-9dad-11d1-80b4-00c04fd430c8", new Uint8Array())); // true
  * validate(crypto.randomUUID()); // false
@@ -29,7 +29,7 @@ export function validate(id: string): boolean {
  *
  * @example
  * ```js
- * import { generate } from "https://deno.land/std@$STD_VERSION/uuid/v5.ts";
+ * import { generate } from "https://deno.land/std/uuid/v5.ts";
  *
  * const NAMESPACE_URL = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
  *

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -54,7 +54,7 @@
  *
  * @example
  * ```ts
- * import Context from "https://deno.land/std@$STD_VERSION/wasi/snapshot_preview1.ts";
+ * import Context from "https://deno.land/std/wasi/snapshot_preview1.ts";
  *
  * const context = new Context({
  *   args: Deno.args,

--- a/yaml/mod.ts
+++ b/yaml/mod.ts
@@ -24,7 +24,7 @@
  * import {
  *   parse,
  *   stringify,
- * } from "https://deno.land/std@$STD_VERSION/yaml/mod.ts";
+ * } from "https://deno.land/std/yaml/mod.ts";
  *
  * const data = parse(`
  * foo: bar

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -25,7 +25,7 @@ export function parse(content: string, options?: ParseOptions): unknown {
  *
  * @example
  * ```ts
- * import { parseAll } from "https://deno.land/std@$STD_VERSION/yaml/parse.ts";
+ * import { parseAll } from "https://deno.land/std/yaml/parse.ts";
  *
  * const data = parseAll(`
  * ---

--- a/yaml/schema/extended.ts
+++ b/yaml/schema/extended.ts
@@ -15,7 +15,7 @@ import { def } from "./default.ts";
  * import {
  *   EXTENDED_SCHEMA,
  *   parse,
- * } from "https://deno.land/std@$STD_VERSION/yaml/mod.ts";
+ * } from "https://deno.land/std/yaml/mod.ts";
  *
  * const data = parse(
  *   `


### PR DESCRIPTION
Including this in the import specifier seems redundant.