### PR TITLE
chore: group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     directory: "/crypto/_wasm"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*" # Matches all packages


### PR DESCRIPTION
Currently, Dependabot opens a new PR for each dependency update available. This change makes Dependabot open only one PR for any available updates, reducing maintenance.

Reference https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#example-2