### PR TITLE
deprecation(io): IO types in favour of Web Streams API

### DIFF
--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -1,9 +1,19 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/** See the Contributing > Types section in the README for an explanation of this file. */
+/**
+ * See the Contributing > Types section in the README for an explanation of this file.
+ *
+ * @deprecate (will be removed in 1.0.0) Use the
+ * [Streams API]{@linkcode https://developer.mozilla.org/en-US/docs/Web/API/Streams_API}
+ * instead.
+ */
 
-/** An abstract interface which when implemented provides an interface to read bytes into an array buffer asynchronously. */
+/**
+ * An abstract interface which when implemented provides an interface to read bytes into an array buffer asynchronously.
+ *
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode ReadableStream} instead.
+ */
 export interface Reader {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
    * bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -30,7 +40,11 @@ export interface Reader {
   read(p: Uint8Array): Promise<number | null>;
 }
 
-/** An abstract interface which when implemented provides an interface to read bytes into an array buffer synchronously. */
+/**
+ * An abstract interface which when implemented provides an interface to read bytes into an array buffer synchronously.
+ *
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode ReadableStream} instead.
+ */
 export interface ReaderSync {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
    * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -56,7 +70,11 @@ export interface ReaderSync {
   readSync(p: Uint8Array): number | null;
 }
 
-/** An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource asynchronously. */
+/**
+ * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource asynchronously.
+ *
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode WritableStream} instead.
+ */
 export interface Writer {
   /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
    * resolves to the number of bytes written from `p` (`0` <= `n` <=
@@ -69,7 +87,11 @@ export interface Writer {
    */
   write(p: Uint8Array): Promise<number>;
 }
-/** An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource synchronously. */
+/**
+ * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource synchronously.
+ *
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode WritableStream} instead.
+ */
 export interface WriterSync {
   /** Writes `p.byteLength` bytes from `p` to the underlying data
    * stream. It returns the number of bytes written from `p` (`0` <= `n`
@@ -83,7 +105,11 @@ export interface WriterSync {
   writeSync(p: Uint8Array): number;
 }
 
-/** An abstract interface which when implemented provides an interface to close files/resources that were previously opened. */
+/**
+ * An abstract interface which when implemented provides an interface to close files/resources that were previously opened.
+ *
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode ReadableStream} and {@linkcode WritableStream} instead.
+ */
 export interface Closer {
   /** Closes the resource, "freeing" the backing file/resource. */
   close(): void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,15 +2,15 @@
 // This module is browser compatible.
 
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * See the Contributing > Types section in the README for an explanation of this file.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * An abstract interface which when implemented provides an interface to read bytes into an array buffer asynchronously.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 export interface Reader {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
@@ -39,9 +39,9 @@ export interface Reader {
 }
 
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * An abstract interface which when implemented provides an interface to read bytes into an array buffer synchronously.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 export interface ReaderSync {
   /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
@@ -69,9 +69,9 @@ export interface ReaderSync {
 }
 
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource asynchronously.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 export interface Writer {
   /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
@@ -86,9 +86,9 @@ export interface Writer {
   write(p: Uint8Array): Promise<number>;
 }
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * An abstract interface which when implemented provides an interface to write bytes from an array buffer to a file/resource synchronously.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 export interface WriterSync {
   /** Writes `p.byteLength` bytes from `p` to the underlying data
@@ -104,9 +104,9 @@ export interface WriterSync {
 }
 
 /**
- * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
- *
  * An abstract interface which when implemented provides an interface to close files/resources that were previously opened.
+ *
+ * @deprecated (will be removed in 0.211.0) Import from {@link https://deno.land/std/io/types.d.ts} instead.
  */
 export interface Closer {
   /** Closes the resource, "freeing" the backing file/resource. */


### PR DESCRIPTION
To be clear, `/types.d.ts` is being deprecated in favour of `/io/types.d.ts` with a removal version of 0.211.0. `/io/types.d.ts` is being deprecated in favour of the Web Streams API. It's being done this way to minimise breaking changes and allow code to still use `/io/types.d.ts` until its removal in 1.0.0.

This change assumes that `Deno.*` IO interfaces and methods will be removed in Deno v2 and Std. Lib. v1, at the same time.

See https://github.com/denoland/deno/pull/21465