### PR TITLE
refactor: cleanup deprecated-related APIs in `std/io` and `std/streams`

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -151,7 +151,7 @@ export interface TarDataWithSource extends TarData {
  * ```ts
  * import { Tar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
  * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const tar = new Tar();
  *

--- a/archive/tar_test.ts
+++ b/archive/tar_test.ts
@@ -14,7 +14,7 @@ import { resolve } from "../path/mod.ts";
 import { Tar } from "./tar.ts";
 import { Untar } from "./untar.ts";
 import { Buffer } from "../io/buffer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "../io/copy.ts";
 import { readAll } from "../io/read_all.ts";
 import { filePath, testdataDir } from "./_test_common.ts";
 

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -185,7 +185,7 @@ export class TarEntry implements Reader {
  * import { Untar } from "https://deno.land/std@$STD_VERSION/archive/untar.ts";
  * import { ensureFile } from "https://deno.land/std@$STD_VERSION/fs/ensure_file.ts";
  * import { ensureDir } from "https://deno.land/std@$STD_VERSION/fs/ensure_dir.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * using reader = await Deno.open("./out.tar", { read: true });
  * const untar = new Untar(reader);

--- a/archive/untar_test.ts
+++ b/archive/untar_test.ts
@@ -9,7 +9,7 @@ import {
   Untar,
 } from "./untar.ts";
 import { Buffer } from "../io/buffer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "../io/copy.ts";
 import { readAll } from "../io/read_all.ts";
 import { filePath, testdataDir } from "./_test_common.ts";
 

--- a/io/limited_reader_test.ts
+++ b/io/limited_reader_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../assert/mod.ts";
 import { LimitedReader } from "./limited_reader.ts";
 import { StringWriter } from "./string_writer.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 import { readAll } from "./read_all.ts";
 import { StringReader } from "./string_reader.ts";
 

--- a/io/multi_reader_test.ts
+++ b/io/multi_reader_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { MultiReader } from "./multi_reader.ts";
 import { StringWriter } from "./string_writer.ts";
 import { copyN } from "./copy_n.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 import { StringReader } from "./string_reader.ts";
 
 Deno.test("ioMultiReader", async function () {

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -15,7 +15,7 @@ const decoder = new TextDecoder();
  *   StringReader,
  *   StringWriter,
  * } from "https://deno.land/std@$STD_VERSION/io/mod.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const w = new StringWriter("base");
  * const r = new StringReader("0123456789");

--- a/io/string_writer_test.ts
+++ b/io/string_writer_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { StringWriter } from "./string_writer.ts";
 import { StringReader } from "./string_reader.ts";
 import { copyN } from "./copy_n.ts";
-import { copy } from "../streams/copy.ts";
+import { copy } from "./copy.ts";
 
 Deno.test("ioStringWriter", async function () {
   const w = new StringWriter("base");

--- a/streams/iterate_reader.ts
+++ b/streams/iterate_reader.ts
@@ -35,7 +35,7 @@ export type { Reader, ReaderSync };
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream} instead.
+ * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStreamDefaultReader} instead.
  */
 export async function* iterateReader(
   r: Reader,

--- a/streams/read_all.ts
+++ b/streams/read_all.ts
@@ -1,8 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { readAll as _readAll } from "../io/read_all.ts";
-import { Buffer } from "../io/buffer.ts";
+import {
+  readAll as _readAll,
+  readAllSync as _readAllSync,
+} from "../io/read_all.ts";
 import type { Reader, ReaderSync } from "../io/types.ts";
 
 /**
@@ -60,7 +62,5 @@ export async function readAll(r: Reader): Promise<Uint8Array> {
  * @deprecated (will be removed in 0.214.0) Import from {@link https://deno.land/std/io/read_all.ts} instead.
  */
 export function readAllSync(r: ReaderSync): Uint8Array {
-  const buf = new Buffer();
-  buf.readFromSync(r);
-  return buf.bytes();
+  return _readAllSync(r);
 }

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
-import { writeAll } from "./write_all.ts";
+import { writeAll } from "../io/write_all.ts";
 import { Reader } from "../io/types.ts";
 
 /**
@@ -10,7 +10,7 @@ import { Reader } from "../io/types.ts";
  *
  * ```ts
  * import { readerFromIterable } from "https://deno.land/std@$STD_VERSION/streams/reader_from_iterable.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  *
  * const file = await Deno.open("metrics.txt", { write: true });
  * const reader = readerFromIterable((async function* () {

--- a/streams/reader_from_stream_reader.ts
+++ b/streams/reader_from_stream_reader.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { Buffer } from "../io/buffer.ts";
-import { writeAll } from "./write_all.ts";
+import { writeAll } from "../io/write_all.ts";
 import type { Reader } from "../io/types.ts";
 
 /**
@@ -10,7 +10,7 @@ import type { Reader } from "../io/types.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  * import { readerFromStreamReader } from "https://deno.land/std@$STD_VERSION/streams/reader_from_stream_reader.ts";
  *
  * const res = await fetch("https://deno.land");

--- a/streams/reader_from_stream_reader_test.ts
+++ b/streams/reader_from_stream_reader_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "../assert/mod.ts";
-import { copy } from "./copy.ts";
+import { copy } from "../io/copy.ts";
 import { readerFromStreamReader } from "./reader_from_stream_reader.ts";
 import { Buffer } from "../io/buffer.ts";
 

--- a/streams/writable_stream_from_writer.ts
+++ b/streams/writable_stream_from_writer.ts
@@ -1,20 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { writeAll } from "./write_all.ts";
-import type { Closer, Writer } from "../io/types.ts";
-
-function isCloser(value: unknown): value is Closer {
-  return typeof value === "object" && value !== null && value !== undefined &&
-    "close" in value &&
-    // deno-lint-ignore no-explicit-any
-    typeof (value as Record<string, any>)["close"] === "function";
-}
+import type { Writer } from "../io/types.ts";
+import { toWritableStream } from "../io/to_writable_stream.ts";
 
 /**
  * Options for {@linkcode writableStreamFromWriter}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStream} directly.
+ * @deprecated (will be removed after 1.0.0) Use {@linkcode toWritableStream} instead.
  */
 export interface WritableStreamFromWriterOptions {
   /**
@@ -29,34 +22,11 @@ export interface WritableStreamFromWriterOptions {
 /**
  * Create a {@linkcode WritableStream} from a {@linkcode Writer}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStream} directly.
+ * @deprecated (will be removed after 1.0.0) Use {@linkcode toWritableStream} instead.
  */
 export function writableStreamFromWriter(
   writer: Writer,
   options: WritableStreamFromWriterOptions = {},
 ): WritableStream<Uint8Array> {
-  const { autoClose = true } = options;
-
-  return new WritableStream({
-    async write(chunk, controller) {
-      try {
-        await writeAll(writer, chunk);
-      } catch (e) {
-        controller.error(e);
-        if (isCloser(writer) && autoClose) {
-          writer.close();
-        }
-      }
-    },
-    close() {
-      if (isCloser(writer) && autoClose) {
-        writer.close();
-      }
-    },
-    abort() {
-      if (isCloser(writer) && autoClose) {
-        writer.close();
-      }
-    },
-  });
+  return toWritableStream(writer, options);
 }

--- a/streams/write_all.ts
+++ b/streams/write_all.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { writeAll as _writeAll } from "../io/write_all.ts";
+import {
+  writeAll as _writeAll,
+  writeAllSync as _writeAllSync,
+} from "../io/write_all.ts";
 import type { Writer, WriterSync } from "../io/types.ts";
 export type { Writer, WriterSync };
 
@@ -62,8 +65,5 @@ export async function writeAll(w: Writer, arr: Uint8Array) {
  * @deprecated (will be removed in 0.214.0) Import from {@link https://deno.land/std/io/write_all.ts} instead.
  */
 export function writeAllSync(w: WriterSync, arr: Uint8Array) {
-  let nwritten = 0;
-  while (nwritten < arr.length) {
-    nwritten += w.writeSync(arr.subarray(nwritten));
-  }
+  _writeAllSync(w, arr);
 }

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -8,7 +8,7 @@ import type { Writer } from "../io/types.ts";
  *
  * @example
  * ```ts
- * import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
+ * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
  * import { writerFromStreamWriter } from "https://deno.land/std@$STD_VERSION/streams/writer_from_stream_writer.ts";
  *
  * using file = await Deno.open("./deno.land.html", { read: true });


### PR DESCRIPTION
Various cleanups that we previously missed.