### PR TITLE
refactor(streams/to_text): use streaming for improved TextDecoder perf

### DIFF
--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -28,8 +28,11 @@ export async function toText(
       break;
     }
 
-    result += typeof value === "string" ? value : textDecoder.decode(value);
+    result += typeof value === "string"
+      ? value
+      : textDecoder.decode(value, { stream: true });
   }
 
+  textDecoder.decode();
   return result;
 }


### PR DESCRIPTION
This simple change leverages the `stream` option in the second parameter of `TextDecoder.decode`, to improve performance when calling the decode method multiple times in a row. It also adds an empty `.decode()` call outside of the loop to properly reset the internal buffer state of the decoder.

Thanks for your time!