### PR TITLE
BREAKING(crypto): remove stable `KeyStack()`

### DIFF
--- a/crypto/keystack.ts
+++ b/crypto/keystack.ts
@@ -1,7 +1,0 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-// This module is browser compatible.
-
-/**
- * @deprecated (will be removed after 0.209.0) Import from {@link https://deno.land/std/crypto/unstable_keystack.ts} instead.
- */
-export * from "./unstable_keystack.ts";


### PR DESCRIPTION
`KeyStack()` is available in `crypto/unstable_keystack.ts`.