### PR TITLE
refactor(datetime): replace enum with object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ deno.lock
 /console/testdata/unicode_width_crate/target
 html_cov/
 cov.lcov
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ deno.lock
 /console/testdata/unicode_width_crate/target
 html_cov/
 cov.lcov
-.tool-versions

--- a/datetime/week_of_year.ts
+++ b/datetime/week_of_year.ts
@@ -5,15 +5,15 @@ import { DAY, WEEK } from "./constants.ts";
 
 const DAYS_PER_WEEK = 7;
 
-enum Day {
-  Sun,
-  Mon,
-  Tue,
-  Wed,
-  Thu,
-  Fri,
-  Sat,
-}
+const Day = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+} as const;
 
 /**
  * Returns the ISO week number of the provided date (1-53).


### PR DESCRIPTION
This PR replaces the used typescript enum in the `datetime` module with a 
as `const object` as requested [here](https://github.com/denoland/deno_std/issues/3782)

As this enum is only used internally, merging this change wouldn't constitute a
breaking change.

History:
- chore(root): ignore .tool-versions
- feat(datetime): replace enum with const object
