### PR TITLE
feat(log): Added support for structured JSON logging

### DIFF
--- a/log/formatters.ts
+++ b/log/formatters.ts
@@ -1,0 +1,19 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { LogRecord } from "./logger.ts";
+
+export function jsonFormatter(logRecord: LogRecord): string {
+  return JSON.stringify({
+    level: logRecord.levelName,
+    datetime: logRecord.datetime.getTime(),
+    message: logRecord.msg,
+    args: flattenArgs(logRecord.args),
+  });
+}
+
+export function flattenArgs(args: unknown[]): unknown {
+  if (args.length === 1) {
+    return args[0];
+  } else if (args.length > 1) {
+    return args;
+  }
+}

--- a/log/formatters_test.ts
+++ b/log/formatters_test.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
+import { FakeTime } from "../testing/time.ts";
 import { jsonFormatter } from "./formatters.ts";
 import { LogRecord } from "./logger.ts";
 
-const makeRecord = (msg: string, args: unknown[] = []) =>
+const log = (msg: string, args: unknown[] = []) =>
   new LogRecord({
     msg,
     args,
@@ -12,34 +13,28 @@ const makeRecord = (msg: string, args: unknown[] = []) =>
   });
 
 Deno.test("jsonFormatter with just a message", function () {
-  const result = JSON.parse(jsonFormatter(makeRecord("User service exploded")));
+  using _time = new FakeTime(1);
 
-  assertEquals(result.level, "INFO");
-  assertEquals(typeof result.datetime, "number");
-  assertEquals(result.message, "User service exploded");
-  assertEquals(Object.keys(result), ["level", "datetime", "message"]);
+  assertEquals(
+    jsonFormatter(log("msg")),
+    `{"level":"INFO","datetime":1,"message":"msg"}`,
+  );
 });
 
 Deno.test("jsonFormatter with one argument", function () {
-  const result = JSON.parse(
-    jsonFormatter(makeRecord("User service exploded", [{ user: "Dave" }])),
-  );
+  using _time = new FakeTime(1);
 
-  assertEquals(result.level, "INFO");
-  assertEquals(typeof result.datetime, "number");
-  assertEquals(result.message, "User service exploded");
-  assertEquals(result.args, { user: "Dave" });
-  assertEquals(Object.keys(result), ["level", "datetime", "message", "args"]);
+  assertEquals(
+    jsonFormatter(log("msg", [{ user: "Dave" }])),
+    `{"level":"INFO","datetime":1,"message":"msg","args":{"user":"Dave"}}`,
+  );
 });
 
 Deno.test("jsonFormatter with many arguments", function () {
-  const result = JSON.parse(
-    jsonFormatter(makeRecord("User service exploded", [1, true, 3, [], {}])),
-  );
+  using _time = new FakeTime(1);
 
-  assertEquals(result.level, "INFO");
-  assertEquals(typeof result.datetime, "number");
-  assertEquals(result.message, "User service exploded");
-  assertEquals(result.args, [1, true, 3, [], {}]);
-  assertEquals(Object.keys(result), ["level", "datetime", "message", "args"]);
+  assertEquals(
+    jsonFormatter(log("msg", [1, true, null, [], {}])),
+    `{"level":"INFO","datetime":1,"message":"msg","args":[1,true,null,[],{}]}`,
+  );
 });

--- a/log/formatters_test.ts
+++ b/log/formatters_test.ts
@@ -1,0 +1,45 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../assert/mod.ts";
+import { jsonFormatter } from "./formatters.ts";
+import { LogRecord } from "./logger.ts";
+
+const makeRecord = (msg: string, args: unknown[] = []) =>
+  new LogRecord({
+    msg,
+    args,
+    level: 20,
+    loggerName: "user-logger",
+  });
+
+Deno.test("jsonFormatter with just a message", function () {
+  const result = JSON.parse(jsonFormatter(makeRecord("User service exploded")));
+
+  assertEquals(result.level, "INFO");
+  assertEquals(typeof result.datetime, "number");
+  assertEquals(result.message, "User service exploded");
+  assertEquals(Object.keys(result), ["level", "datetime", "message"]);
+});
+
+Deno.test("jsonFormatter with one argument", function () {
+  const result = JSON.parse(
+    jsonFormatter(makeRecord("User service exploded", [{ user: "Dave" }])),
+  );
+
+  assertEquals(result.level, "INFO");
+  assertEquals(typeof result.datetime, "number");
+  assertEquals(result.message, "User service exploded");
+  assertEquals(result.args, { user: "Dave" });
+  assertEquals(Object.keys(result), ["level", "datetime", "message", "args"]);
+});
+
+Deno.test("jsonFormatter with many arguments", function () {
+  const result = JSON.parse(
+    jsonFormatter(makeRecord("User service exploded", [1, true, 3, [], {}])),
+  );
+
+  assertEquals(result.level, "INFO");
+  assertEquals(typeof result.datetime, "number");
+  assertEquals(result.message, "User service exploded");
+  assertEquals(result.args, [1, true, 3, [], {}]);
+  assertEquals(Object.keys(result), ["level", "datetime", "message", "args"]);
+});

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -55,15 +55,34 @@ export class BaseHandler {
   destroy() {}
 }
 
