### PR TITLE
fix(assert): disallow scalar string args in `assertArrayIncludes()`

### DIFF
--- a/assert/assert_array_includes.ts
+++ b/assert/assert_array_includes.ts
@@ -3,6 +3,9 @@ import { equal } from "./equal.ts";
 import { format } from "./_format.ts";
 import { AssertionError } from "./assertion_error.ts";
 
+/** An array-like object (`Array`, `Uint8Array`, `NodeList`, etc.) that is not a string */
+type ArrayLikeArg<T> = ArrayLike<T> & object;
+
 /**
  * Make an assertion that `actual` includes the `expected` values. If not then
  * an error will be thrown.
@@ -19,8 +22,8 @@ import { AssertionError } from "./assertion_error.ts";
  * ```
  */
 export function assertArrayIncludes<T>(
-  actual: ArrayLike<T>,
-  expected: ArrayLike<T>,
+  actual: ArrayLikeArg<T>,
+  expected: ArrayLikeArg<T>,
   msg?: string,
 ): void {
   const missing: unknown[] = [];

--- a/assert/assert_array_includes_test.ts
+++ b/assert/assert_array_includes_test.ts
@@ -57,6 +57,7 @@ missing: [
     );
   });
 
+  // https://github.com/denoland/deno_std/issues/3372
   await t.step("Type-check failing cases", () => {
     try {
       // @ts-expect-error 2nd arg - 'string' is not assignable to 'ArrayLikeArg<string>'.

--- a/assert/assert_array_includes_test.ts
+++ b/assert/assert_array_includes_test.ts
@@ -1,19 +1,42 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertArrayIncludes, AssertionError, assertThrows } from "./mod.ts";
 
-Deno.test("ArrayContains", function () {
+Deno.test("assertArrayIncludes", async (t) => {
   const fixture = ["deno", "iz", "luv"];
   const fixtureObject = [{ deno: "luv" }, { deno: "Js" }];
-  assertArrayIncludes(fixture, ["deno"]);
-  assertArrayIncludes(fixtureObject, [{ deno: "luv" }]);
-  assertArrayIncludes(
-    Uint8Array.from([1, 2, 3, 4]),
-    Uint8Array.from([1, 2, 3]),
-  );
-  assertThrows(
-    () => assertArrayIncludes(fixtureObject, [{ deno: "node" }]),
-    AssertionError,
-    `Expected actual: "[
+
+  await t.step("Passing cases", () => {
+    assertArrayIncludes(fixture, ["deno"]);
+    assertArrayIncludes(fixtureObject, [{ deno: "luv" }]);
+    assertArrayIncludes(
+      Uint8Array.from([1, 2, 3, 4]),
+      Uint8Array.from([1, 2, 3]),
+    );
+    assertArrayIncludes(["a"], ["a"]);
+    assertArrayIncludes(["a", "b", "c"], ["a", "b"]);
+  });
+
+  await t.step("Throwing cases", () => {
+    assertThrows(
+      () => assertArrayIncludes(["a"], ["b"]),
+      AssertionError,
+      `
+Expected actual: "[
+  "a",
+]" to include: "[
+  "b",
+]".
+missing: [
+  "b",
+]
+`.trim(),
+    );
+
+    assertThrows(
+      () => assertArrayIncludes(fixtureObject, [{ deno: "node" }]),
+      AssertionError,
+      `
+Expected actual: "[
   {
     deno: "luv",
   },
@@ -29,6 +52,19 @@ missing: [
   {
     deno: "node",
   },
-]`,
-  );
+]
+`.trim(),
+    );
+  });
+
+  await t.step("Type-check failing cases", () => {
+    try {
+      // @ts-expect-error 2nd arg - 'string' is not assignable to 'ArrayLikeArg<string>'.
+      assertArrayIncludes(["a"], "b");
+      // @ts-expect-error 1st arg - 'string' is not assignable to 'ArrayLikeArg<string>'.
+      assertArrayIncludes("a", ["b"]);
+      // @ts-expect-error both args - 'string' is not assignable to 'ArrayLikeArg<string>'.
+      assertArrayIncludes("a", "b");
+    } catch { /* ignore any runtime errors */ }
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_std/issues/3372