### PR TITLE
refactor(front_matter): replace Format enum with const object

### DIFF
--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -2,13 +2,14 @@
 
 type Delimiter = string | [begin: string, end: string];
 
-/** @deprecated (will be removed after 1.0.0) Use literal types `"yaml" | "toml" | "json" | "unknown"`. */
-export enum Format {
-  YAML = "yaml",
-  TOML = "toml",
-  JSON = "json",
-  UNKNOWN = "unknown",
-}
+export const Formats = {
+  YAML: "yaml",
+  TOML: "toml",
+  JSON: "json",
+  UNKNOWN: "unknown",
+} as const
+
+export type Format = typeof Formats[keyof typeof Formats];
 
 const { isArray } = Array;
 


### PR DESCRIPTION
Refers to this [issue](https://github.com/denoland/deno_std/issues/3782)

While the actual change is trivial, it requires a spur of followup changes in the rest of the module (and beyond).
Given that this is a breaking change, and that this module is widely used (e.g. `fresh`), I wanted to check-in with you guys before commencing.

IMO the change is warranted, and the `enum` has already been marked as deprecated. So in principle I would be in favor of completing this.
On the other hand, it's really a low priority issue and low value change, which will require a not so trivial amount of effort across the ecosystem.