+export interface ConsoleHandlerOptions extends HandlerOptions {
+  useColors?: boolean;
+}
+
 /**
  * This is the default logger. It will output color coded log messages to the
  * console via `console.log()`.
  */
 export class ConsoleHandler extends BaseHandler {
+  #useColors?: boolean;
+
+  constructor(levelName: LevelName, options: ConsoleHandlerOptions = {}) {
+    super(levelName, options);
+    this.#useColors = options.useColors ?? true;
+  }
+
   override format(logRecord: LogRecord): string {
     let msg = super.format(logRecord);
 
-    switch (logRecord.level) {
+    if (this.#useColors) {
+      msg = this.applyColors(msg, logRecord.level);
+    }
+
+    return msg;
+  }
+
+  applyColors(msg: string, level: number) {
+    switch (level) {
       case LogLevels.INFO:
         msg = blue(msg);
         break;

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -52,7 +52,7 @@
  * // {"level":"INFO","datetime":1702501580505,"message":"This is the message","args":{"thisWillBe":"JSON.stringify'd"}}
  *
  * log.info({ thisWontBe: "JSON.stringify'd"}, "This is an argument");
- * // {"level":"INFO","datetime":1702484111115,"message":"thisWontBe","args":{"product":"nail"}}
+ * // {"level":"INFO","datetime":1702501580505,"message":"{\"thisWontBe\":\"JSON.stringify'd\"}","args":"This is an argument"}
  * ```
  *
  * ## Inline Logging

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -19,6 +19,42 @@
  *
  * The default log format is `{levelName} {msg}`.
  *
+ * ### Logging Structured JSON Lines
+ *
+ * To output logs in a structured JSON format you can configure most handlers
+ * with a formatter that produces a JSON string. Either use the premade
+ * `log.formatters.jsonFormatter` or write your own function that takes a
+ * {@linkcode LogRecord} and returns a JSON.stringify'd object.
+ * If you want the log to go to stdout then use {@linkcode ConsoleHandler} with
+ * the configuration `useColors: false` to turn off the ANSI terminal colours.
+ *
+ * ```ts
+ * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ *
+ * log.setup({
+ *   handlers: {
+ *     default: new log.handlers.ConsoleHandler("DEBUG", {
+ *       formatter: log.formatters.jsonFormatter,
+ *       useColors: false,
+ *     }),
+ *   },
+ * });
+ * ```
+ *
+ * The first argument passed to a log function is always treated as the
+ * message and will be stringified differently. To have arguments JSON.stringify'd
+ * you must pass them after the first.
+ *
+ * ```ts
+ * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ *
+ * log.info("This is the message", { thisWillBe: "JSON.stringify'd"});
+ * // {"level":"INFO","datetime":1702501580505,"message":"This is the message","args":{"thisWillBe":"JSON.stringify'd"}}
+ *
+ * log.info({ thisWontBe: "JSON.stringify'd"}, "This is an argument");
+ * // {"level":"INFO","datetime":1702484111115,"message":"thisWontBe","args":{"product":"nail"}}
+ * ```
+ *
  * ## Inline Logging
  *
  * Log functions return the data passed in the `msg` parameter. Data is returned
@@ -203,6 +239,76 @@
  * // results in:
  * // [dataLogger] - ERROR oh no! // output from anotherFmt handler.
  * ```
+
+ *
+ * @example
+ * JSON to stdout with no color example
+ * ```ts
+ * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ *
+ * log.setup({
+ *   handlers: {
+ *     jsonStdout: new log.handlers.ConsoleHandler("DEBUG", {
+ *       formatter: log.formatters.jsonFormatter,
+ *       useColors: false,
+ *     }),
+ *   },
+ *
+ *   loggers: {
+ *     default: {
+ *       level: "DEBUG",
+ *       handlers: ["jsonStdout"],
+ *     },
+ *   },
+ * });
+ *
+ * // calling:
+ * log.info("Hey");
+ * // results in:
+ * {"level":"INFO","datetime":1702481922294,"message":"Hey"}
+ *
+ * // calling:
+ * log.info("Hey", { product: "nail" });
+ * // results in:
+ * {"level":"INFO","datetime":1702484111115,"message":"Hey","args":{"product":"nail"}}
+ *
+ * // calling:
+ * log.info("Hey", 1, "two", [3, 4, 5]);
+ * // results in:
+ * {"level":"INFO","datetime":1702481922294,"message":"Hey","args":[1,"two",[3,4,5]]}
+ * ```
+ *
+ * @example
+ * Custom JSON example
+ * ```ts
+ * import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";
+ *
+ * log.setup({
+ *   handlers: {
+ *     customJsonFmt: new log.handlers.ConsoleHandler("DEBUG", {
+ *       formatter: (record) => JSON.stringify({
+ *         lvl: record.level,
+ *         msg: record.msg,
+ *         time: record.datetime.toISOString(),
+ *         name: record.loggerName,
+ *       }),
+ *       useColor: false,
+ *     }),
+ *   },
+ *
+ *   loggers: {
+ *     default: {
+ *       level: "DEBUG",
+ *       handlers: ["customJsonFmt"],
+ *     },
+ *   },
+ * });
+ *
+ * // calling:
+ * log.info("complete");
+ * // results in:
+ * // {"lvl":20,"msg":"complete","time":"2023-12-13T16:38:27.328Z","name":"default"}
+ * ```
  *
  * @example
  * Inline Logging
@@ -261,6 +367,7 @@ import {
 } from "./handlers.ts";
 import { assert } from "../assert/assert.ts";
 import type { LevelName } from "./levels.ts";
+import { jsonFormatter } from "./formatters.ts";
 
 export { LogLevels } from "./levels.ts";
 export type { LevelName, LogLevel } from "./levels.ts";
@@ -330,6 +437,10 @@ export const handlers = {
   WriterHandler,
   FileHandler,
   RotatingFileHandler,
+};
+
+export const formatters = {
+  jsonFormatter,
 };
 
 /** Get a logger instance. If not specified `name`, get the default logger. */

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -292,7 +292,7 @@
  *         time: record.datetime.toISOString(),
  *         name: record.loggerName,
  *       }),
- *       useColor: false,
+ *       useColors: false,
  *     }),
  *   },
  *

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -265,17 +265,17 @@
  * // calling:
  * log.info("Hey");
  * // results in:
