### PR TITLE
chore(fs): log more information about test failure

### DIFF
--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -225,9 +225,13 @@ for (const s of scenes) {
           cwd: testdataDir,
           args,
         });
-        const { stdout } = await command.output();
+        const { stdout, stderr } = await command.output();
         assertStringIncludes(new TextDecoder().decode(stdout), s.output);
+        if (stderr.length > 0) {
+          console.log(new TextDecoder().decode(stderr));
+        }
       } catch (err) {
+        console.log(err);
         await Deno.remove(testfolder, { recursive: true });
         throw err;
       }


### PR DESCRIPTION
The test case sometimes fails at line 237, but the root cause of the test failure is not shown in the log. This PR prints more info about the error to enable further debugging.