### PR TITLE
docs(async): fix doc of `retry.ts` #4129

### DIFF
--- a/async/retry.ts
+++ b/async/retry.ts
@@ -74,10 +74,8 @@ const defaultRetryOptions: Required<RetryOptions> = {
  * Retries as long as the given function throws. If the attempts are exhausted,
  * throws a {@linkcode RetryError} with `cause` set to the inner exception.
  *
- * The backoff is calculated by multiplying `minTimeout` with `multiplier` to
- * the power of the current attempt counter (starting at 0 up to `maxAttempts
- * - 1`). It is capped at `maxTimeout` however. How long the actual delay is,
- * depends on `jitter`.
+ * The backoff is calculated by multiplying `minTimeout` with `multiplier` to the power of the current attempt counter (starting at 0 up to `maxAttempts - 1`). It is capped at `maxTimeout` however.
+ * How long the actual delay is, depends on `jitter`.
  *
  * When `jitter` is the default value of `1`, waits between two attempts for a
  * randomized amount between 0 and the backoff time. With the default options


### PR DESCRIPTION
Resolves #4129

## What I tested
1. Run `deno doc --html --name=std/async async/mod.ts`
2. Open `docs/index.html`

I confirmed that the rendering issue reported in #4129 has been resolved.
<img width="1495" alt="image" src="https://github.com/denoland/deno_std/assets/49891479/64e7318b-2e7d-4cb1-9b3c-1280d8601de4">
