### PR TITLE
`assertVersions` for requiring a min/max version of Deno

### DIFF
--- a/assert/assert_versions.ts
+++ b/assert/assert_versions.ts
@@ -1,0 +1,107 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { parseVersion } from "../text/parse_version.ts";
+import { zip } from "../collections/zip.ts";
+import { AssertionError } from "./assertion_error.ts";
+
+/**
+ * Asserts that the specified versions of the given systems meet the required criteria.
+ *
+ * @example
+ * ```ts
+ * import { assertVersions } from "https://deno.land/std@$STD_VERSION/assert/assert_versions.ts";
+ * assertVersions({
+ *   deno: {
+ *     min: [1, 25],
+ *     max: [4],
+ *   },
+ *   v8: {
+ *     max: [20],
+ *     min: [11, 6],
+ *   },
+ *   typescript: {
+ *     max: [99],
+ *     min: [2, 3, 4],
+ *   },
+ * });
+ * ```
+ * @param {Object} options - An object containing version information for different systems.
+ * @param {Object} options.typescript - Version information for TypeScript.
+ * @param {number[]} [options.typescript.min] - Minimum required version for TypeScript.
+ * @param {number[]} [options.typescript.max] - Maximum allowed version for TypeScript.
+ * @param {Object} options.v8 - Version information for V8.
+ * @param {number[]} [options.v8.min] - Minimum required version for V8.
+ * @param {number[]} [options.v8.max] - Maximum allowed version for V8.
+ * @param {Object} options.deno - Version information for Deno.
+ * @param {number[]} [options.deno.min] - Minimum required version for Deno.
+ * @param {number[]} [options.deno.max] - Maximum allowed version for Deno.
+ *
+ * @throws {AssertionError} Throws an AssertionError if any system's version does not meet the specified criteria.
+ */
+export function assertVersions(options: {
+  typescript?: {
+    min?: number[];
+    max?: number[];
+  };
+  v8?: {
+    min?: number[];
+    max?: number[];
+  };
+  deno?: {
+    min?: number[];
+    max?: number[];
+  };
+}): void {
+  for (const [whichSystem, minMax] of Object.entries(options)) {
+    const { min, max } = { ...minMax };
+    const versionInfo = { ...Deno?.version }[whichSystem];
+    if (typeof versionInfo == "string") {
+      const existingVersion = parseVersion(versionInfo);
+      if (min instanceof Array) {
+        const throwMin = () => {
+          throw new AssertionError(
+            `Current version of ${whichSystem} is ${versionInfo}, however the code requires a minimum version of ${
+              min.join(".")
+            }`,
+          );
+        };
+        for (const [eachExisting, eachMin] of zip(existingVersion, min)) {
+          if (typeof eachExisting !== typeof eachMin) {
+            throwMin();
+          } else if (typeof eachExisting == "string") {
+            // @ts-ignore it complains "dont do string!=number" but beacuse of the if statement above this will never have that case
+            if (eachExisting !== eachMin) {
+              throwMin();
+            }
+          } else if (typeof eachExisting == "number") {
+            if (eachExisting < eachMin) {
+              throwMin();
+            }
+          }
+        }
+      }
+      if (max instanceof Array) {
+        const throwMax = () => {
+          throw new AssertionError(
+            `Current version of ${whichSystem} is ${versionInfo}, however the code requires a maximum version of ${
+              max.join(".")
+            }`,
+          );
+        };
+        for (const [eachExisting, eachMax] of zip(existingVersion, max)) {
+          if (typeof eachExisting !== typeof eachMax) {
+            throwMax();
+          } else if (typeof eachExisting == "string") {
+            // @ts-ignore it complains "dont do string!=number" but beacuse of the if statement above this will never have that case
+            if (eachExisting !== eachMax) {
+              throwMax();
+            }
+          } else if (typeof eachExisting == "number") {
+            if (eachExisting > eachMax) {
+              throwMax();
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assert/assert_versions.ts
+++ b/assert/assert_versions.ts
@@ -75,6 +75,9 @@ export function assertVersions(options: {
           } else if (typeof eachExisting == "number") {
             if (eachExisting < eachMin) {
               throwMin();
+            } else if (eachExisting > eachMin) {
+                // no need to go deeper, it meets the min
+                break
             }
           }
         }
@@ -98,6 +101,9 @@ export function assertVersions(options: {
           } else if (typeof eachExisting == "number") {
             if (eachExisting > eachMax) {
               throwMax();
+            } else if (eachExisting < eachMax) {
+                // no need to go deeper, it meets the max
+                break
             }
           }
         }

--- a/assert/assert_versions.ts
+++ b/assert/assert_versions.ts
@@ -76,8 +76,8 @@ export function assertVersions(options: {
             if (eachExisting < eachMin) {
               throwMin();
             } else if (eachExisting > eachMin) {
-                // no need to go deeper, it meets the min
-                break
+              // no need to go deeper, it meets the min
+              break;
             }
           }
         }
@@ -102,8 +102,8 @@ export function assertVersions(options: {
             if (eachExisting > eachMax) {
               throwMax();
             } else if (eachExisting < eachMax) {
-                // no need to go deeper, it meets the max
-                break
+              // no need to go deeper, it meets the max
+              break;
             }
           }
         }

--- a/assert/assert_versions.ts
+++ b/assert/assert_versions.ts
@@ -68,7 +68,7 @@ export function assertVersions(options: {
           if (typeof eachExisting !== typeof eachMin) {
             throwMin();
           } else if (typeof eachExisting == "string") {
-            // @ts-ignore it complains "dont do string!=number" but beacuse of the if statement above this will never have that case
+            // @ts-ignore it complains "dont do string!=number" but because of the if statement above this will never have that case
             if (eachExisting !== eachMin) {
               throwMin();
             }
@@ -91,7 +91,7 @@ export function assertVersions(options: {
           if (typeof eachExisting !== typeof eachMax) {
             throwMax();
           } else if (typeof eachExisting == "string") {
-            // @ts-ignore it complains "dont do string!=number" but beacuse of the if statement above this will never have that case
+            // @ts-ignore it complains "dont do string!=number" but because of the if statement above this will never have that case
             if (eachExisting !== eachMax) {
               throwMax();
             }

--- a/assert/assert_versions_test.ts
+++ b/assert/assert_versions_test.ts
@@ -1,0 +1,76 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assertVersions } from "./assert_versions.ts";
+import { AssertionError, assertThrows } from "./mod.ts";
+
+Deno.test("assertVersions throws for high versions of typescript", () => {
+  assertThrows(
+    () => {
+      assertVersions({
+        typescript: {
+          max: [1],
+        },
+      });
+    },
+    AssertionError,
+    `Current version of typescript is ${Deno.version.typescript}, however the code requires a maximum version of 1`,
+  );
+});
+
+Deno.test("assertVersions throws for high versions of deno", () => {
+  assertThrows(
+    () => {
+      assertVersions({
+        deno: {
+          max: [0],
+        },
+      });
+    },
+    AssertionError,
+    `Current version of deno is ${Deno.version.deno}, however the code requires a maximum version of 0`,
+  );
+});
+
+Deno.test("assertVersions throws for low versions of deno", () => {
+  assertThrows(
+    () => {
+      assertVersions({
+        deno: {
+          min: [2, 5],
+        },
+      });
+    },
+    AssertionError,
+    `Current version of deno is ${Deno.version.deno}, however the code requires a minimum version of 2.5`,
+  );
+});
+
+Deno.test("assertVersions throws for low versions of v8", () => {
+  assertThrows(
+    () => {
+      assertVersions({
+        v8: {
+          min: [11, 6, 189, 12],
+        },
+      });
+    },
+    AssertionError,
+    `Current version of v8 is ${Deno.version.v8}, however the code requires a minimum version of 11.6.189.12`,
+  );
+});
+
+Deno.test("assertVersions doesnt throw when valid", () => {
+  assertVersions({
+    deno: {
+      min: [1, 25],
+      max: [4],
+    },
+    v8: {
+      max: [20],
+      min: [11, 6],
+    },
+    typescript: {
+      max: [99],
+      min: [2, 3, 4],
+    },
+  });
+});

--- a/assert/assert_versions_test.ts
+++ b/assert/assert_versions_test.ts
@@ -49,12 +49,12 @@ Deno.test("assertVersions throws for low versions of v8", () => {
     () => {
       assertVersions({
         v8: {
-          min: [1, 6, 189, 12],
+          min: [99, 6, 189, 12],
         },
       });
     },
     AssertionError,
-    `Current version of v8 is ${Deno.version.v8}, however the code requires a minimum version of 11.6.189.12`,
+    `Current version of v8 is ${Deno.version.v8}, however the code requires a minimum version of 99.6.189.12`,
   );
 });
 

--- a/assert/assert_versions_test.ts
+++ b/assert/assert_versions_test.ts
@@ -66,7 +66,7 @@ Deno.test("assertVersions doesnt throw when valid", () => {
     },
     v8: {
       max: [20],
-      min: [11, 6],
+      min: [11, 1],
     },
     typescript: {
       max: [99],

--- a/assert/assert_versions_test.ts
+++ b/assert/assert_versions_test.ts
@@ -49,7 +49,7 @@ Deno.test("assertVersions throws for low versions of v8", () => {
     () => {
       assertVersions({
         v8: {
-          min: [11, 6, 189, 12],
+          min: [1, 6, 189, 12],
         },
       });
     },

--- a/text/mod.ts
+++ b/text/mod.ts
@@ -4,3 +4,4 @@ export { levenshteinDistance } from "./levenshtein_distance.ts";
 export { closestString } from "./closest_string.ts";
 export { compareSimilarity } from "./compare_similarity.ts";
 export { wordSimilaritySort } from "./word_similarity_sort.ts";
+export { parseVersion } from "./parse_version.ts";

--- a/text/parse_version.ts
+++ b/text/parse_version.ts
@@ -1,0 +1,20 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Converts a version string to a list of numeric and non-numeric segments.
+ * @example
+ * ```ts
+ * // Example usage:
+ * import { parseVersion } from "https://deno.land/std@$STD_VERSION/assert/parse_version.ts";
+ * const result: Array<number | string> = versionToList("1.2.3.4.5beta");
+ * console.log(result); // [1,2,3,4,5,"beta"]
+ * ```
+ * @param {string} version - The version string to convert.
+ * @returns {Array<number | string>} - An array containing numeric and non-numeric segments.
+ */
+export const parseVersion = (version: string): Array<number | string> =>
+  !version ? [] : version
+    .split(".")
+    .map((each) => each.split(/(?<=\d)(?=\D)|(?<=\D)(?=\d)/))
+    .flat(1)
+    .map((each) => (each.match(/^\d+$/) ? parseInt(each) : each));

--- a/text/parse_version.ts
+++ b/text/parse_version.ts
@@ -5,7 +5,7 @@
  * @example
  * ```ts
  * // Example usage:
- * import { parseVersion } from "https://deno.land/std@$STD_VERSION/assert/parse_version.ts";
+ * import { parseVersion } from "https://deno.land/std@$STD_VERSION/text/parse_version.ts";
  * const result: Array<number | string> = versionToList("1.2.3.4.5beta");
  * console.log(result); // [1,2,3,4,5,"beta"]
  * ```

--- a/text/parse_version.ts
+++ b/text/parse_version.ts
@@ -6,7 +6,7 @@
  * ```ts
  * // Example usage:
  * import { parseVersion } from "https://deno.land/std@$STD_VERSION/text/parse_version.ts";
- * const result: Array<number | string> = versionToList("1.2.3.4.5beta");
+ * const result: Array<number | string> = parseVersion("1.2.3.4.5beta");
  * console.log(result); // [1,2,3,4,5,"beta"]
  * ```
  * @param {string} version - The version string to convert.

--- a/text/parse_version_test.ts
+++ b/text/parse_version_test.ts
@@ -1,0 +1,59 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../assert/mod.ts";
+import { parseVersion } from "./parse_version.ts";
+
+Deno.test("basicParseVersion", function () {
+  const version = "1.2.3";
+  assertEquals(
+    JSON.stringify([1, 2, 3]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("longParseVersion", function () {
+  const version = "1.2.3.4.5.6";
+  assertEquals(
+    JSON.stringify([1, 2, 3, 4, 5, 6]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("shortParseVersion", function () {
+  const version = "1";
+  assertEquals(
+    JSON.stringify([1]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("emptyParseVersion", function () {
+  const version = "";
+  assertEquals(
+    JSON.stringify([]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("trailingStringParseVersion", function () {
+  const version = "1.2.3.4beta";
+  assertEquals(
+    JSON.stringify([1, 2, 3, 4, "beta"]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("leadingStringParseVersion", function () {
+  const version = "beta-1.2.3.4";
+  assertEquals(
+    JSON.stringify(["beta-", 1, 2, 3, 4]),
+    JSON.stringify(parseVersion(version)),
+  );
+});
+
+Deno.test("middleStringParseVersion", function () {
+  const version = "1.2-beta3.4";
+  assertEquals(
+    JSON.stringify([1, 2, "-beta", 3, 4]),
+    JSON.stringify(parseVersion(version)),
+  );
+});


### PR DESCRIPTION
Note: parseSemver doesn't work for parsing the v8 version, which is the only reason I created `parseVersion`

I don't care where these functions are stored or how they're named.