### PR TITLE
feat(expect): support message checks in expect().toThrow

### DIFF
--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -23,7 +23,7 @@ export function assertIsError<E extends Error = Error>(
   error: unknown,
   // deno-lint-ignore no-explicit-any
   ErrorClass?: new (...args: any[]) => E,
-  msgIncludes?: string | RegExp,
+  msgMatches?: string | RegExp,
   msg?: string,
 ): asserts error is E {
   const msgSuffix = msg ? `: ${msg}` : ".";
@@ -39,20 +39,20 @@ export function assertIsError<E extends Error = Error>(
     throw new AssertionError(msg);
   }
   let msgCheck;
-  if (typeof msgIncludes === "string") {
+  if (typeof msgMatches === "string") {
     msgCheck = stripAnsiCode(error.message).includes(
-      stripAnsiCode(msgIncludes),
+      stripAnsiCode(msgMatches),
     );
   }
-  if (msgIncludes instanceof RegExp) {
-    msgCheck = msgIncludes.test(stripAnsiCode(error.message));
+  if (msgMatches instanceof RegExp) {
+    msgCheck = msgMatches.test(stripAnsiCode(error.message));
   }
 
-  if (msgIncludes && !msgCheck) {
+  if (msgMatches && !msgCheck) {
     msg = `Expected error message to include ${
-      msgIncludes instanceof RegExp
-        ? msgIncludes.toString()
-        : JSON.stringify(msgIncludes)
+      msgMatches instanceof RegExp
+        ? msgMatches.toString()
+        : JSON.stringify(msgMatches)
     }, but got ${
       error instanceof Error
         ? JSON.stringify(error.message)

--- a/assert/assert_is_error_test.ts
+++ b/assert/assert_is_error_test.ts
@@ -49,3 +49,12 @@ Deno.test("assertIsError() throws with message diff containing double quotes", (
     `Expected error message to include "doesn't include \\"this message\\"", but got "error with \\"double quotes\\"".`,
   );
 });
+
+Deno.test("assertIsError() throws when given value doesn't match regex ", () => {
+  assertIsError(new AssertionError("Regex test"), Error, /ege/);
+  assertThrows(
+    () => assertIsError(new AssertionError("Regex test"), Error, /egg/),
+    Error,
+    `Expected error message to include /egg/, but got "Regex test"`,
+  );
+});

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -726,9 +726,10 @@ export function toHaveNthReturnedWith(
   }
 }
 
-export function toThrow(
+export function toThrow<E extends Error = Error>(
   context: MatcherContext,
-  expected: unknown,
+  // deno-lint-ignore no-explicit-any
+  expected?: string | RegExp | E | (new (...args: any[]) => E),
 ): MatchResult {
   if (typeof context.value === "function") {
     try {

--- a/expect/_to_throw_test.ts
+++ b/expect/_to_throw_test.ts
@@ -19,4 +19,84 @@ Deno.test("expect().toThrow()", () => {
       throw new Error("hello world");
     }).not.toThrow();
   }, AssertionError);
+
+  // Passes when type is correct
+  expect(() => {
+    throw new AssertionError("hello world");
+  }).toThrow(AssertionError);
+
+  // Throws when type is incorrect
+  assertThrows(
+    () => {
+      expect(() => {
+        throw new Error("hello world");
+      }).toThrow(AssertionError);
+    },
+    AssertionError,
+    'Expected error to be instance of "AssertionError", but was "Error".',
+  );
+
+  // Passes when error instance type is correct
+  expect(() => {
+    throw new AssertionError("hello world");
+  }).toThrow(new AssertionError("hello world"));
+
+  // Throws when error instance type is incorrect
+  assertThrows(
+    () => {
+      expect(() => {
+        throw new Error("hello world");
+      }).toThrow(new AssertionError("hello world"));
+    },
+    AssertionError,
+    'Expected error to be instance of "AssertionError", but was "Error".',
+  );
+
+  // Passes when literal string is in error
+  expect(() => {
+    throw new AssertionError("hello world");
+  }).toThrow("hello");
+
+  // Throws when literal string is not in error
+  assertThrows(
+    () => {
+      expect(() => {
+        throw new AssertionError("hello world");
+      }).toThrow("goodbye");
+    },
+    AssertionError,
+    'Expected error message to include "goodbye", but got "hello world".',
+  );
+
+  // Passes when error instance string is in error
+  expect(() => {
+    throw new AssertionError("hello world");
+  }).toThrow(new AssertionError("hello world"));
+
+  // Throws when error instance string is not in error
+  assertThrows(
+    () => {
+      expect(() => {
+        throw new AssertionError("hello world");
+      }).toThrow(new AssertionError("goodbye"));
+    },
+    AssertionError,
+    'Expected error message to include "goodbye", but got "hello world".',
+  );
+
+  // Passes when regex does match error
+  expect(() => {
+    throw new AssertionError("hello world");
+  }).toThrow(/\w/);
+
+  // Throws when regex does not match error
+  assertThrows(
+    () => {
+      expect(() => {
+        throw new Error("hello world");
+      }).toThrow(/\d/);
+    },
+    AssertionError,
+    'Expected error message to include /\\d/, but got "hello world".',
+  );
 });

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -83,6 +83,7 @@ export interface Expected {
     // deno-lint-ignore no-explicit-any
     expected?: string | RegExp | E | (new (...args: any[]) => E),
   ): void;
+  not: Expected;
   resolves: Async<Expected>;
   rejects: Async<Expected>;
 }

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -79,8 +79,7 @@ export interface Expected {
   toReturnTimes(expected: number): void;
   toReturnWith(expected: unknown): void;
   toStrictEqual(candidate: unknown): void;
-  // deno-lint-ignore no-explicit-any
-  toThrow<E extends Error = Error>(expected?: new (...args: any[]) => E): void;
+  toThrow<E extends Error = Error>(expected?: unknown): void;
   not: Expected;
   resolves: Async<Expected>;
   rejects: Async<Expected>;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -79,8 +79,10 @@ export interface Expected {
   toReturnTimes(expected: number): void;
   toReturnWith(expected: unknown): void;
   toStrictEqual(candidate: unknown): void;
-  toThrow<E extends Error = Error>(expected?: unknown): void;
-  not: Expected;
+  toThrow<E extends Error = Error>(
+    // deno-lint-ignore no-explicit-any
+    expected?: string | RegExp | E | (new (...args: any[]) => E),
+  ): void;
   resolves: Async<Expected>;
   rejects: Async<Expected>;
 }


### PR DESCRIPTION
I'm attempting to support deno testing in valibot: https://github.com/fabian-hiller/valibot/pull/179 and currently trying to swap out the vitest expect for the new deno_std expect, but I came across an unsupported feature.

Currently the parameter for toThrow only supports an Error constructor, this PR also lets you pass a string, RegExp, or Error instance.

Excerpt from the Jest Expect documentation https://jestjs.io/docs/expect#tothrowerror

> You can provide an optional argument to test that a specific error is thrown:
> 
> - regular expression: error message matches the pattern
> - string: error message includes the substring
> - error object: error message is equal to the message property of the object
> - error class: error object is instance of class
> 
> For example, let's say that drinkFlavor is coded like this:
> 
> ```typescript
> function drinkFlavor(flavor) {
>   if (flavor == 'octopus') {
>     throw new DisgustingFlavorError('yuck, octopus flavor');
>   }
>   // Do some other stuff
> }
> ```
> 
> We could test this error gets thrown in several ways:
> 
> ```typescript
> test('throws on octopus', () => {
>   function drinkOctopus() {
>     drinkFlavor('octopus');
>   }
> 
>   // Test that the error message says "yuck" somewhere: these are equivalent
>   expect(drinkOctopus).toThrow(/yuck/);
>   expect(drinkOctopus).toThrow('yuck');
> 
>   // Test the exact error message
>   expect(drinkOctopus).toThrow(/^yuck, octopus flavor$/);
>   expect(drinkOctopus).toThrow(new Error('yuck, octopus flavor'));
> 
>   // Test that we get a DisgustingFlavorError
>   expect(drinkOctopus).toThrow(DisgustingFlavorError);
> });
> ```

This PR also updates the `assert/assert_is_error.ts` function to support the RegExp as a message expectation type, since thats what `expect().toThrow` uses under the hood.

I will shortly add some more comments inline.