### PR TITLE
chore(console): improve console test coverage

### DIFF
--- a/console/_rle_test.ts
+++ b/console/_rle_test.ts
@@ -3,26 +3,30 @@
 import { runLengthDecode, runLengthEncode } from "./_rle.ts";
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 
-const runLengthTestCases: [number[], { d: string; r: string }, string][] = [
-  [
-    [1, 2, 3, 4, 5],
-    { d: "AQIDBAU=", r: "AQEBAQE=" },
-    "return expected value if input is normal value",
-  ],
-  [
-    [1, 1, 1, 1],
-    { d: "AQ==", r: "BA==" },
-    "return expected value if input includes an continuous value",
-  ],
-  [
-    [],
-    { d: "", r: "" },
-    "return expected value if input is empty",
-  ],
+const runLengthTestCases: {
+  list: number[];
+  compressed: { d: string; r: string };
+  testName: string;
+}[] = [
+  {
+    list: [1, 2, 3, 4, 5],
+    compressed: { d: "AQIDBAU=", r: "AQEBAQE=" },
+    testName: "return expected value if input is normal value",
+  },
+  {
+    list: [1, 1, 1, 1],
+    compressed: { d: "AQ==", r: "BA==" },
+    testName: "return expected value if input includes an continuous value",
+  },
+  {
+    list: [],
+    compressed: { d: "", r: "" },
+    testName: "return expected value if input is empty",
+  },
 ];
 
 Deno.test("runLengthEncode()", async (t) => {
-  for (const [list, compressed, testName] of runLengthTestCases) {
+  for (const { list, compressed, testName } of runLengthTestCases) {
     await t.step(`runLengthEncode() ${testName}`, () => {
       const encoded = runLengthEncode(list);
       assertEquals(encoded, compressed);
@@ -47,7 +51,7 @@ Deno.test("runLengthEncode()", async (t) => {
 });
 
 Deno.test("runLengthDecode()", async (t) => {
-  for (const [list, compressed, testName] of runLengthTestCases) {
+  for (const { list, compressed, testName } of runLengthTestCases) {
     await t.step(`runLengthDecode() ${testName}`, () => {
       const decoded = runLengthDecode(compressed);
       assertEquals(decoded, new Uint8Array(list));

--- a/console/_rle_test.ts
+++ b/console/_rle_test.ts
@@ -1,0 +1,60 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { runLengthDecode, runLengthEncode } from "./_rle.ts";
+import { assertEquals, assertThrows } from "../assert/mod.ts";
+
+const runLengthTestCases: [number[], { d: string; r: string }, string][] = [
+  [
+    [1, 2, 3, 4, 5],
+    { d: "AQIDBAU=", r: "AQEBAQE=" },
+    "return expected value if input is normal value",
+  ],
+  [
+    [1, 1, 1, 1],
+    { d: "AQ==", r: "BA==" },
+    "return expected value if input includes an continuous value",
+  ],
+  [
+    [],
+    { d: "", r: "" },
+    "return expected value if input is empty",
+  ],
+];
+
+Deno.test("runLengthEncode()", async (t) => {
+  for (const [list, compressed, testName] of runLengthTestCases) {
+    await t.step(`runLengthEncode() ${testName}`, () => {
+      const encoded = runLengthEncode(list);
+      assertEquals(encoded, compressed);
+    });
+  }
+
+  await t.step(
+    `runLengthEncode() throw an error if input is an array containing more than 256 numbers`,
+    () => {
+      assertThrows(() => runLengthEncode([1, 2, 3, 256]));
+    },
+  );
+
+  await t.step(
+    `runLengthEncode() throw an error if the input is an array longer than 256`,
+    () => {
+      assertThrows(() =>
+        runLengthEncode([...Array.from({ length: 256 }, () => 0)])
+      );
+    },
+  );
+});
+
+Deno.test("runLengthDecode()", async (t) => {
+  for (const [list, compressed, testName] of runLengthTestCases) {
+    await t.step(`runLengthDecode() ${testName}`, () => {
+      const decoded = runLengthDecode(compressed);
+      assertEquals(decoded, new Uint8Array(list));
+    });
+  }
+
+  await t.step(`runLengthDecode() throw an error if input is wrong`, () => {
+    assertThrows(() => runLengthDecode({ d: "wrong", r: "wrong" }));
+  });
+});


### PR DESCRIPTION
Related issue https://github.com/denoland/deno_std/issues/3713

## what I did
- add `runLengthEncode()` test
- add `runLengthDecode()` test

## coverage change
https://app.codecov.io/gh/denoland/deno_std/commit/145c81a3c648f8c0d108f1517536cdfc0f487522/indirect-changes