### PR TITLE
chore(http): deprecate `CookieMap()`

### DIFF
--- a/http/cookie_map.ts
+++ b/http/cookie_map.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+
  *
  * Provides a iterable map interfaces for managing cookies server side.
  *
@@ -83,6 +83,10 @@
  * cookies.set("session", "1234567");
  * ```
  *
+ * @deprecated (will be removed after 0.212.0) Use
+ * {@link https://deno.land/std/http/cookie.ts} and
+ * {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
+ *
  * @module
  */
 
@@ -103,46 +107,48 @@ import {
 } from "./unstable_cookie_map.ts";
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export type CookieMapOptions = CookieMapOptions_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export type CookieMapSetDeleteOptions = CookieMapSetDeleteOptions_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export type Headered = Headered_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export type Mergeable = Mergeable_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use
+ * {@link https://deno.land/std/http/cookie.ts} and
+ * {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export type SecureCookieMapGetOptions = SecureCookieMapGetOptions_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use
+ * {@link https://deno.land/std/http/cookie.ts} and
+ * {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export type SecureCookieMapOptions = SecureCookieMapOptions_;
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export type SecureCookieMapSetDeleteOptions = SecureCookieMapSetDeleteOptions_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
- *
  * Symbol which is used in {@link mergeHeaders} to extract a
  * `[string | string][]` from an instance to generate the final set of
  * headers.
+ *
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export const cookieMapHeadersInitSymbol = cookieMapHeadersInitSymbol_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
- *
  * Allows merging of various sources of headers into a final set of headers
  * which can be used in a {@linkcode Response}.
  *
@@ -150,12 +156,12 @@ export const cookieMapHeadersInitSymbol = cookieMapHeadersInitSymbol_;
  * response to {@linkcode CookieMap} or {@linkcode SecureCookieMap}, merging
  * will not ensure that there are no other `Set-Cookie` headers from other
  * sources, it will simply append the various headers together.
+ *
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export const mergeHeaders = mergeHeaders_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
- *
  * Provides a way to manage cookies in a request and response on the server
  * as a single iterable collection.
  *
@@ -165,24 +171,27 @@ export const mergeHeaders = mergeHeaders_;
  * response can be provided. Alternatively the {@linkcode mergeHeaders}
  * function can be used to generate a final set of headers for sending in the
  * response.
+ *
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  */
 export const CookieMap = CookieMap_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
  * Types of data that can be signed cryptographically.
+ *
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export type Data = Data_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
- *
  * An interface which describes the methods that {@linkcode SecureCookieMap} uses to sign and verify cookies.
+ *
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export type KeyRing = KeyRing_;
 
 /**
- * @deprecated (will be removed after 0.210.0) Import from {@link https://deno.land/std/crypto/unstable_cookie_map.ts} instead.
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
  *
  * Provides an way to manage cookies in a request and response on the server
  * as a single iterable collection, as well as the ability to sign and verify
@@ -200,6 +209,6 @@ export type KeyRing = KeyRing_;
  * {@linkcode KeyRing} interface. While it is optional, if you don't plan to use
  * keys, you might want to consider using just the {@linkcode CookieMap}.
  *
- * @example
+ * @deprecated (will be removed after 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export const SecureCookieMap = SecureCookieMap_;

--- a/http/unstable_cookie_map.ts
+++ b/http/unstable_cookie_map.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/** Provides a iterable map interfaces for managing cookies server side.
+/**
+ * Provides a iterable map interfaces for managing cookies server side.
  *
  * @example
  * To access the keys in a request and have any set keys available for creating
@@ -80,9 +81,16 @@
  * cookies.set("session", "1234567");
  * ```
  *
