### PR TITLE
refactor(uuid): format test names and improve test coverage 

### DIFF
--- a/uuid/constants_test.ts
+++ b/uuid/constants_test.ts
@@ -8,7 +8,7 @@ import {
 } from "./constants.ts";
 import { validate } from "./mod.ts";
 
-Deno.test("[UUID] validate_namespaces", () => {
+Deno.test("validate() validates the pre-defined namespaces", () => {
   assertEquals(validate(NAMESPACE_DNS), true);
   assertEquals(validate(NAMESPACE_URL), true);
   assertEquals(validate(NAMESPACE_OID), true);

--- a/uuid/test.ts
+++ b/uuid/test.ts
@@ -2,14 +2,14 @@
 import { assert, assertEquals, assertThrows } from "../assert/mod.ts";
 import { isNil, NIL_UUID, validate, version } from "./mod.ts";
 
-Deno.test("[UUID] isNil", () => {
+Deno.test("isNil() checks if a UUID is the nil UUID", () => {
   const nil = NIL_UUID;
   const u = "582cbcff-dad6-4f28-888a-e062ae36bafc";
   assert(isNil(nil));
   assert(!isNil(u));
 });
 
-Deno.test("[UUID] validate", () => {
+Deno.test("validate() checks if a string is a valid UUID", () => {
   const u = "582cbcff-dad6-4f28-888a-e062ae36bafc";
   const nil = NIL_UUID;
   assert(validate(u));
@@ -17,7 +17,7 @@ Deno.test("[UUID] validate", () => {
   assert(!validate("not a UUID"));
 });
 
-Deno.test("[UUID] version", () => {
+Deno.test("version() detects the RFC version of a UUID", () => {
   assertEquals(version(NIL_UUID), 0);
   assertEquals(version("d9428888-122b-11e1-b85c-61cd3cbb3210"), 1);
   assertEquals(version("109156be-c4fb-41ea-b1b4-efe1671c5836"), 4);

--- a/uuid/v1_test.ts
+++ b/uuid/v1_test.ts
@@ -1,8 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "../assert/mod.ts";
+import { assert, assertEquals, assertThrows } from "../assert/mod.ts";
 import { generate, validate } from "./v1.ts";
+import { uuidToBytes } from "./_common.ts";
 
-Deno.test("[UUID] is_valid_uuid_v1", () => {
+Deno.test("v1.validate() checks if a string is a valid v1 UUID", () => {
   const u = generate();
   const t = "63655efa-7ee6-11ea-bc55-0242ac130003";
   const n = "63655efa-7ee6-11eg-bc55-0242ac130003";
@@ -12,20 +13,27 @@ Deno.test("[UUID] is_valid_uuid_v1", () => {
   assert(!validate(n), `${n} should not be valid`);
 });
 
-Deno.test("[UUID] test_uuid_v1", () => {
-  const u = generate();
-  assertEquals(typeof u, "string", "returns a string");
-  assert(u !== "", "return string is not empty");
+Deno.test("v1.generate() generates a non-empty string", () => {
+  const u1 = generate();
+  const u2 = generate({
+    msecs: new Date("2011-11-01").getTime(),
+    nsecs: 10000,
+  });
+
+  assertEquals(typeof u1, "string", "returns a string");
+  assert(u1 !== "", "return string is not empty");
+  assertEquals(typeof u2, "string", "returns a string");
+  assert(u2 !== "", "return string is not empty");
 });
 
-Deno.test("[UUID] test_uuid_v1_format", () => {
+Deno.test("v1.generate() generates UUIDs in version 1 format", () => {
   for (let i = 0; i < 10000; i++) {
     const u = generate() as string;
     assert(validate(u), `${u} is not a valid uuid v1`);
   }
 });
 
-Deno.test("[UUID] test_uuid_v1_static", () => {
+Deno.test("v1.generate() can generate a static v1 UUID", () => {
   const v1options = {
     node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
     clockseq: 0x1234,
@@ -34,4 +42,29 @@ Deno.test("[UUID] test_uuid_v1_static", () => {
   };
   const u = generate(v1options);
   assertEquals(u, "710b962e-041c-11e1-9234-0123456789ab");
+});
+
+Deno.test("v1.generate() can fill the UUID into a buffer", () => {
+  const buf: number[] = [];
+  const v1options = {
+    node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
+    clockseq: 0x1234,
+    msecs: new Date("2011-11-01").getTime(),
+    nsecs: 5678,
+  };
+  const uuid = generate(v1options, buf, 0);
+  const expect = uuidToBytes("710b962e-041c-11e1-9234-0123456789ab");
+
+  assertEquals(buf, expect);
+  assertEquals(buf, uuid);
+});
+
+Deno.test("v1.generate() throws when create more than 10M uuids/sec", () => {
+  assertThrows(
+    () => {
+      generate({ nsecs: 10001 });
+    },
+    Error,
+    "Can't create more than 10M uuids/sec",
+  );
 });

--- a/uuid/v1_test.ts
+++ b/uuid/v1_test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals, assertThrows } from "../assert/mod.ts";
 import { generate, validate } from "./v1.ts";
 import { uuidToBytes } from "./_common.ts";
 
-Deno.test("v1.validate() checks if a string is a valid v1 UUID", () => {
+Deno.test("validate() checks if a string is a valid v1 UUID", () => {
   const u = generate();
   const t = "63655efa-7ee6-11ea-bc55-0242ac130003";
   const n = "63655efa-7ee6-11eg-bc55-0242ac130003";
@@ -13,7 +13,7 @@ Deno.test("v1.validate() checks if a string is a valid v1 UUID", () => {
   assert(!validate(n), `${n} should not be valid`);
 });
 
-Deno.test("v1.generate() generates a non-empty string", () => {
+Deno.test("generate() generates a non-empty string", () => {
   const u1 = generate();
   const u2 = generate({
     msecs: new Date("2011-11-01").getTime(),
@@ -26,14 +26,14 @@ Deno.test("v1.generate() generates a non-empty string", () => {
   assert(u2 !== "", "return string is not empty");
 });
 
-Deno.test("v1.generate() generates UUIDs in version 1 format", () => {
+Deno.test("generate() generates UUIDs in version 1 format", () => {
   for (let i = 0; i < 10000; i++) {
     const u = generate() as string;
     assert(validate(u), `${u} is not a valid uuid v1`);
   }
 });
 
-Deno.test("v1.generate() can generate a static v1 UUID", () => {
+Deno.test("generate() can generate a static v1 UUID", () => {
   const v1options = {
     node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
     clockseq: 0x1234,
@@ -44,7 +44,7 @@ Deno.test("v1.generate() can generate a static v1 UUID", () => {
   assertEquals(u, "710b962e-041c-11e1-9234-0123456789ab");
 });
 
-Deno.test("v1.generate() can fill the UUID into a buffer", () => {
+Deno.test("generate() can fill the UUID into a buffer", () => {
   const buf: number[] = [];
   const v1options = {
     node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
@@ -59,7 +59,7 @@ Deno.test("v1.generate() can fill the UUID into a buffer", () => {
   assertEquals(buf, uuid);
 });
 
-Deno.test("v1.generate() throws when create more than 10M uuids/sec", () => {
+Deno.test("generate() throws when create more than 10M uuids/sec", () => {
   assertThrows(
     () => {
       generate({ nsecs: 10001 });

--- a/uuid/v3_test.ts
+++ b/uuid/v3_test.ts
@@ -4,28 +4,28 @@ import { generate, validate } from "./v3.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
 
-Deno.test("[UUID] test_uuid_v3", async () => {
+Deno.test("v3.generate() generates a non-empty string", async () => {
   const u = await generate(NAMESPACE, new Uint8Array());
   assertEquals(typeof u, "string", "returns a string");
   assert(u !== "", "return string is not empty");
 });
 
-Deno.test("[UUID] test_uuid_v3_format", async () => {
+Deno.test("v3.generate() generates UUIDs in version 3 format", async () => {
   for (let i = 0; i < 10000; i++) {
     const u = await generate(
       NAMESPACE,
       new TextEncoder().encode(i.toString()),
     ) as string;
-    assert(validate(u), `${u} is not a valid uuid v5`);
+    assert(validate(u), `${u} is not a valid uuid v3`);
   }
 });
 
-Deno.test("[UUID] test_uuid_v3_option", async () => {
+Deno.test("v3.generate() generates a name-based UUID using MD5 hash", async () => {
   const u = await generate(NAMESPACE, new TextEncoder().encode("Hello, World"));
   assertEquals(u, "71d7129f-e809-30ed-a2c6-ea9032b43c0d");
 });
 
-Deno.test("[UUID] is_valid_uuid_v3", async () => {
+Deno.test("v3.validate() checks if a string is a valid v3 UUID", async () => {
   const u = await generate(
     "1b671a64-40d5-491e-99b0-da01ff1f3341",
     new TextEncoder().encode("Hello, World"),

--- a/uuid/v3_test.ts
+++ b/uuid/v3_test.ts
@@ -4,13 +4,13 @@ import { generate, validate } from "./v3.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
 
-Deno.test("v3.generate() generates a non-empty string", async () => {
+Deno.test("generate() generates a non-empty string", async () => {
   const u = await generate(NAMESPACE, new Uint8Array());
   assertEquals(typeof u, "string", "returns a string");
   assert(u !== "", "return string is not empty");
 });
 
-Deno.test("v3.generate() generates UUIDs in version 3 format", async () => {
+Deno.test("generate() generates UUIDs in version 3 format", async () => {
   for (let i = 0; i < 10000; i++) {
     const u = await generate(
       NAMESPACE,
@@ -20,12 +20,12 @@ Deno.test("v3.generate() generates UUIDs in version 3 format", async () => {
   }
 });
 
-Deno.test("v3.generate() generates a name-based UUID using MD5 hash", async () => {
+Deno.test("generate() generates a name-based UUID using MD5 hash", async () => {
   const u = await generate(NAMESPACE, new TextEncoder().encode("Hello, World"));
   assertEquals(u, "71d7129f-e809-30ed-a2c6-ea9032b43c0d");
 });
 
-Deno.test("v3.validate() checks if a string is a valid v3 UUID", async () => {
+Deno.test("validate() checks if a string is a valid v3 UUID", async () => {
   const u = await generate(
     "1b671a64-40d5-491e-99b0-da01ff1f3341",
     new TextEncoder().encode("Hello, World"),

--- a/uuid/v4_test.ts
+++ b/uuid/v4_test.ts
@@ -2,7 +2,7 @@
 import { assert } from "../assert/mod.ts";
 import { validate } from "./v4.ts";
 
-Deno.test("v4.validate() checks if a string is a valid v4 UUID", () => {
+Deno.test("validate() checks if a string is a valid v4 UUID", () => {
   const u = crypto.randomUUID();
   const t = "84fb7824-b951-490e-8afd-0c13228a8282";
   const n = "84fb7824-b951-490g-8afd-0c13228a8282";

--- a/uuid/v4_test.ts
+++ b/uuid/v4_test.ts
@@ -2,7 +2,7 @@
 import { assert } from "../assert/mod.ts";
 import { validate } from "./v4.ts";
 
-Deno.test("[UUID] is_valid_uuid_v4", () => {
+Deno.test("v4.validate() checks if a string is a valid v4 UUID", () => {
   const u = crypto.randomUUID();
   const t = "84fb7824-b951-490e-8afd-0c13228a8282";
   const n = "84fb7824-b951-490g-8afd-0c13228a8282";

--- a/uuid/v5_test.ts
+++ b/uuid/v5_test.ts
@@ -4,13 +4,13 @@ import { generate, validate } from "./v5.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
 
-Deno.test("v5.generate() generates a non-empty string", async () => {
+Deno.test("generate() generates a non-empty string", async () => {
   const u = await generate(NAMESPACE, new Uint8Array());
   assertEquals(typeof u, "string", "returns a string");
   assert(u !== "", "return string is not empty");
 });
 
-Deno.test("v5.generate() generates UUIDs in version 5 format", async () => {
+Deno.test("generate() generates UUIDs in version 5 format", async () => {
   for (let i = 0; i < 10000; i++) {
     const u = await generate(
       NAMESPACE,
@@ -20,12 +20,12 @@ Deno.test("v5.generate() generates UUIDs in version 5 format", async () => {
   }
 });
 
-Deno.test("v5.generate() generates a name-based UUID using SHA-1 hash", async () => {
+Deno.test("generate() generates a name-based UUID using SHA-1 hash", async () => {
   const u = await generate(NAMESPACE, new TextEncoder().encode("Hello, World"));
   assertEquals(u, "4b4f2adc-5b27-57b5-8e3a-c4c4bcf94f05");
 });
 
-Deno.test("v5.validate() checks if a string is a valid v5 UUID", async () => {
+Deno.test("validate() checks if a string is a valid v5 UUID", async () => {
   const u = await generate(
     "1b671a64-40d5-491e-99b0-da01ff1f3341",
     new TextEncoder().encode("Hello, World"),

--- a/uuid/v5_test.ts
+++ b/uuid/v5_test.ts
@@ -4,13 +4,13 @@ import { generate, validate } from "./v5.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
 
-Deno.test("[UUID] test_uuid_v5", async () => {
+Deno.test("v5.generate() generates a non-empty string", async () => {
   const u = await generate(NAMESPACE, new Uint8Array());
   assertEquals(typeof u, "string", "returns a string");
   assert(u !== "", "return string is not empty");
 });
 
-Deno.test("[UUID] test_uuid_v5_format", async () => {
+Deno.test("v5.generate() generates UUIDs in version 5 format", async () => {
   for (let i = 0; i < 10000; i++) {
     const u = await generate(
       NAMESPACE,
@@ -20,12 +20,12 @@ Deno.test("[UUID] test_uuid_v5_format", async () => {
   }
 });
 
-Deno.test("[UUID] test_uuid_v5_option", async () => {
+Deno.test("v5.generate() generates a name-based UUID using SHA-1 hash", async () => {
   const u = await generate(NAMESPACE, new TextEncoder().encode("Hello, World"));
   assertEquals(u, "4b4f2adc-5b27-57b5-8e3a-c4c4bcf94f05");
 });
 
-Deno.test("[UUID] is_valid_uuid_v5", async () => {
+Deno.test("v5.validate() checks if a string is a valid v5 UUID", async () => {
   const u = await generate(
     "1b671a64-40d5-491e-99b0-da01ff1f3341",
     new TextEncoder().encode("Hello, World"),


### PR DESCRIPTION
Ref: #3713, #3754

This PR updates the test names as well as improving the test coverage in `uuid`.

See: https://app.codecov.io/gh/denoland/deno_std/pull/4002/tree/uuid