### PR TITLE
fix(expect): fix the function signature of `toMatchObject()`

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -432,7 +432,7 @@ export function toMatch(
 
 export function toMatchObject(
   context: MatcherContext,
-  expected: Record<PropertyKey, unknown>,
+  expected: Record<PropertyKey, unknown> | Array<Record<PropertyKey, unknown>>,
 ): MatchResult {
   if (context.isNot) {
     let objectMatch = false;
@@ -440,7 +440,7 @@ export function toMatchObject(
       assertObjectMatch(
         // deno-lint-ignore no-explicit-any
         context.value as Record<PropertyKey, any>,
-        expected,
+        expected as Record<PropertyKey, unknown>,
         context.customMessage,
       );
       objectMatch = true;
@@ -459,7 +459,7 @@ export function toMatchObject(
     assertObjectMatch(
       // deno-lint-ignore no-explicit-any
       context.value as Record<PropertyKey, any>,
-      expected,
+      expected as Record<PropertyKey, unknown>,
       context.customMessage,
     );
   }

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -432,7 +432,7 @@ export function toMatch(
 
 export function toMatchObject(
   context: MatcherContext,
-  expected: Record<PropertyKey, unknown> | Array<Record<PropertyKey, unknown>>,
+  expected: Record<PropertyKey, unknown> | Record<PropertyKey, unknown>[],
 ): MatchResult {
   if (context.isNot) {
     let objectMatch = false;

--- a/expect/_to_match_object_test.ts
+++ b/expect/_to_match_object_test.ts
@@ -31,14 +31,22 @@ Deno.test("expect().toMatchObject()", () => {
   };
 
   expect(house0).toMatchObject(desiredHouse);
+  expect([house0]).toMatchObject([desiredHouse]);
 
   expect(house1).not.toMatchObject(desiredHouse);
+  expect([house1]).not.toMatchObject([desiredHouse]);
 
   assertThrows(() => {
     expect(house1).toMatchObject(desiredHouse);
   }, AssertionError);
+  assertThrows(() => {
+    expect([house1]).toMatchObject([desiredHouse]);
+  }, AssertionError);
 
   assertThrows(() => {
     expect(house0).not.toMatchObject(desiredHouse);
+  }, AssertionError);
+  assertThrows(() => {
+    expect([house0]).not.toMatchObject([desiredHouse]);
   }, AssertionError);
 });

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -75,7 +75,9 @@ export interface Expected {
   toHaveReturned(): void;
   toMatch(expected: RegExp): void;
   toMatchObject(
-    expected: Record<PropertyKey, unknown> | Array<Record<PropertyKey, unknown>>,
+    expected:
+      | Record<PropertyKey, unknown>
+      | Record<PropertyKey, unknown>[],
   ): void;
   toReturn(): void;
   toReturnTimes(expected: number): void;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -74,7 +74,9 @@ export interface Expected {
   toHaveReturnedWith(expected: unknown): void;
   toHaveReturned(): void;
   toMatch(expected: RegExp): void;
-  toMatchObject(expected: Record<PropertyKey, unknown>): void;
+  toMatchObject(
+    expected: Record<PropertyKey, unknown> | Array<Record<PropertyKey, unknown>>,
+  ): void;
   toReturn(): void;
   toReturnTimes(expected: number): void;
   toReturnWith(expected: unknown): void;


### PR DESCRIPTION
Fix https://github.com/denoland/deno_std/issues/4190