### PR TITLE
chore: publish workspace on tag push

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -3,6 +3,8 @@ name: workspace publish
 on:
   push:
     branches: [main, workspace_publish]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   DENO_UNSTABLE_WORKSPACES: true


### PR DESCRIPTION
This updates `workspace publish` workflow. Now the workflow is triggered by the push of tags, which should trigger `Publish (real)` step in it