### PR TITLE
fix(fs): reduce perm requirement of `ensureDir()`

### DIFF
--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -15,6 +15,24 @@ import { getFileInfoType } from "./_get_file_info_type.ts";
  */
 export async function ensureDir(dir: string | URL) {
   try {
+    const fileInfo = await Deno.lstat(dir);
+    if (!fileInfo.isDirectory) {
+      throw new Error(
+        `Ensure path exists, expected 'dir', got '${
+          getFileInfoType(fileInfo)
+        }'`,
+      );
+    }
+    return;
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) {
+      throw err;
+    }
+  }
+
+  // The dir doesn't exist. Create it.
+  // This can be racy. So we catch AlreadyExists and check lstat again.
+  try {
     await Deno.mkdir(dir, { recursive: true });
   } catch (err) {
     if (!(err instanceof Deno.errors.AlreadyExists)) {
@@ -45,6 +63,24 @@ export async function ensureDir(dir: string | URL) {
  * ```
  */
 export function ensureDirSync(dir: string | URL) {
+  try {
+    const fileInfo = Deno.lstatSync(dir);
+    if (!fileInfo.isDirectory) {
+      throw new Error(
+        `Ensure path exists, expected 'dir', got '${
+          getFileInfoType(fileInfo)
+        }'`,
+      );
+    }
+    return;
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) {
+      throw err;
+    }
+  }
+
+  // The dir doesn't exist. Create it.
+  // This can be racy. So we catch AlreadyExists and check lstat again.
   try {
     Deno.mkdirSync(dir, { recursive: true });
   } catch (err) {


### PR DESCRIPTION
Another attempt to solve #3339. (ref. #4008)

This PR updates `ensureDir` behavior. It now first checks the lstat of the path, then tries `mkdir`, then catches `AlreadyExists` error and checks the lstat of the path again. This reduces the permission requirement to the given dir to only `read` permission when the path already exists (currently `write` is always required), and also doesn't fail with concurrent calls (doesn't re-introduce #3233).

closes #3339 
closes #3233