### PR TITLE
fix(cli/spinner): export private type aliases used in public API

### DIFF
--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -13,8 +13,8 @@ const DEFAULT_SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧",
 // This is a hack to allow us to use the same type for both the color name and an ANSI escape code.
 // ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-460346421
 // deno-lint-ignore ban-types
-type Ansi = string & {};
-type Color =
+export type Ansi = string & {};
+export type Color =
   | "black"
   | "red"
   | "green"


### PR DESCRIPTION
Ref: https://github.com/denoland/deno_std/pull/3968

I saw this new feature in the [release notes for 0.210.0](https://github.com/denoland/deno_std/releases/tag/0.210.0) and noticed that there's no way to access the `Color` type alias which is used by the public options property at `SpinnerOptions.color`. This exports that union and one of its members which was also still private.

https://github.com/denoland/deno_std/blob/5ddf32a1eaeb04ce55d2680e32cac19e4dd8a8ca/cli/spinner.ts#L41-L58

https://github.com/denoland/deno_std/blob/5ddf32a1eaeb04ce55d2680e32cac19e4dd8a8ca/cli/spinner.ts#L13-L27