### PR TITLE
docs(media_types): fix erroneous docs in extensions_by_type.ts

### DIFF
--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -8,8 +8,6 @@ export { extensions };
 
 /**
  * Returns the extensions known to be associated with the media type `type`.
- * The returned extensions will each begin with a leading dot, as in `.html`.
- *
  * When `type` has no associated extensions, the function returns `undefined`.
  *
  * Extensions are returned without a leading `.`.


### PR DESCRIPTION
The function `extensionsByType` has conflicting information in its JSDoc comment on whether or not the returned extensions have a leading `.` in their names. They do not, in fact, have a leading dot. This PR updates the docs to accurately reflect that.