### PR TITLE
refactor(streams): simplify `toArrayBuffer()` implementation

### DIFF
--- a/streams/to_array_buffer.ts
+++ b/streams/to_array_buffer.ts
@@ -1,11 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { concat } from "../bytes/concat.ts";
-
 /**
  * Converts a {@linkcode ReadableStream} of {@linkcode Uint8Array}s to an
- * {@linkcode ArrayBuffer}. Works the same as{@linkcode Response.arrayBuffer}.
+ * {@linkcode ArrayBuffer}. Works the same as {@linkcode Response.arrayBuffer}.
  *
  * @example
  * ```ts
@@ -19,20 +17,7 @@ import { concat } from "../bytes/concat.ts";
  * ```
  */
 export async function toArrayBuffer(
-  readableStream: ReadableStream<Uint8Array>,
+  stream: ReadableStream<Uint8Array>,
 ): Promise<ArrayBuffer> {
-  const reader = readableStream.getReader();
-  const chunks: Uint8Array[] = [];
-
-  while (true) {
-    const { done, value } = await reader.read();
-
-    if (done) {
-      break;
-    }
-
-    chunks.push(value);
-  }
-
-  return concat(chunks).buffer;
+  return await new Response(stream).arrayBuffer();
 }


### PR DESCRIPTION
The current implementation is only ~2% faster according to benchmarks. IMO, having a simpler implementation wins over such a small difference in performance. I don't feel strongly about this change, so feel free to close if you disagree, Yoshiya.

Benchmark source code:
```ts
import { toArrayBuffer } from "https://deno.land/std@0.208.0/streams/to_array_buffer.ts";

Deno.bench("toArrayBuffer()", { baseline: true }, async () => {
  const stream = ReadableStream.from([
    new Uint8Array([0, 1, 2, 3]),
    new Uint8Array([4, 5, 6]),
    new Uint8Array([7, 8, 9]),
  ]);

  await toArrayBuffer(stream);
});

Deno.bench("Response.arrayBuffer()", async () => {
  const stream = ReadableStream.from([
    new Uint8Array([0, 1, 2, 3]),
    new Uint8Array([4, 5, 6]),
    new Uint8Array([7, 8, 9]),
  ]);

  await new Response(stream).arrayBuffer();
});
```

Benchmark results:
```
cpu: Apple M2
runtime: deno 1.38.5 (aarch64-apple-darwin)

file:///Users/asher/GitHub/deno_std/bench.ts
benchmark                   time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------------- -----------------------------
toArrayBuffer()               3.3 µs/iter     302,846.8   (2.42 µs … 267.88 µs)   2.71 µs   6.67 µs   7.75 µs
Response.arrayBuffer()       3.38 µs/iter     295,884.6     (3.31 µs … 3.71 µs)    3.4 µs   3.71 µs   3.71 µs

summary
  toArrayBuffer()
   1.02x faster than Response.arrayBuffer()
```