### PR TITLE
chore(crypto): move test scripts to own files

### DIFF
--- a/crypto/testdata/digest_large_inputs.ts
+++ b/crypto/testdata/digest_large_inputs.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { crypto as stdCrypto } from "../crypto.ts";
 import { instantiateWithInstance } from "../_wasm/lib/deno_std_wasm_crypto.generated.mjs";
 import { encodeHex } from "../../encoding/hex.ts";

--- a/crypto/testdata/digest_large_inputs.ts
+++ b/crypto/testdata/digest_large_inputs.ts
@@ -1,0 +1,27 @@
+import { crypto as stdCrypto } from "../crypto.ts";
+import { instantiateWithInstance } from "../_wasm/lib/deno_std_wasm_crypto.generated.mjs";
+import { encodeHex } from "../../encoding/hex.ts";
+
+const { memory } = instantiateWithInstance().instance.exports;
+
+const heapBytesInitial = memory.buffer.byteLength;
+
+const smallData = new Uint8Array(64);
+const smallDigest = encodeHex(
+  stdCrypto.subtle.digestSync("BLAKE3", smallData.buffer),
+);
+const heapBytesAfterSmall = memory.buffer.byteLength;
+
+const largeData = new Uint8Array(64_000_000);
+const largeDigest = encodeHex(
+  stdCrypto.subtle.digestSync("BLAKE3", largeData.buffer),
+);
+const heapBytesAfterLarge = memory.buffer.byteLength;
+
+console.log(JSON.stringify({
+  heapBytesInitial,
+  smallDigest,
+  heapBytesAfterSmall,
+  largeDigest,
+  heapBytesAfterLarge,
+}));

--- a/crypto/testdata/digest_many_calls.ts
+++ b/crypto/testdata/digest_many_calls.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { crypto as stdCrypto } from "../crypto.ts";
 import { instantiateWithInstance } from "../_wasm/lib/deno_std_wasm_crypto.generated.mjs";
 import { encodeHex } from "../../encoding/hex.ts";

--- a/crypto/testdata/digest_many_calls.ts
+++ b/crypto/testdata/digest_many_calls.ts
@@ -1,0 +1,25 @@
+import { crypto as stdCrypto } from "../crypto.ts";
+import { instantiateWithInstance } from "../_wasm/lib/deno_std_wasm_crypto.generated.mjs";
+import { encodeHex } from "../../encoding/hex.ts";
+
+const { memory } = instantiateWithInstance().instance.exports;
+
+const heapBytesInitial = memory.buffer.byteLength;
+
+let state = new ArrayBuffer(0);
+
+for (let i = 0; i < 1_000_000; i++) {
+  state = stdCrypto.subtle.digestSync({
+    name: "BLAKE3",
+  }, state);
+}
+
+const heapBytesFinal = memory.buffer.byteLength;
+
+const stateFinal = encodeHex(state);
+
+console.log(JSON.stringify({
+  heapBytesInitial,
+  heapBytesFinal,
+  stateFinal,
+}));


### PR DESCRIPTION
Fixes test cases in #4346 for `crypto/crypto_test.ts`. I can confirm that these tests pass after running the migration script.

These tests were previously failing because the migration script didn't factor in the inline code.