- * {"level":"INFO","datetime":1702481922294,"message":"Hey"}
+ * // {"level":"INFO","datetime":1702481922294,"message":"Hey"}
  *
  * // calling:
  * log.info("Hey", { product: "nail" });
  * // results in:
- * {"level":"INFO","datetime":1702484111115,"message":"Hey","args":{"product":"nail"}}
+ * // {"level":"INFO","datetime":1702484111115,"message":"Hey","args":{"product":"nail"}}
  *
  * // calling:
  * log.info("Hey", 1, "two", [3, 4, 5]);
  * // results in:
- * {"level":"INFO","datetime":1702481922294,"message":"Hey","args":[1,"two",[3,4,5]]}
+ * // {"level":"INFO","datetime":1702481922294,"message":"Hey","args":[1,"two",[3,4,5]]}
  * ```
  *
  * @example


### PR DESCRIPTION
Implementing a solution for this issue: https://github.com/denoland/deno_std/issues/3394

**What is it?**
Lets you configure the logger to emit structured json logs that will play nicely with log aggregators

**Why do it?**
People like structured json logs:
- https://stackify.com/what-is-structured-logging-and-why-developers-need-it/
- https://sematext.com/glossary/structured-logging/
- https://www.loggly.com/use-cases/what-is-structured-logging-and-how-to-use-it/

TLDR; Easier parsing makes it more reliable, cheap, and fast to gain insight into your logs, whether thats for monitoring, root cause analysis, or business intelligence.

**What does it look like?**

```ts
import * as log from "https://deno.land/std@$STD_VERSION/log/mod.ts";

log.setup({
  handlers: {
    default: new log.handlers.ConsoleHandler("DEBUG", {
      formatter: log.formatters.jsonFormatter,
      useColors: false,
    }),
  },
});

log.info("Hey");
// > {"level":"INFO","datetime":1702481922294,"message":"Hey"}

log.info("Hey", { product: "nail" });
// > {"level":"INFO","datetime":1702484111115,"message":"Hey","args":{"product":"nail"}}

log.info("Hey", 1, "two", [3, 4, 5]);
// > {"level":"INFO","datetime":1702481922294,"message":"Hey","args":[1,"two",[3,4,5]]}
```

The changes include:
- A new `log/formatters.ts` module with the new `jsonFormatter` function
  - Other formatters in future could include logfmt and maybe protobufs
  - DEFAULT_FORMATTER and FormatterFunction could be moved here
- Most log aggregators I've worked with didn't like colour codes, so `ConsoleHandler` now has a new optional property in its constructor parameter `useColors?: boolean` that defaults to true, keeping backwards compatibility. Only when explicitly set to false will the handler skip applying colours. 
  - I could have created a new handler but I couldn't think of a good name name.
- Exporting a new `const formatters` from the `log/mod.ts` so we can use the formatter in a similar way to how we use handlers: `log.formatters.jsonFormatter`
- A ton of docs, please note that I've documented the following topics & quirks:
  - How to configure the logger to emit non-coloured json
  - How the first argument is always treated as the message and will be double encoded if not a string
  - How the emitted json looks based on different types of input
  - How to create a custom json formatter