+ * @deprecated (will be removed after 0.212.0) Use
+ * {@link https://deno.land/std/http/cookie.ts} and
+ * {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
+ *
  * @module
  */
 
+/**
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
+ */
 export interface CookieMapOptions {
   /** The {@linkcode Response} or the headers that will be used with the
    * response. When provided, `Set-Cookie` headers will be set in the headers
@@ -101,6 +109,7 @@ export interface CookieMapOptions {
   secure?: boolean;
 }
 
+/** @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead. */
 export interface CookieMapSetDeleteOptions {
   /** The domain to scope the cookie for. */
   domain?: string;
@@ -123,17 +132,23 @@ export interface CookieMapSetDeleteOptions {
   sameSite?: "strict" | "lax" | "none" | boolean;
 }
 
-/** An object which contains a `headers` property which has a value of an
+/**
+ * An object which contains a `headers` property which has a value of an
  * instance of {@linkcode Headers}, like {@linkcode Request} and
- * {@linkcode Response}. */
+ * {@linkcode Response}.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
+ */
 export interface Headered {
   headers: Headers;
 }
 
+/** @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead. */
 export interface Mergeable {
   [cookieMapHeadersInitSymbol](): [string, string][];
 }
 
+/** @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead. */
 export interface SecureCookieMapOptions {
   /** Keys which will be used to validate and sign cookies. The key ring should
    * implement the {@linkcode KeyRing} interface. */
@@ -157,11 +172,13 @@ export interface SecureCookieMapOptions {
   secure?: boolean;
 }
 
+/** @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead. */
 export interface SecureCookieMapGetOptions {
   /** Overrides the flag that was set when the instance was created. */
   signed?: boolean;
 }
 
+/** @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead. */
 export interface SecureCookieMapSetDeleteOptions {
   /** The domain to scope the cookie for. */
   domain?: string;
@@ -298,9 +315,13 @@ class Cookie implements CookieAttributes {
   }
 }
 
-/** Symbol which is used in {@link mergeHeaders} to extract a
+/**
+ * Symbol which is used in {@link mergeHeaders} to extract a
  * `[string | string][]` from an instance to generate the final set of
- * headers. */
+ * headers.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
+ */
 export const cookieMapHeadersInitSymbol = Symbol.for(
   "Deno.std.cookieMap.headersInit",
 );
@@ -310,13 +331,17 @@ function isMergeable(value: unknown): value is Mergeable {
     cookieMapHeadersInitSymbol in value;
 }
 
-/** Allows merging of various sources of headers into a final set of headers
+/**
+ * Allows merging of various sources of headers into a final set of headers
  * which can be used in a {@linkcode Response}.
  *
  * Note, that unlike when passing a `Response` or {@linkcode Headers} used in a
  * response to {@linkcode CookieMap} or {@linkcode SecureCookieMap}, merging
  * will not ensure that there are no other `Set-Cookie` headers from other
- * sources, it will simply append the various headers together. */
+ * sources, it will simply append the various headers together.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
+ */
 export function mergeHeaders(
   ...sources: (Headered | HeadersInit | Mergeable)[]
 ): Headers {
@@ -423,7 +448,10 @@ abstract class CookieMapBase implements Mergeable {
  * provided, as well as optionally the {@linkcode Response} or `Headers` for the
  * response can be provided. Alternatively the {@linkcode mergeHeaders}
  * function can be used to generate a final set of headers for sending in the
- * response. */
+ * response.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/cookie.ts} instead.
+ */
 export class CookieMap extends CookieMapBase {
   /** Contains the number of valid cookies in the request headers. */
   get size(): number {
@@ -545,11 +573,19 @@ export class CookieMap extends CookieMapBase {
   }
 }
 
-/** Types of data that can be signed cryptographically. */
+/**
+ * Types of data that can be signed cryptographically.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
+ */
 export type Data = string | number[] | ArrayBuffer | Uint8Array;
 
-/** An interface which describes the methods that {@linkcode SecureCookieMap}
- * uses to sign and verify cookies. */
+/**
+ * An interface which describes the methods that {@linkcode SecureCookieMap}
+ * uses to sign and verify cookies.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
+ */
 export interface KeyRing {
   /** Given a set of data and a digest, return the key index of the key used
    * to sign the data. The index is 0 based. A non-negative number indices the
@@ -562,7 +598,8 @@ export interface KeyRing {
   verify(data: Data, digest: string): Promise<boolean> | boolean;
 }
 
-/** Provides an way to manage cookies in a request and response on the server
+/**
+ * Provides an way to manage cookies in a request and response on the server
  * as a single iterable collection, as well as the ability to sign and verify
  * cookies to prevent tampering.
  *
@@ -578,7 +615,7 @@ export interface KeyRing {
  * {@linkcode KeyRing} interface. While it is optional, if you don't plan to use
  * keys, you might want to consider using just the {@linkcode CookieMap}.
  *
- * @example
+ * @deprecated (will be removed in 0.212.0) Use {@link https://deno.land/std/http/unstable_signed_cookie.ts} instead.
  */
 export class SecureCookieMap extends CookieMapBase {
   #keyRing?: KeyRing;


### PR DESCRIPTION
Closes #3942
Prerequisite #3905