### PR TITLE
refactor(expect): prepare for `noUncheckedIndexedAccess`

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -542,7 +542,7 @@ export function toHaveBeenLastCalledWith(
 ): MatchResult {
   const calls = getMockCalls(context.value);
   const hasBeenCalled = calls.length > 0 &&
-    equal(calls[calls.length - 1].args, expected);
+    equal(calls.at(-1)?.args, expected);
 
   if (context.isNot) {
     if (hasBeenCalled) {
@@ -583,7 +583,7 @@ export function toHaveBeenNthCalledWith(
   const calls = getMockCalls(context.value);
   const callIndex = nth - 1;
   const hasBeenCalled = calls.length > callIndex &&
-    equal(calls[callIndex].args, expected);
+    equal(calls[callIndex]?.args, expected);
 
   if (context.isNot) {
     if (hasBeenCalled) {
@@ -596,7 +596,7 @@ export function toHaveBeenNthCalledWith(
   } else {
     if (!hasBeenCalled) {
       const nthCall = calls[callIndex];
-      if (!nth) {
+      if (!nthCall) {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
             inspectArgs(expected)
@@ -689,7 +689,7 @@ export function toHaveLastReturnedWith(
   const calls = getMockCalls(context.value);
   const returned = calls.filter((call) => call.returns);
   const lastReturnedWithExpected = returned.length > 0 &&
-    equal(returned[returned.length - 1].returned, expected);
+    equal(returned.at(-1)?.returned, expected);
 
   if (context.isNot) {
     if (lastReturnedWithExpected) {

--- a/expect/_to_have_been_nth_called_with_test.ts
+++ b/expect/_to_have_been_nth_called_with_test.ts
@@ -22,15 +22,26 @@ Deno.test("expect().", () => {
   assertThrows(() => {
     expect(mockFn).toHaveBeenNthCalledWith(1, 4, 5, 6);
   }, AssertionError);
-  assertThrows(
-    () => {
-      expect(mockFn).toHaveBeenNthCalledWith(4, 10, 11, 12);
-    },
-    AssertionError,
-    "Expected the n-th call (n=4) of mock function is with 10, 11, 12, but the n-th call does not exist.",
-  );
 
   assertThrows(() => {
     expect(mockFn).not.toHaveBeenNthCalledWith(2, 4, 5, 6);
   });
+});
+
+Deno.test("expect().toHaveBeenNthCalledWith() should throw when mock call does not exist", () => {
+  // Given
+  const mockFn = fn();
+
+  // When
+  mockFn("hello");
+
+  // Then
+  expect(mockFn).toHaveBeenNthCalledWith(1, "hello");
+  assertThrows(
+    () => {
+      expect(mockFn).toHaveBeenNthCalledWith(2, "hello");
+    },
+    AssertionError,
+    'Expected the n-th call (n=2) of mock function is with "hello", but the n-th call does not exist.',
+  );
 });

--- a/expect/_to_have_been_nth_called_with_test.ts
+++ b/expect/_to_have_been_nth_called_with_test.ts
@@ -22,6 +22,13 @@ Deno.test("expect().", () => {
   assertThrows(() => {
     expect(mockFn).toHaveBeenNthCalledWith(1, 4, 5, 6);
   }, AssertionError);
+  assertThrows(
+    () => {
+      expect(mockFn).toHaveBeenNthCalledWith(4, 10, 11, 12);
+    },
+    AssertionError,
+    "Expected the n-th call (n=4) of mock function is with 10, 11, 12, but the n-th call does not exist.",
+  );
 
   assertThrows(() => {
     expect(mockFn).not.toHaveBeenNthCalledWith(2, 4, 5, 6);

--- a/expect/_to_have_been_nth_called_with_test.ts
+++ b/expect/_to_have_been_nth_called_with_test.ts
@@ -29,13 +29,10 @@ Deno.test("expect().", () => {
 });
 
 Deno.test("expect().toHaveBeenNthCalledWith() should throw when mock call does not exist", () => {
-  // Given
   const mockFn = fn();
 
-  // When
   mockFn("hello");
 
-  // Then
   expect(mockFn).toHaveBeenNthCalledWith(1, "hello");
   assertThrows(
     () => {


### PR DESCRIPTION
Handling all noUncheckedIndexedAccess issues for the expect module, tracked in https://github.com/denoland/deno_std/issues/4040

# BUG FIX INCLUDED

Looks like toHaveBeenNthCalledWith failure case was checking with the wrong variable, I'll call out where I've updated it to now check the correct variable.