### PR TITLE
chore(semver): remove regexp array

### DIFF
--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -65,65 +65,52 @@ export function compareIdentifier(
   return 0;
 }
 
-// The actual regexps
-const re: RegExp[] = [];
-const src: string[] = [];
-let R = 0;
-
 // The following Regular Expressions can be used for tokenizing,
 // validating, and parsing SemVer version strings.
 
 // ## Numeric Identifier
 // A single `0`, or a non-zero digit followed by zero or more digits.
 
-const NUMERICIDENTIFIER: number = R++;
-src[NUMERICIDENTIFIER] = "0|[1-9]\\d*";
+const NUMERICIDENTIFIER = "0|[1-9]\\d*";
 
 // ## Non-numeric Identifier
 // Zero or more digits, followed by a letter or hyphen, and then zero or
 // more letters, digits, or hyphens.
 
-const NONNUMERICIDENTIFIER: number = R++;
-src[NONNUMERICIDENTIFIER] = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const NONNUMERICIDENTIFIER = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
 
 // ## Main Version
 // Three dot-separated numeric identifiers.
-
-const MAINVERSION: number = R++;
-const nid = src[NUMERICIDENTIFIER];
-src[MAINVERSION] = `(${nid})\\.(${nid})\\.(${nid})`;
+const MAINVERSION =
+  `(${NUMERICIDENTIFIER})\\.(${NUMERICIDENTIFIER})\\.(${NUMERICIDENTIFIER})`;
 
 // ## Pre-release Version Identifier
 // A numeric identifier, or a non-numeric identifier.
 
-const PRERELEASEIDENTIFIER: number = R++;
-src[PRERELEASEIDENTIFIER] = "(?:" + src[NUMERICIDENTIFIER] + "|" +
-  src[NONNUMERICIDENTIFIER] + ")";
+const PRERELEASEIDENTIFIER = "(?:" + NUMERICIDENTIFIER + "|" +
+  NONNUMERICIDENTIFIER + ")";
 
 // ## Pre-release Version
 // Hyphen, followed by one or more dot-separated pre-release version
 // identifiers.
 
-const PRERELEASE: number = R++;
-src[PRERELEASE] = "(?:-(" +
-  src[PRERELEASEIDENTIFIER] +
+const PRERELEASE = "(?:-(" +
+  PRERELEASEIDENTIFIER +
   "(?:\\." +
-  src[PRERELEASEIDENTIFIER] +
+  PRERELEASEIDENTIFIER +
   ")*))";
 
 // ## Build Metadata Identifier
 // Any combination of digits, letters, or hyphens.
 
-const BUILDIDENTIFIER: number = R++;
-src[BUILDIDENTIFIER] = "[0-9A-Za-z-]+";
+const BUILDIDENTIFIER = "[0-9A-Za-z-]+";
 
 // ## Build Metadata
 // Plus sign, followed by one or more period-separated build metadata
 // identifiers.
 
-const BUILD: number = R++;
-src[BUILD] = "(?:\\+(" + src[BUILDIDENTIFIER] + "(?:\\." +
-  src[BUILDIDENTIFIER] + ")*))";
+const BUILD = "(?:\\+(" + BUILDIDENTIFIER + "(?:\\." +
+  BUILDIDENTIFIER + ")*))";
 
 // ## Full Version String
 // A main version, followed optionally by a pre-release version and
@@ -133,84 +120,69 @@ src[BUILD] = "(?:\\+(" + src[BUILDIDENTIFIER] + "(?:\\." +
 // the version string are capturing groups.  The build metadata is not a
 // capturing group, because it should not ever be used in version
 // comparison.
-
-const FULL: number = R++;
-const FULLPLAIN = "v?" + src[MAINVERSION] + src[PRERELEASE] + "?" + src[BUILD] +
+const FULLPLAIN = "v?" + MAINVERSION + PRERELEASE + "?" + BUILD +
   "?";
 
-src[FULL] = "^" + FULLPLAIN + "$";
+export const FULL_REGEXP = new RegExp("^" + FULLPLAIN + "$");
 
-const GTLT: number = R++;
-src[GTLT] = "((?:<|>)?=?)";
+const GTLT = "((?:<|>)?=?)";
 
 // Something like "2.*" or "1.2.x".
 // Note that "x.x" is a valid xRange identifier, meaning "any version"
 // Only the first item is strictly required.
-const XRANGEIDENTIFIER: number = R++;
-src[XRANGEIDENTIFIER] = src[NUMERICIDENTIFIER] + "|x|X|\\*";
+const XRANGEIDENTIFIER = NUMERICIDENTIFIER + "|x|X|\\*";
 
-const XRANGEPLAIN: number = R++;
-src[XRANGEPLAIN] = "[v=\\s]*(" +
-  src[XRANGEIDENTIFIER] +
+const XRANGEPLAIN = "[v=\\s]*(" +
+  XRANGEIDENTIFIER +
   ")" +
   "(?:\\.(" +
