### PR TITLE
fix: add `--no-lock` to spawned process args in tests

### DIFF
--- a/_tools/check_browser_compat.ts
+++ b/_tools/check_browser_compat.ts
@@ -16,6 +16,7 @@ function isBrowserCompatible(filePath: string): boolean {
   const command = new Deno.Command(Deno.execPath(), {
     args: [
       "check",
+      "--no-lock",
       "--config",
       "browser-compat.tsconfig.json",
       filePath,

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -194,7 +194,7 @@ Deno.test("digest() keeps memory usage reasonable with large inputs", async () =
   `;
 
   const command = new Deno.Command(Deno.execPath(), {
-    args: ["eval", code],
+    args: ["eval", "--no-lock", code],
     cwd: moduleDir,
   });
 
@@ -278,7 +278,7 @@ Deno.test("digest() keeps memory usage reasonable with many calls", async () => 
   `;
 
   const command = new Deno.Command(Deno.execPath(), {
-    args: ["eval", code],
+    args: ["eval", "--no-lock", code],
     cwd: moduleDir,
   });
   const { stdout, success } = await command.output();

--- a/dotenv/load_test.ts
+++ b/dotenv/load_test.ts
@@ -13,6 +13,7 @@ Deno.test({
         "run",
         "--allow-read",
         "--allow-env",
+        "--no-lock",
         path.join(testdataDir, "./app_load.ts"),
       ],
       clearEnv: true,
@@ -34,6 +35,7 @@ Deno.test({
     const command = new Deno.Command(Deno.execPath(), {
       args: [
         "run",
+        "--no-lock",
         "--allow-read",
         "--allow-env",
         path.join(testdataDir, "./app_load_parent.ts"),

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -253,6 +253,7 @@ Deno.test("load() loads .env and .env.defaults successfully from default file na
   const command = new Deno.Command(Deno.execPath(), {
     args: [
       "run",
+      "--no-lock",
       "--allow-read",
       "--allow-env",
       path.join(testdataDir, "./app_defaults.ts"),

--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -203,7 +203,7 @@ for (const s of scenes) {
       );
 
       try {
-        const args = ["run", "--quiet", "--no-prompt"];
+        const args = ["run", "--no-lock", "--quiet", "--no-prompt"];
 
         if (s.read) {
           args.push("--allow-read");

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -165,6 +165,7 @@ Deno.test({
       await new Deno.Command(Deno.execPath(), {
         args: [
           "eval",
+          "--no-lock",
           `Deno.removeSync("${testDir}", { recursive: true });`,
         ],
       }).output();
@@ -201,6 +202,7 @@ Deno.test({
       new Deno.Command(Deno.execPath(), {
         args: [
           "eval",
+          "--no-lock",
           `Deno.removeSync("${testDir}", { recursive: true });`,
         ],
       }).outputSync();

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -345,6 +345,7 @@ Deno.test("serveDir() script prints help", async () => {
       "run",
       "--no-check",
       "--quiet",
+      "--no-lock",
       "file_server.ts",
       "--help",
     ],
@@ -361,6 +362,7 @@ Deno.test("serveDir() script prints version", async () => {
       "run",
       "--no-check",
       "--quiet",
+      "--no-lock",
       "file_server.ts",
       "--version",
     ],
@@ -389,6 +391,7 @@ Deno.test("serveDir() script fails with partial TLS args", async () => {
       "--quiet",
       "--allow-read",
       "--allow-net",
+      "--no-lock",
       "file_server.ts",
       ".",
       "--host",
@@ -801,7 +804,7 @@ Deno.test("serveFile() etag value falls back to DENO_DEPLOYMENT_ID if fileInfo.m
     assertEquals(res.headers.get("etag"), \`${hashedDenoDeploymentId}\`);
   `;
   const command = new Deno.Command(Deno.execPath(), {
-    args: ["eval", code],
+    args: ["eval", "--no-lock", code],
     stdout: "null",
     stderr: "null",
     env: { DENO_DEPLOYMENT_ID },

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1541,6 +1541,7 @@ Deno.test("serve - doesn't print the message when onListen set to undefined", as
   const command = new Deno.Command(Deno.execPath(), {
     args: [
       "eval",
+      "--no-lock",
       `
         import { serve } from "./http/server.ts";
         serve(() => new Response("hello"), { onListen: undefined });
@@ -1557,6 +1558,7 @@ Deno.test("serve - can print customized start-up message in onListen handler", a
   const command = new Deno.Command(Deno.execPath(), {
     args: [
       "eval",
+      "--no-lock",
       `
         import { serve } from "./http/server.ts";
         serve(() => new Response("hello"), { onListen({ port, hostname }) {

--- a/ini/parse_test.ts
+++ b/ini/parse_test.ts
@@ -159,13 +159,13 @@ Deno.test({
           throw new Error("Don't try to set the value directly to the key __proto__.")
         }
       });
-      import { parse } from "${import.meta.resolve("./mod.ts")}";
+      import { parse } from "${import.meta.resolve("./parse.ts")}";
       parse('[__proto__]\\nisAdmin = true');
     `;
     const command = new Deno.Command(Deno.execPath(), {
       stdout: "inherit",
       stderr: "inherit",
-      args: ["eval", testCode],
+      args: ["eval", "--no-lock", testCode],
     });
     const { success } = await command.output();
     assert(success);

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -296,6 +296,7 @@ Deno.test("Snapshot Test - Options", async (t) => {
         const process = new Deno.Command(Deno.execPath(), {
           args: [
             "test",
+            "--no-lock",
             "--allow-all",
             tempTestFilePath,
             "--",
@@ -347,7 +348,14 @@ Deno.test(
       await Deno.writeTextFile(tempTestFilePath, test);
 
       const command = new Deno.Command(Deno.execPath(), {
-        args: ["test", "--allow-all", tempTestFilePath, "--", "-u"],
+        args: [
+          "test",
+          "--no-lock",
+          "--allow-all",
+          tempTestFilePath,
+          "--",
+          "-u",
+        ],
       });
       const { stdout, stderr } = await command.output();
 
@@ -492,7 +500,14 @@ Deno.test(
       await Deno.writeTextFile(tempTestFilePath, test);
 
       const command = new Deno.Command(Deno.execPath(), {
-        args: ["test", "--allow-all", tempTestFilePath, "--", "-u"],
+        args: [
+          "test",
+          "--no-lock",
+          "--allow-all",
+          tempTestFilePath,
+          "--",
+          "-u",
+        ],
       });
       const { stdout, stderr } = await command.output();
 
@@ -606,6 +621,7 @@ Deno.test(
       const command = new Deno.Command(Deno.execPath(), {
         args: [
           "test",
+          "--no-lock",
           "--allow-all",
           tempTestFilePath1,
           tempTestFilePath2,

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -210,7 +210,7 @@ merge_test:
     const command = new Deno.Command(Deno.execPath(), {
       stdout: "inherit",
       stderr: "inherit",
-      args: ["eval", testCode],
+      args: ["eval", "--no-lock", testCode],
     });
     const { success } = await command.output();
     assert(success);


### PR DESCRIPTION
I noticed that tests containing spawned processes that use the Deno binary tend to be flaky. There have been a few instances in the past that these processes fail because the runtime is unable to parse the contents of the lockfile. I.e. race condition.

This fix adds the `--no-lock` CLI flag to all such instances. Hopefully, we'll see a noticable reduction in test flakiness in CI.