### PR TITLE
feat(collections): Add `pick` and `omit`

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -54,3 +54,5 @@ export * from "./drop_last_while.ts";
 export * from "./reduce_groups.ts";
 export * from "./sample.ts";
 export * from "./running_reduce.ts";
+export * from "./pick.ts";
+export * from "./omit.ts";

--- a/collections/omit.ts
+++ b/collections/omit.ts
@@ -15,8 +15,8 @@
  * ```
  */
 export function omit<T extends object, K extends keyof T>(
-  obj: T,
-  keys: K[],
+  obj: Readonly<T>,
+  keys: readonly K[],
 ): Omit<T, K> {
   const excludes = new Set(keys);
   const has = excludes.has.bind(excludes);

--- a/collections/omit.ts
+++ b/collections/omit.ts
@@ -1,0 +1,26 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Creates a new object by excluding the specified keys from the provided object.
+ *
+ * @example
+ * ```ts
+ * import { omit } from "https://deno.land/std@$STD_VERSION/collections/omit.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ *
+ * const obj = { a: 5, b: 6, c: 7, d: 8 };
+ * const omitted = omit(obj, ["a", "c"]);
+ *
+ * assertEquals(omitted, { b: 6, d: 8 });
+ * ```
+ */
+export function omit<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Omit<T, K> {
+  const excludes = new Set(keys);
+  const has = excludes.has.bind(excludes);
+  return Object.fromEntries(
+    Object.entries(obj).filter(([k, _]) => !has(k as K)),
+  ) as Omit<T, K>;
+}

--- a/collections/omit_test.ts
+++ b/collections/omit_test.ts
@@ -1,0 +1,38 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals, assertNotStrictEquals } from "../assert/mod.ts";
+import { omit } from "./omit.ts";
+
+Deno.test({
+  name: "omit() returns a new object from the provided object",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const omitted = omit(obj, []);
+
+    assertEquals(omitted, { a: 5, b: 6, c: 7, d: 8 });
+    assertNotStrictEquals(omitted, obj);
+  },
+});
+
+Deno.test({
+  name:
+    "omit() returns a new object from the provided object without the provided keys",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const omitted = omit(obj, ["a", "c"]);
+
+    assertEquals(omitted, { b: 6, d: 8 });
+    assertNotStrictEquals(omitted, obj);
+  },
+});
+
+Deno.test({
+  name: "omit() returns an empty object when the provided keys is empty",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const omitted = omit(obj, ["a", "b", "c", "d"]);
+
+    assertEquals(omitted, {});
+    assertNotStrictEquals(omitted, obj);
+  },
+});

--- a/collections/pick.ts
+++ b/collections/pick.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Creates a new object by including the specified keys from the provided object.
+ *
+ * @example
+ * ```ts
+ * import { pick } from "https://deno.land/std@$STD_VERSION/collections/pick.ts";
+ * import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+ *
+ * const obj = { a: 5, b: 6, c: 7, d: 8 };
+ * const picked = pick(obj, ["a", "c"]);
+ *
+ * assertEquals(picked, { a: 5, c: 7 });
+ * ```
+ */
+export function pick<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Pick<T, K> {
+  return Object.fromEntries(keys.map((k) => [k, obj[k]])) as Pick<T, K>;
+}

--- a/collections/pick.ts
+++ b/collections/pick.ts
@@ -15,8 +15,8 @@
  * ```
  */
 export function pick<T extends object, K extends keyof T>(
-  obj: T,
-  keys: K[],
+  obj: Readonly<T>,
+  keys: readonly K[],
 ): Pick<T, K> {
   return Object.fromEntries(keys.map((k) => [k, obj[k]])) as Pick<T, K>;
 }

--- a/collections/pick_test.ts
+++ b/collections/pick_test.ts
@@ -1,0 +1,39 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals, assertNotStrictEquals } from "../assert/mod.ts";
+import { pick } from "./pick.ts";
+
+Deno.test({
+  name: "pick() returns a new empty object when no keys are provided",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const picked = pick(obj, []);
+
+    assertEquals(picked, {});
+    assertNotStrictEquals(picked, obj);
+  },
+});
+
+Deno.test({
+  name:
+    "pick() returns a new object from the provided object with the provided keys",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const picked = pick(obj, ["a", "c"]);
+
+    assertEquals(picked, { a: 5, c: 7 });
+    assertNotStrictEquals(picked, obj);
+  },
+});
+
+Deno.test({
+  name:
+    "pick() returns a new object from the provided object with the provided keys (all keys are provided)",
+  fn() {
+    const obj = { a: 5, b: 6, c: 7, d: 8 };
+    const picked = pick(obj, ["a", "b", "c", "d"]);
+
+    assertEquals(picked, { a: 5, b: 6, c: 7, d: 8 });
+    assertNotStrictEquals(picked, obj);
+  },
+});


### PR DESCRIPTION
This is like Lodash's [pick](https://lodash.com/docs/#pick) and [omit](https://lodash.com/docs/#omit), but it's a bit more restrictive. Specifically, it only accepts an array of strings (`string[]`) rather than just a single string.