### PR TITLE
refactor(semver): simplify args for `comparatorMin()` and `comparatorMax()`

### DIFF
--- a/semver/_comparator_intersects.ts
+++ b/semver/_comparator_intersects.ts
@@ -14,10 +14,10 @@ export function comparatorIntersects(
   c0: Comparator,
   c1: Comparator,
 ): boolean {
-  const l0 = comparatorMin(c0.semver ?? c0, c0.operator);
-  const l1 = comparatorMax(c0.semver ?? c0, c0.operator);
-  const r0 = comparatorMin(c1.semver ?? c1, c1.operator);
-  const r1 = comparatorMax(c1.semver ?? c1, c1.operator);
+  const l0 = comparatorMin(c0);
+  const l1 = comparatorMax(c0);
+  const r0 = comparatorMin(c1);
+  const r1 = comparatorMax(c1);
 
   // We calculate the min and max ranges of both comparators.
   // The minimum min is 0.0.0, the maximum max is ANY.

--- a/semver/_comparator_max.ts
+++ b/semver/_comparator_max.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import type { Operator, SemVer } from "./types.ts";
+import type { Comparator, SemVer } from "./types.ts";
 import { ANY, INVALID, MAX } from "./constants.ts";
 
 /**
@@ -9,11 +9,10 @@ import { ANY, INVALID, MAX } from "./constants.ts";
  * an out of range semver will be returned.
  * @returns the version, the MAX version or the next smallest patch version
  */
-export function comparatorMax(semver: SemVer, operator: Operator): SemVer {
-  if (semver === ANY) {
-    return MAX;
-  }
-  switch (operator) {
+export function comparatorMax(comparator: Comparator): SemVer {
+  const semver = comparator.semver ?? comparator;
+  if (semver === ANY) return MAX;
+  switch (comparator.operator) {
     case "!=":
     case "!==":
     case ">":

--- a/semver/_comparator_min.ts
+++ b/semver/_comparator_min.ts
@@ -1,21 +1,19 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import type { Operator, SemVer } from "./types.ts";
+import type { Comparator, SemVer } from "./types.ts";
 import { ANY, MAX, MIN } from "./constants.ts";
 import { greaterThan } from "./greater_than.ts";
 import { increment } from "./increment.ts";
 
 /**
  * The minimum semantic version that could match this comparator
- * @param semver The semantic version of the comparator
+ * @param comparator The semantic version of the comparator
  * @param operator The operator of the comparator
  * @returns The minimum valid semantic version
  */
-export function comparatorMin(semver: SemVer, operator: Operator): SemVer {
-  if (semver === ANY) {
-    return MIN;
-  }
-
-  switch (operator) {
+export function comparatorMin(comparator: Comparator): SemVer {
+  const semver = comparator.semver ?? comparator;
+  if (semver === ANY) return MIN;
+  switch (comparator.operator) {
     case ">":
       return semver.prerelease && semver.prerelease.length > 0
         ? increment(semver, "pre")

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -14,10 +14,7 @@ export function rangeMax(range: Range): SemVer {
   let max;
   for (const comparators of range) {
     for (const comparator of comparators) {
-      const candidate = comparatorMax(
-        comparator.semver ?? comparator,
-        comparator.operator,
-      );
+      const candidate = comparatorMax(comparator);
       if (!testRange(candidate, range)) continue;
       max = (max && greaterThan(max, candidate)) ? max : candidate;
     }

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -14,10 +14,7 @@ export function rangeMin(range: Range): SemVer {
   let min;
   for (const comparators of range) {
     for (const comparator of comparators) {
-      const candidate = comparatorMin(
-        comparator.semver ?? comparator,
-        comparator.operator,
-      );
+      const candidate = comparatorMin(comparator);
       if (!testRange(candidate, range)) continue;
       min = (min && lessThan(min, candidate)) ? min : candidate;
     }

--- a/semver/test_range.ts
+++ b/semver/test_range.ts
@@ -18,8 +18,8 @@ export function testRange(
   for (const r of range) {
     if (
       r.every((c) =>
-        greaterOrEqual(version, comparatorMin(c.semver ?? c, c.operator)) &&
-        lessOrEqual(version, comparatorMax(c.semver ?? c, c.operator))
+        greaterOrEqual(version, comparatorMin(c)) &&
+        lessOrEqual(version, comparatorMax(c))
       )
     ) {
       return true;


### PR DESCRIPTION
This refactors `comparatorMin()` and `comparatorMax()` args so they take a `Comparator` instead of two separate args.