### PR TITLE
feat(log): make handlers disposable

### DIFF
--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -51,4 +51,8 @@ export class BaseHandler {
   log(_msg: string) {}
   setup() {}
   destroy() {}
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
 }

--- a/log/handlers_test.ts
+++ b/log/handlers_test.ts
@@ -166,7 +166,7 @@ Deno.test({
       }
     }
 
-    const testFileHandler = new TestFileHandler("WARNING", {
+    using testFileHandler = new TestFileHandler("WARNING", {
       filename: LOG_FILE,
       mode: "w",
     });
@@ -182,8 +182,6 @@ Deno.test({
         }),
       );
     }
-
-    testFileHandler.destroy();
   },
 });
 
@@ -227,7 +225,7 @@ Deno.test({
 Deno.test({
   name: "FileHandler with mode 'x' will throw if log file already exists",
   fn() {
-    const fileHandler = new FileHandler("WARNING", {
+    using fileHandler = new FileHandler("WARNING", {
       filename: LOG_FILE,
       mode: "x",
     });
@@ -236,8 +234,6 @@ Deno.test({
     assertThrows(() => {
       fileHandler.setup();
     }, Deno.errors.AlreadyExists);
-
-    fileHandler.destroy();
 
     Deno.removeSync(LOG_FILE);
   },
@@ -287,7 +283,7 @@ Deno.test({
       LOG_FILE + ".3",
       new TextEncoder().encode("hello world"),
     );
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    using fileHandler = new RotatingFileHandler("WARNING", {
       filename: LOG_FILE,
       maxBytes: 50,
       maxBackupCount: 3,
@@ -301,7 +297,6 @@ Deno.test({
       "Backup log file " + LOG_FILE + ".3 already exists",
     );
 
-    fileHandler.destroy();
     Deno.removeSync(LOG_FILE + ".3");
     Deno.removeSync(LOG_FILE);
   },
@@ -310,7 +305,7 @@ Deno.test({
 Deno.test({
   name: "RotatingFileHandler with first rollover, monitor step by step",
   async fn() {
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    using fileHandler = new RotatingFileHandler("WARNING", {
       filename: LOG_FILE,
       maxBytes: 25,
       maxBackupCount: 3,
@@ -350,7 +345,6 @@ Deno.test({
     // Rollover occurred. Log file now has 1 record, rollover file has the original 2
     assertEquals((await Deno.stat(LOG_FILE)).size, 10);
     assertEquals((await Deno.stat(LOG_FILE + ".1")).size, 20);
-    fileHandler.destroy();
 
     Deno.removeSync(LOG_FILE);
     Deno.removeSync(LOG_FILE + ".1");
@@ -561,7 +555,7 @@ Deno.test({
 Deno.test({
   name: "FileHandler: Critical logs trigger immediate flush",
   async fn() {
-    const fileHandler = new FileHandler("WARNING", {
+    using fileHandler = new FileHandler("WARNING", {
       filename: LOG_FILE,
       mode: "w",
     });
@@ -594,7 +588,6 @@ Deno.test({
     // ERROR record is 10 bytes, CRITICAL is 13 bytes
     assertEquals(fileSize2, 23);
 
-    fileHandler.destroy();
     Deno.removeSync(LOG_FILE);
   },
 });


### PR DESCRIPTION
This change makes all `std/log` handlers disposable.

See https://github.com/tc39/proposal-explicit-resource-management