### PR TITLE
fix(expect): add Error object equal check.

### DIFF
--- a/expect/_equal.ts
+++ b/expect/_equal.ts
@@ -49,6 +49,9 @@ export function equal(c: unknown, d: unknown, strictCheck?: boolean): boolean {
       }
       return aTime === bTime;
     }
+    if (a instanceof Error && b instanceof Error) {
+      return a.message === b.message;
+    }
     if (typeof a === "number" && typeof b === "number") {
       return Number.isNaN(a) && Number.isNaN(b) || a === b;
     }

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -11,6 +11,7 @@ import {
 import { assertThrows } from "../assert/assert_throws.ts";
 import { AssertionError } from "../assert/assertion_error.ts";
 import { expect } from "./expect.ts";
+import { assertFalse } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 const createHeader = (): string[] => [
   "",
@@ -262,4 +263,17 @@ Deno.test("align to jest test cases", () => {
   assertThrows(() => {
     expect(new A()).not.toEqual(new B());
   }, AssertionError);
+});
+
+Deno.test("toEqual case for Error Object", () => {
+  function getError() {
+    return new Error("missing param: name");
+  }
+
+  const expectErrObjectWithName = new Error("missing param: name");
+  expect(getError()).toEqual(expectErrObjectWithName);
+
+  const expectErrObjectWithEmail = new Error("missing param: email");
+  expect(getError()).not.toEqual(expectErrObjectWithEmail);
+  assertFalse(expect(getError()).not.toEqual(expectErrObjectWithEmail));
 });

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -8,7 +8,7 @@ import {
   stripAnsiCode,
   yellow,
 } from "../fmt/colors.ts";
-import { assertFalse, AssertionError, assertThrows } from "../assert/mod.ts";
+import { AssertionError, assertThrows } from "../assert/mod.ts";
 import { expect } from "./expect.ts";
 
 const createHeader = (): string[] => [
@@ -273,5 +273,4 @@ Deno.test("toEqual case for Error Object", () => {
 
   const expectErrObjectWithEmail = new Error("missing param: email");
   expect(getError()).not.toEqual(expectErrObjectWithEmail);
-  assertFalse(expect(getError()).not.toEqual(expectErrObjectWithEmail));
 });

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -8,10 +8,8 @@ import {
   stripAnsiCode,
   yellow,
 } from "../fmt/colors.ts";
-import { assertThrows } from "../assert/assert_throws.ts";
-import { AssertionError } from "../assert/assertion_error.ts";
+import { assertFalse, assertThrows, AssertionError } from "../assert/mod.ts";
 import { expect } from "./expect.ts";
-import { assertFalse } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 const createHeader = (): string[] => [
   "",

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -8,7 +8,7 @@ import {
   stripAnsiCode,
   yellow,
 } from "../fmt/colors.ts";
-import { assertFalse, assertThrows, AssertionError } from "../assert/mod.ts";
+import { assertFalse, AssertionError, assertThrows } from "../assert/mod.ts";
 import { expect } from "./expect.ts";
 
 const createHeader = (): string[] => [


### PR DESCRIPTION
This pr is to solved #4221, which is missed from the previous PR.