### PR TITLE
chore: configure dependabot for `std/crypto`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/crypto/_wasm"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This aims to automate keeping Rust dependencies for `std/crypto/_wasm` up-to-date.