### PR TITLE
deprecation(io): rework deprecations

### DIFF
--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -3,7 +3,8 @@
 
 /**
  * @module
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 
 import { assert } from "../assert/assert.ts";
@@ -17,7 +18,8 @@ const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 export class BufferFullError extends Error {
   override name = "BufferFullError";
@@ -27,7 +29,8 @@ export class BufferFullError extends Error {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 export class PartialReadError extends Error {
   override name = "PartialReadError";
@@ -40,7 +43,10 @@ export class PartialReadError extends Error {
 /**
  * Result type returned by of BufReader.readLine().
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and {@linkcode https://deno.land/std/io/text_line_stream.ts | TextLineStream}
+ * instead.
  */
 export interface ReadLineResult {
   line: Uint8Array;
@@ -48,7 +54,8 @@ export interface ReadLineResult {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 export class BufReader implements Reader {
   #buf!: Uint8Array;
@@ -257,6 +264,11 @@ export class BufReader implements Reader {
    * Calling `unreadByte()` after `readLine()` will always unread the last byte
    * read (possibly a character belonging to the line end) even if that byte is
    * not part of the line returned by `readLine()`.
+   *
+   * @deprecated (will be removed in 0.215.0) Use
+   * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+   * and {@linkcode https://deno.land/std/io/text_line_stream.ts | TextLineStream}
+   * instead.
    */
   async readLine(): Promise<ReadLineResult | null> {
     let line: Uint8Array | null = null;

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -40,7 +40,8 @@ abstract class AbstractBufBase {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.Writer.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 export class BufWriter extends AbstractBufBase implements Writer {
   #writer: Writer;
@@ -133,7 +134,8 @@ export class BufWriter extends AbstractBufBase implements Writer {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.WriterSync.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/buffer.ts | Buffer} instead.
  */
 export class BufWriterSync extends AbstractBufBase implements WriterSync {
   #writer: WriterSync;

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -12,7 +12,11 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param dest Writer
  * @param size Read size
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/streams/limited_transform_stream.ts | LimitedTransformStream}
+ * instead.
  */
 export async function copyN(
   r: Reader,

--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -10,7 +10,11 @@
 import type { Reader } from "./types.ts";
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/io/limited_transform_stream.ts | LimitedTransformStream}
+ * instead.
  */
 export class LimitedReader implements Reader {
   constructor(public reader: Reader, public limit: number) {}

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -6,7 +6,10 @@ import type { Reader } from "./types.ts";
 /**
  * Reader utility for combining multiple readers
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecate (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and {@linkcode https://deno.land/std/streams/merge_readable_streams | mergeReadableStreams}
+ * instead.
  */
 export class MultiReader implements Reader {
   readonly #readers: Reader[];

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -28,7 +28,11 @@ function createLPS(pat: Uint8Array): Uint8Array {
 /**
  * Read delimited bytes from a Reader.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/streams/delimiter_stream.ts | DelimiterStream}
+ * instead.
  */
 export async function* readDelim(
   reader: Reader,

--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -7,7 +7,7 @@ import { readShort } from "./read_short.ts";
  * Read big endian 32bit integer from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0)
  */
 export async function readInt(buf: BufReader): Promise<number | null> {
   const high = await readShort(buf);

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -21,7 +21,10 @@ import { concat } from "../bytes/concat.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and {@linkcode https://deno.land/std/io/text_line_stream.ts | TextLineStream}
+ * instead.
  */
 export async function* readLines(
   reader: Reader,

--- a/io/read_long.ts
+++ b/io/read_long.ts
@@ -9,7 +9,7 @@ const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
  * Read big endian 64bit long from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0)
  */
 export async function readLong(buf: BufReader): Promise<number | null> {
   const high = await readInt(buf);

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -7,7 +7,11 @@ import type { Reader, ReaderSync } from "./types.ts";
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/streams/byte_slice_stream.ts | ByteSliceStream}
+ * instead.
  */
 export interface ByteRange {
   /** The 0 based index of the start byte for a range. */
@@ -32,7 +36,11 @@ export interface ByteRange {
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/streams/byte_slice_stream.ts | ByteSliceStream}
+ * instead.
  */
 export async function readRange(
   r: Reader & Deno.Seeker,
@@ -72,7 +80,11 @@ export async function readRange(
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream}
+ * and
+ * {@linkcode https://deno.land/std/streams/byte_slice_stream.ts | ByteSliceStream}
+ * instead.
  */
 export function readRangeSync(
   r: ReaderSync & Deno.SeekerSync,

--- a/io/read_short.ts
+++ b/io/read_short.ts
@@ -6,7 +6,7 @@ import { type BufReader } from "./buf_reader.ts";
  * Read big endian 16bit short from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0)
  */
 export async function readShort(buf: BufReader): Promise<number | null> {
   const high = await buf.readByte();

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -20,7 +20,11 @@ import { readDelim } from "./read_delim.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_readable_stream.ts | toReadableStream},
+ * {@linkcode TextDecoderStream} and
+ * {@linkcode https://deno.land/std/streams/text_delimiter_stream.ts | TextDelimiterStream}
+ * instead.
  */
 export async function* readStringDelim(
   reader: Reader,

--- a/io/slice_long_to_bytes.ts
+++ b/io/slice_long_to_bytes.ts
@@ -6,7 +6,7 @@
  * @param d The number to be sliced
  * @param dest The sliced array
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 0.215.0)
  */
 export function sliceLongToBytes(
   d: number,

--- a/io/string_reader.ts
+++ b/io/string_reader.ts
@@ -32,7 +32,8 @@ import { Buffer } from "./buffer.ts";
  * abcdef
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode Buffer} and
+ * {@linkcode TextEncoder} instead.
  */
 export class StringReader extends Buffer {
   constructor(s: string) {

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -35,7 +35,9 @@ const decoder = new TextDecoder();
  * base0123456789
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/mod.ts?s=Buffer&p=prototype.bytes | Buffer.bytes}
+ * and {@linkcode TextDecoder} instead.
  */
 export class StringWriter implements Writer, WriterSync {
   #chunks: Uint8Array[] = [];


### PR DESCRIPTION
This change reworks `std/io` deprecations by bringing the removal version forward to v0.215.0 from v1, and providing alternative solutions for advanced I/O use.

It seems that the wide-use of `copy()`, `readAll()`, `writeAll()` and `Buffer` justified having a removal version of v1. But now that these APIs have been undeprecated, I think it's reasonable to remove the other, more advanced, but less-used `std/io` APIs sooner.