### PR TITLE
Revert "BREAKING(media_types): remove `typeByExtension()`"

### DIFF
--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -5,7 +5,7 @@ import { parseMediaType } from "./parse_media_type.ts";
 import { getCharset } from "./get_charset.ts";
 import { formatMediaType } from "./format_media_type.ts";
 import type { db } from "./_db.ts";
-import { types } from "./_db.ts";
+import { typeByExtension } from "./type_by_extension.ts";
 
 type DB = typeof db;
 type ContentTypeToExtension = {
@@ -74,10 +74,4 @@ export function contentType<
   }
   return undefined as Lowercase<T> extends KnownExtensionOrType ? string
     : string | undefined;
-}
-
-function typeByExtension(extension: string): string | undefined {
-  extension = extension.startsWith(".") ? extension.slice(1) : extension;
-  // @ts-ignore workaround around denoland/dnt#148
-  return types.get(extension.toLowerCase());
 }

--- a/media_types/mod.ts
+++ b/media_types/mod.ts
@@ -21,3 +21,4 @@ export * from "./extensions_by_type.ts";
 export * from "./format_media_type.ts";
 export * from "./get_charset.ts";
 export * from "./parse_media_type.ts";
+export * from "./type_by_extension.ts";

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -4,8 +4,6 @@
 import { types } from "./_db.ts";
 
 /**
- * @deprecated (will be removed in 0.209.0) Use {@linkcode import("./content_type.ts").contentType} instead.
- *
  * Returns the media type associated with the file extension. Values are
  * normalized to lower case and matched irrespective of a leading `.`.
  *

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -1,0 +1,28 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { types } from "./_db.ts";
+
+/**
+ * @deprecated (will be removed in 0.209.0) Use {@linkcode import("./content_type.ts").contentType} instead.
+ *
+ * Returns the media type associated with the file extension. Values are
+ * normalized to lower case and matched irrespective of a leading `.`.
+ *
+ * When `extension` has no associated type, the function returns `undefined`.
+ *
+ * @example
+ * ```ts
+ * import { typeByExtension } from "https://deno.land/std@$STD_VERSION/media_types/type_by_extension.ts";
+ *
+ * typeByExtension("js"); // `application/json`
+ * typeByExtension(".HTML"); // `text/html`
+ * typeByExtension("foo"); // undefined
+ * typeByExtension("file.json"); // undefined
+ * ```
+ */
+export function typeByExtension(extension: string): string | undefined {
+  extension = extension.startsWith(".") ? extension.slice(1) : extension;
+  // @ts-ignore workaround around denoland/dnt#148
+  return types.get(extension.toLowerCase());
+}

--- a/media_types/type_by_extension_test.ts
+++ b/media_types/type_by_extension_test.ts
@@ -1,0 +1,24 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "../assert/mod.ts";
+import { typeByExtension } from "./mod.ts";
+
+Deno.test({
+  name: "media_types - typeByExtension",
+  fn() {
+    const fixtures = [
+      ["js", "application/javascript"],
+      [".js", "application/javascript"],
+      ["Js", "application/javascript"],
+      ["html", "text/html"],
+      [".html", "text/html"],
+      [".HTML", "text/html"],
+      ["file.json", undefined],
+      ["foo", undefined],
+      [".foo", undefined],
+    ] as const;
+    for (const [fixture, expected] of fixtures) {
+      assertEquals(typeByExtension(fixture), expected);
+    }
+  },
+});


### PR DESCRIPTION
And undoes the deprecation.

Reverts denoland/deno_std#3848

See https://github.com/denoland/deno_std/issues/3616#issuecomment-1830404615