### PR TITLE
 refactor(assert): correct test names, part 2

### DIFF
--- a/assert/assert_is_error_test.ts
+++ b/assert/assert_is_error_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { AssertionError, assertIsError, assertThrows } from "./mod.ts";
 
-Deno.test("Assert Is Error Non-Error Fail", () => {
+class CustomError extends Error {}
+class AnotherCustomError extends Error {}
+
+Deno.test("assertIsError() throws when given value isn't error", () => {
   assertThrows(
     () => assertIsError("Panic!", undefined, "Panic!"),
     AssertionError,
@@ -21,13 +24,11 @@ Deno.test("Assert Is Error Non-Error Fail", () => {
   );
 });
 
-Deno.test("Assert Is Error Parent Error", () => {
+Deno.test("assertIsError() allows subclass of Error", () => {
   assertIsError(new AssertionError("Fail!"), Error, "Fail!");
 });
 
-Deno.test("Assert Is Error with custom Error", () => {
-  class CustomError extends Error {}
-  class AnotherCustomError extends Error {}
+Deno.test("assertIsError() allows custom error", () => {
   assertIsError(new CustomError("failed"), CustomError, "fail");
   assertThrows(
     () => assertIsError(new AnotherCustomError("failed"), CustomError, "fail"),
@@ -36,8 +37,7 @@ Deno.test("Assert Is Error with custom Error", () => {
   );
 });
 
-Deno.test("assertIsError throws with message diff, where messages contain double quotes", () => {
-  class CustomError extends Error {}
+Deno.test("assertIsError() throws with message diff containing double quotes", () => {
   assertThrows(
     () =>
       assertIsError(

--- a/assert/assert_throws_test.ts
+++ b/assert/assert_throws_test.ts
@@ -7,7 +7,7 @@ import {
   fail,
 } from "./mod.ts";
 
-Deno.test("assertThrows with wrong error class", () => {
+Deno.test("assertThrows() throws when thrown error class does not match expected", () => {
   assertThrows(
     () => {
       //This next assertThrows will throw an AssertionError due to the wrong
@@ -25,13 +25,13 @@ Deno.test("assertThrows with wrong error class", () => {
   );
 });
 
-Deno.test("assertThrows with return type", () => {
+Deno.test("assertThrows() changes its return type by parameter", () => {
   assertThrows(() => {
     throw new Error();
   });
 });
 
-Deno.test("assertThrows with non-error value thrown and error class", () => {
+Deno.test("assertThrows() throws when error class is expected but non-error value is thrown", () => {
   assertThrows(
     () => {
       assertThrows(
@@ -47,7 +47,7 @@ Deno.test("assertThrows with non-error value thrown and error class", () => {
   );
 });
 
-Deno.test("assertThrows with non-error value thrown", () => {
+Deno.test("assertThrows() matches thrown non-error value", () => {
   assertThrows(
     () => {
       throw "Panic!";
@@ -65,7 +65,7 @@ Deno.test("assertThrows with non-error value thrown", () => {
   );
 });
 
-Deno.test("assertThrows with error class", () => {
+Deno.test("assertThrows() matches thrown error with given error class", () => {
   assertThrows(
     () => {
       throw new Error("foo");
@@ -75,7 +75,7 @@ Deno.test("assertThrows with error class", () => {
   );
 });
 
-Deno.test("assertThrows with thrown error returns caught error", () => {
+Deno.test("assertThrows() matches and returns thrown error value", () => {
   const error = assertThrows(
     () => {
       throw new Error("foo");
@@ -85,7 +85,7 @@ Deno.test("assertThrows with thrown error returns caught error", () => {
   assertEquals(error.message, "foo");
 });
 
-Deno.test("assertThrows with thrown non-error returns caught error", () => {
+Deno.test("assertThrows() matches and returns thrown non-error", () => {
   const stringError = assertThrows(
     () => {
       throw "Panic!";
@@ -118,7 +118,7 @@ Deno.test("assertThrows with thrown non-error returns caught error", () => {
   assertEquals(undefinedError, undefined);
 });
 
-Deno.test("Assert Throws Parent Error", () => {
+Deno.test("assertThrows() matches subclass of expected error", () => {
   assertThrows(
     () => {
       throw new AssertionError("Fail!");


### PR DESCRIPTION
## Summary

- part 2 of #3911

## Current progress

- [x] `assert/_diff_test.ts`
- [ ] `assert/_format_test.ts`
- [ ] `assert/assert_almost_equals_test.ts`
- [ ] `assert/assert_array_includes_test.ts`
- [ ] `assert/assert_equals_test.ts`
- [ ] `assert/assert_exists_test.ts`
- [ ] `assert/assert_false_test.ts`
- [ ] `assert/assert_greater_or_equal_test.ts`
- [ ] `assert/assert_greater_test.ts`
- [ ] `assert/assert_instance_of_test.ts`
- [x] `assert/assert_is_error_test.ts`
- [ ] `assert/assert_less_or_equal_test.ts`
- [ ] `assert/assert_less_test.ts`
- [ ] `assert/assert_match_test.ts`
- [ ] `assert/assert_not_equals_test.ts`
- [ ] `assert/assert_not_instance_of_test.ts`
- [ ] `assert/assert_not_match_test.ts`
- [ ] `assert/assert_not_strict_equals_test.ts`
- [x] `assert/assert_object_match_test.ts`
- [ ] `assert/assert_rejects_test.ts`
- [ ] `assert/assert_strict_equals_test.ts`
- [ ] `assert/assert_string_includes_test.ts`
- [x] `assert/assert_throws_test.ts`
- [ ] `assert/equal_test.ts`
- [ ] `assert/fail_test.ts`
- [ ] `assert/shared_test.ts`
- [ ] `assert/unimplemented_test.ts`
- [ ] `assert/unreachable_test.ts`