### PR TITLE
chore: replace deprecated `typeByExtension()` in `content_type.ts`

### DIFF
--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -2,10 +2,10 @@
 // This module is browser compatible.
 
 import { parseMediaType } from "./parse_media_type.ts";
-import { typeByExtension } from "./type_by_extension.ts";
 import { getCharset } from "./get_charset.ts";
 import { formatMediaType } from "./format_media_type.ts";
 import type { db } from "./_db.ts";
+import { types } from "./_db.ts";
 
 type DB = typeof db;
 type ContentTypeToExtension = {
@@ -74,4 +74,10 @@ export function contentType<
   }
   return undefined as Lowercase<T> extends KnownExtensionOrType ? string
     : string | undefined;
+}
+
+function typeByExtension(extension: string): string | undefined {
+  extension = extension.startsWith(".") ? extension.slice(1) : extension;
+  // @ts-ignore workaround around denoland/dnt#148
+  return types.get(extension.toLowerCase());
 }


### PR DESCRIPTION
Replaced call to deprecated `typeByExtension` in `content_type.ts` in favour of private `typeByExtension` function.

See #3718 

Not sure if this is what you were looking for. Seems odd to deprecate typeByExtension when it is needed by content type and would need to be reimplemented for content type when removed.