### PR TITLE
chore: enable `skipLibCheck` option

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "useUnknownInCatchVariables": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "skipLibCheck": true
   },
   "imports": {
     "https://deno.land/std@$STD_VERSION/": "./",


### PR DESCRIPTION
The functionality won't be needed once #4133 is merged. Performance optimisation.

See https://www.typescriptlang.org/tsconfig#skipLibCheck