### PR TITLE
BREAKING(fs): replace `EOL` enum with OS-dependant constant

### DIFF
--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
 
 /** End-of-line character for POSIX platforms like Linux and macOS. */
 export const LF = "\n" as const;

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -1,13 +1,23 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/** Platform-specific conventions for the line ending format (i.e., the "end-of-line"). */
-export enum EOL {
-  /** Line Feed. Typically used in Unix (and Unix-like) systems. */
-  LF = "\n",
-  /** Carriage Return + Line Feed. Historically used in Windows and early DOS systems. */
-  CRLF = "\r\n",
-}
+/** End-of-line character for POSIX platforms like Linux and macOS. */
+export const LF = "\n" as const;
+
+/** End-of-line character for Windows platforms. */
+export const CRLF = "\r\n" as const;
+
+/**
+ * End-of-line character evaluated for the current platform.
+ *
+ * @example
+ * ```ts
+ * import { EOL } from "https://deno.land/std@$STD_VERSION/fs/eol.ts";
+ *
+ * EOL; // Returns "\n" on POSIX platforms or "\r\n" on Windows
+ * ```
+ */
+export const EOL = Deno.build.os === "windows" ? CRLF : LF;
 
 const regDetect = /(?:\r?\n)/g;
 
@@ -30,14 +40,14 @@ const regDetect = /(?:\r?\n)/g;
  * detect(NoNLinput); // output null
  * ```
  */
-export function detect(content: string): EOL | null {
+export function detect(content: string): typeof EOL | null {
   const d = content.match(regDetect);
   if (!d || d.length === 0) {
     return null;
   }
-  const hasCRLF = d.some((x: string): boolean => x === EOL.CRLF);
+  const hasCRLF = d.some((x: string): boolean => x === CRLF);
 
-  return hasCRLF ? EOL.CRLF : EOL.LF;
+  return hasCRLF ? CRLF : LF;
 }
 
 /**
@@ -52,6 +62,6 @@ export function detect(content: string): EOL | null {
  * format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
  * ```
  */
-export function format(content: string, eol: EOL): string {
+export function format(content: string, eol: typeof EOL): string {
   return content.replace(regDetect, eol);
 }

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -27,16 +27,16 @@ const regDetect = /(?:\r?\n)/g;
  *
  * @example
  * ```ts
- * import { detect, EOL } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { detect, LF, CRLF } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";
  * const Mixedinput = "deno\nis not\r\nnode";
  * const LFinput = "deno\nis not\nnode";
  * const NoNLinput = "deno is not node";
  *
- * detect(LFinput); // output EOL.LF
- * detect(CRLFinput); // output EOL.CRLF
- * detect(Mixedinput); // output EOL.CRLF
+ * detect(LFinput); // output LF
+ * detect(CRLFinput); // output CRLF
+ * detect(Mixedinput); // output CRLF
  * detect(NoNLinput); // output null
  * ```
  */
@@ -55,11 +55,11 @@ export function detect(content: string): typeof EOL | null {
  *
  * @example
  * ```ts
- * import { EOL, format } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { LF, format } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";
  *
- * format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
+ * format(CRLFinput, LF); // output "deno\nis not\nnode"
  * ```
  */
 export function format(content: string, eol: typeof EOL): string {

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { detect, EOL, format } from "./eol.ts";
+import { CRLF, detect, EOL, format, LF } from "./eol.ts";
 
 const CRLFinput = "deno\r\nis not\r\nnode";
 const Mixedinput = "deno\nis not\r\nnode";
@@ -11,14 +11,14 @@ const NoNLinput = "deno is not node";
 Deno.test({
   name: "[EOL] Detect CR LF",
   fn() {
-    assertEquals(detect(CRLFinput), EOL.CRLF);
+    assertEquals(detect(CRLFinput), CRLF);
   },
 });
 
 Deno.test({
   name: "[EOL] Detect LF",
   fn() {
-    assertEquals(detect(LFinput), EOL.LF);
+    assertEquals(detect(LFinput), LF);
   },
 });
 
@@ -32,23 +32,23 @@ Deno.test({
 Deno.test({
   name: "[EOL] Detect Mixed",
   fn() {
-    assertEquals(detect(Mixedinput), EOL.CRLF);
-    assertEquals(detect(Mixedinput2), EOL.CRLF);
+    assertEquals(detect(Mixedinput), CRLF);
+    assertEquals(detect(Mixedinput2), CRLF);
   },
 });
 
 Deno.test({
   name: "[EOL] Format",
   fn() {
-    assertEquals(format(CRLFinput, EOL.LF), LFinput);
-    assertEquals(format(LFinput, EOL.LF), LFinput);
-    assertEquals(format(LFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(NoNLinput, EOL.CRLF), NoNLinput);
-    assertEquals(format(Mixedinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(Mixedinput, EOL.LF), LFinput);
-    assertEquals(format(Mixedinput2, EOL.CRLF), CRLFinput);
-    assertEquals(format(Mixedinput2, EOL.LF), LFinput);
+    assertEquals(format(CRLFinput, EOL), LFinput);
+    assertEquals(format(LFinput, EOL), LFinput);
+    assertEquals(format(LFinput, CRLF), CRLFinput);
+    assertEquals(format(CRLFinput, CRLF), CRLFinput);
+    assertEquals(format(CRLFinput, CRLF), CRLFinput);
+    assertEquals(format(NoNLinput, CRLF), NoNLinput);
+    assertEquals(format(Mixedinput, CRLF), CRLFinput);
+    assertEquals(format(Mixedinput, EOL), LFinput);
+    assertEquals(format(Mixedinput2, CRLF), CRLFinput);
+    assertEquals(format(Mixedinput2, EOL), LFinput);
   },
 });


### PR DESCRIPTION
This change replaces the `EOL` enum with an OS-dependent constant. The breaking change is made without deprecation because both implementations share the same `EOL` name. Frankly, I'm uncertain this is the best approach, so I'm open to similar ideas.

Closes #3583
Towards #3782