### PR TITLE
chore(collections): improve deprecation notices

### DIFF
--- a/collections/binary_heap.ts
+++ b/collections/binary_heap.ts
@@ -3,7 +3,7 @@
 
 export {
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/binary_heap.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/binary_heap.ts} instead.
    *
    * A priority queue implemented with a binary heap. The heap is in descending
    * order by default, using JavaScript's built-in comparison operators to sort
@@ -51,13 +51,13 @@ export {
 
 export {
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/comparators.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/comparators.ts} instead.
    *
    * Compares its two arguments for ascending order using JavaScript's built in comparison operators.
    */
   ascend,
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/comparators.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/comparators.ts} instead.
    *
    * Compares its two arguments for descending order using JavaScript's built in comparison operators.
    */

--- a/collections/binary_search_node.ts
+++ b/collections/binary_search_node.ts
@@ -3,10 +3,10 @@
 
 export {
   /**
-   * @deprecated (will be removed in 0.207.0) Use {@linkcode BinarySearchTree} from `data_structures/binary_search_tree.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Use {@linkcode BinarySearchTree} from {@link https://deno.land/std/data_structures/binary_search_tree.ts} instead.
    */
   BinarySearchNode,
 } from "../data_structures/_binary_search_node.ts";
 
-/** @deprecated (will be removed in 0.207.0) Use "left" | "right" union class instead */
+/** @deprecated (will be removed in 0.209.0) Use `"left" | "right"` union class instead */
 export type Direction = "left" | "right";

--- a/collections/binary_search_tree.ts
+++ b/collections/binary_search_tree.ts
@@ -3,7 +3,7 @@
 
 export {
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/binary_search_tree.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/binary_search_tree.ts} instead.
    *
    * An unbalanced binary search tree. The values are in ascending order by default,
    * using JavaScript's built-in comparison operators to sort the values.

--- a/collections/red_black_node.ts
+++ b/collections/red_black_node.ts
@@ -3,10 +3,10 @@
 
 export {
   /**
-   * @deprecated (will be removed in 0.207.0) Use {@linkcode RedBlackTree} from `data_structures/red_black_tree.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Use {@linkcode RedBlackTree} from {@link https://deno.land/std/data_structures/red_black_tree.ts} instead.
    */
   RedBlackNode,
 } from "../data_structures/_red_black_node.ts";
 
-/** @deprecated (will be removed in 0.207.0) Use "left" | "right" union type instead */
+/** @deprecated (will be removed in 0.209.0) Use `"left" | "right"` union type instead */
 export type Direction = "left" | "right";

--- a/collections/red_black_tree.ts
+++ b/collections/red_black_tree.ts
@@ -3,7 +3,7 @@
 
 export {
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/red_black_tree.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/red_black_tree.ts} instead.
    *
    * A red-black tree. This is a kind of self-balancing binary search tree. The
    * values are in ascending order by default, using JavaScript's built-in
@@ -91,13 +91,13 @@ export {
 
 export {
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/comparators.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/comparators.ts} instead.
    *
    * Compares its two arguments for ascending order using JavaScript's built in comparison operators.
    */
   ascend,
   /**
-   * @deprecated (will be removed in 0.209.0) Import from `data_structures/comparators.ts` instead.
+   * @deprecated (will be removed in 0.209.0) Import from {@link https://deno.land/std/data_structures/comparators.ts} instead.
    *
    * Compares its two arguments for descending order using JavaScript's built in comparison operators.
    */


### PR DESCRIPTION
This updates the deprecation notices within `std/collections` with links to new documentation and aligns the removal versions to all be 0.209.0. Previously, some were to be removed in 0.207.0 and others in 0.209.0.