### PR TITLE
fix(media_types): load extensions when directly importing `extensionsByTypes()`

### DIFF
--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -3,6 +3,7 @@
 
 import { parseMediaType } from "./parse_media_type.ts";
 import { extensions } from "./_util.ts";
+import "./_db.ts";
 
 export { extensions };
 

--- a/media_types/extensions_by_type_test.ts
+++ b/media_types/extensions_by_type_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals } from "../assert/mod.ts";
-import { extensionsByType } from "./mod.ts";
+import { extensionsByType } from "./extensions_by_type.ts";
 
 Deno.test({
   name: "media_types - extensionsByType()",


### PR DESCRIPTION
`extensionsByTypes` always returns `undefined` when imported from `media_types/extensions_by_type_test.ts`.

This PR fixes it by importing `_db.ts` (`_db.ts` sets values in `extensions` Map object when imported).