### PR TITLE
docs: add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+- Please email security@deno.com with sufficient information to reproduce the
+  problem as quickly as possible, such as reproduction steps and
+  `deno --version` output.
+- Please do not take advantage of the vulnerability or problem you have
+  discovered.
+- Please do not publish or reveal the problem until it has been resolved.
+- Please do not use attacks on physical security or applications of third
+  parties.
+
+## Our Commitment
+
+- We strive to resolve all problems as quickly as possible, and are more than
+  happy to play an active role in publication of writeups after the problem is
+  resolved.
+- If you act in accordance with this policy, we will not take legal action
+  against you in regard to your report.
+- We will handle your report with strict confidentiality, and not pass on your
+  personal details to third parties without your permission.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -20,3 +20,8 @@
   against you in regard to your report.
 - We will handle your report with strict confidentiality, and not pass on your
   personal details to third parties without your permission.
+
+## Further Reading
+
+See the Security Policy for the Deno CLI
+[here](https://github.com/denoland/deno/blob/main/.github/SECURITY.md).


### PR DESCRIPTION
Inspired mainly by the [Deno CLI's Security Policy](https://github.com/denoland/deno/blob/main/.github/SECURITY.md).