### PR TITLE
chore(_tools): remove unneeded `--unstable` flag

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: deno fmt
 
       - name: Type check
-        run: deno test --unstable --no-run --doc
+        run: deno test --no-run --doc
 
       - name: Publish (dry run)
         if: startsWith(github.ref, 'refs/tags/') == false


### PR DESCRIPTION
Also avoids an unnecessary warning being printed in the terminal.