### PR TITLE
feat(cli): `promptSecret()`

### DIFF
--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -1,0 +1,57 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+const input = Deno.stdin;
+const output = Deno.stdout;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const LF = "\n".charCodeAt(0);
+const CR = "\r".charCodeAt(0);
+
+/**
+ * Shows the given message and waits for the user's input. Returns the user's input as string.
+ * This is similar to `prompt()` but it print user's input as `*` to prevent password from being shown.
+ * Use an empty `mask` if you don't want to show any character.
+ */
+export function promptSecret(
+  message = "Password ",
+  mask = "*",
+): string | null {
+  if (!Deno.isatty(input.rid)) {
+    return null;
+  }
+
+  const maskChar = encoder.encode(mask);
+  const callback = mask === "" ? () => {} : () => {
+    output.writeSync(maskChar);
+  };
+  output.writeSync(encoder.encode(message));
+
+  Deno.stdin.setRaw(true, { cbreak: true });
+  try {
+    return readLineFromStdinSync(callback);
+  } finally {
+    Deno.stdin.setRaw(false);
+  }
+}
+
+// Slightly modified from Deno's runtime/js/41_prompt.js
+// This implementation immediately break on CR or LF and accept callback.
+// The original version waits LF when CR is received.
+// https://github.com/denoland/deno/blob/e4593873a9c791238685dfbb45e64b4485884174/runtime/js/41_prompt.js#L52-L77
+function readLineFromStdinSync(callback: () => void): string {
+  const c = new Uint8Array(1);
+  const buf = [];
+
+  while (true) {
+    const n = input.readSync(c);
+    if (n === null || n === 0) {
+      break;
+    }
+    if (c[0] === CR || c[0] === LF) {
+      break;
+    }
+    buf.push(c[0]);
+    callback();
+  }
+  return decoder.decode(new Uint8Array(buf));
+}

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -13,7 +13,7 @@ const CR = "\r".charCodeAt(0);
  * Use an empty `mask` if you don't want to show any character.
  */
 export function promptSecret(
-  message = "Password ",
+  message = "Secret ",
   mask = "*",
 ): string | null {
   if (!Deno.isatty(input.rid)) {

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -10,6 +10,11 @@ const BS = "\b".charCodeAt(0); // ^H - Backspace on Linux and Windows
 const DEL = 0x7f; // ^? - Backspace on macOS
 const CLR = encoder.encode("\r\u001b[K"); // Clear the current line
 
+// The `cbreak` option is not supported on Windows
+const setRawOptions = Deno.build.os === "windows"
+  ? undefined
+  : { cbreak: true };
+
 export type PromptSecretOptions = {
   /** A character to print instead of the user's input. */
   mask?: string;
@@ -36,7 +41,7 @@ export function promptSecret(
   };
   output.writeSync(encoder.encode(message));
 
-  Deno.stdin.setRaw(true, { cbreak: true });
+  Deno.stdin.setRaw(true, setRawOptions);
   try {
     return readLineFromStdinSync(callback);
   } finally {

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -21,7 +21,7 @@ export function promptSecret(
   }
 
   const maskChar = encoder.encode(mask);
-  const callback = mask === "" ? () => {} : () => {
+  const callback = mask === "" ? undefined : () => {
     output.writeSync(maskChar);
   };
   output.writeSync(encoder.encode(message));
@@ -38,7 +38,7 @@ export function promptSecret(
 // This implementation immediately break on CR or LF and accept callback.
 // The original version waits LF when CR is received.
 // https://github.com/denoland/deno/blob/e4593873a9c791238685dfbb45e64b4485884174/runtime/js/41_prompt.js#L52-L77
-function readLineFromStdinSync(callback: () => void): string {
+function readLineFromStdinSync(callback?: () => void): string {
   const c = new Uint8Array(1);
   const buf = [];
 
@@ -51,7 +51,7 @@ function readLineFromStdinSync(callback: () => void): string {
       break;
     }
     buf.push(c[0]);
-    callback();
+    if (callback) callback();
   }
   return decoder.decode(new Uint8Array(buf));
 }

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -4,8 +4,11 @@ const input = Deno.stdin;
 const output = Deno.stdout;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
-const LF = "\n".charCodeAt(0);
-const CR = "\r".charCodeAt(0);
+const LF = "\n".charCodeAt(0); // ^J - Enter on Linux
+const CR = "\r".charCodeAt(0); // ^M - Enter on macOS and Windows (CRLF)
+const BS = "\b".charCodeAt(0); // ^H - Backspace on Linux and Windows
+const DEL = 0x7f; // ^? - Backspace on macOS
+const CLR = encoder.encode("\r\u001b[K"); // Clear the current line
 
 /**
  * Shows the given message and waits for the user's input. Returns the user's input as string.
@@ -20,9 +23,10 @@ export function promptSecret(
     return null;
   }
 
-  const maskChar = encoder.encode(mask);
-  const callback = mask === "" ? undefined : () => {
-    output.writeSync(maskChar);
+  const callback = mask === "" ? undefined : (n: number) => {
+    // Clear the current line
+    output.writeSync(CLR);
+    output.writeSync(encoder.encode(`${message}${mask.repeat(n)}`));
   };
   output.writeSync(encoder.encode(message));
 
@@ -30,6 +34,7 @@ export function promptSecret(
   try {
     return readLineFromStdinSync(callback);
   } finally {
+    output.writeSync(CLR);
     Deno.stdin.setRaw(false);
   }
 }
@@ -38,7 +43,7 @@ export function promptSecret(
 // This implementation immediately break on CR or LF and accept callback.
 // The original version waits LF when CR is received.
 // https://github.com/denoland/deno/blob/e4593873a9c791238685dfbb45e64b4485884174/runtime/js/41_prompt.js#L52-L77
-function readLineFromStdinSync(callback?: () => void): string {
+function readLineFromStdinSync(callback?: (n: number) => void): string {
   const c = new Uint8Array(1);
   const buf = [];
 
@@ -50,8 +55,12 @@ function readLineFromStdinSync(callback?: () => void): string {
     if (c[0] === CR || c[0] === LF) {
       break;
     }
-    buf.push(c[0]);
-    if (callback) callback();
+    if (c[0] === BS || c[0] === DEL) {
+      buf.pop();
+    } else {
+      buf.push(c[0]);
+    }
+    if (callback) callback(buf.length);
   }
   return decoder.decode(new Uint8Array(buf));
 }


### PR DESCRIPTION
The function is similar to `prompt`, but it prints the user's input as `*` to prevent the password from being shown.

Sometimes, I find the need for this type of function when creating CLI applications, so I decided to implement it. I'm not certain whether it should be included in the standard library, as it's somewhat challenging to test since it hooks into stdin. Therefore, I couldn't provide tests (or please let me know if there is a way).

Please inform me if this function shouldn't be included in the standard library, and I'll develop it as a third-party module. :+1: