### PR TITLE
chore: ignore `coverage/` for formatting, linting, etc.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,7 @@
     "crypto/_wasm/target",
     "cov",
     "jsonc/testdata",
-    "front_matter/testdata"
+    "front_matter/testdata",
+    "coverage"
   ]
 }


### PR DESCRIPTION
Previously, everything in `coverage/` was going through the formatter, linter, etc. Now, it doesn't.