### PR TITLE
fix(fmt): format duration rounding error.

### DIFF
--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -50,14 +50,15 @@ const keyList: Record<keyof DurationObject, string> = {
 function millisecondsToDurationObject(ms: number): DurationObject {
   // Duration cannot be negative
   const millis = Math.abs(ms);
+  const millisFraction = millis.toFixed(7).slice(-7, -1)
   return {
     d: Math.trunc(millis / 86400000),
     h: Math.trunc(millis / 3600000) % 24,
     m: Math.trunc(millis / 60000) % 60,
     s: Math.trunc(millis / 1000) % 60,
-    ms: +millis.toFixed(0).slice(-3),
-    us: +millis.toFixed(6).slice(-6, -3),
-    ns: +millis.toFixed(6).slice(-3),
+    ms: Math.trunc(millis) % 1000,
+    us: +millisFraction.slice(0, 3),
+    ns: +millisFraction.slice(3, 6)
   };
 }
 

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -50,7 +50,7 @@ const keyList: Record<keyof DurationObject, string> = {
 function millisecondsToDurationObject(ms: number): DurationObject {
   // Duration cannot be negative
   const millis = Math.abs(ms);
-  const millisFraction = millis.toFixed(7).slice(-7, -1)
+  const millisFraction = millis.toFixed(7).slice(-7, -1);
   return {
     d: Math.trunc(millis / 86400000),
     h: Math.trunc(millis / 3600000) % 24,
@@ -58,7 +58,7 @@ function millisecondsToDurationObject(ms: number): DurationObject {
     s: Math.trunc(millis / 1000) % 60,
     ms: Math.trunc(millis) % 1000,
     us: +millisFraction.slice(0, 3),
-    ns: +millisFraction.slice(3, 6)
+    ns: +millisFraction.slice(3, 6),
   };
 }
 

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -49,15 +49,15 @@ const keyList: Record<keyof DurationObject, string> = {
 /** Parse milliseconds into a duration. */
 function millisecondsToDurationObject(ms: number): DurationObject {
   // Duration cannot be negative
-  const absolute_ms = Math.abs(ms);
+  const millis = Math.abs(ms);
   return {
-    d: Math.trunc(absolute_ms / 86400000),
-    h: Math.trunc(absolute_ms / 3600000) % 24,
-    m: Math.trunc(absolute_ms / 60000) % 60,
-    s: Math.trunc(absolute_ms / 1000) % 60,
-    ms: Math.trunc(absolute_ms) % 1000,
-    us: Math.trunc(absolute_ms * 1000) % 1000,
-    ns: Math.trunc(absolute_ms * 1000000) % 1000,
+    d: Math.trunc(millis / 86400000),
+    h: Math.trunc(millis / 3600000) % 24,
+    m: Math.trunc(millis / 60000) % 60,
+    s: Math.trunc(millis / 1000) % 60,
+    ms: +millis.toFixed(0).slice(-3),
+    us: +millis.toFixed(6).slice(-6, -3),
+    ns: +millis.toFixed(6).slice(-3),
   };
 }
 

--- a/fmt/duration_test.ts
+++ b/fmt/duration_test.ts
@@ -62,3 +62,10 @@ Deno.test({
     assertEquals(format(99674, { ignoreZero: true }), "1m 39s 674ms");
   },
 });
+
+Deno.test({
+  name: "format duration rounding error",
+  fn() {
+    assertEquals(format(16.342, { ignoreZero: true }), "16ms 342µs");
+  },
+});


### PR DESCRIPTION
this works-around rounding errors in `millisecondsToDurationObject()` of `std/fmt/duration.ts` by converting values in milliseconds or less into as string and use `String.slice()`. 

use-case: I get durations like `16.342` millis when I round my values to microseconds.

`main`:
```ts
> import { format } from "https://deno.land/std@0.204.0/fmt/duration.ts";
> format(16.342, { ignoreZero: true })
"16ms 341µs 999ns"
```

`hastebrot/fix-duration-format-rounding-error`:
```ts
Deno.test({
  name: "format duration rounding error",
  fn() {
    assertEquals(format(16.342, { ignoreZero: true }), "16ms 342µs");
  },
});
```

TODO:
- [x] provide example and tests
- [ ] check if rounding problems are fixed in #3672

related to #3672