### PR TITLE
BREAKING(semver): remove `parse(semver: string)` overload

### DIFF
--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -1,28 +1,15 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { SemVer } from "./types.ts";
 import { parseBuild, parseNumber, parsePrerelease } from "./_shared.ts";
-import { isSemVer } from "./is_semver.ts";
 import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 
-/**
- * @deprecated (will be removed in 0.212.0) Use a string argument instead.
- */
-export function parse(version: SemVer): SemVer;
 /**
  * Attempt to parse a string as a semantic version, returning either a `SemVer`
  * object or throws a TypeError.
  * @param version The version string to parse
  * @returns A valid SemVer
  */
-export function parse(version: string): SemVer;
-export function parse(version: string | SemVer): SemVer {
-  if (typeof version === "object") {
-    if (isSemVer(version)) {
-      return version;
-    } else {
-      throw new TypeError(`not a valid SemVer object`);
-    }
-  }
+export function parse(version: string): SemVer {
   if (typeof version !== "string") {
     throw new TypeError(
       `version must be a string`,

--- a/semver/range_min_test.ts
+++ b/semver/range_min_test.ts
@@ -77,7 +77,7 @@ Deno.test({
     for (const [a, b] of versions) {
       await t.step(a, () => {
         const range = parseRange(a);
-        const version = parse(b as SemVer);
+        const version = typeof b === "string" ? parse(b) : b;
         const min = rangeMin(range);
         assert(eq(min, version), `${format(min)} != ${format(version)}`);
       });


### PR DESCRIPTION
Related #3939