### PR TITLE
chore(semver): remove legacy `Range.ranges` object definition

### DIFF
--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -9,6 +9,5 @@ import { formatComparator } from "./_format_comparator.ts";
  * @returns A string representation of the range
  */
 export function formatRange(range: Range): string {
-  return range.map((c) => c.map((c) => formatComparator(c)).join(" "))
-    .join("||");
+  return range.map((c) => c.map(formatComparator).join(" ")).join("||");
 }

--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -9,5 +9,6 @@ import { formatComparator } from "./_format_comparator.ts";
  * @returns A string representation of the range
  */
 export function formatRange(range: Range): string {
-  return range.map((c) => c.map(formatComparator).join(" ")).join("||");
+  return range.map((c) => c.map((c) => formatComparator(c)).join(" "))
+    .join("||");
 }

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -279,5 +279,5 @@ export function parseRange(range: string): Range {
   const ranges = range
     .split(/\s*\|\|\s*/)
     .map((range) => parseHyphenRange(range).flatMap(parseRangeString));
-  return ranges as Range;
+  return ranges;
 }

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -279,6 +279,5 @@ export function parseRange(range: string): Range {
   const ranges = range
     .split(/\s*\|\|\s*/)
     .map((range) => parseHyphenRange(range).flatMap(parseRangeString));
-  Object.defineProperty(ranges, "ranges", { value: ranges });
   return ranges as Range;
 }


### PR DESCRIPTION
This was missed after the removal of `SemVerRange`.

Ref: https://github.com/denoland/deno_std/pull/4161