### PR TITLE
deprecation(encoding): deprecate `base32.byteLength()`

### DIFF
--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -53,6 +53,8 @@ function getLens(b32: string): [number, number] {
 /**
  * Returns number of bytes encoded in the given RFC4648 base32 string input.
  * @param b32
+ *
+ * @deprecated (will be removed in 0.212.0)
  */
 export function byteLength(b32: string): number {
   const [validLen, placeHoldersLen] = getLens(b32);


### PR DESCRIPTION
Closes #3975