### PR TITLE
deprecation(front_matter): move `Format` enum deprecation forward

### DIFF
--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -2,7 +2,7 @@
 
 type Delimiter = string | [begin: string, end: string];
 
-/** @deprecated (will be removed after 1.0.0) Use literal types `"yaml" | "toml" | "json" | "unknown"`. */
+/** @deprecated (will be removed in 0.211.0) Use literal types `"yaml" | "toml" | "json" | "unknown"`. */
 export enum Format {
   YAML = "yaml",
   TOML = "toml",


### PR DESCRIPTION
Removing in v1 seems like overkill. The deprecation shouldn't be too disruptive, and removing it earlier allows the `front_matter` to be cleaned up sooner alongside the cleanups in #3930.