### PR TITLE
chore: remove `readableStreamFromReader()` & `StringReader()` in CSV stream test

### DIFF
--- a/csv/csv_parse_stream_test.ts
+++ b/csv/csv_parse_stream_test.ts
@@ -2,7 +2,6 @@
 import { CsvParseStream } from "./csv_parse_stream.ts";
 import type { CsvParseStreamOptions } from "./csv_parse_stream.ts";
 import { ERR_QUOTE, ParseError } from "./_io.ts";
-import { readableStreamFromReader } from "../streams/readable_stream_from_reader.ts";
 import {
   assert,
   assertEquals,
@@ -11,7 +10,6 @@ import {
 } from "../assert/mod.ts";
 import type { AssertTrue, IsExact } from "../testing/types.ts";
 import { fromFileUrl, join } from "../path/mod.ts";
-import { StringReader } from "../io/string_reader.ts";
 import { delay } from "../async/delay.ts";
 
 const testdataDir = join(fromFileUrl(import.meta.url), "../testdata");
@@ -331,7 +329,7 @@ x,,,
         if (testCase.columns) {
           options.columns = testCase.columns;
         }
-        const readable = createReadableStreamFromString(testCase.input)
+        const readable = ReadableStream.from(testCase.input)
           .pipeThrough(new CsvParseStream(options));
 
         if (testCase.output) {
@@ -349,12 +347,6 @@ x,,,
     }
   },
 });
-
-function createReadableStreamFromString(s: string): ReadableStream<string> {
-  return readableStreamFromReader(new StringReader(s)).pipeThrough(
-    new TextDecoderStream(),
-  );
-}
 
 // Work around resource leak error with TextDecoderStream:
 //   https://github.com/denoland/deno/issues/13142


### PR DESCRIPTION
Removed the use of `readableStreamFromReader` and `StringReader` in csv stream parse tests since they are deprecated.
See #3718