### PR TITLE
refactor(semver): reduce `minSatisfying()` and `maxSatisfying()` overhead

### DIFF
--- a/semver/max_satisfying.ts
+++ b/semver/max_satisfying.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { SemVer, SemVerRange } from "./types.ts";
-import { sort } from "./sort.ts";
 import { testRange } from "./test_range.ts";
+import { gt } from "./gt.ts";
 
 /**
  * Returns the highest version in the list that satisfies the range, or `undefined`
@@ -14,7 +14,10 @@ export function maxSatisfying(
   versions: SemVer[],
   range: SemVerRange,
 ): SemVer | undefined {
-  const satisfying = versions.filter((v) => testRange(v, range));
-  const sorted = sort(satisfying);
-  return sorted.pop();
+  let max;
+  for (const version of versions) {
+    if (!testRange(version, range)) continue;
+    max = max && gt(max, version) ? max : version;
+  }
+  return max;
 }

--- a/semver/min_satisfying.ts
+++ b/semver/min_satisfying.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import type { SemVer, SemVerRange } from "./types.ts";
-import { sort } from "./sort.ts";
+import type { SemVer, SemVerComparator, SemVerRange } from "./types.ts";
 import { testRange } from "./test_range.ts";
+import { lt } from "https://deno.land/std@$STD_VERSION/semver/lt.ts";
+import { testComparator } from "https://deno.land/std@$STD_VERSION/semver/test_comparator.ts";
 
 /**
  * Returns the lowest version in the list that satisfies the range, or `undefined` if
@@ -14,7 +15,10 @@ export function minSatisfying(
   versions: SemVer[],
   range: SemVerRange,
 ): SemVer | undefined {
-  const satisfying = versions.filter((v) => testRange(v, range));
-  const sorted = sort(satisfying);
-  return sorted.shift();
+  let min;
+  for (const version of versions) {
+    if (!testRange(version, range)) continue;
+    min = min && lt(min, version) ? min : version;
+  }
+  return min;
 }


### PR DESCRIPTION
- reduces `minSatisfying()` and `maxSatisfying()` array overhead.