-  src[XRANGEIDENTIFIER] +
+  XRANGEIDENTIFIER +
   ")" +
   "(?:\\.(" +
-  src[XRANGEIDENTIFIER] +
+  XRANGEIDENTIFIER +
   ")" +
   "(?:" +
-  src[PRERELEASE] +
+  PRERELEASE +
   ")?" +
-  src[BUILD] +
+  BUILD +
   "?" +
   ")?)?";
 
-const XRANGE: number = R++;
-src[XRANGE] = "^" + src[GTLT] + "\\s*" + src[XRANGEPLAIN] + "$";
+export const XRANGE_REGEXP = new RegExp(
+  "^" + GTLT + "\\s*" + XRANGEPLAIN + "$",
+);
 
 // Tilde ranges.
 // Meaning is "reasonably at or greater than"
-const LONETILDE: number = R++;
-src[LONETILDE] = "(?:~>?)";
+const LONETILDE = "(?:~>?)";
 
-const TILDE: number = R++;
-src[TILDE] = "^" + src[LONETILDE] + src[XRANGEPLAIN] + "$";
+export const TILDE_REGEXP = new RegExp("^" + LONETILDE + XRANGEPLAIN + "$");
 
 // Caret ranges.
 // Meaning is "at least and backwards compatible with"
-const LONECARET: number = R++;
-src[LONECARET] = "(?:\\^)";
+const LONECARET = "(?:\\^)";
 
-const CARET: number = R++;
-src[CARET] = "^" + src[LONECARET] + src[XRANGEPLAIN] + "$";
+export const CARET_REGEXP = new RegExp("^" + LONECARET + XRANGEPLAIN + "$");
 
 // A simple gt/lt/eq thing, or just "" to indicate "any version"
-const COMPARATOR: number = R++;
-src[COMPARATOR] = "^" + src[GTLT] + "\\s*(" + FULLPLAIN + ")$|^$";
+export const COMPARATOR_REGEXP = new RegExp(
+  "^" + GTLT + "\\s*(" + FULLPLAIN + ")$|^$",
+);
 
 // Something like `1.2.3 - 1.2.4`
-const HYPHENRANGE: number = R++;
-src[HYPHENRANGE] = "^\\s*(" +
-  src[XRANGEPLAIN] +
-  ")" +
-  "\\s+-\\s+" +
-  "(" +
-  src[XRANGEPLAIN] +
-  ")" +
-  "\\s*$";
+export const HYPHENRANGE_REGEXP = new RegExp(
+  "^\\s*(" +
+    XRANGEPLAIN +
+    ")" +
+    "\\s+-\\s+" +
+    "(" +
+    XRANGEPLAIN +
+    ")" +
+    "\\s*$",
+);
 
 // Star ranges basically just allow anything at all.
