### PR TITLE
refactor(semver): rename `comparatorFormat()` to `formatComparator()`

### DIFF
--- a/semver/_format_comparator.ts
+++ b/semver/_format_comparator.ts
@@ -8,7 +8,7 @@ import { format } from "./format.ts";
  * @param comparator
  * @returns A string representation of the comparator
  */
-export function comparatorFormat(comparator: Comparator): string {
+export function formatComparator(comparator: Comparator): string {
   const { semver, operator } = comparator;
   return `${operator === undefined ? "" : operator}${
     format(semver ?? comparator)

--- a/semver/comparator_test.ts
+++ b/semver/comparator_test.ts
@@ -5,7 +5,7 @@ import { parseRange } from "./parse_range.ts";
 import { parse } from "./parse.ts";
 import { testRange } from "./test_range.ts";
 import { parseComparator } from "./_parse_comparator.ts";
-import { comparatorFormat } from "./_comparator_format.ts";
+import { formatComparator } from "./_format_comparator.ts";
 import { Comparator } from "./types.ts";
 
 Deno.test({
@@ -164,11 +164,11 @@ Deno.test({
 
 Deno.test("comparatorFormat() handles semver inheritance", function () {
   assertEquals(
-    comparatorFormat(parseComparator(">= v1.2.3")),
+    formatComparator(parseComparator(">= v1.2.3")),
     ">=1.2.3",
   );
   assertEquals(
-    comparatorFormat(parseComparator(">= v1.2.3-pre.1+b.2")),
+    formatComparator(parseComparator(">= v1.2.3-pre.1+b.2")),
     ">=1.2.3-pre.1+b.2",
   );
 });
@@ -176,7 +176,7 @@ Deno.test("comparatorFormat() handles semver inheritance", function () {
 Deno.test("comparatorFormat() handles deprecated Comparator.semver property", function () {
   const c1 = parseComparator(">= v1.2.3");
   assertEquals(
-    comparatorFormat(
+    formatComparator(
       { operator: c1.operator, semver: c1.semver } as Comparator,
     ),
     ">=1.2.3",
@@ -184,7 +184,7 @@ Deno.test("comparatorFormat() handles deprecated Comparator.semver property", fu
   const c2 = parseComparator(">= v1.2.3-pre.1+b.2");
 
   assertEquals(
-    comparatorFormat(
+    formatComparator(
       { operator: c2.operator, semver: c2.semver } as Comparator,
     ),
     ">=1.2.3-pre.1+b.2",

--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import type { Range } from "./types.ts";
-import { comparatorFormat } from "./_comparator_format.ts";
+import { formatComparator } from "./_format_comparator.ts";
 
 /**
  * Formats the range into a string
@@ -9,6 +9,6 @@ import { comparatorFormat } from "./_comparator_format.ts";
  * @returns A string representation of the range
  */
 export function formatRange(range: Range): string {
-  return range.map((c) => c.map((c) => comparatorFormat(c)).join(" "))
+  return range.map((c) => c.map((c) => formatComparator(c)).join(" "))
     .join("||");
 }


### PR DESCRIPTION
**Changes**
- renames `comparatorFormat()` to `formatComparator()`

**Reasons**
- javascript generally has a verb-first convention
- this aligns with `parseComparator()`
- this function and file are private, so no breaking changes