### PR TITLE
refactor(webgpu): use internal `Deno.close()` for cleanup of WebGPU resources

### DIFF
--- a/webgpu/_test_util.ts
+++ b/webgpu/_test_util.ts
@@ -36,5 +36,6 @@ export function cleanUp(device: GPUDevice) {
   // TODO(lucacasonato): webgpu spec should add a explicit destroy method for
   // adapters.
   const resources = Object.keys(Deno.resources());
-  Deno.close(Number(resources[resources.length - 1]));
+  // @ts-ignore Until WebGPU resources cleanup is automatically handled.
+  Deno[Deno.internal].core.close(Number(resources[resources.length - 1]));
 }


### PR DESCRIPTION
Towards #4216