### PR TITLE
deprecation(semver): deprecate `sort()`

### DIFF
--- a/semver/sort.ts
+++ b/semver/sort.ts
@@ -5,7 +5,7 @@ import { compare } from "./compare.ts";
 /**
  * Sorts a list of semantic versions in ascending order.
  *
- * @deprecated (will be removed after 0.213.0) Use `list.sort(compare)` with {@linkcode compare} instead.
+ * @deprecated (will be removed after 0.214.0) Use `list.sort(compare)` with {@linkcode compare} instead.
  */
 export function sort(
   list: SemVer[],

--- a/semver/sort.ts
+++ b/semver/sort.ts
@@ -2,7 +2,11 @@
 import type { SemVer } from "./types.ts";
 import { compare } from "./compare.ts";
 
-/** Sorts a list of semantic versions in ascending order. */
+/**
+ * Sorts a list of semantic versions in ascending order.
+ *
+ * @deprecated (will be removed after 0.213.0) Use `list.sort(compare)` with {@linkcode compare} instead.
+ */
 export function sort(
   list: SemVer[],
 ): SemVer[] {


### PR DESCRIPTION
- deprecates `sort()`, which just calls `.sort(compare)` on the array. 

**Note**: This is not discussed but seemed obvious. The User should rather import `compare()` and call sort directly on the array.