### PR TITLE
test(fs): fix `expandGlob()` test assertion

### DIFF
--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -242,7 +242,7 @@ Deno.test("expandGlob() throws permission error without fs permissions", async f
   assert(!success);
   assertEquals(code, 1);
   assertEquals(decoder.decode(stdout), "");
-  assertStringIncludes(decoder.decode(stderr), "Uncaught PermissionDenied");
+  assertStringIncludes(decoder.decode(stderr), "PermissionDenied");
 });
 
 Deno.test("expandGlob() returns single entry when root is not glob", async function () {


### PR DESCRIPTION
Fixes the failures we're seeing here: https://github.com/denoland/deno_std/actions/runs/7122896293/job/19394638369?pr=3905