### PR TITLE
refactor: remove environment variable functionality notice in `warnOnDeprecatedApi()`

### DIFF
--- a/internal/warn_on_deprecated_api.ts
+++ b/internal/warn_on_deprecated_api.ts
@@ -8,7 +8,7 @@ const ALREADY_WARNED_DEPRECATED = new Set<string>();
 const ENV_VAR_KEY = "DENO_NO_DEPRECATION_WARNINGS";
 const shouldDisableDeprecatedApiWarning =
   Deno?.permissions.querySync?.({ name: "env", variable: ENV_VAR_KEY })
-      .state === "granted" && Deno?.env.get(ENV_VAR_KEY) === "1";
+      .state === "granted" && Deno?.env.has(ENV_VAR_KEY);
 
 interface WarnDeprecatedApiConfig {
   /** The name of the deprecated API. */
@@ -78,11 +78,6 @@ export function warnOnDeprecatedApi(config: WarnDeprecatedApiConfig) {
     );
   }
 
-  console.log("%c\u2502", "color: yellow;");
-  console.log(
-    "%c\u251c Set `DENO_NO_DEPRECATION_WARNINGS=1` to disable these deprecation warnings.",
-    "color: yellow;",
-  );
   console.log("%c\u2502", "color: yellow;");
   console.log("%c\u2514 Stack trace:", "color: yellow;");
   for (let i = 0; i < stackLines.length; i++) {

--- a/internal/warn_on_deprecated_api_test.ts
+++ b/internal/warn_on_deprecated_api_test.ts
@@ -20,11 +20,9 @@ Deno.test("warnDeprecatedApi()", async () => {
 │
 ├ Suggestion: Do something else instead.
 │
-├ Set \`DENO_NO_DEPRECATION_WARNINGS=1\` to disable these deprecation warnings.
-│
 └ Stack trace:
-  ├─ at fn (${import.meta.url}:39:12)
-  └─ at ${import.meta.url}:47:31
+  ├─ at fn (${import.meta.url}:37:12)
+  └─ at ${import.meta.url}:45:31
 
 Hello, world!
 Hello, world!


### PR DESCRIPTION
To align it with the runtime. See https://github.com/denoland/deno/pull/21939#discussion_r1462640212