### PR TITLE
fix: use `with` keyword for import attributes

### DIFF
--- a/console/unicode_width.ts
+++ b/console/unicode_width.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // Ported from unicode_width rust crate, Copyright (c) 2015 The Rust Project Developers. MIT license.
 
-import data from "./_data.json" assert { type: "json" };
+import data from "./_data.json" with { type: "json" };
 import { runLengthDecode } from "./_rle.ts";
 
 let tables: Uint8Array[] | null = null;

--- a/html/_tools/generate_data.ts
+++ b/html/_tools/generate_data.ts
@@ -3,7 +3,7 @@
 
 // JSON version of the full canonical list of named HTML entities
 // https://html.spec.whatwg.org/multipage/named-characters.html
-import entityList from "https://html.spec.whatwg.org/entities.json" assert {
+import entityList from "https://html.spec.whatwg.org/entities.json" with {
   type: "json",
 };
 

--- a/html/entities.ts
+++ b/html/entities.ts
@@ -66,7 +66,7 @@ const entityListRegexCache = new WeakMap<EntityList, RegExp>();
  * unescape("&thorn;&eth;"); // "&thorn;&eth;"
  *
  * // Using the full named entity list from the HTML spec (~47K un-minified)
- * import entityList from "https://deno.land/std@$STD_VERSION/html/named_entity_list.json" assert { type: "json" };
+ * import entityList from "https://deno.land/std@$STD_VERSION/html/named_entity_list.json" with { type: "json" };
  *
  * unescape("&thorn;&eth;", { entityList }); // "þð"
  * ```

--- a/html/entities_test.ts
+++ b/html/entities_test.ts
@@ -2,7 +2,7 @@
 
 import { escape, unescape } from "./entities.ts";
 import { assertEquals } from "../assert/mod.ts";
-import entityList from "./named_entity_list.json" assert { type: "json" };
+import entityList from "./named_entity_list.json" with { type: "json" };
 
 Deno.test("escape()", async (t) => {
   await t.step('escapes &<>"', () => {

--- a/http/user_agent_test.ts
+++ b/http/user_agent_test.ts
@@ -7,7 +7,7 @@ Deno.test({
   name: "UserAgent.prototype.browser",
   async fn(t) {
     const specs = (await import("./testdata/user_agent/browser-all.json", {
-      assert: { type: "json" },
+      with: { type: "json" },
     })).default;
     for (const { desc, ua, expect: { major, name, version } } of specs) {
       await t.step({
@@ -29,7 +29,7 @@ Deno.test({
   name: "UserAgent.prototype.cpu",
   async fn(t) {
     const specs = (await import("./testdata/user_agent/cpu-all.json", {
-      assert: { type: "json" },
+      with: { type: "json" },
     })).default;
     for (const { desc: name, ua, expect } of specs) {
       await t.step({
@@ -47,7 +47,7 @@ Deno.test({
   name: "UserAgent.prototype.device",
   async fn(t) {
     const specs = (await import("./testdata/user_agent/device-all.json", {
-      assert: { type: "json" },
+      with: { type: "json" },
     })).default;
     for (const { desc: name, ua, expect: { vendor, model, type } } of specs) {
       await t.step({
@@ -69,7 +69,7 @@ Deno.test({
   name: "UserAgent.prototype.engine",
   async fn(t) {
     const specs = (await import("./testdata/user_agent/engine-all.json", {
-      assert: { type: "json" },
+      with: { type: "json" },
     })).default;
     for (const { desc, ua, expect: { name, version } } of specs) {
       await t.step({
@@ -90,7 +90,7 @@ Deno.test({
   name: "UserAgent.prototype.os",
   async fn(t) {
     const specs = (await import("./testdata/user_agent/os-all.json", {
-      assert: { type: "json" },
+      with: { type: "json" },
     })).default;
     for (const { desc, ua, expect: { name, version } } of specs) {
       await t.step({


### PR DESCRIPTION
Fixes lint errors on canary: https://github.com/denoland/deno_std/actions/runs/7472961212/job/20336165920?pr=4121

See https://github.com/denoland/deno_lint/pull/1209