### PR TITLE
docs: fix broken `{@link}` hyperlinks

### DIFF
--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -3,11 +3,13 @@
 
 /**
  * Pure functions for common tasks around collection types like arrays and
- * objects. Heavily inspired by
- * [Kotlin's `kotlin.collections`]{@linkcode https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/}
+ * objects.
+ *
+ * Heavily inspired by
+ * {@link https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/ | Kotlin's Collections}
  * package.
  *
- * @module.
+ * @module
  */
 
 export * from "./aggregate_groups.ts";

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -3,7 +3,7 @@
 
 /**
  * Extensions to the
- * [Web Crypto API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API}
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API | Web Crypto API}
  * supporting additional encryption APIs, but also delegating to the built-in
  * APIs when possible.
  *

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { validateBinaryLike } from "./_util.ts";
-
 /**
- * Utilities for working with [ascii85]{@link https://en.wikipedia.org/wiki/Ascii85} encoding.
+ * Utilities for working with {@link https://en.wikipedia.org/wiki/Ascii85 | ascii85} encoding.
  *
  * This module is browser compatible.
  *
@@ -13,8 +11,8 @@ import { validateBinaryLike } from "./_util.ts";
  * By default, all functions are using the most popular Adobe version of ascii85
  * and not adding any delimiter. However, there are three more standards
  * supported - btoa (different delimiter and additional compression of 4 bytes
- * equal to 32), [Z85](https://rfc.zeromq.org/spec/32/) and
- * [RFC 1924](https://tools.ietf.org/html/rfc1924). It's possible to use a
+ * equal to 32), {@link https://rfc.zeromq.org/spec/32/ | Z85} and
+ * {@link https://tools.ietf.org/html/rfc1924 | RFC 1924}. It's possible to use a
  * different encoding by specifying it in `options` object as a second parameter.
  *
  * Similarly, it's possible to make `encode` add a delimiter (`<~` and `~>` for
@@ -24,6 +22,8 @@ import { validateBinaryLike } from "./_util.ts";
  *
  * @module
  */
+
+import { validateBinaryLike } from "./_util.ts";
 
 /** Supported ascii85 standards for {@linkcode Ascii85Options}. */
 export type Ascii85Standard = "Adobe" | "btoa" | "RFC 1924" | "Z85";

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -2,11 +2,9 @@
 // Copyright (c) 2014 Jameson Little. MIT License.
 // This module is browser compatible.
 
-import { validateBinaryLike } from "./_util.ts";
-
 /**
  * Utilities for
- * [base32]{@link https://datatracker.ietf.org/doc/html/rfc4648#section-6}
+ * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-6 | base32}
  * encoding and decoding.
  *
  * Modified from {@link https://github.com/beatgammit/base64-js}.
@@ -15,6 +13,8 @@ import { validateBinaryLike } from "./_util.ts";
  *
  * @module
  */
+
+import { validateBinaryLike } from "./_util.ts";
 
 const lookup: string[] = [];
 const revLookup: number[] = [];

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -1,17 +1,17 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { validateBinaryLike } from "./_util.ts";
-
 /**
  * Utilities for
- * [base58]{@link https://datatracker.ietf.org/doc/html/draft-msporny-base58-03}
+ * {@link https://datatracker.ietf.org/doc/html/draft-msporny-base58-03 | base58}
  * encoding and decoding.
  *
  * This module is browser compatible.
  *
  * @module
  */
