### PR TITLE
refactor(path): format  test names

### DIFF
--- a/path/basename_test.ts
+++ b/path/basename_test.ts
@@ -84,7 +84,7 @@ const WIN32_TESTSUITE = [
   [["file:stream"], "file:stream"],
 ];
 
-Deno.test("basename", function () {
+Deno.test("posix.basename()", function () {
   for (const [[name, suffix], expected] of COREUTILS_TESTSUITE) {
     assertEquals(path.basename(name, suffix), expected);
   }
@@ -112,7 +112,7 @@ Deno.test("basename", function () {
   );
 });
 
-Deno.test("basenameWin32", function () {
+Deno.test("win32.basename()", function () {
   for (const [[name, suffix], expected] of WIN32_TESTSUITE) {
     assertEquals(path.win32.basename(name, suffix), expected);
   }

--- a/path/common_test.ts
+++ b/path/common_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { common } from "./mod.ts";
 
 Deno.test({
-  name: "path - common - basic usage",
+  name: "common() returns shared path",
   fn() {
     const actual = common(
       [
@@ -18,7 +18,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "path - common - no shared",
+  name: "common() returns empty string if no shared path is present",
   fn() {
     const actual = common(
       ["file://deno/cli/js/deno.ts", "https://deno.land/std/path/mod.ts"],
@@ -29,7 +29,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "path - common - windows sep",
+  name: "common() checks windows separator",
   fn() {
     const actual = common(
       [

--- a/path/dirname_test.ts
+++ b/path/dirname_test.ts
@@ -69,7 +69,7 @@ const WIN32_TESTSUITE = [
   ["foo", "."],
 ];
 
-Deno.test("dirname", function () {
+Deno.test("posix.dirname()", function () {
   for (const [name, expected] of COREUTILS_TESTSUITE) {
     assertEquals(path.dirname(name), expected);
   }
@@ -85,7 +85,7 @@ Deno.test("dirname", function () {
   assertEquals(path.posix.dirname("/foo/bar/baz\\"), "/foo/bar");
 });
 
-Deno.test("dirnameWin32", function () {
+Deno.test("win32.dirname()", function () {
   for (const [name, expected] of WIN32_TESTSUITE) {
     assertEquals(path.win32.dirname(name), expected);
   }

--- a/path/extname_test.ts
+++ b/path/extname_test.ts
@@ -51,7 +51,7 @@ const pairs = [
   ["file.//", "."],
 ];
 
-Deno.test("extname", function () {
+Deno.test("posix.extname()", function () {
   pairs.forEach(function (p) {
     const input = p[0];
     const expected = p[1];
@@ -69,7 +69,7 @@ Deno.test("extname", function () {
   assertEquals(path.posix.extname("file.\\\\"), ".\\\\");
 });
 
-Deno.test("extnameWin32", function () {
+Deno.test("win32.extname()", function () {
   pairs.forEach(function (p) {
     const input = p[0].replace(slashRE, "\\");
     const expected = p[1];

--- a/path/from_file_url_test.ts
+++ b/path/from_file_url_test.ts
@@ -2,7 +2,7 @@
 import { posix, win32 } from "./mod.ts";
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 
-Deno.test("[path] fromFileUrl", function () {
+Deno.test("posix.fromFileUrl()", function () {
   assertEquals(posix.fromFileUrl(new URL("file:///home/foo")), "/home/foo");
   assertEquals(posix.fromFileUrl("file:///"), "/");
   assertEquals(posix.fromFileUrl("file:///home/foo"), "/home/foo");
@@ -25,7 +25,7 @@ Deno.test("[path] fromFileUrl", function () {
   );
 });
 
-Deno.test("[path] fromFileUrl (win32)", function () {
+Deno.test("win32.fromFileUrl()", function () {
   assertEquals(win32.fromFileUrl(new URL("file:///home/foo")), "\\home\\foo");
   assertEquals(win32.fromFileUrl("file:///"), "\\");
   assertEquals(win32.fromFileUrl("file:///home/foo"), "\\home\\foo");

--- a/path/glob_test.ts
+++ b/path/glob_test.ts
@@ -380,7 +380,7 @@ Deno.test({
 Deno.test({
   name: "globToRegExp() matches special RegExp characters in range",
   fn() {
-    // Excluding characters checksed in the previous test.
+    // Excluding characters checked in the previous test.
     assertEquals(globToRegExp("[\\\\$^.=]", { os: "linux" }), /^[\\$^.=]\/*$/);
     assertEquals(
       globToRegExp("[!\\\\$^.=]", { os: "linux" }),

--- a/path/glob_test.ts
+++ b/path/glob_test.ts
@@ -42,14 +42,14 @@ function match(
 }
 
 Deno.test({
-  name: "[path] globToRegExp() Basic RegExp",
+  name: "globToRegExp() returns RegExp from a glob",
   fn() {
     assertEquals(globToRegExp("*.js", { os: "linux" }), /^[^/]*\.js\/*$/);
   },
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Empty glob",
+  name: "globToRegExp() returns RegExp from an empty glob",
   fn() {
     assertEquals(globToRegExp(""), /(?!)/);
     assertEquals(globToRegExp("*.js", { os: "linux" }), /^[^/]*\.js\/*$/);
@@ -57,7 +57,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() * (wildcard)",
+  name: `globToRegExp() checks "*" (wildcard)`,
   fn() {
     assert(match("*", "foo", { extended: false, globstar: false }));
     assert(match("*", "foo", { extended: false, globstar: false }));
@@ -74,7 +74,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() ? (match one character)",
+  name: `globToRegExp() checks "?" (match one character)`,
   fn() {
     assert(match("f?o", "foo", { extended: false, globstar: false }));
     assert(match("f?o?", "fooo", { extended: false, globstar: false }));
@@ -86,7 +86,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() [seq] (character range)",
+  name: "globToRegExp() checks [seq] (character range)",
   fn() {
     assert(match("fo[oz]", "foo", { extended: false, globstar: false }));
     assert(match("fo[oz]", "foz", { extended: false, globstar: false }));
@@ -99,7 +99,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() [[:alnum:]] (character class in range)",
+  name: "globToRegExp() checks [[:alnum:]] (character class in range)",
   fn() {
     assert(
       match(
@@ -168,7 +168,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() {} (brace expansion)",
+  name: `globToRegExp() checks {} (brace expansion)`,
   fn() {
     assert(
       match("foo{bar,baaz}", "foobaaz", { extended: false, globstar: false }),
@@ -186,7 +186,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Complex matches",
+  name: "globToRegExp() checks complex matches",
   fn() {
     assert(
       match(
@@ -227,7 +227,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() ** (globstar)",
+  name: `globToRegExp() checks "**" (globstar)`,
   fn() {
     assert(match("/foo/**", "/foo/bar.txt"));
     assert(match("/foo/**", "/foo/bar/baz.txt"));
@@ -278,7 +278,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() ?(pattern-list) (extended: match zero or one)",
+  name:
+    `globToRegExp() checks "?" (pattern-list) (extended: match zero or one)`,
   fn() {
     assert(match("?(foo).txt", "foo.txt"));
     assert(!match("?(foo).txt", "foo.txt", { extended: false }));
@@ -301,7 +302,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() *(pattern-list) (extended: match zero or more)",
+  name: "globToRegExp() checks *(pattern-list) (extended: match zero or more)",
   fn() {
     assert(match("*(foo).txt", "foo.txt"));
     assert(!match("*(foo).txt", "foo.txt", { extended: false }));
@@ -324,7 +325,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() +(pattern-list) (extended: match 1 or more)",
+  name: "globToRegExp() checks +(pattern-list) (extended: match 1 or more)",
   fn() {
     assert(match("+(foo).txt", "foo.txt"));
     assert(!match("+(foo).txt", "foo.txt", { extended: false }));
@@ -335,7 +336,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() @(pattern-list) (extended: match one)",
+  name: "globToRegExp() checks @(pattern-list) (extended: match one)",
   fn() {
     assert(match("@(foo).txt", "foo.txt"));
     assert(!match("@(foo).txt", "foo.txt", { extended: false }));
@@ -348,7 +349,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() !(pattern-list) (extended: match any except)",
+  name: "globToRegExp() checks !(pattern-list) (extended: match any except)",
   fn() {
     assert(match("!(boo).txt", "foo.txt"));
     assert(!match("!(boo).txt", "foo.txt", { extended: false }));
@@ -360,8 +361,7 @@ Deno.test({
 });
 
 Deno.test({
-  name:
-    "[path] globToRegExp() Special extended characters should match themselves",
+  name: "globToRegExp() matches special extended characters with themselves",
   fn() {
     const glob = "\\/$^+.()=!|,.*";
     assert(match(glob, glob));
@@ -370,7 +370,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Special extended characters in range",
+  name: "globToRegExp() matches special extended characters in range",
   fn() {
     assertEquals(globToRegExp("[?*+@!|]", { os: "linux" }), /^[?*+@!|]\/*$/);
     assertEquals(globToRegExp("[!?*+@!|]", { os: "linux" }), /^[^?*+@!|]\/*$/);
@@ -378,9 +378,9 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Special RegExp characters in range",
+  name: "globToRegExp() matches special RegExp characters in range",
   fn() {
-    // Excluding characters checked in the previous test.
+    // Excluding characters checksed in the previous test.
     assertEquals(globToRegExp("[\\\\$^.=]", { os: "linux" }), /^[\\$^.=]\/*$/);
     assertEquals(
       globToRegExp("[!\\\\$^.=]", { os: "linux" }),
@@ -391,7 +391,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Repeating separators",
+  name: "globToRegExp() checks repeating separators",
   fn() {
     assert(match("foo/bar", "foo//bar"));
     assert(match("foo//bar", "foo/bar"));
@@ -403,7 +403,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Trailing separators",
+  name: "globToRegExp() checks trailing separators",
   fn() {
     assert(match("foo", "foo/"));
     assert(match("foo/", "foo"));
@@ -415,7 +415,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Backslashes on Windows",
+  name: "globToRegExp() checks backslashes on Windows",
   fn() {
     assert(match("foo/bar", "foo\\bar", { os: "windows" }));
     assert(match("foo\\bar", "foo/bar", { os: "windows" }));
@@ -427,7 +427,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Unclosed groups",
+  name: "globToRegExp() checks unclosed groups",
   fn() {
     assert(match("{foo,bar}/[ab", "foo/[ab"));
     assert(match("{foo,bar}/{foo,bar", "foo/{foo,bar"));
@@ -442,7 +442,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Escape glob characters",
+  name: "globToRegExp() escapes glob characters",
   fn() {
     assert(match("\\[ab]", "[ab]", { os: "linux" }));
     assert(match("`[ab]", "[ab]", { os: "windows" }));
@@ -466,7 +466,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] globToRegExp() Dangling escape prefix",
+  name: "globToRegExp() checks dangling escape prefix",
   fn() {
     assert(match("{foo,bar}/[ab]\\", "foo/[ab]\\", { os: "linux" }));
     assert(match("{foo,bar}/[ab]`", "foo/[ab]`", { os: "windows" }));
@@ -474,7 +474,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] GlobToRegExpOptions::extended",
+  name: "globToRegExp() checks options.extended",
   fn() {
     const pattern1 = globToRegExp("?(foo|bar)");
     assertEquals("foo".match(pattern1)?.[0], "foo");
@@ -488,7 +488,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] GlobToRegExpOptions::globstar",
+  name: "globToRegExp() checks options.globstar",
   fn() {
     const pattern1 = globToRegExp("**/foo");
     assertEquals("foo".match(pattern1)?.[0], "foo");
@@ -502,7 +502,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] GlobToRegExpOptions::caseInsensitive",
+  name: "globToRegExp() checks options.caseInsensitive",
   fn() {
     const pattern1 = globToRegExp("foo/bar", { caseInsensitive: false });
     assertEquals("foo/bar".match(pattern1)?.[0], "foo/bar");
@@ -515,7 +515,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] GlobToRegExpOptions::os",
+  name: "globToRegExp() checks options.os",
   fn() {
     const pattern1 = globToRegExp("foo/bar", { os: "linux" });
     assertEquals("foo/bar".match(pattern1)?.[0], "foo/bar");
@@ -528,7 +528,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "[path] isGlob()",
+  name: "isGlob()",
   fn() {
     // should be true if valid glob pattern
     assert(isGlob("!foo.js"));
@@ -634,10 +634,10 @@ Deno.test({
   },
 });
 
-Deno.test("[path] normalizeGlob() Globstar", function () {
+Deno.test("normalizeGlob() checks options.globstar", function () {
   assertEquals(normalizeGlob(`**${SEP}..`, { globstar: true }), `**${SEP}..`);
 });
 
-Deno.test("[path] joinGlobs() Globstar", function () {
+Deno.test("joinGlobs() checks options.globstar", function () {
   assertEquals(joinGlobs(["**", ".."], { globstar: true }), `**${SEP}..`);
 });

--- a/path/is_absolute_test.ts
+++ b/path/is_absolute_test.ts
@@ -4,14 +4,14 @@
 import { assertEquals } from "../assert/mod.ts";
 import * as path from "./mod.ts";
 
-Deno.test("isAbsolute", function () {
+Deno.test("posix.isAbsolute()", function () {
   assertEquals(path.posix.isAbsolute("/home/foo"), true);
   assertEquals(path.posix.isAbsolute("/home/foo/.."), true);
   assertEquals(path.posix.isAbsolute("bar/"), false);
   assertEquals(path.posix.isAbsolute("./baz"), false);
 });
 
-Deno.test("isAbsoluteWin32", function () {
+Deno.test("win32.isAbsolute()", function () {
   assertEquals(path.win32.isAbsolute("/"), true);
   assertEquals(path.win32.isAbsolute("//"), true);
   assertEquals(path.win32.isAbsolute("//server"), true);

--- a/path/join_test.ts
+++ b/path/join_test.ts
@@ -106,7 +106,7 @@ const windowsJoinTests = [
   [["c:", "file"], "c:\\file"],
 ];
 
-Deno.test("join", function () {
+Deno.test("posix.join()", function () {
   joinTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.posix.join.apply(null, _p);
@@ -114,7 +114,7 @@ Deno.test("join", function () {
   });
 });
 
-Deno.test("joinWin32", function () {
+Deno.test("win32.join()", function () {
   joinTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.win32.join.apply(null, _p).replace(backslashRE, "/");

--- a/path/parse_format_test.ts
+++ b/path/parse_format_test.ts
@@ -131,20 +131,20 @@ function checkFormat(
   });
 }
 
-Deno.test("parseWin32", function () {
+Deno.test("win32.parse()", function () {
   checkParseFormat(win32, winPaths);
   checkSpecialCaseParseFormat(win32, winSpecialCaseParseTests);
 });
 
-Deno.test("parse", function () {
+Deno.test("posix.parse()", function () {
   checkParseFormat(posix, unixPaths);
 });
 
-Deno.test("formatWin32", function () {
+Deno.test("win32.format()", function () {
   checkFormat(win32, winSpecialCaseFormatTests);
 });
 
-Deno.test("format", function () {
+Deno.test("posix.format()", function () {
   checkFormat(posix, unixSpecialCaseFormatTests);
 });
 
@@ -180,7 +180,7 @@ const posixTrailingTests: ParseTestCase[] = [
   ],
 ];
 
-Deno.test("parseTrailingWin32", function () {
+Deno.test("win32.parseTrailing()", function () {
   windowsTrailingTests.forEach(function (p) {
     const actual = win32.parse(p[0]);
     const expected = p[1];
@@ -188,7 +188,7 @@ Deno.test("parseTrailingWin32", function () {
   });
 });
 
-Deno.test("parseTrailing", function () {
+Deno.test("parseTrailing()", function () {
   posixTrailingTests.forEach(function (p) {
     const actual = posix.parse(p[0]);
     const expected = p[1];

--- a/path/relative_test.ts
+++ b/path/relative_test.ts
@@ -49,7 +49,7 @@ const relativeTests = {
   ],
 };
 
-Deno.test("relative", function () {
+Deno.test("posix.relative()", function () {
   relativeTests.posix.forEach(function (p) {
     const expected = p[2];
     const actual = path.posix.relative(p[0], p[1]);
@@ -57,7 +57,7 @@ Deno.test("relative", function () {
   });
 });
 
-Deno.test("relativeWin32", function () {
+Deno.test("win32.relative()", function () {
   relativeTests.win32.forEach(function (p) {
     const expected = p[2];
     const actual = path.win32.relative(p[0], p[1]);

--- a/path/resolve_test.ts
+++ b/path/resolve_test.ts
@@ -33,7 +33,7 @@ const posixTests =
     [["/foo/tmp.3/", "../tmp.3/cycles/root.js"], "/foo/tmp.3/cycles/root.js"],
   ];
 
-Deno.test("resolve", function () {
+Deno.test("posix.resolve()", function () {
   posixTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.posix.resolve.apply(null, _p);
@@ -41,7 +41,7 @@ Deno.test("resolve", function () {
   });
 });
 
-Deno.test("resolveWin32", function () {
+Deno.test("win32.resolve()", function () {
   windowsTests.forEach(function (p) {
     const _p = p[0] as string[];
     const actual = path.win32.resolve.apply(null, _p);

--- a/path/to_file_url_test.ts
+++ b/path/to_file_url_test.ts
@@ -3,7 +3,7 @@
 import { posix, win32 } from "./mod.ts";
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 
-Deno.test("[path] toFileUrl", function () {
+Deno.test("posix.toFileUrl()", function () {
   assertEquals(posix.toFileUrl("/home/foo").href, "file:///home/foo");
   assertEquals(posix.toFileUrl("/home/ ").href, "file:///home/%20");
   assertEquals(posix.toFileUrl("/home/%20").href, "file:///home/%2520");
@@ -26,7 +26,7 @@ Deno.test("[path] toFileUrl", function () {
   assertEquals(posix.toFileUrl("//:/home/foo").href, "file:///:/home/foo");
 });
 
-Deno.test("[path] toFileUrl (win32)", function () {
+Deno.test("win32.toFileUrl()", function () {
   assertEquals(win32.toFileUrl("/home/foo").href, "file:///home/foo");
   assertEquals(win32.toFileUrl("/home/ ").href, "file:///home/%20");
   assertEquals(win32.toFileUrl("/home/%20").href, "file:///home/%2520");

--- a/path/zero_length_strings_test.ts
+++ b/path/zero_length_strings_test.ts
@@ -5,10 +5,7 @@ import { assertEquals } from "../assert/mod.ts";
 import * as path from "./mod.ts";
 
 const pwd = Deno.cwd();
-
-Deno.test("joinZeroLength", function () {
-  // join will internally ignore all the zero-length strings and it will return
-  // '.' if the joined string is a zero-length string.
+Deno.test(`join() returns "." if input is empty`, function () {
   assertEquals(path.posix.join(""), ".");
   assertEquals(path.posix.join("", ""), ".");
   if (path.win32) assertEquals(path.win32.join(""), ".");
@@ -17,30 +14,23 @@ Deno.test("joinZeroLength", function () {
   assertEquals(path.join(pwd, ""), pwd);
 });
 
-Deno.test("normalizeZeroLength", function () {
-  // normalize will return '.' if the input is a zero-length string
+Deno.test(`normalize() returns "." if input is empty`, function () {
   assertEquals(path.posix.normalize(""), ".");
   if (path.win32) assertEquals(path.win32.normalize(""), ".");
   assertEquals(path.normalize(pwd), pwd);
 });
 
-Deno.test("isAbsoluteZeroLength", function () {
-  // Since '' is not a valid path in any of the common environments,
-  // return false
+Deno.test("isAbsolute() retuns false if input is empty", function () {
   assertEquals(path.posix.isAbsolute(""), false);
   if (path.win32) assertEquals(path.win32.isAbsolute(""), false);
 });
 
-Deno.test("resolveZeroLength", function () {
-  // resolve, internally ignores all the zero-length strings and returns the
-  // current working directory
+Deno.test("resolve() returns current working directory if input is empty", function () {
   assertEquals(path.resolve(""), pwd);
   assertEquals(path.resolve("", ""), pwd);
 });
 
-Deno.test("relativeZeroLength", function () {
-  // relative, internally calls resolve. So, '' is actually the current
-  // directory
+Deno.test("relative() returns current working directory if input is empty", function () {
   assertEquals(path.relative("", pwd), "");
   assertEquals(path.relative(pwd, ""), "");
   assertEquals(path.relative(pwd, pwd), "");


### PR DESCRIPTION
Ref: https://github.com/denoland/deno_std/issues/3754

I added `posix` and `win32` as prefixes to the function name (for example ` posix.toFileUrl()`).

Question: lots of tests do not have a description. Most of these would repeat the information in the function name. Do all tests need a description?