### PR TITLE
refactor: use `Deno.stdin.isTerminal()`

### DIFF
--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -31,7 +31,7 @@ export function promptSecret(
   message = "Secret ",
   { mask = "*", clear }: PromptSecretOptions = {},
 ): string | null {
-  if (!Deno.isatty(input.rid)) {
+  if (!input.isTerminal()) {
     return null;
   }
 


### PR DESCRIPTION
~~This will fail in stable until Deno 1.40 is released.~~

Oh yeah. We don't test this function.

Towards #4216