### PR TITLE
refactor: use `copy()` from `std/io`

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -151,7 +151,7 @@ export interface TarDataWithSource extends TarData {
  * ```ts
  * import { Tar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const tar = new Tar();
  *

--- a/archive/tar_test.ts
+++ b/archive/tar_test.ts
@@ -14,7 +14,7 @@ import { resolve } from "../path/mod.ts";
 import { Tar } from "./tar.ts";
 import { Untar } from "./untar.ts";
 import { Buffer } from "../io/buffer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "../io/copy.ts";
 import { readAll } from "../io/read_all.ts";
 import { filePath, testdataDir } from "./_test_common.ts";
 

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -185,7 +185,7 @@ export class TarEntry implements Reader {
  * import { Untar } from "https://deno.land/std@$STD_VERSION/archive/untar.ts";
  * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/ensure_file.ts";
  * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * using reader = await Deno.open("./out.tar", { read: true });
  * const untar = new Untar(reader);

--- a/archive/untar_test.ts
+++ b/archive/untar_test.ts
@@ -9,7 +9,7 @@ import {
   Untar,
 } from "./untar.ts";
 import { Buffer } from "../io/buffer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "../io/copy.ts";
 import { readAll } from "../io/read_all.ts";
 import { filePath, testdataDir } from "./_test_common.ts";
 

--- a/io/limited_reader_test.ts
+++ b/io/limited_reader_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../assert/mod.ts";
 import { LimitedReader } from "./limited_reader.ts";
 import { StringWriter } from "./string_writer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 import { readAll } from "./read_all.ts";
 import { StringReader } from "./string_reader.ts";
 

--- a/io/multi_reader_test.ts
+++ b/io/multi_reader_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { MultiReader } from "./multi_reader.ts";
 import { StringWriter } from "./string_writer.ts";
 import { copyN } from "./copy_n.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 import { StringReader } from "./string_reader.ts";
 
 Deno.test("ioMultiReader", async function () {

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -15,7 +15,7 @@ const decoder = new TextDecoder();
  *   StringReader,
  *   StringWriter,
  * } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const w = new StringWriter("base");
  * const r = new StringReader("0123456789");

--- a/io/string_writer_test.ts
+++ b/io/string_writer_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { StringWriter } from "./string_writer.ts";
 import { StringReader } from "./string_reader.ts";
 import { copyN } from "./copy_n.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 
 Deno.test("ioStringWriter", async function () {
   const w = new StringWriter("base");

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -10,7 +10,7 @@ import { Reader } from "../io/types.ts";
  *
  * ```ts
  * import { readerFromIterable } from "https://deno.land/std@$STD_VERSION/streams/reader_from_iterable.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const file = await Deno.open("metrics.txt", { write: true });
  * const reader = readerFromIterable((async function* () {

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -10,7 +10,7 @@ import type { Reader } from "../io/types.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  * import { readerFromStreamReader } from "https://deno.land/std@$STD_VERSION/streams/reader_from_stream_reader.ts";
  *
  * const res = await fetch("https://deno.land");

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -8,7 +8,7 @@ import type { Writer } from "../io/types.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  * import { writerFromStreamWriter } from "https://deno.land/std@$STD_VERSION/streams/writer_from_stream_writer.ts";
  *
  * using file = await Deno.open("./deno.land.html", { read: true });


### PR DESCRIPTION
While this change mostly touches deprecated APIs, it might at least help with awareness of the new location of `copy()`.