### PR TITLE
deprecation(semver): rename `rangeFormat()` to `formatRange()`

### DIFF
--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import type { SemVerRange } from "./types.ts";
+import { comparatorFormat } from "./comparator_format.ts";
+
+/**
+ * Formats the range into a string
+ * @example >=0.0.0 || <1.0.0
+ * @param range The range to format
+ * @returns A string representation of the range
+ */
+export function formatRange(range: SemVerRange): string {
+  return range.ranges.map((c) => c.map((c) => comparatorFormat(c)).join(" "))
+    .join("||");
+}

--- a/semver/range_format.ts
+++ b/semver/range_format.ts
@@ -1,14 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import type { SemVerRange } from "./types.ts";
-import { comparatorFormat } from "./comparator_format.ts";
+
+import { formatRange } from "./format_range.ts";
 
 /**
  * Formats the range into a string
  * @example >=0.0.0 || <1.0.0
  * @param range The range to format
  * @returns A string representation of the range
+ *
+ * @deprecated (will be removed after 0.213.0) Use {@linkcode formatRange} instead.
  */
-export function rangeFormat(range: SemVerRange): string {
-  return range.ranges.map((c) => c.map((c) => comparatorFormat(c)).join(" "))
-    .join("||");
-}
+export const rangeFormat = formatRange;

--- a/semver/range_test.ts
+++ b/semver/range_test.ts
@@ -1,7 +1,7 @@
 // Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../assert/mod.ts";
-import { rangeFormat } from "./range_format.ts";
+import { formatRange } from "./format_range.ts";
 import { parse } from "./parse.ts";
 import { parseRange } from "./parse_range.ts";
 import { testRange } from "./test_range.ts";
@@ -278,7 +278,7 @@ Deno.test({
         name: `${r} -> ${expected}`,
         fn: () => {
           const range = parseRange(r);
-          const actual = rangeFormat(range);
+          const actual = formatRange(range);
           assertEquals(actual, expected);
         },
       });


### PR DESCRIPTION
- renames `rangeFormat()` to `formatRange()`