### PR TITLE
chore: fix .editorconfig syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.ts,*.js]
+[*.{ts,js}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
fix .editorconfig to make .js/.ts settings take effect.

Previously those settings were being ignored