### PR TITLE
chore: ignore `/docs` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,13 @@
 .vscode/settings.json
 .vim
 **/cov/
-/crypto/_wasm/target
+crypto/_wasm/target
 deno.lock
-/console/testdata/unicode_width_crate/target
+console/testdata/unicode_width_crate/target
 html_cov/
 cov.lcov
-/http/testdata/%25A.txt
-/http/testdata/file#2.txt
-/http/testdata/test file.txt
-/coverage/
+http/testdata/%25A.txt
+http/testdata/file#2.txt
+http/testdata/test file.txt
+coverage/
+docs/

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -17,7 +17,7 @@ const EXCLUDED_PATHS = [
   "crypto/_wasm",
   "crypto/_fnv",
   "encoding/_yaml",
-  "encoing/_toml",
+  "encoding/_toml",
   "_tools",
   "_util",
   "docs",

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -20,6 +20,7 @@ const EXCLUDED_PATHS = [
   "encoing/_toml",
   "_tools",
   "_util",
+  "docs",
 ];
 
 const ROOT = new URL("../", import.meta.url);

--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "cov",
     "jsonc/testdata",
     "front_matter/testdata",
-    "coverage"
+    "coverage",
+    "docs"
   ]
 }


### PR DESCRIPTION
This change ensures the `/docs` directory is ignored in appropriate checks, etc. This is so nothing is ever accidentally committed when working with `deno doc --html`.