### PR TITLE
perf(streams): make `toBlob()` 20-30% faster

### DIFF
--- a/streams/to_blob.ts
+++ b/streams/to_blob.ts
@@ -2,8 +2,8 @@
 // This module is browser compatible.
 
 /**
- * Converts a {@linkcode ReadableStream} of strings or {@linkcode Uint8Array}s
- * to a {@linkcode Blob}. Works the same as {@linkcode Response.blob}.
+ * Converts a {@linkcode ReadableStream} of {@linkcode Uint8Array}s to a
+ * {@linkcode Blob}. Works the same as {@linkcode Response.blob}.
  *
  * @example
  * ```ts
@@ -14,20 +14,7 @@
  * ```
  */
 export async function toBlob(
-  readableStream: ReadableStream,
+  stream: ReadableStream<Uint8Array>,
 ): Promise<Blob> {
-  const reader = readableStream.getReader();
-  const chunks: Uint8Array[] = [];
-
-  while (true) {
-    const { done, value } = await reader.read();
-
-    if (done) {
-      break;
-    }
-
-    chunks.push(value);
-  }
-
-  return new Blob(chunks);
+  return await new Response(stream).blob();
 }


### PR DESCRIPTION
It's faster just to use `Response.blob()`. This also makes the argument more stricter by only allowing `Uint8Array`s, which the previous implementation implied. Inspired by talks in #3894.

Benchmark source code:
```ts
import { toBlob } from "https://deno.land/std@0.208.0/streams/mod.ts";

Deno.bench("toBlob()", { group: "blob" }, async () => {
  const stream = ReadableStream.from([
    new Uint8Array([1, 2, 3, 4, 5]),
    new Uint8Array([6, 7]),
    new Uint8Array([8, 9]),
  ]);

  await toBlob(stream);
});

Deno.bench("Response.blob()", { group: "blob", baseline: true }, async () => {
  const stream = ReadableStream.from([
    new Uint8Array([1, 2, 3, 4, 5]),
    new Uint8Array([6, 7]),
    new Uint8Array([8, 9]),
  ]);

  await new Response(stream).blob();
});
```

Benchmark results:
```
cpu: Apple M2
runtime: deno 1.38.5 (aarch64-apple-darwin)

file:///Users/asher/GitHub/deno_std/bench.ts
benchmark            time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------------- -----------------------------


toBlob()              5.89 µs/iter     169,894.7      (4.25 µs … 4.6 ms)   5.33 µs  10.08 µs  12.75 µs
Response.blob()       4.68 µs/iter     213,504.9     (4.37 µs … 6.61 µs)   4.55 µs   6.61 µs   6.61 µs

summary
  Response.blob()
   1.26x faster than toBlob()
```