### PR TITLE
docs: remove link to github discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,6 @@ assignees: ''
 
 ---
 
-<!-- NOTE: for larger scale feature requests like additions to the standard library, consider opening a new discussion under the "Proposals" category over here: https://github.com/denoland/deno_std/discussions/new?category=proposals -->
-
 **Is your feature request related to a problem? Please describe.**
 
 <!-- A clear and concise description of what the problem is. -->


### PR DESCRIPTION
github discussions were disabled in #3753, however it was still mentioned in feature request issue template.