### PR TITLE
fix(expect): expect.toEqual need to return original obj

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -37,15 +37,16 @@ function filterUndefined(obj: any): any {
   if (Symbol.iterator in obj) return obj;
   if (Array.isArray(obj)) return obj.map(filterUndefined);
 
+  const result = Object.create(obj);
   for (const key in obj) {
     const val = obj[key];
     if (val === undefined) {
-      delete obj[key];
+      delete result[key];
       continue;
     }
-    obj[key] = filterUndefined(val);
+    result[key] = filterUndefined(val);
   }
-  return obj;
+  return result;
 }
 
 export function toEqual(

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -40,10 +40,7 @@ function filterUndefined(obj: any): any {
   const result = Object.create(obj);
   for (const key in obj) {
     const val = obj[key];
-    if (val === undefined) {
-      delete result[key];
-      continue;
-    }
+    if (val === undefined) continue;
     result[key] = filterUndefined(val);
   }
   return result;

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -37,14 +37,15 @@ function filterUndefined(obj: any): any {
   if (Symbol.iterator in obj) return obj;
   if (Array.isArray(obj)) return obj.map(filterUndefined);
 
-  // deno-lint-ignore no-explicit-any
-  const result = {} as any;
   for (const key in obj) {
     const val = obj[key];
-    if (val === undefined) continue;
-    result[key] = filterUndefined(val);
+    if (val === undefined) {
+      delete obj[key];
+      continue;
+    }
+    obj[key] = filterUndefined(val);
   }
-  return result;
+  return obj;
 }
 
 export function toEqual(


### PR DESCRIPTION
If support `addEqualityTester`, this case will fail, because it return a new object.

```js
import { expect } from "https://deno.land/std/expect/mod.ts";

class Volume { /* specify logic*/ }

function createVolume() {
  return new Volume();
}

function areVolumeEqual(a: unknown, b unknown) {
   return a instacneof Volume && b instanceof Volume
}

Deno.test('custom equality tester', () => {
    expect.addEqualityTester([areVolumeEqual]);
    const volume1 = createVolume();
    const volume2 = createVolume();
    expect(volume1).toEqual(volume2);
});
```

And current ` expect(source1).toEqual(source2)` will return `false`.