### PR TITLE
docs(path): fix `@deprecated` note for `isGlob()`

### DIFF
--- a/path/glob.ts
+++ b/path/glob.ts
@@ -6,7 +6,7 @@ export type { GlobToRegExpOptions } from "./glob_to_regexp.ts";
 
 export {
   /**
-   * @deprecated (will be removed in 0.215.0) Import from "std/path/windows/is_glob.ts"
+   * @deprecated (will be removed in 0.215.0) Import from "std/path/is_glob.ts"
    *
    * Test whether the given string is a glob
    */


### PR DESCRIPTION
This PR fixes a `@deprecated` comment so that `isGlob` is imported from [`std/path/is_glob.ts`](https://deno.land/std@0.206.0/path/is_glob.ts) instead of [`std/path/windows/is_glob.ts`](https://deno.land/std@0.206.0/path/windows/is_glob.ts).