### PR TITLE
feat(collections): improve mapValues typing

### DIFF
--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -26,15 +26,51 @@
  * );
  * ```
  */
-export function mapValues<T, O>(
-  record: Readonly<Record<string, T>>,
+export function mapValues<T, O, K extends string>(
+  record: Readonly<Record<K, T>>,
   transformer: (value: T) => O,
-): Record<string, O> {
-  const ret: Record<string, O> = {};
+): Record<K, O>;
+/**
+ * Applies the given transformer to all values in the given record and returns a
+ * new record containing the resulting keys associated to the last value that
+ * produced them.
+ *
+ * @example
+ * ```ts
+ * import { mapValues } from "https://deno.land/std@$STD_VERSION/collections/map_values.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ *
+ * const usersById = {
+ *   "a5ec": { name: "Mischa" },
+ *   "de4f": { name: "Kim" },
+ * };
+ * const namesById = mapValues(usersById, (it) => it.name);
+ *
+ * assertEquals(
+ *   namesById,
+ *   {
+ *     "a5ec": "Mischa",
+ *     "de4f": "Kim",
+ *   },
+ * );
+ * ```
+ */
+export function mapValues<T, O, K extends string>(
+  record: Readonly<Partial<Record<K, T>>>,
+  transformer: (value: T) => O,
+): Partial<Record<K, O>>;
+export function mapValues<T, O, K extends string>(
+  record: Record<K, T>,
+  transformer: (value: T) => O,
+  // deno-lint-ignore no-explicit-any
+): any {
+  // deno-lint-ignore no-explicit-any
+  const ret: any = {};
   const entries = Object.entries(record);
 
   for (const [key, value] of entries) {
-    const mappedValue = transformer(value);
+    // deno-lint-ignore no-explicit-any
+    const mappedValue = transformer(value as any);
 
     ret[key] = mappedValue;
   }

--- a/collections/map_values_test.ts
+++ b/collections/map_values_test.ts
@@ -109,3 +109,33 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "[collections/mapValues] preserves key type (Record)",
+  fn() {
+    type Variants = "a" | "b";
+    const input: Record<Variants, string> = { a: "a", b: "b" };
+    const actual = mapValues(
+      input,
+      (_: string) => 1,
+    );
+    const expected = { a: 1, b: 1 };
+
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "[collections/mapValues] preserves key type (Partial Record)",
+  fn() {
+    type Variants = "a" | "b";
+    const input: Partial<Record<Variants, string>> = { a: "a" };
+    const actual = mapValues(
+      input,
+      (_: string) => 1,
+    );
+    const expected = { a: 1 };
+
+    assertEquals(actual, expected);
+  },
+});


### PR DESCRIPTION
continued from #3430. Key types are inferred better from mapValues inputs.

Also allow to accept `Partial<Record<..>>`