### PR TITLE
fix(fmt): correct `stripColor()` deprecation notice

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -572,7 +572,9 @@ const ANSI_PATTERN = new RegExp(
  *
  *  @deprecated (will be removed in 1.0.0) Use {@linkcode stripAnsiCode} instead.
  */
-export const stripColor: typeof stripAnsiCode = stripAnsiCode;
+export function stripColor(string: string): string {
+  return stripAnsiCode(string);
+}
 
 /**
  * Remove ANSI escape codes from the string.


### PR DESCRIPTION
This change fixes how `stripColor()`'s signature is documented by calling `stripAnsiCode()` within it.

Before:
![image](https://github.com/denoland/deno_std/assets/29347852/dc3c3899-c0fd-434e-bc45-d7cfacec7f9c)

After:
![image](https://github.com/denoland/deno_std/assets/29347852/dca13f63-b0b4-4692-b601-5d949a9e5673)
