### PR TITLE
refactor: remove use of `deferred()`

### DIFF
--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -1,25 +1,24 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertRejects } from "../assert/mod.ts";
-import { deferred } from "./deferred.ts";
 import { abortable } from "./abortable.ts";
 
 Deno.test("[async] abortable (Promise)", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
-  const result = await abortable(p, c.signal);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
+  const result = await abortable(promise, c.signal);
   assertEquals(result, "Hello");
   clearTimeout(t);
 });
 
 Deno.test("[async] abortable (Promise) with signal aborted after delay", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
   setTimeout(() => c.abort(), 50);
   await assertRejects(
     async () => {
-      await abortable(p, c.signal);
+      await abortable(promise, c.signal);
     },
     DOMException,
     "AbortError",
@@ -29,12 +28,12 @@ Deno.test("[async] abortable (Promise) with signal aborted after delay", async (
 
 Deno.test("[async] abortable (Promise) with already aborted signal", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
   c.abort();
   await assertRejects(
     async () => {
-      await abortable(p, c.signal);
+      await abortable(promise, c.signal);
     },
     DOMException,
     "AbortError",
@@ -44,11 +43,11 @@ Deno.test("[async] abortable (Promise) with already aborted signal", async () =>
 
 Deno.test("[async] abortable (AsyncIterable)", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";
-    await p;
+    await promise;
     yield "World";
   };
   const items: string[] = [];
@@ -61,11 +60,11 @@ Deno.test("[async] abortable (AsyncIterable)", async () => {
 
 Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";
-    await p;
+    await promise;
     yield "World";
   };
   setTimeout(() => c.abort(), 50);
@@ -85,11 +84,11 @@ Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", a
 
 Deno.test("[async] abortable (AsyncIterable) with already aborted signal", async () => {
   const c = new AbortController();
-  const p = deferred();
-  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const { promise, resolve } = Promise.withResolvers();
+  const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";
-    await p;
+    await promise;
     yield "World";
   };
   c.abort();

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -4,7 +4,7 @@ import { abortable } from "./abortable.ts";
 
 Deno.test("[async] abortable (Promise)", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   const result = await abortable(promise, c.signal);
   assertEquals(result, "Hello");
@@ -13,7 +13,7 @@ Deno.test("[async] abortable (Promise)", async () => {
 
 Deno.test("[async] abortable (Promise) with signal aborted after delay", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   setTimeout(() => c.abort(), 50);
   await assertRejects(
@@ -28,7 +28,7 @@ Deno.test("[async] abortable (Promise) with signal aborted after delay", async (
 
 Deno.test("[async] abortable (Promise) with already aborted signal", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   c.abort();
   await assertRejects(
@@ -43,7 +43,7 @@ Deno.test("[async] abortable (Promise) with already aborted signal", async () =>
 
 Deno.test("[async] abortable (AsyncIterable)", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";
@@ -60,7 +60,7 @@ Deno.test("[async] abortable (AsyncIterable)", async () => {
 
 Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";
@@ -84,7 +84,7 @@ Deno.test("[async] abortable (AsyncIterable) with signal aborted after delay", a
 
 Deno.test("[async] abortable (AsyncIterable) with already aborted signal", async () => {
   const c = new AbortController();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<string>();
   const t = setTimeout(() => resolve("Hello"), 100);
   const a = async function* () {
     yield "Hello";

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -85,7 +85,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
       }
       // Clear the `yields` list and reset the `signal` promise.
       this.#yields.length = 0;
-      this.#signal = Promise.withResolvers();
+      this.#signal = Promise.withResolvers<void>();
     }
   }
 

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1081,8 +1081,8 @@ Deno.test(
     };
     const listener = Deno.listen(listenOptions);
 
-    const onRequest = Promise.withResolvers();
-    const postRespondWith = Promise.withResolvers();
+    const onRequest = Promise.withResolvers<void>();
+    const postRespondWith = Promise.withResolvers<void>();
 
     const handler = async () => {
       onRequest.resolve();
@@ -1120,7 +1120,7 @@ Deno.test("Server should not reject when the handler throws", async () => {
   };
   const listener = Deno.listen(listenOptions);
 
-  const postRespondWith = Promise.withResolvers();
+  const postRespondWith = Promise.withResolvers<void>();
 
   const handler = () => {
     try {
@@ -1155,7 +1155,7 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   const url = `https://${listenOptions.hostname}:${listenOptions.port}/`;
 
   let n = 0;
-  const a = Promise.withResolvers();
+  const a = Promise.withResolvers<void>();
   const connections = new Set();
 
   const handler = (_req: Request, connInfo: ConnInfo) => {

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1103,10 +1103,10 @@ Deno.test(
 
     await writeAll(conn, new TextEncoder().encode(`GET / HTTP/1.0\r\n\r\n`));
 
-    await onRequest;
+    await onRequest.promise;
     conn.close();
 
-    await postRespondWith;
+    await postRespondWith.promise;
     server.close();
 
     await servePromise;
@@ -1137,7 +1137,7 @@ Deno.test("Server should not reject when the handler throws", async () => {
 
   await writeAll(conn, new TextEncoder().encode(`GET / HTTP/1.0\r\n\r\n`));
 
-  await postRespondWith;
+  await postRespondWith.promise;
   conn.close();
   server.close();
   await servePromise;
@@ -1167,7 +1167,7 @@ Deno.test("Server should not close the http2 downstream connection when the resp
           if (n === 3) {
             throw new Error("test-error");
           }
-          await a;
+          await a.promise;
           controller.enqueue(new TextEncoder().encode("a"));
           controller.close();
         },

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -4,7 +4,7 @@ import { mockConn as createMockConn } from "./_mock_conn.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 import { writeAll } from "../streams/write_all.ts";
 import { readAll } from "../streams/read_all.ts";
-import { deferred, delay } from "../async/mod.ts";
+import { delay } from "../async/mod.ts";
 import {
   assert,
   assertEquals,
@@ -1081,8 +1081,8 @@ Deno.test(
     };
     const listener = Deno.listen(listenOptions);
 
-    const onRequest = deferred();
-    const postRespondWith = deferred();
+    const onRequest = Promise.withResolvers();
+    const postRespondWith = Promise.withResolvers();
 
     const handler = async () => {
       onRequest.resolve();
@@ -1120,7 +1120,7 @@ Deno.test("Server should not reject when the handler throws", async () => {
   };
   const listener = Deno.listen(listenOptions);
 
-  const postRespondWith = deferred();
+  const postRespondWith = Promise.withResolvers();
 
   const handler = () => {
     try {
@@ -1155,7 +1155,7 @@ Deno.test("Server should not close the http2 downstream connection when the resp
   const url = `https://${listenOptions.hostname}:${listenOptions.port}/`;
 
   let n = 0;
-  const a = deferred();
+  const a = Promise.withResolvers();
   const connections = new Set();
 
   const handler = (_req: Request, connInfo: ConnInfo) => {

--- a/signal/mod.ts
+++ b/signal/mod.ts
@@ -7,7 +7,6 @@
  */
 
 import { MuxAsyncIterator } from "../async/mux_async_iterator.ts";
-import { deferred } from "../async/deferred.ts";
 
 export type Disposable = { dispose: () => void };
 
@@ -65,15 +64,15 @@ export function signal(
 function createSignalStream(
   signal: Deno.Signal,
 ): AsyncIterable<void> & Disposable {
-  let streamContinues = deferred<boolean>();
+  let streamContinues = Promise.withResolvers<boolean>();
   const handler = () => {
     streamContinues.resolve(true);
   };
   Deno.addSignalListener(signal, handler);
 
   const gen = async function* () {
-    while (await streamContinues) {
-      streamContinues = deferred<boolean>();
+    while (await streamContinues.promise) {
+      streamContinues = Promise.withResolvers<boolean>();
       yield undefined;
     }
   };

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { deferred } from "../async/deferred.ts";
-
 /**
  * Merge multiple streams into a single one, not taking order into account.
  * If a stream ends before other ones, the other will continue adding data,
@@ -10,11 +8,11 @@ import { deferred } from "../async/deferred.ts";
 export function mergeReadableStreams<T>(
   ...streams: ReadableStream<T>[]
 ): ReadableStream<T> {
-  const resolvePromises = streams.map(() => deferred<void>());
+  const resolvePromises = streams.map(() => Promise.withResolvers<void>());
   return new ReadableStream<T>({
     start(controller) {
       let mustClose = false;
-      Promise.all(resolvePromises)
+      Promise.all(resolvePromises.map(({ promise }) => promise))
         .then(() => {
           controller.close();
         })


### PR DESCRIPTION
`deferred()` from `std/async` is now deprecated.

Towards #3718