### PR TITLE
deprecation(semver): rename rsort to reverseSort

### DIFF
--- a/semver/reverse_sort.ts
+++ b/semver/reverse_sort.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import type { SemVer } from "./types.ts";
+import { compare } from "./compare.ts";
+
+/** Sorts a list of semantic versions in descending order. */
+export function reverseSort(
+  versions: SemVer[],
+): SemVer[] {
+  return versions.sort((a, b) => compare(b, a));
+}

--- a/semver/reverse_sort_test.ts
+++ b/semver/reverse_sort_test.ts
@@ -1,11 +1,14 @@
 // Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { rsort } from "./rsort.ts";
+import { reverseSort } from "./reverse_sort.ts";
 import { parse } from "./parse.ts";
 
-Deno.test("rsort", function () {
+Deno.test("reverseSort()", function () {
   const list = ["1.2.3+1", "1.2.3+0", "1.2.3", "5.9.6", "0.1.2"];
   const rsorted = ["5.9.6", "1.2.3+1", "1.2.3+0", "1.2.3", "0.1.2"];
-  assertEquals(rsort(list.map((v) => parse(v))), rsorted.map((v) => parse(v)));
+  assertEquals(
+    reverseSort(list.map((v) => parse(v))),
+    rsorted.map((v) => parse(v)),
+  );
 });

--- a/semver/rsort.ts
+++ b/semver/rsort.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import type { SemVer } from "./types.ts";
-import { compare } from "./compare.ts";
+import { reverseSort } from "./reverse_sort.ts";
 
-/** Sorts a list of semantic versions in descending order. */
-export function rsort(
-  list: SemVer[],
-): SemVer[] {
-  return list.sort((a, b) => compare(b, a));
-}
+/**
+ * Sorts a list of semantic versions in descending order.
+ * @deprecated (will be removed after 0.212.0) Use {@linkcode reverseSort} instead.
+ */
+export const rsort = reverseSort;


### PR DESCRIPTION
renames `rsort` to `reverseSort`.