### PR TITLE
fix(text): fix closestString

### DIFF
--- a/text/closest_string.ts
+++ b/text/closest_string.ts
@@ -46,7 +46,7 @@ export function closestString(
   }
 
   let nearestWord = possibleWords[0];
-  let closestStringDistance = 0;
+  let closestStringDistance = Infinity;
   for (const each of possibleWords) {
     const distance = caseSensitive
       ? getWordDistance(givenWord, each)

--- a/text/closest_string_test.ts
+++ b/text/closest_string_test.ts
@@ -7,7 +7,7 @@ Deno.test("closestString - basic", function () {
 
   assertEquals(
     JSON.stringify(closestString("hep", words)),
-    '"hi"',
+    '"help"',
   );
 });
 


### PR DESCRIPTION
Currently `closestString` always returns the first element of the given `possibleWords`. This PR fixes it to choose closest string using levenshtein distance.

```js
import { closestString } from "https://deno.land/std@0.208.0/text/mod.ts";
console.log(closestString("a", ["b", "a"])); // this currently prints b
```