### PR TITLE
deprecation: move `types.d.ts` to `std/io`

### DIFF
--- a/_tools/check_circular_submodule_dependencies.ts
+++ b/_tools/check_circular_submodule_dependencies.ts
@@ -38,7 +38,7 @@ async function check(
     }
   }
   deps.delete(submod);
-  deps.delete("types.d.ts");
+  deps.delete("io/types.d.ts");
   return { name: submod, set: deps, state };
 }
 

--- a/_tools/check_circular_submodule_dependencies.ts
+++ b/_tools/check_circular_submodule_dependencies.ts
@@ -38,7 +38,6 @@ async function check(
     }
   }
   deps.delete(submod);
-  deps.delete("io/types.d.ts");
   return { name: submod, set: deps, state };
 }
 

--- a/archive/_common.ts
+++ b/archive/_common.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import { PartialReadError } from "../io/buf_reader.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "../io/types.d.ts";
 
 export interface TarInfo {
   fileMode?: number;

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -35,7 +35,7 @@ import {
   type TarOptions,
   ustarStructure,
 } from "./_common.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "../io/types.d.ts";
 import { MultiReader } from "../io/multi_reader.ts";
 import { Buffer } from "../io/buffer.ts";
 import { assert } from "../assert/assert.ts";

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -37,7 +37,7 @@ import {
   ustarStructure,
 } from "./_common.ts";
 import { readAll } from "../streams/read_all.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "../io/types.d.ts";
 
 /**
  * Extend TarMeta with the `linkName` property so that readers can access

--- a/io/_test_common.ts
+++ b/io/_test_common.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 
 export const MIN_READ_BUFFER_SIZE = 16;
 export const bufsizes: number[] = [

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -8,7 +8,7 @@
 
 import { assert } from "../assert/assert.ts";
 import { copy } from "../bytes/copy.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 const MIN_BUF_SIZE = 16;

--- a/io/buf_reader_test.ts
+++ b/io/buf_reader_test.ts
@@ -7,7 +7,7 @@ import { BufferFullError, BufReader, PartialReadError } from "./buf_reader.ts";
 import { StringReader } from "./string_reader.ts";
 import { bufsizes, MIN_READ_BUFFER_SIZE } from "./_test_common.ts";
 import { Buffer } from "./buffer.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 import { copy } from "../bytes/copy.ts";
 
 /** OneByteReader returns a Reader that implements

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { copy } from "../bytes/copy.ts";
-import type { Writer, WriterSync } from "../types.d.ts";
+import type { Writer, WriterSync } from "./types.d.ts";
 
 const DEFAULT_BUF_SIZE = 4096;
 

--- a/io/buf_writer_test.ts
+++ b/io/buf_writer_test.ts
@@ -7,7 +7,7 @@ import { BufWriter, BufWriterSync } from "./buf_writer.ts";
 import { Buffer } from "./buffer.ts";
 import { StringWriter } from "./string_writer.ts";
 import { bufsizes } from "./_test_common.ts";
-import type { Writer, WriterSync } from "../types.d.ts";
+import type { Writer, WriterSync } from "./types.d.ts";
 
 Deno.test("bufioWriter", async function () {
   const data = new Uint8Array(8192);

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "../assert/assert.ts";
 import { copy } from "../bytes/copy.ts";
-import type { Reader, ReaderSync } from "../types.d.ts";
+import type { Reader, ReaderSync } from "./types.d.ts";
 
 // MIN_READ is the minimum ArrayBuffer size passed to a read call by
 // buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { assert } from "../assert/assert.ts";
-import type { Reader, Writer } from "../types.d.ts";
+import type { Reader, Writer } from "./types.d.ts";
 
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 

--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -7,7 +7,7 @@
  * `read` returns `null` when `limit` <= `0` or
  * when the underlying `reader` returns `null`.
  */
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 
 /**
  * Reader utility for combining multiple readers

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { concat } from "../bytes/concat.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "./types.d.ts";
 
 /** Generate longest proper prefix which is also suffix array. */
 function createLPS(pat: Uint8Array): Uint8Array {

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { type Reader } from "../types.d.ts";
+import { type Reader } from "./types.d.ts";
 import { BufReader } from "./buf_reader.ts";
 import { concat } from "../bytes/concat.ts";
 

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -2,7 +2,7 @@
 
 import { copy as copyBytes } from "../bytes/copy.ts";
 import { assert } from "../assert/assert.ts";
-import type { Reader, ReaderSync } from "../types.d.ts";
+import type { Reader, ReaderSync } from "./types.d.ts";
 
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 

--- a/io/read_range_test.ts
+++ b/io/read_range_test.ts
@@ -8,7 +8,7 @@ import {
   assertThrows,
 } from "../assert/mod.ts";
 import { readRange, readRangeSync } from "./read_range.ts";
-import type { Closer, Reader, ReaderSync } from "../types.d.ts";
+import type { Closer, Reader, ReaderSync } from "./types.d.ts";
 
 // N controls how many iterations of certain checks are performed.
 const N = 100;

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { type Reader } from "../types.d.ts";
+import { type Reader } from "./types.d.ts";
 import { readDelim } from "./read_delim.ts";
 
 /**

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Writer, WriterSync } from "../types.d.ts";
+import type { Writer, WriterSync } from "./types.d.ts";
 
 const decoder = new TextDecoder();
 

--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -1,17 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * See the Contributing > Types section in the README for an explanation of this file.
- */
+/** See the Contributing > Types section in the README for an explanation of this file. */
 
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * An abstract interface which when implemented provides an interface to read bytes into an array buffer asynchronously.
- */
+/** An abstract interface which when implemented provides an interface to read bytes into an array buffer asynchronously. */
 export interface Reader {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
    * bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -38,11 +30,7 @@ export interface Reader {
   read(p: Uint8Array): Promise<number | null>;
 }
 
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * An abstract interface which when implemented provides an interface to read bytes into an array buffer synchronously.
- */
+/** An abstract interface which when implemented provides an interface to read bytes into an array buffer synchronously. */
 export interface ReaderSync {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
    * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -68,11 +56,7 @@ export interface ReaderSync {
   readSync(p: Uint8Array): number | null;
 }
 
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource asynchronously.
- */
+/** An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource asynchronously. */
 export interface Writer {
   /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
    * resolves to the number of bytes written from `p` (`0` <= `n` <=
@@ -85,11 +69,7 @@ export interface Writer {
    */
   write(p: Uint8Array): Promise<number>;
 }
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource synchronously.
- */
+/** An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource synchronously. */
 export interface WriterSync {
   /** Writes `p.byteLength` bytes from `p` to the underlying data
    * stream. It returns the number of bytes written from `p` (`0` <= `n`
@@ -103,11 +83,7 @@ export interface WriterSync {
   writeSync(p: Uint8Array): number;
 }
 
-/**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
- * An abstract interface which when implemented provides an interface to close files/resources that were previously opened.
- */
+/** An abstract interface which when implemented provides an interface to close files/resources that were previously opened. */
 export interface Closer {
   /** Closes the resource, "freeing" the backing file/resource. */
   close(): void;

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -4,7 +4,7 @@ import type { LogRecord } from "./logger.ts";
 import { blue, bold, red, yellow } from "../fmt/colors.ts";
 import { existsSync } from "../fs/exists.ts";
 import { BufWriterSync } from "../io/buf_writer.ts";
-import type { Writer } from "../types.d.ts";
+import type { Writer } from "../io/types.d.ts";
 
 const DEFAULT_FORMATTER = "{levelName} {msg}";
 export type FormatterFunction = (logRecord: LogRecord) => string;

--- a/streams/copy.ts
+++ b/streams/copy.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
-import type { Reader, Writer } from "../types.d.ts";
+import type { Reader, Writer } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream.pipeTo} instead.

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { DEFAULT_BUFFER_SIZE } from "./_common.ts";
-import type { Reader, ReaderSync } from "../types.d.ts";
+import type { Reader, ReaderSync } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream} instead.

--- a/streams/iterate_reader_test.ts
+++ b/streams/iterate_reader_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { iterateReader, iterateReaderSync } from "./iterate_reader.ts";
 import { readerFromIterable } from "./reader_from_iterable.ts";
 import { delay } from "../async/delay.ts";
-import type { Reader, ReaderSync } from "../types.d.ts";
+import type { Reader, ReaderSync } from "../io/types.d.ts";
 
 Deno.test("iterateReader", async () => {
   // ref: https://github.com/denoland/deno/issues/2330

--- a/streams/read_all.ts
+++ b/streams/read_all.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
-import type { Reader, ReaderSync } from "../types.d.ts";
+import type { Reader, ReaderSync } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream} and {@linkcode import("./to_array_buffer.ts").toArrayBuffer} instead.

--- a/streams/readable_stream_from_reader.ts
+++ b/streams/readable_stream_from_reader.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { DEFAULT_CHUNK_SIZE } from "./_common.ts";
-import type { Closer, Reader } from "../types.d.ts";
+import type { Closer, Reader } from "../io/types.d.ts";
 
 function isCloser(value: unknown): value is Closer {
   return typeof value === "object" && value !== null && value !== undefined &&

--- a/streams/readable_stream_from_reader_test.ts
+++ b/streams/readable_stream_from_reader_test.ts
@@ -5,7 +5,7 @@ import { readableStreamFromReader } from "./readable_stream_from_reader.ts";
 import { Buffer } from "../io/buffer.ts";
 import { concat } from "../bytes/concat.ts";
 import { copy } from "../bytes/copy.ts";
-import type { Closer, Reader } from "../types.d.ts";
+import type { Closer, Reader } from "../io/types.d.ts";
 
 class MockReaderCloser implements Reader, Closer {
   chunks: Uint8Array[] = [];

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -3,7 +3,7 @@
 
 import { Buffer } from "../io/buffer.ts";
 import { writeAll } from "./write_all.ts";
-import { Reader } from "../types.d.ts";
+import { Reader } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream.from} instead.

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -3,7 +3,7 @@
 
 import { Buffer } from "../io/buffer.ts";
 import { writeAll } from "./write_all.ts";
-import type { Reader } from "../types.d.ts";
+import type { Reader } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStreamDefaultReader} directly.

--- a/streams/writable_stream_from_writer.ts
+++ b/streams/writable_stream_from_writer.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { writeAll } from "./write_all.ts";
-import type { Closer, Writer } from "../types.d.ts";
+import type { Closer, Writer } from "../io/types.d.ts";
 
 function isCloser(value: unknown): value is Closer {
   return typeof value === "object" && value !== null && value !== undefined &&

--- a/streams/writable_stream_from_writer_test.ts
+++ b/streams/writable_stream_from_writer_test.ts
@@ -2,7 +2,7 @@
 
 import { assertEquals } from "../assert/mod.ts";
 import { writableStreamFromWriter } from "./writable_stream_from_writer.ts";
-import type { Closer, Writer } from "../types.d.ts";
+import type { Closer, Writer } from "../io/types.d.ts";
 
 class MockWriterCloser implements Writer, Closer {
   chunks: Uint8Array[] = [];

--- a/streams/write_all.ts
+++ b/streams/write_all.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Writer, WriterSync } from "../types.d.ts";
+import type { Writer, WriterSync } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStream}, {@linkcode ReadableStream.from} and {@linkcode ReadableStream.pipeTo} instead.

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Writer } from "../types.d.ts";
+import type { Writer } from "../io/types.d.ts";
 
 /**
  * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStreamDefaultWriter} directly.


### PR DESCRIPTION
This change is required for workspaces support.