### PR TITLE
docs(io): fix `io` module is marked deprecated

### DIFF
--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -1,11 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/**
- * @module
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
- */
-
 import { assert } from "../assert/assert.ts";
 import { copy } from "../bytes/copy.ts";
 import type { Reader } from "./types.ts";


### PR DESCRIPTION
I think this deprecation notice is unnecessary because all APIs in `buf_reader.ts` have already been marked deprecated.

Fix: #4249
Ref: #3556