### PR TITLE
docs(fmt/colors): warn that `dim` is incompatible accross terminals

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -134,6 +134,11 @@ export function bold(str: string): string {
 /**
  * The text emits only a small amount of light.
  * @param str text to dim
+ *
+ * ## Warning
+ *
+ * Not all terminal emulators support `dim`.
+ * For compatibility, use {@linkcode gray} or {@linkcode brightBlack} instead.
  */
 export function dim(str: string): string {
   return run(str, code([2], 22));

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -135,9 +135,7 @@ export function bold(str: string): string {
  * The text emits only a small amount of light.
  * @param str text to dim
  *
- * ## Warning
- *
- * Not all terminal emulators support `dim`.
+ * Warning: Not all terminal emulators support `dim`.
  * For compatibility, use {@linkcode gray} or {@linkcode brightBlack} instead.
  */
 export function dim(str: string): string {

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -136,7 +136,7 @@ export function bold(str: string): string {
  * @param str text to dim
  *
  * Warning: Not all terminal emulators support `dim`.
- * For compatibility, use {@linkcode gray} or {@linkcode brightBlack} instead.
+ * For compatibility across all terminals, use {@linkcode gray} or {@linkcode brightBlack} instead.
  */
 export function dim(str: string): string {
   return run(str, code([2], 22));


### PR DESCRIPTION
- fixes #4296 