### PR TITLE
deprecation(semver): deprecate `reverseSort()`

### DIFF
--- a/semver/reverse_sort.ts
+++ b/semver/reverse_sort.ts
@@ -1,10 +1,20 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { SemVer } from "./types.ts";
 import { compare } from "./compare.ts";
+import { warnOnDeprecatedApi } from "https://deno.land/std@$STD_VERSION/internal/warn_on_deprecated_api.ts";
 
-/** Sorts a list of semantic versions in descending order. */
+/**
+ * Sorts a list of semantic versions in descending order.
+ * @deprecated (will be removed in 0.217.0) Use `versions.sort((a, b) => compare(b, a))` instead.
+ */
 export function reverseSort(
   versions: SemVer[],
 ): SemVer[] {
+  warnOnDeprecatedApi({
+    apiName: "reverseSort",
+    stack: new Error().stack!,
+    removalVersion: "0.217.0",
+    suggestion: "Use `versions.sort((a, b) => compare(b, a))` instead.",
+  });
   return versions.sort((a, b) => compare(b, a));
 }

--- a/semver/reverse_sort.ts
+++ b/semver/reverse_sort.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { SemVer } from "./types.ts";
 import { compare } from "./compare.ts";
-import { warnOnDeprecatedApi } from "https://deno.land/std@$STD_VERSION/internal/warn_on_deprecated_api.ts";
 
 /**
  * Sorts a list of semantic versions in descending order.
@@ -10,11 +9,5 @@ import { warnOnDeprecatedApi } from "https://deno.land/std@$STD_VERSION/internal
 export function reverseSort(
   versions: SemVer[],
 ): SemVer[] {
-  warnOnDeprecatedApi({
-    apiName: "reverseSort",
-    stack: new Error().stack!,
-    removalVersion: "0.217.0",
-    suggestion: "Use `versions.sort((a, b) => compare(b, a))` instead.",
-  });
   return versions.sort((a, b) => compare(b, a));
 }


### PR DESCRIPTION
Deprecates `reverseSort()` function

This function seems like a really special user case and trivial by using `compare()`.

ref: https://github.com/denoland/deno_std/issues/3948