### PR TITLE
docs(http): fix `Status` enum deprecation notice

### DIFF
--- a/http/status.ts
+++ b/http/status.ts
@@ -32,7 +32,7 @@
  */
 
 /**
- * @deprecated (will be removed in 0.209.0) Use {@linkcode STATUS_CODE} instead.
+ * @deprecated (will be removed in 0.211.0) Use {@linkcode STATUS_CODE} instead.
  *
  * Standard HTTP status codes.
  */


### PR DESCRIPTION
This moves the removal version of the `Status` enum back to match the deletion of the `http/http_status.ts` file. Otherwise, the `Status` enum will get removed before the `http_status.ts` file is deleted.