### PR TITLE
chore(semver): align removal version of reverseSort to others

### DIFF
--- a/semver/reverse_sort.ts
+++ b/semver/reverse_sort.ts
@@ -4,7 +4,7 @@ import { compare } from "./compare.ts";
 
 /**
  * Sorts a list of semantic versions in descending order.
- * @deprecated (will be removed in 0.217.0) Use `versions.sort((a, b) => compare(b, a))` instead.
+ * @deprecated (will be removed after 0.217.0) Use `versions.sort((a, b) => compare(b, a))` instead.
  */
 export function reverseSort(
   versions: SemVer[],


### PR DESCRIPTION
This PR suggests to move the removal version of `reverseSort` to `after 0.217.0` to align it to other items (By this change, the users are exposed to the breaking changes less often. That will cause less frictions to the existing users of semver)