### PR TITLE
chore: add `cov:*` tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,22 +47,13 @@ jobs:
         run: deno task test:browser
 
       - name: Generate lcov
-        shell: bash
-        # excludes tests, testdata, and generated sources from coverage report
-        run: |
-          deno coverage ./cov/ --lcov --exclude="test\\.(ts|js)|wasm\\.js|testdata" > cov.lcov
+        run: deno task cov:gen
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
           name: ${{ matrix.os }}-${{ matrix.deno }}
           files: cov.lcov
-
-      - name: Remove coverage report
-        shell: bash
-        run: |
-          rm -rf ./cov/
-          rm cov.lcov
 
       - name: Release if version change
         if: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /crypto/_wasm/target
 deno.lock
 /console/testdata/unicode_width_crate/target
+html_cov/
+cov.lcov

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,10 @@
     "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:deprecations && deno task lint:doc-imports && deno task lint:circular && deno task lint:tools-types",
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
-    "wasmbuild": "deno run --unstable -A https://deno.land/x/wasmbuild@0.15.0/main.ts --js-ext mjs --sync"
+    "wasmbuild": "deno run --unstable -A https://deno.land/x/wasmbuild@0.15.0/main.ts --js-ext mjs --sync",
+    "cov:clean": "rm -rf cov html_cov cov.lcov",
+    "cov:gen": "deno coverage ./cov/ --lcov --output=cov.lcov",
+    "cov:view": "genhtml --ignore-errors unmapped -o html_cov cov.lcov && open html_cov/index.html"
   },
   "exclude": [
     ".git",


### PR DESCRIPTION
This will make analysing test coverage locally easier and align local coverage-related processes with CI. I'll elaborate on how they work in a follow-up PR that improves the CONTRIBUTING.md file.