### PR TITLE
deprecation(semver): deprecate `testComparator()`

### DIFF
--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -7,6 +7,7 @@ import { cmp } from "./cmp.ts";
  * @param version The version to compare
  * @param comparator The comparator
  * @returns True if the version is within the comparators set otherwise false
+ * @deprecated (will be removed in 0.212.0) Use {@linkcode compare} instead.
  */
 export function testComparator(
   version: SemVer,

--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -7,7 +7,7 @@ import { cmp } from "./cmp.ts";
  * @param version The version to compare
  * @param comparator The comparator
  * @returns True if the version is within the comparators set otherwise false
- * @deprecated (will be removed in 0.212.0) Use {@linkcode compare} instead.
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode compare} instead.
  */
 export function testComparator(
   version: SemVer,


### PR DESCRIPTION
deprecates `testComparator` in favour of using `compare`.