### PR TITLE
refactor(semver): cleanup comparison functions

### DIFF
--- a/semver/comparator_intersects.ts
+++ b/semver/comparator_intersects.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Comparator } from "./types.ts";
-import { gte } from "./gte.ts";
-import { lte } from "./lte.ts";
+import { greaterOrEqual } from "./greater_or_equal.ts";
+import { lessOrEqual } from "./less_or_equal.ts";
 import { comparatorMin } from "./comparator_min.ts";
 import { comparatorMax } from "./comparator_max.ts";
 /**
@@ -51,5 +51,6 @@ export function comparatorIntersects(
   // l0 -- l1
   //          r0 -- r1
   // ```
-  return (gte(l0, r0) && lte(l0, r1)) || (gte(r0, l0) && lte(r0, l1));
+  return (greaterOrEqual(l0, r0) && lessOrEqual(l0, r1)) ||
+    (greaterOrEqual(r0, l0) && lessOrEqual(r0, l1));
 }

--- a/semver/comparator_min.ts
+++ b/semver/comparator_min.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Operator, SemVer } from "./types.ts";
 import { ANY, MAX, MIN } from "./constants.ts";
-import { gt } from "./gt.ts";
+import { greaterThan } from "./greater_than.ts";
 import { increment } from "./increment.ts";
 
 /**
@@ -27,7 +27,7 @@ export function comparatorMin(semver: SemVer, operator: Operator): SemVer {
     case "<=":
     case "<":
       // The min(<0.0.0) is MAX
-      return gt(semver, MIN) ? MIN : MAX;
+      return greaterThan(semver, MIN) ? MIN : MAX;
     case ">=":
     case "":
     case "=":

--- a/semver/constants.ts
+++ b/semver/constants.ts
@@ -29,10 +29,10 @@ export const MIN: SemVer = {
  * which may be the result of impossible ranges or comparator operations.
  * @example
  * ```ts
- * import { eq } from "https://deno.land/std@$STD_VERSION/semver/eq.ts";
+ * import { equals } from "https://deno.land/std@$STD_VERSION/semver/equals.ts";
  * import { parse } from "https://deno.land/std@$STD_VERSION/semver/parse.ts";
  * import { INVALID } from "https://deno.land/std@$STD_VERSION/semver/constants.ts"
- * eq(parse("1.2.3"), INVALID);
+ * equals(parse("1.2.3"), INVALID);
  * ```
  */
 export const INVALID: SemVer = {
@@ -48,10 +48,10 @@ export const INVALID: SemVer = {
  * SemVer object and should not be used directly.
  * @example
  * ```ts
- * import { eq } from "https://deno.land/std@$STD_VERSION/semver/eq.ts";
+ * import { equals } from "https://deno.land/std@$STD_VERSION/semver/equals.ts";
  * import { parse } from "https://deno.land/std@$STD_VERSION/semver/parse.ts";
  * import { ANY } from "https://deno.land/std@$STD_VERSION/semver/constants.ts"
- * eq(parse("1.2.3"), ANY); // false
+ * equals(parse("1.2.3"), ANY); // false
  * ```
  */
 export const ANY: SemVer = {

--- a/semver/gtr.ts
+++ b/semver/gtr.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { rangeMax } from "./range_max.ts";
-import { gt } from "./gt.ts";
+import { greaterThan } from "./greater_than.ts";
 
 /** Checks to see if the version is greater than all possible versions of the range. */
 export function gtr(
   version: SemVer,
   range: SemVerRange | Range,
 ): boolean {
-  return gt(version, rangeMax(range));
+  return greaterThan(version, rangeMax(range));
 }

--- a/semver/ltr.ts
+++ b/semver/ltr.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range, SemVer, SemVerRange } from "./types.ts";
-import { lt } from "./lt.ts";
+import { lessThan } from "./less_than.ts";
 import { rangeMin } from "./range_min.ts";
 
 /** Less than range comparison */
@@ -8,5 +8,5 @@ export function ltr(
   version: SemVer,
   range: SemVerRange | Range,
 ): boolean {
-  return lt(version, rangeMin(range));
+  return lessThan(version, rangeMin(range));
 }

--- a/semver/max_satisfying.ts
+++ b/semver/max_satisfying.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { testRange } from "./test_range.ts";
-import { gt } from "./gt.ts";
+import { greaterThan } from "./greater_than.ts";
 
 /**
  * Returns the highest version in the list that satisfies the range, or `undefined`
@@ -17,7 +17,7 @@ export function maxSatisfying(
   let max;
   for (const version of versions) {
     if (!testRange(version, range)) continue;
-    max = max && gt(max, version) ? max : version;
+    max = max && greaterThan(max, version) ? max : version;
   }
   return max;
 }

--- a/semver/min_satisfying.ts
+++ b/semver/min_satisfying.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { testRange } from "./test_range.ts";
-import { lt } from "./lt.ts";
+import { lessThan } from "./less_than.ts";
 
 /**
  * Returns the lowest version in the list that satisfies the range, or `undefined` if
@@ -17,7 +17,7 @@ export function minSatisfying(
   let min;
   for (const version of versions) {
     if (!testRange(version, range)) continue;
-    min = min && lt(min, version) ? min : version;
+    min = min && lessThan(min, version) ? min : version;
   }
   return min;
 }

--- a/semver/outside.ts
+++ b/semver/outside.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { gt } from "./gt.ts";
-import { lt } from "./lt.ts";
+import { greaterThan } from "./greater_than.ts";
+import { lessThan } from "./less_than.ts";
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { rangeMax } from "./range_max.ts";
 import { rangeMin } from "./range_min.ts";
@@ -23,10 +23,11 @@ export function outside(
 ): boolean {
   switch (hilo) {
     case ">":
-      return gt(version, rangeMax(range));
+      return greaterThan(version, rangeMax(range));
     case "<":
-      return lt(version, rangeMin(range));
+      return lessThan(version, rangeMin(range));
     default:
-      return lt(version, rangeMin(range)) || gt(version, rangeMax(range));
+      return lessThan(version, rangeMin(range)) ||
+        greaterThan(version, rangeMax(range));
   }
 }

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -3,7 +3,7 @@ import { INVALID } from "./constants.ts";
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { testRange } from "./test_range.ts";
 import { comparatorMax } from "./comparator_max.ts";
-import { gt } from "./gt.ts";
+import { greaterThan } from "./greater_than.ts";
 
 /**
  * The maximum valid SemVer for a given range or INVALID
@@ -19,7 +19,7 @@ export function rangeMax(range: SemVerRange | Range): SemVer {
         comparator.operator,
       );
       if (!testRange(candidate, range)) continue;
-      max = (max && gt(max, candidate)) ? max : candidate;
+      max = (max && greaterThan(max, candidate)) ? max : candidate;
     }
   }
   return max ?? INVALID;

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -3,7 +3,7 @@ import { INVALID } from "./constants.ts";
 import type { Range, SemVer, SemVerRange } from "./types.ts";
 import { testRange } from "./test_range.ts";
 import { comparatorMin } from "./comparator_min.ts";
-import { lt } from "./lt.ts";
+import { lessThan } from "./less_than.ts";
 
 /**
  * The minimum valid SemVer for a given range or INVALID
@@ -19,7 +19,7 @@ export function rangeMin(range: SemVerRange | Range): SemVer {
         comparator.operator,
       );
       if (!testRange(candidate, range)) continue;
-      min = (min && lt(min, candidate)) ? min : candidate;
+      min = (min && lessThan(min, candidate)) ? min : candidate;
     }
   }
   return min ?? INVALID;

--- a/semver/range_min_test.ts
+++ b/semver/range_min_test.ts
@@ -2,7 +2,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert } from "../assert/mod.ts";
 import { format } from "./format.ts";
-import { eq } from "./eq.ts";
+import { equals } from "./equals.ts";
 import { parse } from "./parse.ts";
 import { parseRange } from "./parse_range.ts";
 import { rangeMin } from "./range_min.ts";
@@ -79,7 +79,7 @@ Deno.test({
         const range = parseRange(a);
         const version = typeof b === "string" ? parse(b) : b;
         const min = rangeMin(range);
-        assert(eq(min, version), `${format(min)} != ${format(version)}`);
+        assert(equals(min, version), `${format(min)} != ${format(version)}`);
       });
     }
   },
@@ -155,7 +155,7 @@ Deno.test({
         const range = parseRange(a);
         const version = typeof b === "string" ? parse(b) : b;
         const min = rangeMin({ ranges: range.ranges });
-        assert(eq(min, version), `${format(min)} != ${format(version)}`);
+        assert(equals(min, version), `${format(min)} != ${format(version)}`);
       });
     }
   },

--- a/semver/test_comparator.ts
+++ b/semver/test_comparator.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Comparator, SemVer } from "./types.ts";
-import { eq } from "./eq.ts";
-import { gt } from "./gt.ts";
-import { gte } from "./gte.ts";
-import { lt } from "./lt.ts";
-import { lte } from "./lte.ts";
-import { neq } from "./neq.ts";
+import { equals } from "./equals.ts";
+import { greaterThan } from "./greater_than.ts";
+import { greaterOrEqual } from "./greater_or_equal.ts";
+import { lessThan } from "./less_than.ts";
+import { lessOrEqual } from "./less_or_equal.ts";
+import { notEquals } from "./not_equals.ts";
 
 /**
  * Test to see if a semantic version falls within the range of the comparator.
@@ -24,18 +24,18 @@ export function testComparator(
     case "=":
     case "==":
     case "===":
-      return eq(version, comparator.semver ?? comparator);
+      return equals(version, comparator.semver ?? comparator);
     case "!=":
     case "!==":
-      return neq(version, comparator.semver ?? comparator);
+      return notEquals(version, comparator.semver ?? comparator);
     case ">":
-      return gt(version, comparator.semver ?? comparator);
+      return greaterThan(version, comparator.semver ?? comparator);
     case ">=":
-      return gte(version, comparator.semver ?? comparator);
+      return greaterOrEqual(version, comparator.semver ?? comparator);
     case "<":
-      return lt(version, comparator.semver ?? comparator);
+      return lessThan(version, comparator.semver ?? comparator);
     case "<=":
-      return lte(version, comparator.semver ?? comparator);
+      return lessOrEqual(version, comparator.semver ?? comparator);
     default:
       throw new TypeError(`Invalid operator: ${comparator.operator}`);
   }

--- a/semver/test_range.ts
+++ b/semver/test_range.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range, SemVer, SemVerRange } from "./types.ts";
-import { gte } from "./gte.ts";
-import { lte } from "./lte.ts";
+import { greaterOrEqual } from "./greater_or_equal.ts";
+import { lessOrEqual } from "./less_or_equal.ts";
 import { comparatorMin } from "./comparator_min.ts";
 import { comparatorMax } from "./comparator_max.ts";
 
@@ -18,8 +18,8 @@ export function testRange(
   for (const r of (Array.isArray(range) ? range : range.ranges)) {
     if (
       r.every((c) =>
-        gte(version, comparatorMin(c.semver ?? c, c.operator)) &&
-        lte(version, comparatorMax(c.semver ?? c, c.operator))
+        greaterOrEqual(version, comparatorMin(c.semver ?? c, c.operator)) &&
+        lessOrEqual(version, comparatorMax(c.semver ?? c, c.operator))
       )
     ) {
       return true;


### PR DESCRIPTION
This change removes the internal use of the deprecated `eq()`, `lt()`, `lte()`, `neq()`, `gt()` and `gte()` functions.

This will make the future removal PR cleaner.