### PR TITLE
fix(assert): export parameter type alias for `assertArrayIncludes()`

### DIFF
--- a/assert/assert_array_includes.ts
+++ b/assert/assert_array_includes.ts
@@ -4,7 +4,7 @@ import { format } from "./_format.ts";
 import { AssertionError } from "./assertion_error.ts";
 
 /** An array-like object (`Array`, `Uint8Array`, `NodeList`, etc.) that is not a string */
-type ArrayLikeArg<T> = ArrayLike<T> & object;
+export type ArrayLikeArg<T> = ArrayLike<T> & object;
 
 /**
  * Make an assertion that `actual` includes the `expected` values. If not then


### PR DESCRIPTION
Resolves https://github.com/denoland/deno_std/pull/3910#discussion_r1420087019

/cc @kt3k