-const STAR: number = R++;
-src[STAR] = "(<|>)?=?\\s*\\*";
-
-// Compile to actual regexp objects.
-// All are flag-free, unless they were created above with a flag.
-for (let i = 0; i < R; i++) {
-  if (!re[i]) {
-    re[i] = new RegExp(src[i]);
-  }
-}
+export const STAR = new RegExp("(<|>)?=?\\s*\\*");
 
 /**
  * Returns true if the value is a valid SemVer number.
@@ -274,16 +246,3 @@ export function isValidOperator(value: unknown): value is Operator {
       return false;
   }
 }
-
-export {
-  CARET,
-  COMPARATOR,
-  FULL,
-  HYPHENRANGE,
-  NUMERICIDENTIFIER,
-  re,
-  src,
-  STAR,
-  TILDE,
-  XRANGE,
-};

--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -182,7 +182,7 @@ export const HYPHENRANGE_REGEXP = new RegExp(
 );
 
 // Star ranges basically just allow anything at all.
-export const STAR = new RegExp("(<|>)?=?\\s*\\*");
+export const STAR_REGEXP = new RegExp("(<|>)?=?\\s*\\*");
 
 /**
  * Returns true if the value is a valid SemVer number.

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -2,7 +2,7 @@
 import { SemVer } from "./types.ts";
 import { isValidNumber } from "./_shared.ts";
 import { isSemVer } from "./is_semver.ts";
-import { FULL, MAX_LENGTH, NUMERICIDENTIFIER, re, src } from "./_shared.ts";
+import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 
 /**
  * Attempt to parse a string as a semantic version, returning either a `SemVer`
@@ -32,8 +32,7 @@ export function parse(version: string | SemVer): SemVer {
 
   version = version.trim();
 
-  const r = re[FULL];
-  const m = version.match(r);
+  const m = version.match(FULL_REGEXP);
   if (!m) {
     throw new TypeError(`Invalid Version: ${version}`);
   }
@@ -56,7 +55,7 @@ export function parse(version: string | SemVer): SemVer {
   }
 
   // number-ify any prerelease numeric ids
-  const numericIdentifier = new RegExp(`^(${src[NUMERICIDENTIFIER]})$`);
+  const numericIdentifier = new RegExp(`^(0|[1-9]\\d*)$`);
   const prerelease = (m[4] ?? "")
     .split(".")
     .filter((id) => id)

--- a/semver/parse_comparator.ts
+++ b/semver/parse_comparator.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { parse } from "./parse.ts";
 import type { Operator, SemVerComparator } from "./types.ts";
-import { COMPARATOR, re } from "./_shared.ts";
+import { COMPARATOR_REGEXP } from "./_shared.ts";
 import { comparatorMax } from "./comparator_max.ts";
 import { comparatorMin } from "./comparator_min.ts";
 import { ANY, NONE } from "./constants.ts";
@@ -12,8 +12,7 @@ import { ANY, NONE } from "./constants.ts";
  * @returns A valid SemVerComparator
  */
 export function parseComparator(comparator: string): SemVerComparator {
-  const r = re[COMPARATOR];
-  const m = comparator.match(r);
+  const m = comparator.match(COMPARATOR_REGEXP);
 
   if (!m) {
     return NONE;

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -1,7 +1,13 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { ALL } from "./constants.ts";
 import type { SemVerRange } from "./types.ts";
-import { CARET, HYPHENRANGE, re, STAR, TILDE, XRANGE } from "./_shared.ts";
+import {
+  CARET_REGEXP,
+  HYPHENRANGE_REGEXP,
+  STAR,
+  TILDE_REGEXP,
+  XRANGE_REGEXP,
+} from "./_shared.ts";
 import { parseComparator } from "./parse_comparator.ts";
 
 // ~, ~> --> * (any, kinda silly)
@@ -19,9 +25,8 @@ function replaceTildes(comp: string): string {
 }
 
 function replaceTilde(comp: string): string {
-  const r: RegExp = re[TILDE];
   return comp.replace(
-    r,
+    TILDE_REGEXP,
     (_: string, M: string, m: string, p: string, pr: string) => {
       let ret: string;
 
@@ -71,8 +76,7 @@ function replaceCarets(comp: string): string {
 }
 
 function replaceCaret(comp: string): string {
-  const r: RegExp = re[CARET];
-  return comp.replace(r, (_: string, M, m, p, pr) => {
+  return comp.replace(CARET_REGEXP, (_: string, M, m, p, pr) => {
     let ret: string;
 
     if (isX(M)) {
@@ -147,8 +151,7 @@ function replaceXRanges(comp: string): string {
 
 function replaceXRange(comp: string): string {
   comp = comp.trim();
-  const r: RegExp = re[XRANGE];
-  return comp.replace(r, (ret: string, gtlt, M, m, p, _pr) => {
+  return comp.replace(XRANGE_REGEXP, (ret: string, gtlt, M, m, p, _pr) => {
     const xM: boolean = isX(M);
     const xm: boolean = xM || isX(m);
     const xp: boolean = xm || isX(p);
@@ -212,7 +215,7 @@ function replaceXRange(comp: string): string {
 // Because * is AND-ed with everything else in the comparator,
 // and '' means "any version", just remove the *s entirely.
 function replaceStars(comp: string): string {
-  return comp.trim().replace(re[STAR], "");
+  return comp.trim().replace(STAR, "");
 }
 
 // This function is passed to string.replace(re[HYPHENRANGE])
@@ -283,8 +286,7 @@ export function parseRange(range: string): SemVerRange {
     .split(/\s*\|\|\s*/)
     .map((range) => {
       // convert `1.2.3 - 1.2.4` into `>=1.2.3 <=1.2.4`
-      const hr: RegExp = re[HYPHENRANGE];
-      range = range.replace(hr, hyphenReplace);
+      range = range.replace(HYPHENRANGE_REGEXP, hyphenReplace);
       range = replaceCarets(range);
       range = replaceTildes(range);
       range = replaceXRanges(range);

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -4,7 +4,7 @@ import type { SemVerRange } from "./types.ts";
 import {
   CARET_REGEXP,
   HYPHENRANGE_REGEXP,
-  STAR,
+  STAR_REGEXP,
   TILDE_REGEXP,
   XRANGE_REGEXP,
 } from "./_shared.ts";
@@ -215,7 +215,7 @@ function replaceXRange(comp: string): string {
 // Because * is AND-ed with everything else in the comparator,
 // and '' means "any version", just remove the *s entirely.
 function replaceStars(comp: string): string {
-  return comp.trim().replace(STAR, "");
+  return comp.trim().replace(STAR_REGEXP, "");
 }
 
 // This function is passed to string.replace(re[HYPHENRANGE])


### PR DESCRIPTION
removes unnecessary regexp array storage in favour of direct regexp exports.