### PR TITLE
buffer pull only once data has been written

### DIFF
--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -70,7 +70,12 @@ export class Buffer {
 
   /** Constructs a new instance. */
   constructor(ab?: ArrayBufferLike | ArrayLike<number>) {
-    this.#buf = ab === undefined ? new Uint8Array(0) : new Uint8Array(ab);
+    if (ab === undefined) {
+      this.#buf = new Uint8Array(0);
+    } else {
+      this.#buf = new Uint8Array(ab);
+      this.#startedPromise.resolve(undefined);
+    }
   }
 
   /** Returns a slice holding the unread portion of the buffer.

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -24,9 +24,15 @@ const DEFAULT_CHUNK_SIZE = 16_640;
 export class Buffer {
   #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
   #off = 0; // read at buf[off], write at buf[buf.byteLength]
+  #startedPromise = Promise.withResolvers();
+  #startedBool = false;
   #readable: ReadableStream<Uint8Array> = new ReadableStream({
     type: "bytes",
-    pull: (controller) => {
+    pull: async (controller) => {
+      if (!this.#startedBool) {
+        await this.#startedPromise.promise;
+      }
+
       const view = new Uint8Array(controller.byobRequest!.view!.buffer);
       if (this.empty()) {
         // Buffer is empty, reset to recover space.
@@ -37,7 +43,9 @@ export class Buffer {
       }
       const nread = copy(this.#buf.subarray(this.#off), view);
       this.#off += nread;
-      controller.byobRequest!.respond(nread);
+      if (nread !== 0) {
+        controller.byobRequest!.respond(nread);
+      }
     },
     autoAllocateChunkSize: DEFAULT_CHUNK_SIZE,
   });
@@ -51,6 +59,7 @@ export class Buffer {
     write: (chunk) => {
       const m = this.#grow(chunk.byteLength);
       copy(chunk, this.#buf, m);
+      this.#startedPromise.resolve(undefined);
     },
   });
 


### PR DESCRIPTION
Currently, when a Buffer is read from, and no data was written, it will instantly close. This PR adds logic so that the buffer needs to be written to first before starting to read.