### PR TITLE
feat(assert): assertion signatures on more of the assert modules

### DIFF
--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -23,12 +23,12 @@ import { CAN_NOT_DISPLAY } from "./_constants.ts";
  *
  * Note: formatter option is experimental and may be removed in the future.
  */
-export function assertEquals<T>(
-  actual: T,
+export function assertEquals<A, T extends A>(
+  actual: A,
   expected: T,
   msg?: string,
   options: { formatter?: (value: unknown) => string } = {},
-) {
+): asserts actual is T {
   if (equal(actual, expected)) {
     return;
   }

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -23,8 +23,8 @@ import { CAN_NOT_DISPLAY } from "./_constants.ts";
  *
  * Note: formatter option is experimental and may be removed in the future.
  */
-export function assertEquals<A, T extends A>(
-  actual: A,
+export function assertEquals<T>(
+  actual: unknown,
   expected: T,
   msg?: string,
   options: { formatter?: (value: unknown) => string } = {},

--- a/assert/assert_equals_test.ts
+++ b/assert/assert_equals_test.ts
@@ -59,7 +59,7 @@ Deno.test({
   name: "assertEquals() throws when types are not equal",
   fn() {
     assertThrows(
-      () => assertEquals<unknown, unknown>(1, "1"),
+      () => assertEquals<unknown>(1, "1"),
       AssertionError,
       [
         "Values are not equal.",
@@ -92,11 +92,7 @@ Deno.test({
   name: "assertEquals() throws when object elements are not equal",
   fn() {
     assertThrows(
-      () =>
-        assertEquals<unknown, unknown>(
-          { a: 1, b: "2", c: 3 },
-          { a: 1, b: 2, c: [3] },
-        ),
+      () => assertEquals({ a: 1, b: "2", c: 3 }, { a: 1, b: 2, c: [3] }),
       AssertionError,
       `
     {

--- a/assert/assert_equals_test.ts
+++ b/assert/assert_equals_test.ts
@@ -59,7 +59,7 @@ Deno.test({
   name: "assertEquals() throws when types are not equal",
   fn() {
     assertThrows(
-      () => assertEquals<unknown>(1, "1"),
+      () => assertEquals<unknown, unknown>(1, "1"),
       AssertionError,
       [
         "Values are not equal.",
@@ -92,7 +92,11 @@ Deno.test({
   name: "assertEquals() throws when object elements are not equal",
   fn() {
     assertThrows(
-      () => assertEquals({ a: 1, b: "2", c: 3 }, { a: 1, b: 2, c: [3] }),
+      () =>
+        assertEquals<unknown, unknown>(
+          { a: 1, b: "2", c: 3 },
+          { a: 1, b: 2, c: [3] },
+        ),
       AssertionError,
       `
     {

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -16,7 +16,11 @@ import { AssertionError } from "./assertion_error.ts";
  * assertNotEquals(1, 1); // Throws
  * ```
  */
-export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
+export function assertNotEquals<A, T extends A>(
+  actual: A,
+  expected: T,
+  msg?: string,
+): asserts actual is Exclude<A, T> {
   if (!equal(actual, expected)) {
     return;
   }

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -12,8 +12,8 @@ import { AssertionError } from "./assertion_error.ts";
  * ```ts
  * import { assertNotEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_not_equals.ts";
  *
- * assertNotEquals(1, 2); // Doesn't throw
- * assertNotEquals(1, 1); // Throws
+ * assertNotEquals(1 as number, 2); // Doesn't throw
+ * assertNotEquals(1 as number, 1); // Throws
  * ```
  */
 export function assertNotEquals<A, T extends A>(

--- a/assert/assert_not_equals_test.ts
+++ b/assert/assert_not_equals_test.ts
@@ -9,8 +9,8 @@ import {
 Deno.test("NotEquals", function () {
   const a = { foo: "bar" };
   const b = { bar: "foo" };
-  assertNotEquals<unknown>(a, b);
-  assertNotEquals("Denosaurus", "Tyrannosaurus");
+  assertNotEquals<unknown, unknown>(a, b);
+  assertNotEquals<unknown, unknown>("Denosaurus", "Tyrannosaurus");
   assertNotEquals(
     new Date(2019, 0, 3, 4, 20, 1, 10),
     new Date(2019, 0, 3, 4, 20, 1, 20),

--- a/assert/assert_not_strict_equals.ts
+++ b/assert/assert_not_strict_equals.ts
@@ -10,8 +10,8 @@ import { format } from "./_format.ts";
  * ```ts
  * import { assertNotStrictEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_not_strict_equals.ts";
  *
- * assertNotStrictEquals(1, 1); // Doesn't throw
- * assertNotStrictEquals(1, 2); // Throws
+ * assertNotStrictEquals(1 as number, 1); // Doesn't throw
+ * assertNotStrictEquals(1 as number, 2); // Throws
  * ```
  */
 export function assertNotStrictEquals<A, T extends A>(

--- a/assert/assert_not_strict_equals.ts
+++ b/assert/assert_not_strict_equals.ts
@@ -14,11 +14,11 @@ import { format } from "./_format.ts";
  * assertNotStrictEquals(1, 2); // Throws
  * ```
  */
-export function assertNotStrictEquals<T>(
-  actual: T,
+export function assertNotStrictEquals<A, T extends A>(
+  actual: A,
   expected: T,
   msg?: string,
-) {
+): asserts actual is Exclude<A, T> {
   if (!Object.is(actual, expected)) {
     return;
   }

--- a/assert/assert_not_strict_equals_test.ts
+++ b/assert/assert_not_strict_equals_test.ts
@@ -4,10 +4,10 @@ import { AssertionError, assertNotStrictEquals, assertThrows } from "./mod.ts";
 Deno.test({
   name: "strictly unequal pass case",
   fn() {
-    assertNotStrictEquals(true, false);
-    assertNotStrictEquals(10, 11);
-    assertNotStrictEquals("abc", "xyz");
-    assertNotStrictEquals<unknown>(1, "1");
+    assertNotStrictEquals<unknown, unknown>(true, false);
+    assertNotStrictEquals<unknown, unknown>(10, 11);
+    assertNotStrictEquals<unknown, unknown>("abc", "xyz");
+    assertNotStrictEquals<unknown, unknown>(1, "1");
     assertNotStrictEquals(-0, +0);
 
     const xs = [1, false, "foo"];

--- a/assert/shared_test.ts
+++ b/assert/shared_test.ts
@@ -11,10 +11,10 @@ Deno.test({
   name: "assert* functions with specified type parameter",
   fn() {
     assertEquals<string>("hello", "hello");
-    assertNotEquals<number>(1, 2);
+    assertNotEquals<number, number>(1, 2);
     assertArrayIncludes<boolean>([true, false], [true]);
     const value = { x: 1 };
     assertStrictEquals<typeof value>(value, value);
-    assertNotStrictEquals<object>(value, { x: 1 });
+    assertNotStrictEquals<object, object>(value, { x: 1 });
   },
 });

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -266,7 +266,7 @@ export function toBeNaN(context: MatcherContext): MatchResult {
 export function toBeNull(context: MatcherContext): MatchResult {
   if (context.isNot) {
     assertNotStrictEquals(
-      context.value as number,
+      context.value,
       null,
       context.customMessage || `Expected ${context.value} to not be null`,
     );

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -333,12 +333,8 @@ export function assertMatch(
  *
  * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_equals.ts} instead.
  */
-export function assertNotEquals<A, T extends A>(
-  actual: T,
-  expected: T,
-  msg?: string,
-) {
-  asserts.assertNotEquals<A, T>(actual, expected, msg);
+export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
+  asserts.assertNotEquals<T, T>(actual, expected, msg);
 }
 
 /**

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -333,8 +333,12 @@ export function assertMatch(
  *
  * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_equals.ts} instead.
  */
-export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
-  asserts.assertNotEquals<T>(actual, expected, msg);
+export function assertNotEquals<A, T extends A>(
+  actual: T,
+  expected: T,
+  msg?: string,
+) {
+  asserts.assertNotEquals<A, T>(actual, expected, msg);
 }
 
 /**

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -264,6 +264,7 @@ Deno.test("spy instance method symbol", () => {
     args: [],
   });
   assertSpyCalls(func, 2);
+
   assertNotEquals(func as unknown, Point.prototype[Symbol.iterator]);
   assertEquals(point[Symbol.iterator], func);
 

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -227,7 +227,7 @@ Deno.test("spy instance method", () => {
   });
   assertSpyCalls(func, 10);
 
-  assertNotEquals(func, Point.prototype.action);
+  assertNotEquals<unknown, Point["action"]>(func, Point.prototype.action);
   assertEquals(point.action, func);
 
   assertEquals(func.restored, false);
@@ -264,8 +264,11 @@ Deno.test("spy instance method symbol", () => {
     args: [],
   });
   assertSpyCalls(func, 2);
-
-  assertNotEquals(func, Point.prototype[Symbol.iterator]);
+  assertNotEquals<unknown, Point[typeof Symbol.iterator]>(
+    func,
+    Point.prototype[Symbol.iterator],
+  );
+  func;
   assertEquals(point[Symbol.iterator], func);
 
   assertEquals(func.restored, false);
@@ -326,7 +329,10 @@ Deno.test("spy instance method property descriptor", () => {
   });
   assertSpyCalls(action, 4);
 
-  assertNotEquals(action, actionDescriptor.value);
+  assertNotEquals<unknown, () => void>(
+    action,
+    actionDescriptor.value,
+  );
   assertEquals(point.action, action);
 
   assertEquals(action.restored, false);

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -265,7 +265,6 @@ Deno.test("spy instance method symbol", () => {
   });
   assertSpyCalls(func, 2);
   assertNotEquals(func as unknown, Point.prototype[Symbol.iterator]);
-  func;
   assertEquals(point[Symbol.iterator], func);
 
   assertEquals(func.restored, false);

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -227,7 +227,7 @@ Deno.test("spy instance method", () => {
   });
   assertSpyCalls(func, 10);
 
-  assertNotEquals<unknown, Point["action"]>(func, Point.prototype.action);
+  assertNotEquals(func as unknown, Point.prototype.action);
   assertEquals(point.action, func);
 
   assertEquals(func.restored, false);
@@ -264,10 +264,7 @@ Deno.test("spy instance method symbol", () => {
     args: [],
   });
   assertSpyCalls(func, 2);
-  assertNotEquals<unknown, Point[typeof Symbol.iterator]>(
-    func,
-    Point.prototype[Symbol.iterator],
-  );
+  assertNotEquals(func as unknown, Point.prototype[Symbol.iterator]);
   func;
   assertEquals(point[Symbol.iterator], func);
 


### PR DESCRIPTION
Spawned from this conversation https://github.com/denoland/deno_std/pull/4121#discussion_r1444173340

Adding more assertion signatures to assert modules.

### Background

There are two ways assertion signatures are already implemented in assert/* and thats:

**actual unknown** - assertInstanceOf & assertIsError & assertStrictEquals:

```typescript
export function assert???<T>(
  actual: unknown,
  expected: T,
  msg?: string,
): asserts actual is T { /**/ }
```

This seems to be used for all positive asserts.

and

**two type params** - assertNotInstanceOf:

```typescript
export function assert???<A, T extends A>(
  actual: A,
  expected: T,
  msg?: string,
): asserts actual is T { /**/ }
```

This seems to be uses for all negative/not asserts.

I expect the reason that negative/not asserts use the **two type params** is because its the only way to do type narrowing by doing `asserts actual is Exclude<A, T>`.

### This PR

In this PR I've implemented assertion signatures on the remaining assert functions that make sense to have assertion signatures, following the pattern thats been previously established:
- assertEquals using the **actual unknown** style
- assertNotEquals and assertNotStrictEquals using the **two type params** style