### PR TITLE
fix: add `[Symbol.dispose]()` to `MockListener()`

### DIFF
--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -89,6 +89,10 @@ class MockListener implements Deno.Listener {
       : Promise.resolve(this.conn);
   }
 
+  [Symbol.dispose]() {
+    this.close();
+  }
+
   close() {
     this.#closed = true;
   }


### PR DESCRIPTION
This should fix the current CI issue.