### PR TITLE
deprecation(semver): deprecate `Comparator` functions

### DIFF
--- a/semver/comparator_format.ts
+++ b/semver/comparator_format.ts
@@ -7,6 +7,8 @@ import { format } from "./format.ts";
  * @example >=0.0.0
  * @param comparator
  * @returns A string representation of the comparator
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode formatRange} instead.
  */
 export function comparatorFormat(comparator: Comparator): string {
   const { semver, operator } = comparator;

--- a/semver/comparator_format.ts
+++ b/semver/comparator_format.ts
@@ -8,7 +8,7 @@ import { format } from "./format.ts";
  * @param comparator
  * @returns A string representation of the comparator
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode formatRange} instead.
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode SemVerRange} instead of {@linkcode Comparator} and {@linkcode formatRange} for formatting it.
  */
 export function comparatorFormat(comparator: Comparator): string {
   const { semver, operator } = comparator;

--- a/semver/comparator_format.ts
+++ b/semver/comparator_format.ts
@@ -8,7 +8,7 @@ import { format } from "./format.ts";
  * @param comparator
  * @returns A string representation of the comparator
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode SemVerRange} instead of {@linkcode Comparator} and {@linkcode formatRange} for formatting it.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode SemVerRange} instead of {@linkcode Comparator} and {@linkcode formatRange} for formatting it.
  */
 export function comparatorFormat(comparator: Comparator): string {
   const { semver, operator } = comparator;

--- a/semver/comparator_intersects.ts
+++ b/semver/comparator_intersects.ts
@@ -9,6 +9,8 @@ import { comparatorMax } from "./comparator_max.ts";
  * @param c0 The left side comparator
  * @param c1 The right side comparator
  * @returns True if any part of the comparators intersect
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeIntersects} instead.
  */
 export function comparatorIntersects(
   c0: Comparator,

--- a/semver/comparator_intersects.ts
+++ b/semver/comparator_intersects.ts
@@ -10,7 +10,7 @@ import { comparatorMax } from "./comparator_max.ts";
  * @param c1 The right side comparator
  * @returns True if any part of the comparators intersect
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeIntersects} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeIntersects} instead.
  */
 export function comparatorIntersects(
   c0: Comparator,

--- a/semver/comparator_max.ts
+++ b/semver/comparator_max.ts
@@ -9,7 +9,7 @@ import { ANY, INVALID, MAX } from "./constants.ts";
  * an out of range semver will be returned.
  * @returns the version, the MAX version or the next smallest patch version
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeMax} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeMax} instead.
  */
 export function comparatorMax(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/comparator_max.ts
+++ b/semver/comparator_max.ts
@@ -8,6 +8,8 @@ import { ANY, INVALID, MAX } from "./constants.ts";
  * If an invalid comparator is given such as <0.0.0 then
  * an out of range semver will be returned.
  * @returns the version, the MAX version or the next smallest patch version
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeMax} instead.
  */
 export function comparatorMax(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/comparator_min.ts
+++ b/semver/comparator_min.ts
@@ -9,6 +9,8 @@ import { increment } from "./increment.ts";
  * @param semver The semantic version of the comparator
  * @param operator The operator of the comparator
  * @returns The minimum valid semantic version
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeMin} instead.
  */
 export function comparatorMin(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/comparator_min.ts
+++ b/semver/comparator_min.ts
@@ -10,7 +10,7 @@ import { increment } from "./increment.ts";
  * @param operator The operator of the comparator
  * @returns The minimum valid semantic version
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode rangeMin} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeMin} instead.
  */
 export function comparatorMin(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/is_comparator.ts
+++ b/semver/is_comparator.ts
@@ -14,7 +14,7 @@ import { ALL, NONE } from "./constants.ts";
  * @param value The value to check if its a Comparator
  * @returns True if the object is a Comparator otherwise false
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode isSemVerRange} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode isSemVerRange} instead.
  */
 export function isComparator(value: unknown): value is Comparator {
   if (

--- a/semver/is_comparator.ts
+++ b/semver/is_comparator.ts
@@ -13,6 +13,8 @@ import { ALL, NONE } from "./constants.ts";
  * Adds a type assertion if true.
  * @param value The value to check if its a Comparator
  * @returns True if the object is a Comparator otherwise false
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode isSemVerRange} instead.
  */
 export function isComparator(value: unknown): value is Comparator {
   if (

--- a/semver/parse_comparator.ts
+++ b/semver/parse_comparator.ts
@@ -22,7 +22,7 @@ type REGEXP_GROUPS = {
  * @param comparator
  * @returns A valid Comparator
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode parseRange} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode parseRange} instead.
  */
 export function parseComparator(comparator: string): Comparator {
   const match = comparator.match(COMPARATOR_REGEXP);

--- a/semver/parse_comparator.ts
+++ b/semver/parse_comparator.ts
@@ -21,6 +21,8 @@ type REGEXP_GROUPS = {
  * Parses a comparator string into a valid Comparator.
  * @param comparator
  * @returns A valid Comparator
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode parseRange} instead.
  */
 export function parseComparator(comparator: string): Comparator {
   const match = comparator.match(COMPARATOR_REGEXP);

--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -8,7 +8,7 @@ import { cmp } from "./cmp.ts";
  * @param comparator The comparator
  * @returns True if the version is within the comparators set otherwise false
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode testRange} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode testRange} instead.
  */
 export function testComparator(
   version: SemVer,

--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -7,7 +7,8 @@ import { cmp } from "./cmp.ts";
  * @param version The version to compare
  * @param comparator The comparator
  * @returns True if the version is within the comparators set otherwise false
- * @deprecated (will be removed in 0.213.0) Use {@linkcode compare} instead.
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode testRange} instead.
  */
 export function testComparator(
   version: SemVer,

--- a/semver/try_parse_comparator.ts
+++ b/semver/try_parse_comparator.ts
@@ -7,7 +7,7 @@ import { parseComparator } from "./parse_comparator.ts";
  * @param comparator
  * @returns A valid Comparator or undefined
  *
- * @deprecated (will be removed in 0.213.0) Use {@linkcode tryParseRange} instead.
+ * @deprecated (will be removed in 0.214.0) Use {@linkcode tryParseRange} instead.
  */
 export function tryParseComparator(
   comparator: string,

--- a/semver/try_parse_comparator.ts
+++ b/semver/try_parse_comparator.ts
@@ -6,6 +6,8 @@ import { parseComparator } from "./parse_comparator.ts";
  * Parses a comparator string into a valid Comparator or returns undefined if not valid.
  * @param comparator
  * @returns A valid Comparator or undefined
+ *
+ * @deprecated (will be removed in 0.213.0) Use {@linkcode tryParseRange} instead.
  */
 export function tryParseComparator(
   comparator: string,


### PR DESCRIPTION
ref: https://github.com/denoland/deno_std/issues/4047

This PR deprecates all public `Comparator` functions.

 **Note**: Some of these functions are used in range functions, which means they should be made private (for example `is_comparator.ts` -> `_is_comparator.ts`) after the deprecation deadline or combined into one `_comparator.ts` file.