### PR TITLE
refactor(assert): remove `void` return types

### DIFF
--- a/assert/assert_almost_equals.ts
+++ b/assert/assert_almost_equals.ts
@@ -22,7 +22,7 @@ export function assertAlmostEquals(
   expected: number,
   tolerance = 1e-7,
   msg?: string,
-): void {
+) {
   if (Object.is(actual, expected)) {
     return;
   }

--- a/assert/assert_array_includes.ts
+++ b/assert/assert_array_includes.ts
@@ -25,7 +25,7 @@ export function assertArrayIncludes<T>(
   actual: ArrayLikeArg<T>,
   expected: ArrayLikeArg<T>,
   msg?: string,
-): void {
+) {
   const missing: unknown[] = [];
   for (let i = 0; i < expected.length; i++) {
     let found = false;

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -28,7 +28,7 @@ export function assertEquals<T>(
   expected: T,
   msg?: string,
   options: { formatter?: (value: unknown) => string } = {},
-): void {
+) {
   if (equal(actual, expected)) {
     return;
   }

--- a/assert/assert_greater.ts
+++ b/assert/assert_greater.ts
@@ -15,7 +15,7 @@ import { AssertionError } from "./assertion_error.ts";
  * assertGreater(0, 1); // Throws
  * ```
  */
-export function assertGreater<T>(actual: T, expected: T, msg?: string): void {
+export function assertGreater<T>(actual: T, expected: T, msg?: string) {
   if (actual > expected) return;
 
   const actualString = format(actual);

--- a/assert/assert_greater_or_equal.ts
+++ b/assert/assert_greater_or_equal.ts
@@ -19,7 +19,7 @@ export function assertGreaterOrEqual<T>(
   actual: T,
   expected: T,
   msg?: string,
-): void {
+) {
   if (actual >= expected) return;
 
   const actualString = format(actual);

--- a/assert/assert_less.ts
+++ b/assert/assert_less.ts
@@ -14,7 +14,7 @@ import { AssertionError } from "./assertion_error.ts";
  * assertLess(2, 1); // Throws
  * ```
  */
-export function assertLess<T>(actual: T, expected: T, msg?: string): void {
+export function assertLess<T>(actual: T, expected: T, msg?: string) {
   if (actual < expected) return;
 
   const actualString = format(actual);

--- a/assert/assert_less_or_equal.ts
+++ b/assert/assert_less_or_equal.ts
@@ -19,7 +19,7 @@ export function assertLessOrEqual<T>(
   actual: T,
   expected: T,
   msg?: string,
-): void {
+) {
   if (actual <= expected) return;
 
   const actualString = format(actual);

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -16,7 +16,7 @@ import { AssertionError } from "./assertion_error.ts";
  * assertNotEquals(1, 1); // Throws
  * ```
  */
-export function assertNotEquals<T>(actual: T, expected: T, msg?: string): void {
+export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   if (!equal(actual, expected)) {
     return;
   }

--- a/assert/assert_not_strict_equals.ts
+++ b/assert/assert_not_strict_equals.ts
@@ -18,7 +18,7 @@ export function assertNotStrictEquals<T>(
   actual: T,
   expected: T,
   msg?: string,
-): void {
+) {
   if (!Object.is(actual, expected)) {
     return;
   }

--- a/assert/assert_object_match.ts
+++ b/assert/assert_object_match.ts
@@ -18,7 +18,7 @@ export function assertObjectMatch(
   actual: Record<PropertyKey, any>,
   expected: Record<PropertyKey, unknown>,
   msg?: string,
-) {
+): void {
   type loose = Record<PropertyKey, unknown>;
 
   function filter(a: loose, b: loose) {

--- a/assert/assert_object_match.ts
+++ b/assert/assert_object_match.ts
@@ -18,7 +18,7 @@ export function assertObjectMatch(
   actual: Record<PropertyKey, any>,
   expected: Record<PropertyKey, unknown>,
   msg?: string,
-): void {
+) {
   type loose = Record<PropertyKey, unknown>;
 
   function filter(a: loose, b: loose) {


### PR DESCRIPTION
Deno sees `void` return types are unncessary boilerplate.