### PR TITLE
refactor(jsonc): replace `enum` with string union type

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -51,30 +51,32 @@ export function parse(
   return new JSONCParser(text, { allowTrailingComma }).parse();
 }
 
-enum TokenType {
-  BeginObject,
-  EndObject,
-  BeginArray,
-  EndArray,
-  NameSeparator,
-  ValueSeparator,
-  NullOrTrueOrFalseOrNumber,
-  String,
-}
+const TokenType = {
+  BeginObject: "BeginObject",
+  EndObject: "EndObject",
+  BeginArray: "BeginArray",
+  EndArray: "EndArray",
+  NameSeparator: "NameSeparator",
+  ValueSeparator: "ValueSeparator",
+  NullOrTrueOrFalseOrNumber: "NullOrTrueOrFalseOrNumber",
+  String: "String",
+} as const;
+
+type TokenTypes = keyof typeof TokenType;
 
 type Token = {
   type: Exclude<
-    TokenType,
-    TokenType.String | TokenType.NullOrTrueOrFalseOrNumber
+    TokenTypes,
+    typeof TokenType.String | typeof TokenType.NullOrTrueOrFalseOrNumber
   >;
   sourceText?: undefined;
   position: number;
 } | {
-  type: TokenType.String;
+  type: typeof TokenType.String;
   sourceText: string;
   position: number;
 } | {
-  type: TokenType.NullOrTrueOrFalseOrNumber;
+  type: typeof TokenType.NullOrTrueOrFalseOrNumber;
   sourceText: string;
   position: number;
 };
@@ -318,7 +320,7 @@ class JSONCParser {
     }
   }
   #parseString(value: {
-    type: TokenType.String;
+    type: typeof TokenType.String;
     sourceText: string;
     position: number;
   }): string {
@@ -333,7 +335,7 @@ class JSONCParser {
     return parsed;
   }
   #parseNullOrTrueOrFalseOrNumber(value: {
-    type: TokenType.NullOrTrueOrFalseOrNumber;
+    type: typeof TokenType.NullOrTrueOrFalseOrNumber;
     sourceText: string;
     position: number;
   }): null | boolean | number {


### PR DESCRIPTION
This PR replaces the used typescript enum in the `jsonc` module with a
`const object` as requested  [here](https://github.com/denoland/deno_std/issues/3782).

As this enum is only used internally, merging this change wouldn't constitute a
breaking change.

This change seems a little bit clunky but does the trick.