+
+import { validateBinaryLike } from "./_util.ts";
 
 // deno-fmt-ignore
 const mapBase58: Record<string, number> = {

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -1,17 +1,17 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { validateBinaryLike } from "./_util.ts";
-
 /**
  * Utilities for
- * [base64]{@link https://datatracker.ietf.org/doc/html/rfc4648#section-4}
+ * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-4 | base64}
  * encoding and decoding.
  *
  * This module is browser compatible.
  *
  * @module
  */
+
+import { validateBinaryLike } from "./_util.ts";
 
 const base64abc = [
   "A",

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -3,7 +3,7 @@
 
 /**
  * Utilities for
- * [base64url]{@link https://datatracker.ietf.org/doc/html/rfc4648#section-5}
+ * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-5 | base64url}
  * encoding and decoding.
  *
  * This module is browser compatible.
@@ -13,9 +13,10 @@
 
 import * as base64 from "./base64.ts";
 
-/*
+/**
  * Some variants allow or require omitting the padding '=' signs:
  * https://en.wikipedia.org/wiki/Base64#The_URL_applications
+ *
  * @param base64url
  */
 function addPaddingToBase64url(base64url: string): string {

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -3,11 +3,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { validateBinaryLike } from "./_util.ts";
-
 /**
  * Port of the Go
- * [encoding/hex](https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go)
+ * {@link https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go | encoding/hex}
  * library.
  *
  * This module is browser compatible.
@@ -30,6 +28,8 @@ import { validateBinaryLike } from "./_util.ts";
  *
  * @module
  */
+
+import { validateBinaryLike } from "./_util.ts";
 
 const hexTable = new TextEncoder().encode("0123456789abcdef");
 const textEncoder = new TextEncoder();

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -3,7 +3,7 @@
 
 /**
  * @module
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 
 import { assert } from "../assert/assert.ts";
@@ -17,7 +17,7 @@ const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufferFullError extends Error {
   override name = "BufferFullError";
@@ -27,7 +27,7 @@ export class BufferFullError extends Error {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class PartialReadError extends Error {
   override name = "PartialReadError";
@@ -40,7 +40,7 @@ export class PartialReadError extends Error {
 /**
  * Result type returned by of BufReader.readLine().
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export interface ReadLineResult {
   line: Uint8Array;
@@ -48,7 +48,7 @@ export interface ReadLineResult {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufReader implements Reader {
   #buf!: Uint8Array;

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -40,7 +40,7 @@ abstract class AbstractBufBase {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.Writer.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufWriter extends AbstractBufBase implements Writer {
   #writer: Writer;
@@ -133,7 +133,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.WriterSync.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufWriterSync extends AbstractBufBase implements WriterSync {
   #writer: WriterSync;

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -12,7 +12,7 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param dest Writer
  * @param size Read size
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function copyN(
   r: Reader,

--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -10,7 +10,7 @@
 import type { Reader } from "./types.ts";
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class LimitedReader implements Reader {
   constructor(public reader: Reader, public limit: number) {}

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -6,7 +6,7 @@ import type { Reader } from "./types.ts";
 /**
  * Reader utility for combining multiple readers
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class MultiReader implements Reader {
   readonly #readers: Reader[];

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -28,7 +28,7 @@ function createLPS(pat: Uint8Array): Uint8Array {
 /**
  * Read delimited bytes from a Reader.
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readDelim(
   reader: Reader,

--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -7,7 +7,7 @@ import { readShort } from "./read_short.ts";
  * Read big endian 32bit integer from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readInt(buf: BufReader): Promise<number | null> {
   const high = await readShort(buf);

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -21,7 +21,7 @@ import { concat } from "../bytes/concat.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readLines(
   reader: Reader,

--- a/io/read_long.ts
+++ b/io/read_long.ts
@@ -9,7 +9,7 @@ const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
  * Read big endian 64bit long from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readLong(buf: BufReader): Promise<number | null> {
   const high = await readInt(buf);

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -7,7 +7,7 @@ import type { Reader, ReaderSync } from "./types.ts";
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export interface ByteRange {
   /** The 0 based index of the start byte for a range. */
@@ -32,7 +32,7 @@ export interface ByteRange {
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readRange(
   r: Reader & Deno.Seeker,
@@ -72,7 +72,7 @@ export async function readRange(
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export function readRangeSync(
   r: ReaderSync & Deno.SeekerSync,

--- a/io/read_short.ts
+++ b/io/read_short.ts
@@ -6,7 +6,7 @@ import { type BufReader } from "./buf_reader.ts";
  * Read big endian 16bit short from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readShort(buf: BufReader): Promise<number | null> {
   const high = await buf.readByte();

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -20,7 +20,7 @@ import { readDelim } from "./read_delim.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readStringDelim(
   reader: Reader,

--- a/io/slice_long_to_bytes.ts
+++ b/io/slice_long_to_bytes.ts
@@ -6,7 +6,7 @@
  * @param d The number to be sliced
  * @param dest The sliced array
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export function sliceLongToBytes(
   d: number,

--- a/io/string_reader.ts
+++ b/io/string_reader.ts
@@ -32,7 +32,7 @@ import { Buffer } from "./buffer.ts";
  * abcdef
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class StringReader extends Buffer {
   constructor(s: string) {

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -35,7 +35,7 @@ const decoder = new TextDecoder();
  * base0123456789
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the [Web Streams API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API} instead.
+ * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class StringWriter implements Writer, WriterSync {
   #chunks: Uint8Array[] = [];

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -2,7 +2,7 @@
 /**
  * Helpers for interacting with Deno's permissions system.
  * @module
- * @deprecated (will be removed in 1.0.0) Use the [Deno Permissions API]{@link https://deno.land/api?s=Deno.Permissions} directly instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 
 const { PermissionDenied } = Deno.errors;
@@ -47,7 +47,7 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions.
  *
- * @deprecated (will be removed in 1.0.0) Use the [Deno Permissions API]{@link https://deno.land/api?s=Deno.Permissions} directly instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 export async function grant(
   ...descriptors: Deno.PermissionDescriptor[]
@@ -68,7 +68,7 @@ export async function grant(
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions.
  *
- * @deprecated (will be removed in 1.0.0) Use the [Deno Permissions API]{@link https://deno.land/api?s=Deno.Permissions} directly instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 export async function grant(
   descriptors: Deno.PermissionDescriptor[],
@@ -105,7 +105,7 @@ export async function grant(
  * permission that is denied.  If all permissions are granted, the function
  * will resolve.
  *
- * @deprecated (will be removed in 1.0.0) Use the [Deno Permissions API]{@link https://deno.land/api?s=Deno.Permissions} directly instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 export async function grantOrThrow(
   ...descriptors: Deno.PermissionDescriptor[]
@@ -122,7 +122,7 @@ export async function grantOrThrow(
  * the denied permissions.  If all permissions are granted, the function will
  * resolve.
  *
- * @deprecated (will be removed in 1.0.0) Use the [Deno Permissions API]{@link https://deno.land/api?s=Deno.Permissions} directly instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 export async function grantOrThrow(
   descriptors: Deno.PermissionDescriptor[],

--- a/ulid/mod.ts
+++ b/ulid/mod.ts
@@ -5,7 +5,7 @@
 
 /**
  * Utilities for generating and working with
- * [Universally Unique Lexicographically Sortable Identifiers (ULIDs)]{@link https://github.com/ulid/spec}.
+ * {@link https://github.com/ulid/spec | Universally Unique Lexicographically Sortable Identifiers (ULIDs)}.
  *
  * @module
  */

--- a/webgpu/mod.ts
+++ b/webgpu/mod.ts
@@ -3,7 +3,7 @@
 /**
  * Utilities for interacting with the
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API | WebGPU API}.
- * 
+ *
  * @module
  */
 

--- a/webgpu/mod.ts
+++ b/webgpu/mod.ts
@@ -3,6 +3,8 @@
 /**
  * Utilities for interacting with the
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API | WebGPU API}.
+ * 
+ * @module
  */
 
 export * from "./create_capture.ts";

--- a/webgpu/mod.ts
+++ b/webgpu/mod.ts
@@ -2,7 +2,7 @@
 
 /**
  * Utilities for interacting with the
- * [WebGPU API]{@link https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API}.
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API | WebGPU API}.
  */
 
 export * from "./create_capture.ts";


### PR DESCRIPTION
I have changed `{@link}` syntax from `[text]{@link namepathOrURL}` to `{@link namepathOrURL | text}` to fix broken hyperlinks.

Inspired by #4167, #4169, #4209,...