### PR TITLE
chore(encoding): improve test coverage

### DIFF
--- a/encoding/_util_test.ts
+++ b/encoding/_util_test.ts
@@ -51,4 +51,11 @@ Deno.test("validateBinaryLike with invalid inputs", () => {
     TypeError,
     "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type MyClass.",
   );
+  assertThrows(
+    () => {
+      validateBinaryLike(Object.create(null));
+    },
+    TypeError,
+    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type object.",
+  )
 });

--- a/encoding/_util_test.ts
+++ b/encoding/_util_test.ts
@@ -57,5 +57,5 @@ Deno.test("validateBinaryLike with invalid inputs", () => {
     },
     TypeError,
     "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type object.",
-  )
+  );
 });

--- a/encoding/ascii85_test.ts
+++ b/encoding/ascii85_test.ts
@@ -192,3 +192,21 @@ Deno.test({
     assertEquals(encoded2, "F)YQ)");
   },
 });
+
+Deno.test({
+  name: `[encoding/ascii85] decode with default standard`,
+  fn() {
+    const tests = [
+      ["<~FCfN8Bl7P~>", "testing"],
+      ["<~A7]XsCgh3l~>", "denoland"],
+      ["<~@<5pmBfIsm@:X:cAH~>", "ascii85 adobe"],
+    ];
+
+    for (const [input, expect] of tests) {
+      assertEquals(
+        decodeAscii85(input),
+        utf8encoder.encode(expect),
+      );
+    }
+  },
+});

--- a/encoding/base32_test.ts
+++ b/encoding/base32_test.ts
@@ -1,8 +1,8 @@
 // Test cases copied from https://github.com/LinusU/base32-encode/blob/master/test.js
 // Copyright (c) 2016-2017 Linus Unnebäck. MIT license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "../assert/mod.ts";
-import { decodeBase32, encodeBase32 } from "./base32.ts";
+import { assert, assertEquals, assertExists } from "../assert/mod.ts";
+import { byteLength, decodeBase32, encodeBase32 } from "./base32.ts";
 
 // Lifted from https://stackoverflow.com/questions/38987784
 const fromHexString = (hexString: string): Uint8Array =>
@@ -133,5 +133,29 @@ Deno.test({
       errorCaught = true;
     }
     assert(errorCaught);
+  },
+});
+
+Deno.test({
+  name: "[encoding.base32] byteLength",
+  fn() {
+    const tests: [string, number][] = [
+      ["JBSWY3DPEBLW64TMMQ======", 11],
+      ["3X4A5PRBX4NR4EVGJROMNJ2LLWJN2===", 18],
+      ["WB2K5C467XQPC7ZXXTFN3YAG2A4ZS62ZZDX3AWW5", 25],
+      ["6L6CGGN5FFCXZTIB5DQZJ3U327UXFGFWMEG7JKYPHVN2UCZNPTHWTAU63N2O33Y=", 39],
+    ];
+
+    for (const [input, expect] of tests) {
+      assertEquals(byteLength(input), expect);
+    }
+  },
+});
+
+Deno.test({
+  name: "[encoding.base32] encode very long text",
+  fn() {
+    const data = "a".repeat(16400);
+    assertExists(encodeBase32(data));
   },
 });

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -27,6 +27,13 @@ const testsetInvalid = [
   "PDw/Pz8+Pg==",
 ];
 
+const testsetIllegalBase64url = [
+  "w58De",
+  "Zm9vYmFyy",
+  "DPj8-ZD_DnwEg",
+  "SGVsbG8gV29ybGQ-_",
+];
+
 Deno.test("[encoding/base64url] testBase64urlEncodeString", () => {
   for (const [input, output] of testsetString) {
     assertEquals(encodeBase64Url(input), output);
@@ -51,6 +58,16 @@ Deno.test("[decoding/base64url] base64url.decode throws on invalid input", () =>
       () => decodeBase64Url(invalidb64url),
       TypeError,
       "invalid character",
+    );
+  }
+});
+
+Deno.test("[decoding/base64url] base64url.decode throws on illegal base64url string", () => {
+  for (const illegalBase64url of testsetIllegalBase64url) {
+    assertThrows(
+      () => decodeBase64Url(illegalBase64url),
+      TypeError,
+      "Illegal base64url string!",
     );
   }
 });

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -27,13 +27,6 @@ const testsetInvalid = [
   "PDw/Pz8+Pg==",
 ];
 
-const testsetIllegalBase64url = [
-  "w58De",
-  "Zm9vYmFyy",
-  "DPj8-ZD_DnwEg",
-  "SGVsbG8gV29ybGQ-_",
-];
-
 Deno.test("[encoding/base64url] testBase64urlEncodeString", () => {
   for (const [input, output] of testsetString) {
     assertEquals(encodeBase64Url(input), output);
@@ -63,6 +56,13 @@ Deno.test("[decoding/base64url] base64url.decode throws on invalid input", () =>
 });
 
 Deno.test("[decoding/base64url] base64url.decode throws on illegal base64url string", () => {
+  const testsetIllegalBase64url = [
+    "w58De",
+    "Zm9vYmFyy",
+    "DPj8-ZD_DnwEg",
+    "SGVsbG8gV29ybGQ-_",
+  ];
+
   for (const illegalBase64url of testsetIllegalBase64url) {
     assertThrows(
       () => decodeBase64Url(illegalBase64url),

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -95,8 +95,11 @@ Deno.test("VarInt encode manual", () => {
     [Uint8Array.of(255, 255, 255, 255, 255, 255, 255, 255, 255, 1), 10],
   );
 });
+Deno.test("VarInt encode overflow uint64", () => {
+  assertThrows(() => encode(1e+30), RangeError, "overflows uint64");
+});
 Deno.test("VarInt encode overflow with negative", () => {
-  assertThrows(() => encode(-1), RangeError);
+  assertThrows(() => encode(-1), RangeError, "signed input given");
 });
 Deno.test("VarInt encode with offset", () => {
   let uint = new Uint8Array(3);


### PR DESCRIPTION
Related: #3713

## New test cases

`_util.ts`
- For object with empty prototype.

`ascii85.ts`
- When decoding with default `standard` option.

`base32.ts`
- For `byteLength` function.
- When encoding a very long text.

`base64url.ts`
- When decoding illegal base64url strings.

`varint.ts`
- When encoding overflow uint64.

See: https://app.codecov.io/gh/denoland/deno_std/pull/3971/indirect-changes