### PR TITLE
deprecation(semver): deprecate `format()` `style` argument

### DIFF
--- a/semver/format.ts
+++ b/semver/format.ts
@@ -13,6 +13,10 @@ function formatNumber(value: number) {
 }
 
 /**
+ * @deprecated (will be removed in 0.213.0)
+ */
+export function format(semver: SemVer, style?: FormatStyle): string;
+/**
  * Format a SemVer object into a string.
  *
  * If any number is NaN then NaN will be printed.
@@ -22,10 +26,12 @@ function formatNumber(value: number) {
  * @param semver The semantic version to format
  * @returns The string representation of a semantic version.
  */
-export function format(semver: SemVer, style: FormatStyle = "full"): string {
+export function format(semver: SemVer, style?: FormatStyle): string {
   if (semver === ANY) {
     return "*";
   }
+
+  style ??= "full";
 
   const major = formatNumber(semver.major);
   const minor = formatNumber(semver.minor);

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -15,7 +15,7 @@ function formatNumber(value: number) {
 /**
  * @deprecated (will be removed in 0.213.0)
  */
-export function format(semver: SemVer, style?: FormatStyle): string;
+export function format(semver: SemVer, style: FormatStyle): string;
 /**
  * Format a SemVer object into a string.
  *
@@ -26,12 +26,11 @@ export function format(semver: SemVer, style?: FormatStyle): string;
  * @param semver The semantic version to format
  * @returns The string representation of a semantic version.
  */
-export function format(semver: SemVer, style?: FormatStyle): string {
+export function format(semver: SemVer): string;
+export function format(semver: SemVer, style: FormatStyle = "full"): string {
   if (semver === ANY) {
     return "*";
   }
-
-  style ??= "full";
 
   const major = formatNumber(semver.major);
   const minor = formatNumber(semver.minor);

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -15,7 +15,7 @@ function formatNumber(value: number) {
 /**
  * @deprecated (will be removed in 0.213.0)
  */
-export function format(semver: SemVer, style: FormatStyle): string;
+export function format(semver: SemVer, style?: FormatStyle): string;
 /**
  * Format a SemVer object into a string.
  *

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -13,7 +13,9 @@ function formatNumber(value: number) {
 }
 
 /**
- * @deprecated (will be removed in 0.213.0)
+ * Format a SemVer object into a string.
+ *
+ * @deprecated (will be removed in 0.213.0) `style` option is deprecated. Use `format(semver)` for full formatting. semver[prop] for getting a part of the version.
  */
 export function format(semver: SemVer, style?: FormatStyle): string;
 /**

--- a/semver/types.ts
+++ b/semver/types.ts
@@ -23,6 +23,7 @@ export type Operator = typeof OPERATORS[number];
 
 /**
  * The style to use when formatting a SemVer object into a string
+ * @deprecated (will be removed in 0.213.0)
  */
 export type FormatStyle =
   | "full"


### PR DESCRIPTION
ref: https://github.com/denoland/deno_std/pull/3962#issuecomment-1864389806
- deprecates `format()` `style` argument as it is obsolete due to optional `SemVer` properties