### PR TITLE
feat(uuid): add type predicate return type to validate (v4)

### DIFF
--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -17,6 +17,8 @@ const UUID_RE =
  * validate("this-is-not-a-uuid"); // false
  * ```
  */
-export function validate(id: string): id is ReturnType<typeof crypto.randomUUID> {
+export function validate(
+  id: string,
+): id is ReturnType<typeof crypto.randomUUID> {
   return UUID_RE.test(id);
 }

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -17,6 +17,6 @@ const UUID_RE =
  * validate("this-is-not-a-uuid"); // false
  * ```
  */
-export function validate(id: string): boolean {
+export function validate(id: string): id is ReturnType<typeof crypto.randomUUID> {
   return UUID_RE.test(id);
 }


### PR DESCRIPTION
I added this so that one could use `validate` to actually narrow down a value for further usage at places where a v4 UUID is expected, like for example:

```ts
import { validate } from "std/uuid/v4";

const getUserByName = (name: string) => { /* ... */ };

const getUserById1 = (id: ReturnType<typeof crypto.randomUUID>) => { /* ... */ };

const getUserById2 = (id: `${string}-${string}-${string}-${string}-${string}`) => { /* ... */ };

// stupid unrealistic function but I hope you get the point
const getUser = (idOrName: string) => {
	if (validate(idOrName)) {
		// Without the change in this PR, TS/Deno will complain here with
		// "Argument of type 'string' is not assignable to parameter of type
		// '`${string}-${string}-${string}-${string}-${string}`'",
		// because the `validate` check above doesn't actually narrow it down for TS
		return [getUserById1(idOrName), getUserById2(idOrName)];
	}
	
	return getUserByName(idOrName);
};

```

I'm not actually writing in TypeScript often so I'm already sorry if I did something wrong here.

I know this is still not "exact", but the best we can do without regex types, I guess.