### PR TITLE
deprecate(log): remove enums and add deprecation notices

### DIFF
--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -61,7 +61,7 @@ Deno.test("simpleHandler", function () {
     const handler = new TestHandler(testLevel);
 
     for (const levelName of LogLevelNames) {
-      const level = getLevelByName(levelName as LevelName);
+      const level = getLevelByName(levelName);
       handler.handle(
         new LogRecord({
           msg: `${levelName.toLowerCase()}-test`,

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -9,6 +9,7 @@ import {
   getLevelByName,
   getLevelName,
   LevelName,
+  LogLevel,
   LogLevelNames,
   LogLevels,
 } from "./levels.ts";
@@ -27,7 +28,7 @@ class TestHandler extends BaseHandler {
 }
 
 Deno.test("simpleHandler", function () {
-  const cases = new Map<number, string[]>([
+  const cases = new Map<LogLevel, string[]>([
     [
       LogLevels.DEBUG,
       [

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -8,7 +8,6 @@ import {
 import {
   getLevelByName,
   getLevelName,
-  LevelName,
   LogLevel,
   LogLevelNames,
   LogLevels,

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -3,7 +3,7 @@
 
 /**
  * @deprecated (will be changed after 0.211.0) Entries with numeric keys will be removed.
- *
+ * 
  * Use this to retrieve the numeric log level by it's associated name.
  * Defaults to INFO.
  */
@@ -56,7 +56,7 @@ export function getLevelByName(name: LevelName): LogLevel {
 
 /**
  * Returns the stringy log level name provided the numeric log level.
- */
+ **/
 export function getLevelName(level: LogLevel): LevelName {
   const levelName = byLevel[level as LogLevel];
   if (levelName) {

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -12,16 +12,30 @@ export const LogLevels = {
   WARNING: 30,
   ERROR: 40,
   CRITICAL: 50,
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  0: "NOTSET",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  10: "DEBUG",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  20: "INFO",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  30: "WARNING",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  40: "ERROR",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
+  50: "CRITICAL",
 } as const;
 
 /** Union of valid log levels */
 export type LogLevel = typeof LogLevels[LevelName];
 
 /** Union of valid log level names */
-export type LevelName = keyof typeof LogLevels;
+export type LevelName = Exclude<keyof typeof LogLevels, number>;
 
 /** Permitted log level names */
-export const LogLevelNames = Object.keys(LogLevels) as LevelName[];
+export const LogLevelNames = Object.keys(LogLevels).filter((key) =>
+  isNaN(Number(key))
+) as LevelName[];
 
 const byLevel: Record<LogLevel, LevelName> = {
   [LogLevels.NOTSET]: "NOTSET",
@@ -35,18 +49,26 @@ const byLevel: Record<LogLevel, LevelName> = {
 /**
  * Returns the numeric log level associated with the passed,
  * stringy log level name.
+ *
+ * @param {LevelName} name
+ * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
  */
-export function getLevelByName(name: LevelName): LogLevel {
+export function getLevelByName(name: LevelName): number {
   const level = LogLevels[name];
   if (level !== undefined) {
     return level;
   }
-  throw new Error(`no log level found for "${name}"`);
+  throw new Error(`no log level found for name: ${name}`);
 }
 
-/** Returns the stringy log level name provided the numeric log level */
-export function getLevelName(level: LogLevel): LevelName {
-  const levelName = byLevel[level];
+/**
+ * Returns the stringy log level name provided the numeric log level
+ *
+ * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
+ * @returns {LevelName}
+ */
+export function getLevelName(level: number): LevelName {
+  const levelName = byLevel[level as LogLevel];
   if (levelName) {
     return levelName;
   }

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -2,8 +2,6 @@
 // This module is browser compatible.
 
 /**
- * @deprecated (will be changed after 0.211.0) Entries with numeric keys will be removed.
- * 
  * Use this to retrieve the numeric log level by it's associated name.
  * Defaults to INFO.
  */
@@ -14,11 +12,17 @@ export const LogLevels = {
   WARNING: 30,
   ERROR: 40,
   CRITICAL: 50,
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   0: "NOTSET",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   10: "DEBUG",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   20: "INFO",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   30: "WARNING",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   40: "ERROR",
+  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   50: "CRITICAL",
 } as const;
 
@@ -45,8 +49,11 @@ const byLevel: Record<LogLevel, LevelName> = {
 /**
  * Returns the numeric log level associated with the passed,
  * stringy log level name.
+ *
+ * @param {LevelName} name
+ * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
  */
-export function getLevelByName(name: LevelName): LogLevel {
+export function getLevelByName(name: LevelName): number {
   const level = LogLevels[name];
   if (level !== undefined) {
     return level;
@@ -55,9 +62,12 @@ export function getLevelByName(name: LevelName): LogLevel {
 }
 
 /**
- * Returns the stringy log level name provided the numeric log level.
- **/
-export function getLevelName(level: LogLevel): LevelName {
+ * Returns the stringy log level name provided the numeric log level
+ *
+ * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
+ * @returns {LevelName}
+ */
+export function getLevelName(level: number): LevelName {
   const levelName = byLevel[level as LogLevel];
   if (levelName) {
     return levelName;

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -3,7 +3,7 @@
 
 /**
  * @deprecated (will be changed after 0.211.0) Entries with numeric keys will be removed.
- * 
+ *
  * Use this to retrieve the numeric log level by it's associated name.
  * Defaults to INFO.
  */
@@ -56,7 +56,7 @@ export function getLevelByName(name: LevelName): LogLevel {
 
 /**
  * Returns the stringy log level name provided the numeric log level.
- **/
+ */
 export function getLevelName(level: LogLevel): LevelName {
   const levelName = byLevel[level as LogLevel];
   if (levelName) {

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -2,6 +2,8 @@
 // This module is browser compatible.
 
 /**
+ * @deprecated (will be changed after 0.211.0) Entries with numeric keys will be removed.
+ * 
  * Use this to retrieve the numeric log level by it's associated name.
  * Defaults to INFO.
  */
@@ -12,17 +14,11 @@ export const LogLevels = {
   WARNING: 30,
   ERROR: 40,
   CRITICAL: 50,
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   0: "NOTSET",
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   10: "DEBUG",
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   20: "INFO",
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   30: "WARNING",
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   40: "ERROR",
-  /* @deprecated (will be removed after 0.211.0) Use {@linkcode getLevelName} instead */
   50: "CRITICAL",
 } as const;
 
@@ -49,11 +45,8 @@ const byLevel: Record<LogLevel, LevelName> = {
 /**
  * Returns the numeric log level associated with the passed,
  * stringy log level name.
- *
- * @param {LevelName} name
- * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
  */
-export function getLevelByName(name: LevelName): number {
+export function getLevelByName(name: LevelName): LogLevel {
   const level = LogLevels[name];
   if (level !== undefined) {
     return level;
@@ -62,12 +55,9 @@ export function getLevelByName(name: LevelName): number {
 }
 
 /**
- * Returns the stringy log level name provided the numeric log level
- *
- * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
- * @returns {LevelName}
- */
-export function getLevelName(level: number): LevelName {
+ * Returns the stringy log level name provided the numeric log level.
+ **/
+export function getLevelName(level: LogLevel): LevelName {
   const levelName = byLevel[level as LogLevel];
   if (levelName) {
     return levelName;

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -50,8 +50,7 @@ const byLevel: Record<LogLevel, LevelName> = {
  * Returns the numeric log level associated with the passed,
  * stringy log level name.
  *
- * @param {LevelName} name
- * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
+ * @returns - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
  */
 export function getLevelByName(name: LevelName): number {
   const level = LogLevels[name];
@@ -64,8 +63,7 @@ export function getLevelByName(name: LevelName): number {
 /**
  * Returns the stringy log level name provided the numeric log level
  *
- * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
- * @returns {LevelName}
+ * @param level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
  */
 export function getLevelName(level: number): LevelName {
   const levelName = byLevel[level as LogLevel];

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -2,59 +2,50 @@
 // This module is browser compatible.
 
 /**
- * Get log level numeric values through enum constants.
+ * Use this to retrieve the numeric log level by it's associated name.
  * Defaults to INFO.
  */
-export enum LogLevels {
-  NOTSET = 0,
-  DEBUG = 10,
-  INFO = 20,
-  WARNING = 30,
-  ERROR = 40,
-  CRITICAL = 50,
-}
+export const LogLevels = {
+  NOTSET: 0,
+  DEBUG: 10,
+  INFO: 20,
+  WARNING: 30,
+  ERROR: 40,
+  CRITICAL: 50,
+} as const;
 
-/** Permitted log level names */
-export const LogLevelNames = Object.keys(LogLevels).filter((key) =>
-  isNaN(Number(key))
-);
+/** Union of valid log levels */
+export type LogLevel = typeof LogLevels[LevelName];
 
-/** Union of valid log level strings */
+/** Union of valid log level names */
 export type LevelName = keyof typeof LogLevels;
 
-const byLevel: Record<string, LevelName> = {
-  [String(LogLevels.NOTSET)]: "NOTSET",
-  [String(LogLevels.DEBUG)]: "DEBUG",
-  [String(LogLevels.INFO)]: "INFO",
-  [String(LogLevels.WARNING)]: "WARNING",
-  [String(LogLevels.ERROR)]: "ERROR",
-  [String(LogLevels.CRITICAL)]: "CRITICAL",
+/** Permitted log level names */
+export const LogLevelNames = Object.keys(LogLevels) as LevelName[];
+
+const byLevel: Record<LogLevel, LevelName> = {
+  [LogLevels.NOTSET]: "NOTSET",
+  [LogLevels.DEBUG]: "DEBUG",
+  [LogLevels.INFO]: "INFO",
+  [LogLevels.WARNING]: "WARNING",
+  [LogLevels.ERROR]: "ERROR",
+  [LogLevels.CRITICAL]: "CRITICAL",
 };
 
-/** Returns the numeric log level associated with the passed,
+/**
+ * Returns the numeric log level associated with the passed,
  * stringy log level name.
  */
-export function getLevelByName(name: LevelName): number {
-  switch (name) {
-    case "NOTSET":
-      return LogLevels.NOTSET;
-    case "DEBUG":
-      return LogLevels.DEBUG;
-    case "INFO":
-      return LogLevels.INFO;
-    case "WARNING":
-      return LogLevels.WARNING;
-    case "ERROR":
-      return LogLevels.ERROR;
-    case "CRITICAL":
-      return LogLevels.CRITICAL;
-    default:
-      throw new Error(`no log level found for "${name}"`);
+export function getLevelByName(name: LevelName): LogLevel {
+  const level = LogLevels[name];
+  if (level !== undefined) {
+    return level;
   }
+  throw new Error(`no log level found for "${name}"`);
 }
 
 /** Returns the stringy log level name provided the numeric log level */
-export function getLevelName(level: number): LevelName {
+export function getLevelName(level: LogLevel): LevelName {
   const levelName = byLevel[level];
   if (levelName) {
     return levelName;

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -65,7 +65,7 @@ export class Logger {
   /**
    * Use this to retrieve the current numeric log level.
    *
-   * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
+   * @returns - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
    */
   get level(): number {
     return this.#level;
@@ -74,7 +74,7 @@ export class Logger {
   /**
    * Use this to set the numeric log level.
    *
-   * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
+   * @param level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
    */
   set level(level: number) {
     try {

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -56,14 +56,17 @@ export class Logger {
     options: LoggerOptions = {},
   ) {
     this.#loggerName = loggerName;
-    this.#level = getLevelByName(levelName);
+    /* TODO: Remove this unnecessary typecast after 0.211.0 */
+    this.#level = getLevelByName(levelName) as LogLevel;
     this.#handlers = options.handlers || [];
   }
 
   /**
    * Use this to retrieve the current numeric log level.
+   *
+   * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
    */
-  get level(): LogLevel {
+  get level(): number {
     return this.#level;
   }
 

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { getLevelByName, getLevelName, LogLevels } from "./levels.ts";
-import type { LevelName } from "./levels.ts";
+import type { LevelName, LogLevel } from "./levels.ts";
 import type { BaseHandler } from "./handlers.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -9,7 +9,7 @@ export type GenericFunction = (...args: any[]) => any;
 export interface LogRecordOptions {
   msg: string;
   args: unknown[];
-  level: number;
+  level: LogLevel;
   loggerName: string;
 }
 
@@ -46,7 +46,7 @@ export interface LoggerOptions {
 }
 
 export class Logger {
-  #level: LogLevels;
+  #level: LogLevel;
   #handlers: BaseHandler[];
   readonly #loggerName: string;
 
@@ -60,10 +60,10 @@ export class Logger {
     this.#handlers = options.handlers || [];
   }
 
-  get level(): LogLevels {
+  get level(): LogLevel {
     return this.#level;
   }
-  set level(level: LogLevels) {
+  set level(level: LogLevel) {
     this.#level = level;
   }
 
@@ -85,7 +85,8 @@ export class Logger {
     return this.#handlers;
   }
 
-  /** If the level of the logger is greater than the level to log, then nothing
+  /**
+   * If the level of the logger is greater than the level to log, then nothing
    * is logged, otherwise a log record is passed to each log handler.  `msg` data
    * passed in is returned.  If a function is passed in, it is only evaluated
    * if the msg will be logged and the return value will be the result of the
@@ -93,7 +94,7 @@ export class Logger {
    * case undefined is returned.  All types are coerced to strings for logging.
    */
   #_log<T>(
-    level: number,
+    level: LogLevel,
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -9,8 +9,7 @@ export type GenericFunction = (...args: any[]) => any;
 export interface LogRecordOptions {
   msg: string;
   args: unknown[];
-  /* @deprecated (will be changed 0.211.0) Use {@linkcode LogLevel} instead */
-  level: number;
+  level: LogLevel;
   loggerName: string;
 }
 
@@ -22,7 +21,7 @@ export class LogRecord {
   readonly msg: string;
   #args: unknown[];
   #datetime: Date;
-  readonly level: number;
+  readonly level: LogLevel;
   readonly levelName: string;
   readonly loggerName: string;
 
@@ -73,13 +72,10 @@ export class Logger {
 
   /**
    * Use this to set the numeric log level.
-   *
-   * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
    */
-  set level(level: number) {
+  set level(level: LogLevel) {
     try {
-      /* TODO: Remove this unnecessary typecast after 0.211.0 */
-      this.#level = getLevelByName(getLevelName(level)) as LogLevel;
+      this.#level = getLevelByName(getLevelName(level));
     } catch (_) {
       throw new TypeError(`Invalid log level: ${level}`);
     }
@@ -89,8 +85,7 @@ export class Logger {
     return getLevelName(this.#level);
   }
   set levelName(levelName: LevelName) {
-    /* TODO: Remove this unnecessary typecast after 0.211.0 */
-    this.#level = getLevelByName(levelName) as LogLevel;
+    this.#level = getLevelByName(levelName);
   }
 
   get loggerName(): string {

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -56,17 +56,14 @@ export class Logger {
     options: LoggerOptions = {},
   ) {
     this.#loggerName = loggerName;
-    /* TODO: Remove this unnecessary typecast after 0.211.0 */
-    this.#level = getLevelByName(levelName) as LogLevel;
+    this.#level = getLevelByName(levelName);
     this.#handlers = options.handlers || [];
   }
 
   /**
    * Use this to retrieve the current numeric log level.
-   *
-   * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
    */
-  get level(): number {
+  get level(): LogLevel {
     return this.#level;
   }
 

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -9,7 +9,8 @@ export type GenericFunction = (...args: any[]) => any;
 export interface LogRecordOptions {
   msg: string;
   args: unknown[];
-  level: LogLevel;
+  /* @deprecated (will be changed 0.211.0) Use {@linkcode LogLevel} instead */
+  level: number;
   loggerName: string;
 }
 
@@ -21,7 +22,7 @@ export class LogRecord {
   readonly msg: string;
   #args: unknown[];
   #datetime: Date;
-  readonly level: LogLevel;
+  readonly level: number;
   readonly levelName: string;
   readonly loggerName: string;
 
@@ -72,10 +73,13 @@ export class Logger {
 
   /**
    * Use this to set the numeric log level.
+   *
+   * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
    */
-  set level(level: LogLevel) {
+  set level(level: number) {
     try {
-      this.#level = getLevelByName(getLevelName(level));
+      /* TODO: Remove this unnecessary typecast after 0.211.0 */
+      this.#level = getLevelByName(getLevelName(level)) as LogLevel;
     } catch (_) {
       throw new TypeError(`Invalid log level: ${level}`);
     }
@@ -85,7 +89,8 @@ export class Logger {
     return getLevelName(this.#level);
   }
   set levelName(levelName: LevelName) {
-    this.#level = getLevelByName(levelName);
+    /* TODO: Remove this unnecessary typecast after 0.211.0 */
+    this.#level = getLevelByName(levelName) as LogLevel;
   }
 
   get loggerName(): string {

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -9,7 +9,8 @@ export type GenericFunction = (...args: any[]) => any;
 export interface LogRecordOptions {
   msg: string;
   args: unknown[];
-  level: LogLevel;
+  /* @deprecated (will be changed 0.211.0) Use {@linkcode LogLevel} instead */
+  level: number;
   loggerName: string;
 }
 
@@ -56,22 +57,40 @@ export class Logger {
     options: LoggerOptions = {},
   ) {
     this.#loggerName = loggerName;
-    this.#level = getLevelByName(levelName);
+    /* TODO: Remove this unnecessary typecast after 0.211.0 */
+    this.#level = getLevelByName(levelName) as LogLevel;
     this.#handlers = options.handlers || [];
   }
 
-  get level(): LogLevel {
+  /**
+   * Use this to retrieve the current numeric log level.
+   *
+   * @returns {number} - Deprecated (will return {@linkcode LogLevel} after 0.211.0)
+   */
+  get level(): number {
     return this.#level;
   }
-  set level(level: LogLevel) {
-    this.#level = level;
+
+  /**
+   * Use this to set the numeric log level.
+   *
+   * @param {number} level - Deprecated (will accept {@linkcode LogLevel} after 0.211.0)
+   */
+  set level(level: number) {
+    try {
+      /* TODO: Remove this unnecessary typecast after 0.211.0 */
+      this.#level = getLevelByName(getLevelName(level)) as LogLevel;
+    } catch (_) {
+      throw new TypeError(`Invalid log level: ${level}`);
+    }
   }
 
   get levelName(): LevelName {
     return getLevelName(this.#level);
   }
   set levelName(levelName: LevelName) {
-    this.#level = getLevelByName(levelName);
+    /* TODO: Remove this unnecessary typecast after 0.211.0 */
+    this.#level = getLevelByName(levelName) as LogLevel;
   }
 
   get loggerName(): string {

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -263,7 +263,7 @@ import { assert } from "../assert/assert.ts";
 import type { LevelName } from "./levels.ts";
 
 export { LogLevels } from "./levels.ts";
-export type { LevelName } from "./levels.ts";
+export type { LevelName, LogLevel } from "./levels.ts";
 export { Logger } from "./logger.ts";
 export type { LogRecord } from "./logger.ts";
 export type { FormatterFunction, HandlerOptions, LogMode } from "./handlers.ts";

--- a/log/test.ts
+++ b/log/test.ts
@@ -5,6 +5,7 @@ import {
   getLevelByName,
   getLevelName,
   LevelName,
+  LogLevel,
   LogLevelNames,
 } from "./levels.ts";
 
@@ -110,5 +111,5 @@ Deno.test("getLoggerUnknown", async function () {
 
 Deno.test("getInvalidLoggerLevels", function () {
   assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LevelName));
-  assertThrows(() => getLevelName(5000));
+  assertThrows(() => getLevelName(5000 as LogLevel));
 });

--- a/log/test.ts
+++ b/log/test.ts
@@ -34,7 +34,7 @@ Deno.test("defaultHandlers", async function () {
     }
 
     const logger = loggers[levelName];
-    const handler = new TestHandler(levelName as LevelName);
+    const handler = new TestHandler(levelName);
 
     await log.setup({
       handlers: {


### PR DESCRIPTION
 References this [issue](https://github.com/denoland/deno_std/issues/3782) and is the successor of this [PR](https://github.com/denoland/deno_std/pull/3838)

- feat(log): replaced LogLevels enum with object and enforced stricter types
- feat(log): updated types
- chore(log): updated types in tests
- chore(log): retain bimap for const object and add deprecation notices
- refactor(log): added deprecation notices and hardened level setter
- feat(log): added LogLevel to module API
- chore(log): removed unnecessary type casts in tests
