### PR TITLE
BREAKIING(fs): remove `EOL` enum, add OS-dependent `EOL`

### DIFF
--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
 
 // End-of-line character for POSIX platforms such as macOS and Linux.
 export const LF = "\n" as const;
@@ -16,24 +15,8 @@ export const CRLF = "\r\n" as const;
  *
  * EOL; // Returns "\n" on POSIX platforms or "\r\n" on Windows
  * ```
- *
- * @todo(iuioiua): Uncomment the following line upon deprecation of the `EOL`
- * enum.
  */
-// export const EOL = Deno.build.os === "windows" ? CRLF : LF;
-
-/**
- * Platform-specific conventions for the line ending format (i.e., the "end-of-line").
- *
- * @deprecated (will be removed in 0.209.0) This will be replaced by an
- * OS-dependent `EOL` constant.
- */
-export enum EOL {
-  /** Line Feed. Typically used in Unix (and Unix-like) systems. */
-  LF = "\n",
-  /** Carriage Return + Line Feed. Historically used in Windows and early DOS systems. */
-  CRLF = "\r\n",
-}
+export const EOL = Deno?.build.os === "windows" ? CRLF : LF;
 
 const regDetect = /(?:\r?\n)/g;
 
@@ -56,14 +39,14 @@ const regDetect = /(?:\r?\n)/g;
  * detect(NoNLinput); // output null
  * ```
  */
-export function detect(content: string): EOL | null {
+export function detect(content: string): typeof EOL | null {
   const d = content.match(regDetect);
   if (!d || d.length === 0) {
     return null;
   }
-  const hasCRLF = d.some((x: string): boolean => x === EOL.CRLF);
+  const hasCRLF = d.some((x: string): boolean => x === CRLF);
 
-  return hasCRLF ? EOL.CRLF : EOL.LF;
+  return hasCRLF ? CRLF : LF;
 }
 
 /**
@@ -71,13 +54,13 @@ export function detect(content: string): EOL | null {
  *
  * @example
  * ```ts
- * import { EOL, format } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
+ * import { LF, format } from "https://deno.land/std@$STD_VERSION/fs/mod.ts";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";
  *
- * format(CRLFinput, EOL.LF); // output "deno\nis not\nnode"
+ * format(CRLFinput, LF); // output "deno\nis not\nnode"
  * ```
  */
-export function format(content: string, eol: EOL): string {
+export function format(content: string, eol: typeof EOL): string {
   return content.replace(regDetect, eol);
 }

--- a/fs/eol_test.ts
+++ b/fs/eol_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { detect, EOL, format } from "./eol.ts";
+import { CRLF, detect, format, LF } from "./eol.ts";
 
 const CRLFinput = "deno\r\nis not\r\nnode";
 const Mixedinput = "deno\nis not\r\nnode";
@@ -11,14 +11,14 @@ const NoNLinput = "deno is not node";
 Deno.test({
   name: "detect() detects CRLF as the end-of-line character",
   fn() {
-    assertEquals(detect(CRLFinput), EOL.CRLF);
+    assertEquals(detect(CRLFinput), CRLF);
   },
 });
 
 Deno.test({
   name: "detect() detects LF as the end-of-line character",
   fn() {
-    assertEquals(detect(LFinput), EOL.LF);
+    assertEquals(detect(LFinput), LF);
   },
 });
 
@@ -33,23 +33,23 @@ Deno.test({
   name:
     "detect() detects the most common end-of-line character in a mixed string",
   fn() {
-    assertEquals(detect(Mixedinput), EOL.CRLF);
-    assertEquals(detect(Mixedinput2), EOL.CRLF);
+    assertEquals(detect(Mixedinput), CRLF);
+    assertEquals(detect(Mixedinput2), CRLF);
   },
 });
 
 Deno.test({
   name: "format() converts the end-of-line character to the specified one",
   fn() {
-    assertEquals(format(CRLFinput, EOL.LF), LFinput);
-    assertEquals(format(LFinput, EOL.LF), LFinput);
-    assertEquals(format(LFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(CRLFinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(NoNLinput, EOL.CRLF), NoNLinput);
-    assertEquals(format(Mixedinput, EOL.CRLF), CRLFinput);
-    assertEquals(format(Mixedinput, EOL.LF), LFinput);
-    assertEquals(format(Mixedinput2, EOL.CRLF), CRLFinput);
-    assertEquals(format(Mixedinput2, EOL.LF), LFinput);
+    assertEquals(format(CRLFinput, LF), LFinput);
+    assertEquals(format(LFinput, LF), LFinput);
+    assertEquals(format(LFinput, CRLF), CRLFinput);
+    assertEquals(format(CRLFinput, CRLF), CRLFinput);
+    assertEquals(format(CRLFinput, CRLF), CRLFinput);
+    assertEquals(format(NoNLinput, CRLF), NoNLinput);
+    assertEquals(format(Mixedinput, CRLF), CRLFinput);
+    assertEquals(format(Mixedinput, LF), LFinput);
+    assertEquals(format(Mixedinput2, CRLF), CRLFinput);
+    assertEquals(format(Mixedinput2, LF), LFinput);
   },
 });


### PR DESCRIPTION
This was deprecated in favour of a plain JS object.