### PR TITLE
docs(async): use `Array.fromAsync()` in `debounce()` example

### DIFF
--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -26,15 +26,12 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * ```
  * import { debounce } from "https://deno.land/std@$STD_VERSION/async/debounce.ts";
  *
- * const log = debounce(
- *   (event: Deno.FsEvent) =>
- *     console.log("[%s] %s", event.kind, event.paths[0]),
- *   200,
+ * Array.fromAsync(
+ *   Deno.watchFs('./'),
+ *   debounce((event) => {
+ *     console.log('[%s] %s', event.kind, event.paths[0]);
+ *   }, 200),
  * );
- *
- * for await (const event of Deno.watchFs("./")) {
- *   log(event);
- * }
  * // wait 200ms ...
  * // output: Function debounced after 200ms with baz
  * ```

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -26,7 +26,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * ```
  * import { debounce } from "https://deno.land/std@$STD_VERSION/async/debounce.ts";
  *
- * Array.fromAsync(
+ * await Array.fromAsync(
  *   Deno.watchFs('./'),
  *   debounce((event) => {
  *     console.log('[%s] %s', event.kind, event.paths[0]);


### PR DESCRIPTION
resolves #4282