### PR TITLE
fix(assert): fix diff of long string in objects

### DIFF
--- a/assert/_format.ts
+++ b/assert/_format.ts
@@ -18,6 +18,7 @@ export function format(v: unknown): string {
       iterableLimit: Infinity,
       // getters should be true in assertEquals.
       getters: true,
+      strAbbreviateSize: Infinity,
     })
     : `"${String(v).replace(/(?=["\\])/g, "\\")}"`;
 }

--- a/assert/_format_test.ts
+++ b/assert/_format_test.ts
@@ -78,3 +78,16 @@ Deno.test("assert diff formatting", () => {
 ]`,
   );
 });
+
+Deno.test("format() doesn't truncate long strings in object", () => {
+  const str = format({
+    foo:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  });
+  assertEquals(
+    str,
+    `{
+  foo: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+}`,
+  );
+});


### PR DESCRIPTION
closes #939 

Now [the original example](https://gist.github.com/wperron/f4a7bf79172f5c354d5c75850bb7d511) shows the diff like the below:

```
$ deno test a.js 
running 1 test from ./a.js
test ... FAILED (2ms)

 ERRORS 

test => ./a.js:3:6
error: AssertionError: Values are not equal.


    [Diff] Actual / Expected


    {
-     foo: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of ERROR ERROR.",
+     foo: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
    }
```