### PR TITLE
refactor(assert): replace DiffTypeEnum with const object

### DIFF
--- a/assert/_diff.ts
+++ b/assert/_diff.ts
@@ -16,11 +16,13 @@ interface FarthestPoint {
   id: number;
 }
 
-export enum DiffType {
-  removed = "removed",
-  common = "common",
-  added = "added",
-}
+export const DiffType = {
+  removed: "removed",
+  common: "common",
+  added: "added",
+} as const;
+
+export type DiffType = keyof typeof DiffType;
 
 export interface DiffResult<T> {
   type: DiffType;


### PR DESCRIPTION
Refers to this [issue](https://github.com/denoland/deno_std/issues/3782)

This change is internal only. The changed `DiffType` was solely exported to facilitate tests in `_diff_test.ts`.
