### PR TITLE
chore(semver): postpone removal versions of some APIs

### DIFF
--- a/semver/eq.ts
+++ b/semver/eq.ts
@@ -5,7 +5,7 @@ import { SemVer } from "./types.ts";
 /**
  * Returns `true` if they're logically equivalent, even if they're not the exact same version object.
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode equals} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode equals} instead.
  */
 export function eq(s0: SemVer, s1: SemVer): boolean {
   return equals(s0, s1);

--- a/semver/gt.ts
+++ b/semver/gt.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Greater than comparison
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode greaterThan} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode greaterThan} instead.
  */
 export function gt(s0: SemVer, s1: SemVer): boolean {
   return greaterThan(s0, s1);

--- a/semver/gte.ts
+++ b/semver/gte.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Greater than or equal to comparison
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode greaterOrEqual} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode greaterOrEqual} instead.
  */
 export function gte(s0: SemVer, s1: SemVer): boolean {
   return greaterOrEqual(s0, s1);

--- a/semver/is_semver_range.ts
+++ b/semver/is_semver_range.ts
@@ -12,7 +12,7 @@ import { isComparator } from "./is_comparator.ts";
  * @param value The value to check if its a valid SemVerRange
  * @returns True if its a valid SemVerRange otherwise false.
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode isRange} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode isRange} instead.
  */
 export function isSemVerRange(value: unknown): value is SemVerRange {
   if (value === null || value === undefined) return false;

--- a/semver/lt.ts
+++ b/semver/lt.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Less than comparison
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode lessThan} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode lessThan} instead.
  */
 export function lt(s0: SemVer, s1: SemVer): boolean {
   return lessThan(s0, s1);

--- a/semver/lte.ts
+++ b/semver/lte.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Less than or equal to comparison
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode lessOrEqual} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode lessOrEqual} instead.
  */
 export function lte(s0: SemVer, s1: SemVer): boolean {
   return lessOrEqual(s0, s1);

--- a/semver/neq.ts
+++ b/semver/neq.ts
@@ -6,7 +6,7 @@ import { SemVer } from "./types.ts";
 /**
  * Not equal comparison
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode notEquals} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode notEquals} instead.
  */
 export function neq(s0: SemVer, s1: SemVer): boolean {
   return notEquals(s0, s1);

--- a/semver/outside.ts
+++ b/semver/outside.ts
@@ -14,7 +14,7 @@ import { rangeMin } from "./range_min.ts";
  * @param hilo The operator for the comparison or both if undefined.
  * @returns True if the version is outside of the range based on the operator
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode gtr}, {@linkcode ltr} or {@linkcode testRange} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode gtr}, {@linkcode ltr} or {@linkcode testRange} instead.
  */
 export function outside(
   version: SemVer,

--- a/semver/types.ts
+++ b/semver/types.ts
@@ -28,7 +28,7 @@ export type Operator = typeof OPERATORS[number];
 export interface Comparator extends SemVer {
   operator: Operator;
   /**
-   * @deprecated (will be removed in 0.215.0) {@linkcode Comparator} extends {@linkcode SemVer}. Use `major`, `minor`, `patch`, `prerelease`, and `build` properties instead.
+   * @deprecated (will be removed in 0.216.0) {@linkcode Comparator} extends {@linkcode SemVer}. Use `major`, `minor`, `patch`, `prerelease`, and `build` properties instead.
    */
   semver?: SemVer;
 }
@@ -56,7 +56,7 @@ export type Range = Comparator[][];
  * a nested array, which represents a set of OR comparisons while the
  * inner array represents AND comparisons.
  *
- * @deprecated (will be removed in 0.215.0) Use {@linkcode Range} instead.
+ * @deprecated (will be removed in 0.216.0) Use {@linkcode Range} instead.
  */
 export interface SemVerRange {
   // The outer array is OR while each inner array is AND


### PR DESCRIPTION
This change postpones the removal version of the following APIs from 0.215.0 to 0.216.0: `eq()`, `gt()`, `gte()`, `neq()`, `lt()`, `lte()`, `SemVerRange` and `isSemVerRange()`.

A removal version of 0.215.0 is too early, considering they were deprecated in 0.213.0.

CC @timreichen