### PR TITLE
docs(crypto): remove use of deprecated `toHashString()`

### DIFF
--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -103,19 +103,20 @@
  * ```ts
  * import {
  *   crypto,
- *   toHashString,
  * } from "https://deno.land/std@$STD_VERSION/crypto/mod.ts";
+ * import { encodeHex } from "https://deno.land/std@$STD_VERSION/encoding/hex.ts"
+ * import { encodeBase64 } from "https://deno.land/std@$STD_VERSION/encoding/base64.ts"
  *
  * const hash = await crypto.subtle.digest(
  *   "SHA-384",
  *   new TextEncoder().encode("You hear that Mr. Anderson?"),
  * );
  *
- * // Hex encoding by default
- * console.log(toHashString(hash));
+ * // Hex encoding
+ * console.log(encodeHex(hash));
  *
  * // Or with base64 encoding
- * console.log(toHashString(hash, "base64"));
+ * console.log(encodeBase64(hash, "base64"));
  * ```
  *
  * @module

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -116,7 +116,7 @@
  * console.log(encodeHex(hash));
  *
  * // Or with base64 encoding
- * console.log(encodeBase64(hash, "base64"));
+ * console.log(encodeBase64(hash));
  * ```
  *
  * @module


### PR DESCRIPTION
Towards #3718 