### PR TITLE
deprecation(semver): deprecate `SemVer` argument for `parse()` and `canParse()`

### DIFF
--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -3,7 +3,7 @@ import { SemVer } from "./types.ts";
 import { parse } from "./parse.ts";
 
 /**
- * @deprecated (will be removed in 0.211.0) Use a string argument instead.
+ * @deprecated (will be removed in 0.212.0) Use a string argument instead.
  */
 export function canParse(version: SemVer): boolean;
 export function canParse(version: string): boolean;

--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -3,7 +3,7 @@ import { SemVer } from "./types.ts";
 import { parse } from "./parse.ts";
 
 /**
- * @deprecated (will be removed in 0.211.0) use string as an argument
+ * @deprecated (will be removed in 0.211.0) Use a string argument instead.
  */
 export function canParse(version: SemVer): boolean;
 export function canParse(version: string): boolean;

--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -6,6 +6,7 @@ import { parse } from "./parse.ts";
  * @deprecated (will be removed in 0.211.0) use string as an argument
  */
 export function canParse(version: SemVer): boolean;
+export function canParse(version: string): boolean;
 export function canParse(version: string | SemVer) {
   try {
     parse(version as SemVer);

--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -2,9 +2,13 @@
 import { SemVer } from "./types.ts";
 import { parse } from "./parse.ts";
 
+/**
+ * @deprecated (will be removed in 0.211.0) use string as an argument
+ */
+export function canParse(version: SemVer): boolean;
 export function canParse(version: string | SemVer) {
   try {
-    parse(version);
+    parse(version as SemVer);
     return true;
   } catch (err) {
     if (!(err instanceof TypeError)) {

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -77,7 +77,7 @@ Deno.test("format", async (t) => {
     await t.step({
       name: `format(${version} ${style} ${expected})`,
       fn: () => {
-        const v = parse(version)!;
+        const v = parse(version as SemVer)!;
         const actual = format(v, style);
         assertEquals(actual, expected);
       },

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -7,7 +7,7 @@ import { INVALID, MAX, MIN } from "./constants.ts";
 import { FormatStyle, SemVer } from "./types.ts";
 
 Deno.test("format", async (t) => {
-  const versions: [string | SemVer, FormatStyle | undefined, string][] = [
+  const versions: [string, FormatStyle | undefined, string][] = [
     ["1.2.3", undefined, "1.2.3"],
     ["1.2.3", "full", "1.2.3"],
     ["1.2.3", "release", "1.2.3"],
@@ -67,18 +67,29 @@ Deno.test("format", async (t) => {
     ["1.2.3-pre.0+b.0", "patch", "3"],
     ["1.2.3-pre.0+b.0", "minor", "2"],
     ["1.2.3-pre.0+b.0", "major", "1"],
-
-    [MAX, "full", "∞.∞.∞"],
-    [MIN, "full", "0.0.0"],
-    [INVALID, "full", "⧞.∞.∞"],
   ];
 
   for (const [version, style, expected] of versions) {
     await t.step({
       name: `format(${version} ${style} ${expected})`,
       fn: () => {
-        const v = parse(version as SemVer)!;
+        const v = parse(version)!;
         const actual = format(v, style);
+        assertEquals(actual, expected);
+      },
+    });
+  }
+
+  const constantSemVers: [SemVer, FormatStyle | undefined, string][] = [
+    [MAX, "full", "∞.∞.∞"],
+    [MIN, "full", "0.0.0"],
+    [INVALID, "full", "⧞.∞.∞"],
+  ];
+  for (const [version, style, expected] of constantSemVers) {
+    await t.step({
+      name: `format(${version} ${style} ${expected})`,
+      fn: () => {
+        const actual = format(version, style);
         assertEquals(actual, expected);
       },
     });

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -5,7 +5,7 @@ import { isSemVer } from "./is_semver.ts";
 import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 
 /**
- * @deprecated (will be removed in 0.211.0) Use a string argument instead.
+ * @deprecated (will be removed in 0.212.0) Use a string argument instead.
  */
 export function parse(version: SemVer): SemVer;
 /**

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -8,13 +8,13 @@ import { FULL, MAX_LENGTH, NUMERICIDENTIFIER, re, src } from "./_shared.ts";
  * @deprecated (will be removed in 0.211.0) parse only parses strings
  */
 export function parse(version: SemVer): SemVer;
-export function parse(version: string): SemVer;
 /**
  * Attempt to parse a string as a semantic version, returning either a `SemVer`
  * object or throws a TypeError.
  * @param version The version string to parse
  * @returns A valid SemVer
  */
+export function parse(version: string): SemVer;
 export function parse(version: string | SemVer): SemVer {
   if (typeof version === "object") {
     if (isSemVer(version)) {

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -5,7 +5,7 @@ import { isSemVer } from "./is_semver.ts";
 import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 
 /**
- * @deprecated (will be removed in 0.211.0) parse only parses strings
+ * @deprecated (will be removed in 0.211.0) Use a string argument instead.
  */
 export function parse(version: SemVer): SemVer;
 /**

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -5,6 +5,11 @@ import { isSemVer } from "./is_semver.ts";
 import { FULL, MAX_LENGTH, NUMERICIDENTIFIER, re, src } from "./_shared.ts";
 
 /**
+ * @deprecated (will be removed in 0.211.0) parse only parses strings
+ */
+export function parse(version: SemVer): SemVer;
+export function parse(version: string): SemVer;
+/**
  * Attempt to parse a string as a semantic version, returning either a `SemVer`
  * object or throws a TypeError.
  * @param version The version string to parse

--- a/semver/range_min_test.ts
+++ b/semver/range_min_test.ts
@@ -77,7 +77,7 @@ Deno.test({
     for (const [a, b] of versions) {
       await t.step(a, () => {
         const range = parseRange(a);
-        const version = parse(b);
+        const version = parse(b as SemVer);
         const min = rangeMin(range);
         assert(eq(min, version), `${format(min)} != ${format(version)}`);
       });


### PR DESCRIPTION
deprecates SemVer as argument type for `parse` and `canParse`.