### PR TITLE
BREAKING: deprecate `std/wasi`

### DIFF
--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -401,6 +401,8 @@ export interface ContextOptions {
 }
 
 /**
+ * @deprecated (to be removed in 0.207.0)
+ *
  * The Context class provides the environment required to run WebAssembly
  * modules compiled to run with the WebAssembly System Interface.
  *

--- a/wasi/snapshot_preview1.ts
+++ b/wasi/snapshot_preview1.ts
@@ -356,6 +356,9 @@ class ExitStatus {
   }
 }
 
+/**
+ * @deprecated (will be removed in 0.207.0)
+ */
 export interface ContextOptions {
   /**
    * An array of strings that the WebAssembly instance will see as command-line
@@ -401,7 +404,7 @@ export interface ContextOptions {
 }
 
 /**
- * @deprecated (to be removed in 0.207.0)
+ * @deprecated (will be removed in 0.207.0)
  *
  * The Context class provides the environment required to run WebAssembly
  * modules compiled to run with the WebAssembly System Interface.


### PR DESCRIPTION
After a discussion with @kt3k, there appears to be nearly no interest or development in this module. Best it be removed.