### PR TITLE
refactor(archive): replace FileTypes enum with const object

### DIFF
--- a/archive/_common.ts
+++ b/archive/_common.ts
@@ -36,16 +36,26 @@ export interface TarMeta extends TarInfo {
   fileSize?: number;
 }
 
-export enum FileTypes {
-  "file" = 0,
-  "link" = 1,
-  "symlink" = 2,
-  "character-device" = 3,
-  "block-device" = 4,
-  "directory" = 5,
-  "fifo" = 6,
-  "contiguous-file" = 7,
-}
+export const FileTypes = {
+  "file": 0,
+  "link": 1,
+  "symlink": 2,
+  "character-device": 3,
+  "block-device": 4,
+  "directory": 5,
+  "fifo": 6,
+  "contiguous-file": 7,
+  0: "file",
+  1: "link",
+  2: "symlink",
+  3: "character-device",
+  4: "block-device",
+  5: "directory",
+  6: "fifo",
+  7: "contiguous-file",
+} as const;
+
+export type FileTypes = typeof FileTypes[keyof typeof FileTypes];
 
 export const HEADER_LENGTH = 512;
 

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -270,8 +270,9 @@ export class Tar {
     assert(fileSize !== undefined, "fileSize must be set");
 
     const type = source.type
-      ? FileTypes[source.type as keyof typeof FileTypes]
+      ? FileTypes[source.type as FileTypes]
       : (info?.isDirectory ? FileTypes.directory : FileTypes.file);
+
     const tarData: TarDataWithSource = {
       fileName,
       fileNamePrefix,

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -263,7 +263,7 @@ export class Untar {
       meta.fileName = decoder.decode(fileNamePrefix) + "/" + meta.fileName;
     }
     (
-      ["fileMode", "mtime", "uid", "gid"] as ["fileMode", "mtime", "uid", "gid"]
+      ["fileMode", "mtime", "uid", "gid"] as const
     ).forEach((key) => {
       const arr = trim(header[key]);
       if (arr.byteLength > 0) {
@@ -280,7 +280,8 @@ export class Untar {
     );
 
     meta.fileSize = parseInt(decoder.decode(header.fileSize), 8);
-    meta.type = FileTypes[parseInt(meta.type!)] ?? meta.type;
+    meta.type = FileTypes[parseInt(meta.type!) as Exclude<FileTypes, string>] ??
+      meta.type;
 
     // Only create the `linkName` property for symbolic links to minimize
     // the effect on existing code that only deals with non-links.


### PR DESCRIPTION
Refers to this [issue](https://github.com/denoland/deno_std/issues/3782)

This change was a little bit tricky because the exposed interfaces do not enforce `FileTypes` in the input they receive. The old `enum` also wasn't exposed via the module API.
Consequently, the implementations also don't really trust their input but it seems that failing to provide a correct filetype doesn't necessarily lead to a panic.

I've tried to make this change as minimally invasive as possible, but IMO it doesn't improve anything. Maybe this refactor should be completed in tandem with the stabilization of the `archive` module API to actually contribute something to the overall maintainability and quality of this module.
