### PR TITLE
test(jsonc): do not use deno.lock in subcommand

### DIFF
--- a/jsonc/parse_test.ts
+++ b/jsonc/parse_test.ts
@@ -194,7 +194,7 @@ Deno.test({
     const command = new Deno.Command(Deno.execPath(), {
       stdout: "inherit",
       stderr: "inherit",
-      args: ["eval", testCode],
+      args: ["eval", "--no-lock", testCode],
     });
     const { success } = await command.output();
     assert(success);


### PR DESCRIPTION
This PR tries to fix flaky test failure of `[jsonc] use Object.defineProperty when setting object property` case.

The test case sometimes fails with the below error message:

```
------- output -------
error: Unable to parse contents of lockfile. /home/runner/work/deno_std/deno_std/deno.lock
./jsonc/parse_test.ts => [jsonc] use Object.defineProperty when setting object property ...----- output end -----
./jsonc/parse_test.ts => [jsonc] use Object.defineProperty when setting object property ... FAILED (7ms)
```
https://github.com/denoland/deno_std/actions/runs/7292878535/job/19874783040

The command doesn't need to use lock file. So we can avoid the above flaky failure by passing `--no-lock` flag.

closes #4015
