### PR TITLE
chore(semver): move breaking versions

### DIFF
--- a/semver/gtr.ts
+++ b/semver/gtr.ts
@@ -5,7 +5,7 @@ import { greaterThan } from "./greater_than.ts";
 
 /**
  * Checks to see if the version is greater than all possible versions of the range.
- * @deprecated (will be removed after 0.217.0) See
+ * @deprecated (will be removed in 0.219.0) See
  * {@link https://github.com/denoland/deno_std/issues/4273 | deno_std#4273}
  * for details.
  */

--- a/semver/ltr.ts
+++ b/semver/ltr.ts
@@ -5,7 +5,7 @@ import { rangeMin } from "./range_min.ts";
 
 /**
  *  Less than range comparison
- * @deprecated (will be removed after 0.217.0) See
+ * @deprecated (will be removed in 0.219.0) See
  * {@link https://github.com/denoland/deno_std/issues/4273 | deno_std#4273}
  * for details.
  */

--- a/semver/reverse_sort.ts
+++ b/semver/reverse_sort.ts
@@ -4,7 +4,7 @@ import { compare } from "./compare.ts";
 
 /**
  * Sorts a list of semantic versions in descending order.
- * @deprecated (will be removed after 0.217.0) Use `versions.sort((a, b) => compare(b, a))` instead.
+ * @deprecated (will be removed in 0.219.0) Use `versions.sort((a, b) => compare(b, a))` instead.
  */
 export function reverseSort(
   versions: SemVer[],

--- a/semver/types.ts
+++ b/semver/types.ts
@@ -29,7 +29,7 @@ export type Operator = typeof OPERATORS[number];
 export interface Comparator extends SemVer {
   operator?: Operator;
   /**
-   * @deprecated (will be removed after 0.217.0) {@linkcode Comparator} extends {@linkcode SemVer}. Use `major`, `minor`, `patch`, `prerelease`, and `build` properties instead.
+   * @deprecated (will be removed in 0.219.0) {@linkcode Comparator} extends {@linkcode SemVer}. Use `major`, `minor`, `patch`, `prerelease`, and `build` properties instead.
    */
   semver?: SemVer;
 }


### PR DESCRIPTION
Move the breaking versions of `gtr`, `ltr`, `reverseSort`, and `Comparator.semver` forward to align them to the breaking version of obsolete operators (https://github.com/denoland/deno_std/pull/4271)

Note: We might move these further if we decide to accept #4365