### PR TITLE
fix(cli): re-export promptSecret from mod.ts

### DIFF
--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -8,3 +8,4 @@
  */
 
 export * from "./parse_args.ts";
+export * from "./prompt_secret.ts";

--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
 
 /**
  * Tools for creating interactive command line tools.


### PR DESCRIPTION
This PR adds re-export of `promptSecret` from mod.ts

ref https://github.com/denoland/deno_std/pull/3777