### PR TITLE
deprecation(streams): rework deprecations

### DIFF
--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -35,7 +35,7 @@ export type { Reader, ReaderSync };
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode ReadableStream} instead.
  */
 export async function* iterateReader(
   r: Reader,
@@ -87,7 +87,7 @@ export async function* iterateReader(
  * responsibility to copy contents of the buffer if needed; otherwise the
  * next iteration will overwrite contents of previously returned chunk.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode ReadableStream} instead.
  */
 export function* iterateReaderSync(
   r: ReaderSync,

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -35,7 +35,7 @@ export type { Reader, ReaderSync };
  * }
  * ```
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode ReadableStream} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode ReadableStreamDefaultReader} instead.
  */
 export async function* iterateReader(
   r: Reader,

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -23,7 +23,7 @@ import { Reader } from "../io/types.ts";
  * await copy(reader, file);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream.from} instead.
+ * @deprecated (will be removed after 0.215.0) Use {@linkcode ReadableStream.from} instead.
  */
 export function readerFromIterable(
   iterable: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -20,7 +20,7 @@ import type { Reader } from "../io/types.ts";
  * await copy(reader, file);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStreamDefaultReader} directly.
+ * @deprecated (will be removed after 0.215.0) Use {@linkcode ReadableStreamDefaultReader} directly.
  */
 export function readerFromStreamReader(
   streamReader: ReadableStreamDefaultReader<Uint8Array>,

--- a/streams/writable_stream_from_writer.ts
+++ b/streams/writable_stream_from_writer.ts
@@ -14,7 +14,9 @@ function isCloser(value: unknown): value is Closer {
 /**
  * Options for {@linkcode writableStreamFromWriter}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStream} directly.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_writable_stream.ts | toWritableStream}
+ * instead.
  */
 export interface WritableStreamFromWriterOptions {
   /**
@@ -29,7 +31,9 @@ export interface WritableStreamFromWriterOptions {
 /**
  * Create a {@linkcode WritableStream} from a {@linkcode Writer}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStream} directly.
+ * @deprecated (will be removed in 0.215.0) Use
+ * {@linkcode https://deno.land/std/io/to_writable_stream.ts | toWritableStream}
+ * instead.
  */
 export function writableStreamFromWriter(
   writer: Writer,

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -22,7 +22,7 @@ import type { Writer } from "../io/types.ts";
  * await copy(file, writer);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStreamDefaultWriter} directly.
+ * @deprecated (will be removed after 0.215.0) Use {@linkcode WritableStreamDefaultWriter} directly.
  */
 export function writerFromStreamWriter(
   streamWriter: WritableStreamDefaultWriter<Uint8Array>,


### PR DESCRIPTION
This change reworks `std/streams` deprecations for various reasons (see comments). I think it's reasonable to bring some of the removal versions forward because:
1. Some of these APIs aren't heavily used.
2. Their migrations aren't too involved.
3. These APIs are still available through import version pinning.