### PR TITLE
chore(fmt): replace `stripColor()` use with `stripAnsiCode()`

### DIFF
--- a/assert/_format_test.ts
+++ b/assert/_format_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { green, red, stripColor } from "../fmt/colors.ts";
+import { green, red, stripAnsiCode } from "../fmt/colors.ts";
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 import { format } from "./_format.ts";
 
@@ -29,7 +29,7 @@ Deno.test("assert diff formatting", () => {
   // Wraps objects into multiple lines even when they are small. Prints trailing
   // commas.
   assertEquals(
-    stripColor(format({ a: 1, b: 2 })),
+    stripAnsiCode(format({ a: 1, b: 2 })),
     `{
   a: 1,
   b: 2,
@@ -51,7 +51,7 @@ Deno.test("assert diff formatting", () => {
 
   // Same for nested small objects.
   assertEquals(
-    stripColor(format([{ x: { a: 1, b: 2 }, y: ["a", "b"] }])),
+    stripAnsiCode(format([{ x: { a: 1, b: 2 }, y: ["a", "b"] }])),
     `[
   {
     x: {
@@ -68,7 +68,7 @@ Deno.test("assert diff formatting", () => {
 
   // Grouping is disabled.
   assertEquals(
-    stripColor(format(["i", "i", "i", "i", "i", "i", "i"])),
+    stripAnsiCode(format(["i", "i", "i", "i", "i", "i", "i"])),
     `[
   "i",
   "i",

--- a/assert/assert_equals_test.ts
+++ b/assert/assert_equals_test.ts
@@ -1,6 +1,13 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, AssertionError, assertThrows } from "./mod.ts";
-import { bold, gray, green, red, stripColor, yellow } from "../fmt/colors.ts";
+import {
+  bold,
+  gray,
+  green,
+  red,
+  stripAnsiCode,
+  yellow,
+} from "../fmt/colors.ts";
 
 const createHeader = (): string[] => [
   "",
@@ -15,9 +22,9 @@ const createHeader = (): string[] => [
 ];
 
 const added: (s: string) => string = (s: string): string =>
-  green(bold(stripColor(s)));
+  green(bold(stripAnsiCode(s)));
 const removed: (s: string) => string = (s: string): string =>
-  red(bold(stripColor(s)));
+  red(bold(stripAnsiCode(s)));
 
 Deno.test({
   name: "pass case",

--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { AssertionError } from "./assertion_error.ts";
-import { stripColor } from "../fmt/colors.ts";
+import { stripAnsiCode } from "../fmt/colors.ts";
 
 /**
  * Make an assertion that `error` is an `Error`.
@@ -29,7 +29,7 @@ export function assertIsError<E extends Error = Error>(
   }
   if (
     msgIncludes && (!(error instanceof Error) ||
-      !stripColor(error.message).includes(stripColor(msgIncludes)))
+      !stripAnsiCode(error.message).includes(stripAnsiCode(msgIncludes)))
   ) {
     msg = `Expected error message to include ${
       JSON.stringify(msgIncludes)

--- a/console/unicode_width.ts
+++ b/console/unicode_width.ts
@@ -40,21 +40,21 @@ function charWidth(ch: string) {
  * Get the width of a string's constituent characters in columns in TTY-like
  * environments.
  *
- * Combine with `stripColor` from `fmt/colors.ts` to get the expected physical
+ * Combine with `stripAnsiCode` from `fmt/colors.ts` to get the expected physical
  * width of a string in the console.
  *
  * @example
  * ```ts
  * import { unicodeWidth } from "https://deno.land/std@$STD_VERSION/console/unicode_width.ts";
  * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
- * import { stripColor } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * import { stripAnsiCode } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *
  * assertEquals(unicodeWidth("hello world"), 11);
  * assertEquals(unicodeWidth("天地玄黃宇宙洪荒"), 16);
  * assertEquals(unicodeWidth("ｆｕｌｌｗｉｄｔｈ"), 18);
- * assertEquals(unicodeWidth(stripColor("\x1b[36mголубой\x1b[39m")), 7);
- * assertEquals(unicodeWidth(stripColor("\x1b[31m紅色\x1b[39m")), 4);
- * assertEquals(unicodeWidth(stripColor("\x1B]8;;https://deno.land\x07🦕\x1B]8;;\x07")), 2);
+ * assertEquals(unicodeWidth(stripAnsiCode("\x1b[36mголубой\x1b[39m")), 7);
+ * assertEquals(unicodeWidth(stripAnsiCode("\x1b[31m紅色\x1b[39m")), 4);
+ * assertEquals(unicodeWidth(stripAnsiCode("\x1B]8;;https://deno.land\x07🦕\x1B]8;;\x07")), 2);
  * ```
  */
 export function unicodeWidth(str: string) {

--- a/expect/_format_test.ts
+++ b/expect/_format_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { green, red, stripColor } from "../fmt/colors.ts";
+import { green, red, stripAnsiCode } from "../fmt/colors.ts";
 import { assertEquals, assertThrows } from "../assert/mod.ts";
 import { format } from "./_format.ts";
 
@@ -29,7 +29,7 @@ Deno.test("assert diff formatting", () => {
   // Wraps objects into multiple lines even when they are small. Prints trailing
   // commas.
   assertEquals(
-    stripColor(format({ a: 1, b: 2 })),
+    stripAnsiCode(format({ a: 1, b: 2 })),
     `{
   a: 1,
   b: 2,
@@ -51,7 +51,7 @@ Deno.test("assert diff formatting", () => {
 
   // Same for nested small objects.
   assertEquals(
-    stripColor(format([{ x: { a: 1, b: 2 }, y: ["a", "b"] }])),
+    stripAnsiCode(format([{ x: { a: 1, b: 2 }, y: ["a", "b"] }])),
     `[
   {
     x: {
@@ -68,7 +68,7 @@ Deno.test("assert diff formatting", () => {
 
   // Grouping is disabled.
   assertEquals(
-    stripColor(format(["i", "i", "i", "i", "i", "i", "i"])),
+    stripAnsiCode(format(["i", "i", "i", "i", "i", "i", "i"])),
     `[
   "i",
   "i",

--- a/fmt/colors_test.ts
+++ b/fmt/colors_test.ts
@@ -233,9 +233,9 @@ Deno.test("test bgRgb24 number", function () {
 });
 
 // https://github.com/chalk/strip-ansi/blob/2b8c961e75760059699373f9a69101065c3ded3a/test.js#L4-L6
-Deno.test("test stripColor", function () {
+Deno.test("test stripAnsiCode", function () {
   assertEquals(
-    c.stripColor(
+    c.stripAnsiCode(
       "\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m",
     ),
     "foofoo",

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -101,14 +101,14 @@
  * ```ts
  * // example_test.ts
  * import { createAssertSnapshot } from "https://deno.land/std@$STD_VERSION/testing/snapshot.ts";
- * import { stripColor } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
+ * import { stripAnsiCode } from "https://deno.land/std@$STD_VERSION/fmt/colors.ts";
  *
  * const assertSnapshot = createAssertSnapshot({
  *   dir: ".snaps",
  * });
  *
  * const assertMonochromeSnapshot = createAssertSnapshot<string>(
- *   { serializer: stripColor },
+ *   { serializer: stripAnsiCode },
  *   assertSnapshot,
  * );
  *

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { stripColor } from "../fmt/colors.ts";
+import { stripAnsiCode } from "../fmt/colors.ts";
 import { dirname, fromFileUrl, join, toFileUrl } from "../path/mod.ts";
 import {
   assert,
@@ -17,7 +17,7 @@ const SNAPSHOT_MODULE_URL = toFileUrl(join(
 
 function formatTestOutput(string: string) {
   // Strip colors and obfuscate any timings
-  return stripColor(string).replace(/([0-9])+m?s/g, "--ms").replace(
+  return stripAnsiCode(string).replace(/([0-9])+m?s/g, "--ms").replace(
     /(?<=running ([0-9])+ test(s)? from )(.*)(?=test.ts)/g,
     "<tempDir>/",
   );
@@ -26,7 +26,7 @@ function formatTestOutput(string: string) {
 function formatTestError(string: string) {
   // Strip colors and remove "Check file:///workspaces/deno_std/testing/.tmp/test.ts"
   // as this is always output to stderr
-  return stripColor(string).replace(/^Check file:\/\/(.+)\n/gm, "");
+  return stripAnsiCode(string).replace(/^Check file:\/\/(.+)\n/gm, "");
 }
 
 function testFnWithTempDir(
@@ -190,12 +190,12 @@ ${serialize(snapshot)}
 
     await t.step("Object", async (t) => {
       const error = await testFailedAssertion([1, 2, 3], [1, 2]);
-      await assertSnapshot(t, stripColor(error.message));
+      await assertSnapshot(t, stripAnsiCode(error.message));
     });
 
     await t.step("String", async (t) => {
       const error = await testFailedAssertion("Hello World!", "Hello!");
-      await assertSnapshot(t, stripColor(error.message));
+      await assertSnapshot(t, stripAnsiCode(error.message));
     });
   }),
 );
@@ -749,7 +749,7 @@ Deno.test("Snapshot Test - Empty #2245", async (t) => {
 
 Deno.test("SnapshotTest - createAssertSnapshot", async (t) => {
   const assertMonochromeSnapshot = createAssertSnapshot<string>({
-    serializer: stripColor,
+    serializer: stripAnsiCode,
   });
 
   await t.step("No Options", async (t) => {


### PR DESCRIPTION
`stripColor()` is now deprecated in favour of `stripAnsiCode()`.