### PR TITLE
docs(semver): fix arg names in jsdoc

### DIFF
--- a/semver/compare.ts
+++ b/semver/compare.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Compare two semantic version objects.
  *
- * Returns `0` if `v1 === v2`, or `1` if `v1` is greater, or `-1` if `v2` is
+ * Returns `0` if `s0 === s1`, or `1` if `s0` is greater, or `-1` if `s1` is
  * greater.
  *
  * Sorts in ascending order if passed to `Array.sort()`,


### PR DESCRIPTION
This PR fixes the arg names in jsdoc of `compare`. Currently the jsdoc and the function signature use different names for arguments, and they look confusing.

This change makes the following change in VS Code overlay view.

BEFORE
<img width="563" alt="Screenshot 2024-02-14 at 12 54 38" src="https://github.com/denoland/deno_std/assets/613956/43184664-2248-4367-b58b-6fe93e7c800a">

AFTER
<img width="561" alt="Screenshot 2024-02-14 at 12 54 02" src="https://github.com/denoland/deno_std/assets/613956/16f39bd8-9fa7-48dd-9dec-750b518863a5">
