### PR TITLE
deprecation(path): deprecate `posix.toNamespacedPath()`

### DIFF
--- a/path/posix/to_namespaced_path.ts
+++ b/path/posix/to_namespaced_path.ts
@@ -5,7 +5,8 @@
  * Resolves path to a namespace path
  * @param path to resolve to namespace
  *
- * @deprecated (will be removed in 0.214.0)
+ * @deprecated (will be removed in 0.214.0) Use the path value itself as this
+ * is a no-op function.
  */
 export function toNamespacedPath(path: string): string {
   // Non-op on posix systems

--- a/path/posix/to_namespaced_path.ts
+++ b/path/posix/to_namespaced_path.ts
@@ -4,6 +4,8 @@
 /**
  * Resolves path to a namespace path
  * @param path to resolve to namespace
+ *
+ * @deprecated (will be removed in 0.214.0)
  */
 export function toNamespacedPath(path: string): string {
   // Non-op on posix systems

--- a/path/to_namespaced_path.ts
+++ b/path/to_namespaced_path.ts
@@ -2,7 +2,6 @@
 // This module is browser compatible.
 
 import { isWindows } from "./_os.ts";
-import { toNamespacedPath as posixToNamespacedPath } from "./posix/to_namespaced_path.ts";
 import { toNamespacedPath as windowsToNamespacedPath } from "./windows/to_namespaced_path.ts";
 
 /**
@@ -10,7 +9,5 @@ import { toNamespacedPath as windowsToNamespacedPath } from "./windows/to_namesp
  * @param path to resolve to namespace
  */
 export function toNamespacedPath(path: string): string {
-  return isWindows
-    ? windowsToNamespacedPath(path)
-    : posixToNamespacedPath(path);
+  return isWindows ? windowsToNamespacedPath(path) : path;
 }


### PR DESCRIPTION
Closes #4069.