### PR TITLE
deprecation(semver): deprecate cmp

### DIFF
--- a/semver/cmp.ts
+++ b/semver/cmp.ts
@@ -13,7 +13,8 @@ import { lte } from "./lte.ts";
  * @param operator The operator to use for the comparison
  * @param s1 The right side of the comparison
  * @returns True or false based on the operator
- * @deprecated (will be removed in 0.212.0) use {@linkcode compare} instead.
+ *
+ * @deprecated (will be removed in 0.212.0) Use {@linkcode compare} instead.
  */
 export function cmp(
   s0: SemVer,

--- a/semver/cmp.ts
+++ b/semver/cmp.ts
@@ -13,6 +13,7 @@ import { lte } from "./lte.ts";
  * @param operator The operator to use for the comparison
  * @param s1 The right side of the comparison
  * @returns True or false based on the operator
+ * @deprecated (will be removed in 0.212.0) use {@linkcode compare} instead.
  */
 export function cmp(
   s0: SemVer,


### PR DESCRIPTION
deprecates `cmp`, because one can achieve the same with `compare` and operators or `eq`, `neq` etc. `cmp` even uses them internally.