### PR TITLE
docs: update `versions.json` URL in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Check out the contributing guidelines [here](.github/CONTRIBUTING.md).
 
 The Standard Library is versioned independently of the Deno CLI. This will
 change once the Standard Library is stabilized. See
-[here](https://raw.githubusercontent.com/denoland/dotland/main/versions.json)
+[here](https://deno.com/versions.json)
 for the compatibility of different versions of the Deno Standard Library and the
 Deno CLI.
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,8 @@ Check out the contributing guidelines [here](.github/CONTRIBUTING.md).
 
 The Standard Library is versioned independently of the Deno CLI. This will
 change once the Standard Library is stabilized. See
-[here](https://deno.com/versions.json)
-for the compatibility of different versions of the Deno Standard Library and the
-Deno CLI.
+fm[here](https://deno.com/versions.json) for the compatibility of different
+versions of the Deno Standard Library and the Deno CLI.
 
 A new minor version of the Standard Library is published at the same time as
 every new version of the Deno CLI (including patch versions).


### PR DESCRIPTION
Correct compatibility of different versions of the Deno Standard Library and the Deno CLI