### PR TITLE
chore: cleanup after removal of `std/wasi`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -62,7 +62,5 @@ toml:
   - toml/**
 uuid:
   - uuid/**
-wasi:
-  - wasi/**
 yaml:
   - yaml/**

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,6 +1,7 @@
 [default]
 check-filename = false
 
+[default.extend-identifiers]
 # variable name used by node-semver
 _fpr = "_fpr"
 

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,10 +1,6 @@
 [default]
 check-filename = false
 
-[default.extend-identifiers]
-# The typo also exists in https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/typenames.witx.
-ERRNO_ACCES = "ERRNO_ACCES"
-
 # variable name used by node-semver
 _fpr = "_fpr"
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Check out the documentation [here](https://deno.land/std?doc).
 | ulid         | Unstable   |
 | url          | Unstable   |
 | uuid         | Stable     |
-| wasi         | Deprecated |
 | yaml         | Stable     |
 
 > For background and discussions regarding the stability of the following


### PR DESCRIPTION
This cleans up some remnants of the `std/wasi` deprecation and removal, some of which had to happen after the actual removal.