### PR TITLE
fix(toml): handle CRLF as newline in parsing multiline string

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -481,13 +481,20 @@ export function MultilineBasicString(
     return failure();
   }
   if (scanner.char() === "\n") {
-    // The first newline is trimmed
+    // The first newline (LF) is trimmed
     scanner.next();
+  } else if (scanner.slice(0, 2) === "\r\n") {
+    // The first newline (CRLF) is trimmed
+    scanner.next(2);
   }
   const acc: string[] = [];
   while (scanner.slice(0, 3) !== '"""' && !scanner.eof()) {
     // line ending backslash
     if (scanner.slice(0, 2) === "\\\n") {
+      scanner.next();
+      scanner.nextUntilChar({ comment: false });
+      continue;
+    } else if (scanner.slice(0, 3) === "\\\r\n") {
       scanner.next();
       scanner.nextUntilChar({ comment: false });
       continue;
@@ -525,8 +532,11 @@ export function MultilineLiteralString(
     return failure();
   }
   if (scanner.char() === "\n") {
-    // The first newline is trimmed
+    // The first newline (LF) is trimmed
     scanner.next();
+  } else if (scanner.slice(0, 2) === "\r\n") {
+    // The first newline (CRLF) is trimmed
+    scanner.next(2);
   }
   const acc: string[] = [];
   while (scanner.slice(0, 3) !== "'''" && !scanner.eof()) {

--- a/toml/parse_test.ts
+++ b/toml/parse_test.ts
@@ -100,6 +100,27 @@ Violets are\\tblue"""`),
 });
 
 Deno.test({
+  name: "[TOML parser] multi-line basic string (CRLF)",
+  fn() {
+    const parse = ParserFactory(MultilineBasicString);
+    assertEquals(
+      parse(`"""\r
+Roses are red\r
+Violets are\\tblue"""`),
+      "Roses are red\r\nViolets are\tblue",
+    );
+    assertEquals(
+      parse(`"""\\\r
+    The quick brown \\\r
+    fox jumps over \\\r
+    the lazy dog.\\\r
+    """`),
+      "The quick brown fox jumps over the lazy dog.",
+    );
+  },
+});
+
+Deno.test({
   name: "[TOML parser] multi-line literal string",
   fn() {
     const parse = ParserFactory(MultilineLiteralString);
@@ -108,6 +129,19 @@ Deno.test({
 Roses are red
 Violets are\\tblue'''`),
       "Roses are red\nViolets are\\tblue",
+    );
+  },
+});
+
+Deno.test({
+  name: "[TOML parser] multi-line literal string (CRLF)",
+  fn() {
+    const parse = ParserFactory(MultilineLiteralString);
+    assertEquals(
+      parse(`'''\r
+Roses are red\r
+Violets are\\tblue'''`),
+      "Roses are red\r\nViolets are\\tblue",
     );
   },
 });


### PR DESCRIPTION
Fix #3918
