### PR TITLE
feat(collections): pass `key` to `mapValues()` transformer

### DIFF
--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -28,7 +28,7 @@
  */
 export function mapValues<T, O, K extends string>(
   record: Readonly<Record<K, T>>,
-  transformer: (value: T) => O,
+  transformer: (value: T, key: K) => O,
 ): Record<K, O>;
 /**
  * Applies the given transformer to all values in the given record and returns a
@@ -57,20 +57,19 @@ export function mapValues<T, O, K extends string>(
  */
 export function mapValues<T, O, K extends string>(
   record: Readonly<Partial<Record<K, T>>>,
-  transformer: (value: T) => O,
+  transformer: (value: T, key: K) => O,
 ): Partial<Record<K, O>>;
 export function mapValues<T, O, K extends string>(
   record: Record<K, T>,
-  transformer: (value: T) => O,
+  transformer: (value: T, key: K) => O,
   // deno-lint-ignore no-explicit-any
 ): any {
   // deno-lint-ignore no-explicit-any
   const ret: any = {};
-  const entries = Object.entries(record);
+  const entries = Object.entries<T>(record);
 
   for (const [key, value] of entries) {
-    // deno-lint-ignore no-explicit-any
-    const mappedValue = transformer(value as any);
+    const mappedValue = transformer(value, key as K);
 
     ret[key] = mappedValue;
   }

--- a/collections/map_values_test.ts
+++ b/collections/map_values_test.ts
@@ -139,3 +139,17 @@ Deno.test({
     assertEquals(actual, expected);
   },
 });
+
+Deno.test({
+  name: "mapValues() pass key to transformer",
+  fn() {
+    const key = "key";
+    const actual = mapValues(
+      { [key]: "value" },
+      (_, k) => k,
+    );
+    const expected = { [key]: key };
+
+    assertEquals(actual, expected);
+  },
+});


### PR DESCRIPTION
Pass `key` parameter to `mapValues()` transformer to support transformed values that depends on `key`.