### PR TITLE
deprecation(semver): postpone removals to 0.215.0

### DIFF
--- a/semver/comparator_format.ts
+++ b/semver/comparator_format.ts
@@ -8,7 +8,7 @@ import { format } from "./format.ts";
  * @param comparator
  * @returns A string representation of the comparator
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode SemVerRange} instead of {@linkcode Comparator} and {@linkcode formatRange} for formatting it.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode SemVerRange} instead of {@linkcode Comparator} and {@linkcode formatRange} for formatting it.
  */
 export function comparatorFormat(comparator: Comparator): string {
   const { semver, operator } = comparator;

--- a/semver/comparator_intersects.ts
+++ b/semver/comparator_intersects.ts
@@ -10,7 +10,7 @@ import { comparatorMax } from "./comparator_max.ts";
  * @param c1 The right side comparator
  * @returns True if any part of the comparators intersect
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeIntersects} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode rangeIntersects} instead.
  */
 export function comparatorIntersects(
   c0: Comparator,

--- a/semver/comparator_max.ts
+++ b/semver/comparator_max.ts
@@ -9,7 +9,7 @@ import { ANY, INVALID, MAX } from "./constants.ts";
  * an out of range semver will be returned.
  * @returns the version, the MAX version or the next smallest patch version
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeMax} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode rangeMax} instead.
  */
 export function comparatorMax(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/comparator_min.ts
+++ b/semver/comparator_min.ts
@@ -10,7 +10,7 @@ import { increment } from "./increment.ts";
  * @param operator The operator of the comparator
  * @returns The minimum valid semantic version
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode rangeMin} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode rangeMin} instead.
  */
 export function comparatorMin(semver: SemVer, operator: Operator): SemVer {
   if (semver === ANY) {

--- a/semver/eq.ts
+++ b/semver/eq.ts
@@ -5,7 +5,7 @@ import { SemVer } from "./types.ts";
 /**
  * Returns `true` if they're logically equivalent, even if they're not the exact same version object.
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode equals} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode equals} instead.
  */
 export function eq(s0: SemVer, s1: SemVer): boolean {
   return equals(s0, s1);

--- a/semver/gt.ts
+++ b/semver/gt.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Greater than comparison
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode greaterThan} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode greaterThan} instead.
  */
 export function gt(s0: SemVer, s1: SemVer): boolean {
   return greaterThan(s0, s1);

--- a/semver/gte.ts
+++ b/semver/gte.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Greater than or equal to comparison
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode greaterOrEqual} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode greaterOrEqual} instead.
  */
 export function gte(s0: SemVer, s1: SemVer): boolean {
   return greaterOrEqual(s0, s1);

--- a/semver/is_comparator.ts
+++ b/semver/is_comparator.ts
@@ -14,7 +14,7 @@ import { ALL, NONE } from "./constants.ts";
  * @param value The value to check if its a Comparator
  * @returns True if the object is a Comparator otherwise false
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode isSemVerRange} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode isSemVerRange} instead.
  */
 export function isComparator(value: unknown): value is Comparator {
   if (

--- a/semver/lt.ts
+++ b/semver/lt.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Less than comparison
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode lessThan} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode lessThan} instead.
  */
 export function lt(s0: SemVer, s1: SemVer): boolean {
   return lessThan(s0, s1);

--- a/semver/lte.ts
+++ b/semver/lte.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Less than or equal to comparison
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode lessOrEqual} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode lessOrEqual} instead.
  */
 export function lte(s0: SemVer, s1: SemVer): boolean {
   return lessOrEqual(s0, s1);

--- a/semver/neq.ts
+++ b/semver/neq.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Not equal comparison
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode notEquals} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode notEquals} instead.
  */
 export function neq(s0: SemVer, s1: SemVer): boolean {
   return notEquals(s0, s1);

--- a/semver/parse_comparator.ts
+++ b/semver/parse_comparator.ts
@@ -22,7 +22,7 @@ type REGEXP_GROUPS = {
  * @param comparator
  * @returns A valid Comparator
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode parseRange} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode parseRange} instead.
  */
 export function parseComparator(comparator: string): Comparator {
   const match = comparator.match(COMPARATOR_REGEXP);

--- a/semver/range_format.ts
+++ b/semver/range_format.ts
@@ -9,7 +9,7 @@ import { Range, SemVerRange } from "./types.ts";
  * @param range The range to format
  * @returns A string representation of the range
  *
- * @deprecated (will be removed after 0.213.0) Use {@linkcode formatRange} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode formatRange} instead.
  */
 export function rangeFormat(range: SemVerRange | Range): string {
   return formatRange(range);

--- a/semver/sort.ts
+++ b/semver/sort.ts
@@ -5,7 +5,7 @@ import { compare } from "./compare.ts";
 /**
  * Sorts a list of semantic versions in ascending order.
  *
- * @deprecated (will be removed after 0.214.0) Use `list.sort(compare)` with {@linkcode compare} instead.
+ * @deprecated (will be removed in 0.215.0) Use `list.sort(compare)` with {@linkcode compare} instead.
  */
 export function sort(
   list: SemVer[],

--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -13,7 +13,7 @@ import { neq } from "./neq.ts";
  * @param comparator The comparator
  * @returns True if the version is within the comparators set otherwise false
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode testRange} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode testRange} instead.
  */
 export function testComparator(
   version: SemVer,

--- a/semver/try_parse_comparator.ts
+++ b/semver/try_parse_comparator.ts
@@ -7,7 +7,7 @@ import { parseComparator } from "./parse_comparator.ts";
  * @param comparator
  * @returns A valid Comparator or undefined
  *
- * @deprecated (will be removed in 0.214.0) Use {@linkcode tryParseRange} instead.
+ * @deprecated (will be removed in 0.215.0) Use {@linkcode tryParseRange} instead.
  */
 export function tryParseComparator(
   comparator: string,


### PR DESCRIPTION
This change postpones `std/semver` deprecations to 0.215.0. This allows all the removals to happen simultaneously, making the removals easier to apply, and allows a little more time for those needing to make changes to their code.

This also unblocks the 0.214.0 release.