### PR TITLE
docs: fix typo in versions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Check out the contributing guidelines [here](.github/CONTRIBUTING.md).
 
 The Standard Library is versioned independently of the Deno CLI. This will
 change once the Standard Library is stabilized. See
-fm[here](https://deno.com/versions.json) for the compatibility of different
+[here](https://deno.com/versions.json) for the compatibility of different
 versions of the Deno Standard Library and the Deno CLI.
 
 A new minor version of the Standard Library is published at the same time as


### PR DESCRIPTION
It looks like the formatting applied in
33c09251bee9cb78fd2896f1c8160140df2436c8 introduced a typo. This commit removes it.
