### PR TITLE
refactor(collections): unify function overloads

### DIFF
--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -23,27 +23,7 @@
  */
 export function maxBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
-): T | undefined;
-export function maxBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => string,
-): T | undefined;
-export function maxBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => bigint,
-): T | undefined;
-export function maxBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => Date,
-): T | undefined;
-export function maxBy<T>(
-  array: Iterable<T>,
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => number | string | bigint | Date,
 ): T | undefined {
   let max: T | undefined = undefined;
   let maxValue: ReturnType<typeof selector> | undefined = undefined;

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -22,17 +22,7 @@
  * assertEquals(maxCount, 32);
  * ```
  */
-export function maxOf<T>(
-  array: Iterable<T>,
-  selector: (el: T) => number,
-): number | undefined;
-
-export function maxOf<T>(
-  array: Iterable<T>,
-  selector: (el: T) => bigint,
-): bigint | undefined;
-
-export function maxOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function maxOf<T, S extends (el: T) => number | bigint>(
   array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -23,27 +23,7 @@
  */
 export function minBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
-): T | undefined;
-export function minBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => string,
-): T | undefined;
-export function minBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => bigint,
-): T | undefined;
-export function minBy<T>(
-  array: Iterable<T>,
-  selector: (el: T) => Date,
-): T | undefined;
-export function minBy<T>(
-  array: Iterable<T>,
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => number | string | bigint | Date,
 ): T | undefined {
   let min: T | undefined = undefined;
   let minValue: ReturnType<typeof selector> | undefined = undefined;

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -21,17 +21,7 @@
  * assertEquals(minCount, 2);
  * ```
  */
-export function minOf<T>(
-  array: Iterable<T>,
-  selector: (el: T) => number,
-): number | undefined;
-
-export function minOf<T>(
-  array: Iterable<T>,
-  selector: (el: T) => bigint,
-): bigint | undefined;
-
-export function minOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function minOf<T, S extends (el: T) => number | bigint>(
   array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -18,20 +18,12 @@
  * assertEquals(odd, [5, 7, 9]);
  * ```
  */
-export function partition<T, U extends T>(
-  array: Iterable<T>,
-  predicate: (el: T) => el is U,
-): [U[], Exclude<T, U>[]];
 export function partition<T>(
   array: Iterable<T>,
   predicate: (el: T) => boolean,
-): [T[], T[]];
-export function partition(
-  array: Iterable<unknown>,
-  predicate: (el: unknown) => boolean,
-): [unknown[], unknown[]] {
-  const matches: Array<unknown> = [];
-  const rest: Array<unknown> = [];
+): [T[], T[]] {
+  const matches = [];
+  const rest = [];
 
   for (const element of array) {
     if (predicate(element)) {

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -43,31 +43,7 @@ export type SortByOptions = {
  */
 export function sortBy<T>(
   array: readonly T[],
-  selector: (el: T) => number,
-  options?: SortByOptions,
-): T[];
-export function sortBy<T>(
-  array: readonly T[],
-  selector: (el: T) => string,
-  options?: SortByOptions,
-): T[];
-export function sortBy<T>(
-  array: readonly T[],
-  selector: (el: T) => bigint,
-  options?: SortByOptions,
-): T[];
-export function sortBy<T>(
-  array: readonly T[],
-  selector: (el: T) => Date,
-  options?: SortByOptions,
-): T[];
-export function sortBy<T>(
-  array: readonly T[],
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => number | string | bigint | Date,
   options?: SortByOptions,
 ): T[] {
   const len = array.length;

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+import { minOf } from "./min_of.ts";
+
 /**
  * Builds N-tuples of elements from the given N arrays with matching indices,
  * stopping when the smallest array's end is reached.
@@ -26,9 +28,6 @@
  * );
  * ```
  */
-
-import { minOf } from "./min_of.ts";
-
 export function zip<T extends unknown[]>(
   ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
 ): T[] {


### PR DESCRIPTION
This refactor combines multiple function overloads within `std/collections`. The functions are now easier to understand, and the documentation required for this module has been reduced.

More functions can be cleaned up in follow-up PRs.

Towards #3764