### PR TITLE
chore: use `Deno.readTextFile()` and `Deno.writeTextFile()` in tests

### DIFF
--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -80,7 +80,7 @@ testCopy(
     const srcFile = path.join(testdataDir, "copy_file.txt");
     const destFile = path.join(tempDir, "copy_file_copy.txt");
 
-    const srcContent = new TextDecoder().decode(await Deno.readFile(srcFile));
+    const srcContent = await Deno.readTextFile(srcFile);
 
     assert(await Deno.lstat(srcFile), "source should exist before copy");
     await assertRejects(
@@ -93,7 +93,7 @@ testCopy(
     assert(await Deno.lstat(srcFile), "source should exist after copy");
     assert(await Deno.lstat(destFile), "destination should exist after copy");
 
-    const destContent = new TextDecoder().decode(await Deno.readFile(destFile));
+    const destContent = await Deno.readTextFile(destFile);
 
     assertEquals(
       srcContent,
@@ -111,21 +111,16 @@ testCopy(
     );
 
     // Modify destination file.
-    await Deno.writeFile(destFile, new TextEncoder().encode("txt copy"));
 
-    assertEquals(
-      new TextDecoder().decode(await Deno.readFile(destFile)),
-      "txt copy",
-    );
+    await Deno.writeTextFile(destFile, "txt copy");
+
+    assertEquals(await Deno.readTextFile(destFile), "txt copy");
 
     // Copy again with overwrite option.
     await copy(srcFile, destFile, { overwrite: true });
 
     // Make sure the file has been overwritten.
-    assertEquals(
-      new TextDecoder().decode(await Deno.readFile(destFile)),
-      "txt",
-    );
+    assertEquals(await Deno.readTextFile(destFile), "txt");
   },
 );
 
@@ -209,12 +204,12 @@ testCopy(
 
     // After copy. The source and destination should have the same content.
     assertEquals(
-      new TextDecoder().decode(await Deno.readFile(srcFile)),
-      new TextDecoder().decode(await Deno.readFile(destFile)),
+      await Deno.readTextFile(srcFile),
+      await Deno.readTextFile(destFile),
     );
     assertEquals(
-      new TextDecoder().decode(await Deno.readFile(srcNestFile)),
-      new TextDecoder().decode(await Deno.readFile(destNestFile)),
+      await Deno.readTextFile(srcNestFile),
+      await Deno.readTextFile(destNestFile),
     );
 
     // Copy again without overwrite option and it should throw an error.
@@ -227,20 +222,14 @@ testCopy(
     );
 
     // Modify the file in the destination directory.
-    await Deno.writeFile(destNestFile, new TextEncoder().encode("nest copy"));
-    assertEquals(
-      new TextDecoder().decode(await Deno.readFile(destNestFile)),
-      "nest copy",
-    );
+    await Deno.writeTextFile(destNestFile, "nest copy");
+    assertEquals(await Deno.readTextFile(destNestFile), "nest copy");
 
     // Copy again with overwrite option.
     await copy(srcDir, destDir, { overwrite: true });
 
     // Make sure the file has been overwritten.
-    assertEquals(
-      new TextDecoder().decode(await Deno.readFile(destNestFile)),
-      "nest",
-    );
+    assertEquals(await Deno.readTextFile(destNestFile), "nest");
   },
 );
 

--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -197,9 +197,9 @@ for (const s of scenes) {
     try {
       await Deno.mkdir(testfolder);
 
-      await Deno.writeFile(
+      await Deno.writeTextFile(
         path.join(testfolder, "child.txt"),
-        new TextEncoder().encode("hello world"),
+        "hello world",
       );
 
       try {

--- a/fs/ensure_link_test.ts
+++ b/fs/ensure_link_test.ts
@@ -53,14 +53,10 @@ Deno.test("ensureLinkIfItExist", async function () {
   // har link success. try to change one of them. they should be change both.
 
   // let's change origin file.
-  await Deno.writeFile(testFile, new TextEncoder().encode("123"));
+  await Deno.writeTextFile(testFile, "123");
 
-  const testFileContent1 = new TextDecoder().decode(
-    await Deno.readFile(testFile),
-  );
-  const linkFileContent1 = new TextDecoder().decode(
-    await Deno.readFile(testFile),
-  );
+  const testFileContent1 = await Deno.readTextFile(testFile);
+  const linkFileContent1 = await Deno.readTextFile(testFile);
 
   assertEquals(testFileContent1, "123");
   assertEquals(testFileContent1, linkFileContent1);
@@ -68,12 +64,8 @@ Deno.test("ensureLinkIfItExist", async function () {
   // let's change link file.
   await Deno.writeFile(testFile, new TextEncoder().encode("abc"));
 
-  const testFileContent2 = new TextDecoder().decode(
-    await Deno.readFile(testFile),
-  );
-  const linkFileContent2 = new TextDecoder().decode(
-    await Deno.readFile(testFile),
-  );
+  const testFileContent2 = await Deno.readTextFile(testFile);
+  const linkFileContent2 = await Deno.readTextFile(testFile);
 
   assertEquals(testFileContent2, "abc");
   assertEquals(testFileContent2, linkFileContent2);

--- a/fs/move_test.ts
+++ b/fs/move_test.ts
@@ -96,8 +96,8 @@ Deno.test("moveFileIfDestExists", async function () {
   ]);
 
   // make sure the test file have been created
-  assertEquals(new TextDecoder().decode(await Deno.readFile(srcFile)), "src");
-  assertEquals(new TextDecoder().decode(await Deno.readFile(destFile)), "dest");
+  assertEquals(await Deno.readTextFile(srcFile), "src");
+  assertEquals(await Deno.readTextFile(destFile), "dest");
 
   // move it without override
   await assertRejects(
@@ -119,7 +119,7 @@ Deno.test("moveFileIfDestExists", async function () {
   );
 
   await assertRejects(async () => await Deno.lstat(srcFile));
-  assertEquals(new TextDecoder().decode(await Deno.readFile(destFile)), "src");
+  assertEquals(await Deno.readTextFile(destFile), "src");
 
   // clean up
   await Promise.all([
@@ -145,9 +145,7 @@ Deno.test("moveDirectory", async function () {
   assert(await Deno.lstat(destDir));
   assert(await Deno.lstat(destFile));
 
-  const destFileContent = new TextDecoder().decode(
-    await Deno.readFile(destFile),
-  );
+  const destFileContent = await Deno.readTextFile(destFile);
   assertEquals(destFileContent, "src");
 
   await Deno.remove(destDir, { recursive: true });
@@ -180,9 +178,7 @@ Deno.test(
     assert(await Deno.lstat(destDir));
     assert(await Deno.lstat(destFile));
 
-    const destFileContent = new TextDecoder().decode(
-      await Deno.readFile(destFile),
-    );
+    const destFileContent = await Deno.readTextFile(destFile);
     assertEquals(destFileContent, "src");
 
     await Deno.remove(destDir, { recursive: true });

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -193,9 +193,7 @@ Deno.test(
         "video/mp2t",
       );
       const downloadedFile = await res.text();
-      const localFile = new TextDecoder().decode(
-        await Deno.readFile(join(moduleDir, "mod.ts")),
-      );
+      const localFile = await Deno.readTextFile(join(moduleDir, "mod.ts"));
       assertEquals(downloadedFile, localFile);
     } finally {
       await killFileServer();
@@ -211,8 +209,8 @@ Deno.test(
       const res = await fetch("http://localhost:4507/hello.html");
       assertEquals(res.headers.get("content-type"), "text/html; charset=UTF-8");
       const downloadedFile = await res.text();
-      const localFile = new TextDecoder().decode(
-        await Deno.readFile(join(testdataDir, "hello.html")),
+      const localFile = await Deno.readTextFile(
+        join(testdataDir, "hello.html"),
       );
       assertEquals(downloadedFile, localFile);
     } finally {
@@ -232,8 +230,8 @@ Deno.test(
         "text/plain; charset=UTF-8",
       );
       const downloadedFile = await res.text();
-      const localFile = new TextDecoder().decode(
-        await Deno.readFile(join(testdataDir, "file#2.txt")),
+      const localFile = await Deno.readTextFile(
+        join(testdataDir, "file#2.txt"),
       );
       assertEquals(downloadedFile, localFile);
     } finally {
@@ -473,9 +471,7 @@ Deno.test("file_server should ignore query params", async () => {
     const res = await fetch("http://localhost:4507/mod.ts?key=value");
     assertEquals(res.status, 200);
     const downloadedFile = await res.text();
-    const localFile = new TextDecoder().decode(
-      await Deno.readFile(join(moduleDir, "mod.ts")),
-    );
+    const localFile = await Deno.readTextFile(join(moduleDir, "mod.ts"));
     assertEquals(downloadedFile, localFile);
   } finally {
     await killFileServer();
@@ -736,8 +732,8 @@ Deno.test(
       );
       const text = await res.text();
 
-      const localFile = new TextDecoder().decode(
-        await Deno.readFile(join(testdataDir, "test file.txt")),
+      const localFile = await Deno.readTextFile(
+        join(testdataDir, "test file.txt"),
       );
 
       const contentLength = await getTestFileSize();
@@ -1245,9 +1241,7 @@ Deno.test(
     const req = new Request("http://localhost:4507/testdata/test file.txt");
     const testdataPath = join(testdataDir, "test file.txt");
     const res = await serveFile(req, testdataPath);
-    const localFile = new TextDecoder().decode(
-      await Deno.readFile(testdataPath),
-    );
+    const localFile = await Deno.readTextFile(testdataPath);
     assertEquals(res.status, 200);
     assertEquals(await res.text(), localFile);
   },


### PR DESCRIPTION
While looking at the failing HTTP tests, I realised these should be cleaned up.