### PR TITLE
chore(log): rework `std/log` to work without deprecated `Deno.Writer`

### DIFF
--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -183,18 +183,22 @@ export class FileHandler extends WriterHandler {
       this.flush();
     }
     this._buf.set(bytes, this._pointer);
-    this._pointer += bytes.length;
+    this._pointer += bytes.byteLength;
   }
 
   flush() {
-    if (this._buf?.byteLength > 0 && this._file) {
-      this._file?.writeSync(this._buf.subarray(0, this._pointer));
+    if (this._pointer > 0 && this._file) {
+      let written = 0;
+      while (written < this._pointer) {
+        written += this._file.writeSync(
+          this._buf.subarray(written, this._pointer),
+        );
+      }
       this.resetBuffer();
     }
   }
 
   resetBuffer() {
-    this._buf.fill(0);
     this._pointer = 0;
   }
 

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -163,7 +163,7 @@ export class FileHandler extends WriterHandler {
 
   override setup() {
     this._file = Deno.openSync(this._filename, this._openOptions);
-    this.resetBuffer();
+    this.#resetBuffer();
 
     addEventListener("unload", this.#unloadCallback);
   }
@@ -194,11 +194,11 @@ export class FileHandler extends WriterHandler {
           this._buf.subarray(written, this._pointer),
         );
       }
-      this.resetBuffer();
+      this.#resetBuffer();
     }
   }
 
-  resetBuffer() {
+  #resetBuffer() {
     this._pointer = 0;
   }
 
@@ -329,6 +329,5 @@ export class RotatingFileHandler extends FileHandler {
     }
 
     this._file = Deno.openSync(this._filename, this._openOptions);
-    this.resetBuffer();
   }
 }

--- a/log/handlers.ts
+++ b/log/handlers.ts
@@ -137,7 +137,7 @@ interface FileHandlerOptions extends HandlerOptions {
  */
 export class FileHandler extends WriterHandler {
   protected _file: Deno.FsFile | undefined;
-  protected _buf: Uint8Array = new Uint8Array(new ArrayBuffer(PAGE_SIZE));
+  protected _buf: Uint8Array = new Uint8Array(PAGE_SIZE);
   protected _pointer = 0;
   protected _filename: string;
   protected _mode: LogMode;


### PR DESCRIPTION
Attempting to solve https://github.com/denoland/deno_std/issues/3907

> std/log is the last of the sub-modules that uses the deprecated Writer (i.e. Deno.Writer) interface. It should use WritableStream instead.

Previous attempt of https://github.com/denoland/deno_std/pull/3969 was trying to use `std/streams/buffer.ts` and the streams API, but moving to async flushes resulted in potentially lost logs.

Now just solving with a `Uint8Array` and a `ArrayBuffer` and a number pointer.