### PR TITLE
chore: use 'release' event for triggering jsr publish

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -2,9 +2,9 @@ name: workspace publish
 
 on:
   push:
-    branches: [main, workspace_publish]
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+    branches: [main]
+  release:
+    types: [published]
 
 env:
   DENO_UNSTABLE_WORKSPACES: true
@@ -37,9 +37,9 @@ jobs:
         run: deno test --no-run --doc
 
       - name: Publish (dry run)
-        if: startsWith(github.ref, 'refs/tags/') == false
+        if: github.event_name == 'push'
         run: deno publish --dry-run
 
       - name: Publish (real)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         run: deno publish


### PR DESCRIPTION
This updates `workspace publish` workflow.

This workflow wasn't triggered for the latest 2 tags for some reason (It was triggered for [0.215.0](https://github.com/denoland/deno_std/actions/runs/7827572342) though).

(This might be caused by the behavior described in [this page](https://stackoverflow.com/questions/57963374/github-actions-tag-filter-with-branch-filter), or by the misconfig of PAT)

This change uses `release` event (triggered when the github release is published) to avoid the above issue.