### PR TITLE
BREAKING(log): remove `WARNING` log level

### DIFF
--- a/log/base_handler_test.ts
+++ b/log/base_handler_test.ts
@@ -25,7 +25,7 @@ Deno.test("simpleHandler", function () {
       [
         "DEBUG debug-test",
         "INFO info-test",
-        "WARNING warning-test",
+        "WARN warn-test",
         "ERROR error-test",
         "CRITICAL critical-test",
       ],
@@ -34,14 +34,14 @@ Deno.test("simpleHandler", function () {
       LogLevels.INFO,
       [
         "INFO info-test",
-        "WARNING warning-test",
+        "WARN warn-test",
         "ERROR error-test",
         "CRITICAL critical-test",
       ],
     ],
     [
-      LogLevels.WARNING,
-      ["WARNING warning-test", "ERROR error-test", "CRITICAL critical-test"],
+      LogLevels.WARN,
+      ["WARN warn-test", "ERROR error-test", "CRITICAL critical-test"],
     ],
     [LogLevels.ERROR, ["ERROR error-test", "CRITICAL critical-test"]],
     [LogLevels.CRITICAL, ["CRITICAL critical-test"]],

--- a/log/console_handler.ts
+++ b/log/console_handler.ts
@@ -35,7 +35,7 @@ export class ConsoleHandler extends BaseHandler {
       case LogLevels.INFO:
         msg = blue(msg);
         break;
-      case LogLevels.WARNING:
+      case LogLevels.WARN:
         msg = yellow(msg);
         break;
       case LogLevels.ERROR:

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -24,7 +24,7 @@ Deno.test({
       }
     }
 
-    using testFileHandler = new TestFileHandler("WARNING", {
+    using testFileHandler = new TestFileHandler("WARN", {
       filename: LOG_FILE,
       mode: "w",
     });
@@ -35,7 +35,7 @@ Deno.test({
         new LogRecord({
           msg: "The starry heavens above me and the moral law within me.",
           args: [],
-          level: LogLevels.WARNING,
+          level: LogLevels.WARN,
           loggerName: "default",
         }),
       );
@@ -46,7 +46,7 @@ Deno.test({
 Deno.test({
   name: "FileHandler with mode 'w' will wipe clean existing log file",
   async fn() {
-    const fileHandler = new FileHandler("WARNING", {
+    const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
       mode: "w",
     });
@@ -56,7 +56,7 @@ Deno.test({
       new LogRecord({
         msg: "Hello World",
         args: [],
-        level: LogLevels.WARNING,
+        level: LogLevels.WARN,
         loggerName: "default",
       }),
     );
@@ -68,7 +68,7 @@ Deno.test({
       new LogRecord({
         msg: "Hello World",
         args: [],
-        level: LogLevels.WARNING,
+        level: LogLevels.WARN,
         loggerName: "default",
       }),
     );
@@ -83,7 +83,7 @@ Deno.test({
 Deno.test({
   name: "FileHandler with mode 'x' will throw if log file already exists",
   fn() {
-    using fileHandler = new FileHandler("WARNING", {
+    using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
       mode: "x",
     });
@@ -100,7 +100,7 @@ Deno.test({
 Deno.test({
   name: "Window unload flushes buffer",
   async fn() {
-    const fileHandler = new FileHandler("WARNING", {
+    const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
       mode: "w",
     });
@@ -126,7 +126,7 @@ Deno.test({
 Deno.test({
   name: "FileHandler: Critical logs trigger immediate flush",
   async fn() {
-    using fileHandler = new FileHandler("WARNING", {
+    using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
       mode: "w",
     });

--- a/log/levels.ts
+++ b/log/levels.ts
@@ -9,8 +9,7 @@ export const LogLevels = {
   NOTSET: 0,
   DEBUG: 10,
   INFO: 20,
-  /** @deprecated (will be removed after 0.214.0) Will be changed to {@linkcode WARN}. */
-  WARNING: 30,
+  WARN: 30,
   ERROR: 40,
   CRITICAL: 50,
 } as const;
@@ -30,7 +29,7 @@ const byLevel: Record<LogLevel, LevelName> = {
   [LogLevels.NOTSET]: "NOTSET",
   [LogLevels.DEBUG]: "DEBUG",
   [LogLevels.INFO]: "INFO",
-  [LogLevels.WARNING]: "WARNING",
+  [LogLevels.WARN]: "WARN",
   [LogLevels.ERROR]: "ERROR",
   [LogLevels.CRITICAL]: "CRITICAL",
 };

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -181,24 +181,13 @@ export class Logger {
     return this.#log(LogLevels.INFO, msg, ...args);
   }
 
-  /** @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead. */
-  warning<T>(msg: () => T, ...args: unknown[]): T | undefined;
-  /** @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead. */
-  warning<T>(msg: T extends GenericFunction ? never : T, ...args: unknown[]): T;
-  warning<T>(
-    msg: (T extends GenericFunction ? never : T) | (() => T),
-    ...args: unknown[]
-  ): T | undefined {
-    return this.warn(msg as () => T, ...args);
-  }
-
   warn<T>(msg: () => T, ...args: unknown[]): T | undefined;
   warn<T>(msg: T extends GenericFunction ? never : T, ...args: unknown[]): T;
   warn<T>(
     msg: (T extends GenericFunction ? never : T) | (() => T),
     ...args: unknown[]
   ): T | undefined {
-    return this.#log(LogLevels.WARNING, msg, ...args);
+    return this.#log(LogLevels.WARN, msg, ...args);
   }
 
   error<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -88,7 +88,7 @@ Deno.test("logFunctions", function () {
   assertEquals(handler.messages, [
     "DEBUG foo",
     "INFO bar",
-    "WARNING baz",
+    "WARN baz",
     "ERROR boo",
     "CRITICAL doo",
   ]);
@@ -97,14 +97,14 @@ Deno.test("logFunctions", function () {
 
   assertEquals(handler.messages, [
     "INFO bar",
-    "WARNING baz",
+    "WARN baz",
     "ERROR boo",
     "CRITICAL doo",
   ]);
 
-  handler = doLog("WARNING");
+  handler = doLog("WARN");
 
-  assertEquals(handler.messages, ["WARNING baz", "ERROR boo", "CRITICAL doo"]);
+  assertEquals(handler.messages, ["WARN baz", "ERROR boo", "CRITICAL doo"]);
 
   handler = doLog("ERROR");
 
@@ -182,8 +182,8 @@ Deno.test(
     assertEquals(data5, 3);
     const data6: number = logger.warn(3, 1);
     assertEquals(data6, 3);
-    assertEquals(handler.messages[4], "WARNING 3");
-    assertEquals(handler.messages[5], "WARNING 3");
+    assertEquals(handler.messages[4], "WARN 3");
+    assertEquals(handler.messages[5], "WARN 3");
 
     // bigint
     const data7: bigint = logger.error(5n);
@@ -222,8 +222,8 @@ Deno.test(
     assertEquals(data15, "abc");
     const data16: string | undefined = logger.warn(fn, 1);
     assertEquals(data16, "abc");
-    assertEquals(handler.messages[14], "WARNING abc");
-    assertEquals(handler.messages[15], "WARNING abc");
+    assertEquals(handler.messages[14], "WARN abc");
+    assertEquals(handler.messages[15], "WARN abc");
 
     // object
     const data17: { payload: string; other: number } = logger.error({

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -148,7 +148,7 @@
  *   handlers: {
  *     console: new log.ConsoleHandler("DEBUG"),
  *
- *     file: new log.FileHandler("WARNING", {
+ *     file: new log.FileHandler("WARN", {
  *       filename: "./log.txt",
  *       // you can change format of output message using any keys in `LogRecord`.
  *       formatter: (record) => `${record.levelName} ${record.msg}`,
@@ -173,7 +173,7 @@
  *
  * // get default logger.
  * logger = log.getLogger();
- * logger.debug("fizz"); // logs to `console`, because `file` handler requires "WARNING" level.
+ * logger.debug("fizz"); // logs to `console`, because `file` handler requires "WARN" level.
  * logger.warn(41256); // logs to both `console` and `file` handlers.
  *
  * // get custom logger
@@ -477,33 +477,7 @@ export function info<T>(
   return getLogger("default").info(msg, ...args);
 }
 
-/**
- * @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead.
- *
- * Log with warning level, using default logger.
- */
-export function warning<T>(msg: () => T, ...args: unknown[]): T | undefined;
-/**
- * @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead.
- *
- * Log with warning level, using default logger.
- */
-export function warning<T>(
-  msg: T extends GenericFunction ? never : T,
-  ...args: unknown[]
-): T;
-export function warning<T>(
-  msg: (T extends GenericFunction ? never : T) | (() => T),
-  ...args: unknown[]
-): T | undefined {
-  // Assist TS compiler with pass-through generic type
-  if (msg instanceof Function) {
-    return warn(msg, ...args);
-  }
-  return warn(msg, ...args);
-}
-
-/** Log with warning level, using default logger. */
+/** Log with warn level, using default logger. */
 export function warn<T>(msg: () => T, ...args: unknown[]): T | undefined;
 export function warn<T>(
   msg: T extends GenericFunction ? never : T,

--- a/log/mod_test.ts
+++ b/log/mod_test.ts
@@ -123,9 +123,9 @@ Deno.test({
     assertEquals(testHandler.messages[2], "CRITICAL critical");
 
     testHandler.messages = [];
-    logger.level = LogLevels.WARNING;
-    assertEquals(logger.levelName, "WARNING");
-    assertEquals(logger.level, LogLevels.WARNING);
+    logger.level = LogLevels.WARN;
+    assertEquals(logger.levelName, "WARN");
+    assertEquals(logger.level, LogLevels.WARN);
 
     logger.debug("debug2");
     logger.error("error2");

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -30,7 +30,7 @@ Deno.test({
       new TextEncoder().encode("hello world"),
     );
 
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 50,
       maxBackupCount: 3,
@@ -56,7 +56,7 @@ Deno.test({
       LOG_FILE + ".3",
       new TextEncoder().encode("hello world"),
     );
-    using fileHandler = new RotatingFileHandler("WARNING", {
+    using fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 50,
       maxBackupCount: 3,
@@ -78,7 +78,7 @@ Deno.test({
 Deno.test({
   name: "RotatingFileHandler with first rollover, monitor step by step",
   async fn() {
-    using fileHandler = new RotatingFileHandler("WARNING", {
+    using fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 25,
       maxBackupCount: 3,
@@ -127,7 +127,7 @@ Deno.test({
 Deno.test({
   name: "RotatingFileHandler with first rollover, check all at once",
   async fn() {
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 25,
       maxBackupCount: 3,
@@ -187,7 +187,7 @@ Deno.test({
       new TextEncoder().encode("original log.3 file"),
     );
 
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 2,
       maxBackupCount: 3,
@@ -232,7 +232,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        const fileHandler = new RotatingFileHandler("WARNING", {
+        const fileHandler = new RotatingFileHandler("WARN", {
           filename: LOG_FILE,
           maxBytes: 0,
           maxBackupCount: 3,
@@ -251,7 +251,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => {
-        const fileHandler = new RotatingFileHandler("WARNING", {
+        const fileHandler = new RotatingFileHandler("WARN", {
           filename: LOG_FILE,
           maxBytes: 50,
           maxBackupCount: 0,
@@ -268,7 +268,7 @@ Deno.test({
 Deno.test({
   name: "RotatingFileHandler: rotate on byte length, not msg length",
   async fn() {
-    const fileHandler = new RotatingFileHandler("WARNING", {
+    const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
       maxBytes: 7,
       maxBackupCount: 1,

--- a/log/test.ts
+++ b/log/test.ts
@@ -23,7 +23,7 @@ Deno.test("defaultHandlers", async function () {
   } = {
     DEBUG: log.debug,
     INFO: log.info,
-    WARNING: log.warn,
+    WARN: log.warn,
     ERROR: log.error,
     CRITICAL: log.critical,
   };

--- a/log/warn.ts
+++ b/log/warn.ts
@@ -19,29 +19,3 @@ export function warn<T>(
   }
   return getLogger("default").warn(msg, ...args);
 }
-
-/**
- * @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead.
- *
- * Log with warning level, using default logger.
- */
-export function warning<T>(msg: () => T, ...args: unknown[]): T | undefined;
-/**
- * @deprecated (will be removed after 0.214.0) Use {@linkcode warn} instead.
- *
- * Log with warning level, using default logger.
- */
-export function warning<T>(
-  msg: T extends GenericFunction ? never : T,
-  ...args: unknown[]
-): T;
-export function warning<T>(
-  msg: (T extends GenericFunction ? never : T) | (() => T),
-  ...args: unknown[]
-): T | undefined {
-  // Assist TS compiler with pass-through generic type
-  if (msg instanceof Function) {
-    return warn(msg, ...args);
-  }
-  return warn(msg, ...args);
-}


### PR DESCRIPTION
Users should use the `WARN` log level and `warn()` instead.

Deprecations were made in #4170 and #4117.
Original proposal in #4099.

CC @timreichen