### PR TITLE
fix(expect): align toStrictEqual behavior to jest

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -42,13 +42,9 @@ export function toStrictEqual(
   expected: unknown,
 ): MatchResult {
   if (context.isNot) {
-    assertNotStrictEquals(
-      context.value,
-      expected,
-      context.customMessage,
-    );
+    assertNotEquals(context.value, expected, context.customMessage);
   } else {
-    assertStrictEquals(context.value, expected, context.customMessage);
+    assertEquals(context.value, expected, context.customMessage);
   }
 }
 

--- a/expect/_to_strict_equal_test.ts
+++ b/expect/_to_strict_equal_test.ts
@@ -4,24 +4,27 @@ import { expect } from "./expect.ts";
 import { AssertionError, assertThrows } from "../assert/mod.ts";
 
 Deno.test("expect().toStrictEqual()", () => {
-  const obj = { a: 1 };
   expect(1).toStrictEqual(1);
-  expect(obj).toStrictEqual(obj);
+  expect({ a: 1 }).toStrictEqual({ a: 1 });
 
   expect(1).not.toStrictEqual(2);
-  expect(obj).not.toStrictEqual({ a: 1 });
+  expect({ a: 2 }).not.toStrictEqual({ a: 1 });
+  expect({ a: 1, b: undefined }).not.toStrictEqual({ a: 1 });
 
   assertThrows(() => {
     expect(1).toStrictEqual(2);
   }, AssertionError);
   assertThrows(() => {
-    expect(obj).toStrictEqual({ a: 1 });
+    expect({ a: 2 }).toStrictEqual({ a: 1 });
+  }, AssertionError);
+  assertThrows(() => {
+    expect({ a: 1, b: undefined }).toStrictEqual({ a: 1 });
   }, AssertionError);
 
   assertThrows(() => {
     expect(1).not.toStrictEqual(1);
   }, AssertionError);
   assertThrows(() => {
-    expect(obj).not.toStrictEqual(obj);
+    expect({ a: 1 }).not.toStrictEqual({ a: 1 });
   }, AssertionError);
 });


### PR DESCRIPTION
This PR changes the behavior of `expect().toStrictEqual()` to make it aligned to jest's. This has been pointed in https://github.com/denoland/deno_std/issues/3947#issuecomment-1870858120