### PR TITLE
Allow for asserting throws on async methods 

### DIFF
--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -3,15 +3,15 @@ import { assertIsError } from "./assert_is_error.ts";
 import { AssertionError } from "./assertion_error.ts";
 
 /**
- * Executes a function, expecting it to throw. If it does not, then it
+ * Executes an async function, expecting it to throw. If it does not, then it
  * throws.
  *
  * @example
  * ```ts
- * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ * import { assertThrowsAsync } from "https://deno.land/std@$STD_VERSION/assert/assert_throws_async.ts";
  *
- * assertThrows(() => { throw new TypeError("hello world!"); }); // Doesn't throw
- * assertThrows(() => console.log("hello world!")); // Throws
+ * await assertThrowsAsync(async () => { return await new Promise(() => { throw new TypeError("hello world!"); }) }); // Doesn't throw
+ * await assertThrowsAsync(async () => { return await new Promise(() => console.log("hello world!"))}); // Throws
  * ```
  */
 export function assertThrowsAsync(
@@ -19,7 +19,7 @@ export function assertThrowsAsync(
   msg?: string
 ): Promise<unknown>;
 /**
- * Executes a function, expecting it to throw. If it does not, then it
+ * Executes an async function, expecting it to throw. If it does not, then it
  * throws. An error class and a string that should be included in the
  * error message can also be asserted.
  *
@@ -27,8 +27,8 @@ export function assertThrowsAsync(
  * ```ts
  * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
  *
- * assertThrows(() => { throw new TypeError("hello world!"); }, TypeError); // Doesn't throw
- * assertThrows(() => { throw new TypeError("hello world!"); }, RangeError); // Throws
+ * await assertThrowsAsync(async () => { return await new Promise(() => { throw new TypeError("hello world!"); }) }, TypeError); // Doesn't throw
+ * await assertThrowsAsync(async () => { return await new Promise(() => { throw new TypeError("hello world!"); }) }, RangeError); // Throws
  * ```
  */
 export function assertThrowsAsync<E extends Error = Error>(

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -36,7 +36,7 @@ export function assertThrowsAsync<E extends Error = Error>(
   // deno-lint-ignore no-explicit-any
   ErrorClass: new (...args: any[]) => E,
   msgIncludes?: string,
-  msg?: string
+  msg?: string,
 ): Promise<E>;
 export async function assertThrowsAsync<E extends Error = Error>(
   fn: () => Promise<unknown>,

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -25,7 +25,7 @@ export function assertThrowsAsync(
  *
  * @example
  * ```ts
- * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ * import { assertThrowsAsync } from "https://deno.land/std@$STD_VERSION/assert/assert_throws_async.ts";
  *
  * await assertThrowsAsync(async () => { return await new Promise(() => { throw new TypeError("hello world!"); }) }, TypeError); // Doesn't throw
  * await assertThrowsAsync(async () => { return await new Promise(() => { throw new TypeError("hello world!"); }) }, RangeError); // Throws

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -16,7 +16,7 @@ import { AssertionError } from "./assertion_error.ts";
  */
 export function assertThrowsAsync(
   fn: () => Promise<unknown>,
-  msg?: string
+  msg?: string,
 ): Promise<unknown>;
 /**
  * Executes an async function, expecting it to throw. If it does not, then it
@@ -36,15 +36,15 @@ export function assertThrowsAsync<E extends Error = Error>(
   // deno-lint-ignore no-explicit-any
   ErrorClass: new (...args: any[]) => E,
   msgIncludes?: string,
-  msg?: string
+  msg?: string,
 ): Promise<E>;
 
 export async function assertThrowsAsync<E extends Error = Error>(
   fn: () => Promise<unknown>,
   errorClassOrMsg?: // deno-lint-ignore no-explicit-any
-  (new (...args: any[]) => E) | string,
+    (new (...args: any[]) => E) | string,
   msgIncludesOrMsg?: string,
-  msg?: string
+  msg?: string,
 ): Promise<E | Error | unknown> {
   // deno-lint-ignore no-explicit-any
   let ErrorClass: (new (...args: any[]) => E) | undefined = undefined;

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -14,7 +14,7 @@ import { AssertionError } from "./assertion_error.ts";
  * assertThrows(() => console.log("hello world!")); // Throws
  * ```
  */
-export function assertThrows(
+export function assertThrowsAsync(
   fn: () => Promise<unknown>,
   msg?: string
 ): Promise<unknown>;
@@ -31,14 +31,15 @@ export function assertThrows(
  * assertThrows(() => { throw new TypeError("hello world!"); }, RangeError); // Throws
  * ```
  */
-export function assertThrows<E extends Error = Error>(
+export function assertThrowsAsync<E extends Error = Error>(
   fn: () => Promise<unknown>,
   // deno-lint-ignore no-explicit-any
   ErrorClass: new (...args: any[]) => E,
   msgIncludes?: string,
   msg?: string
 ): Promise<E>;
-export async function assertThrows<E extends Error = Error>(
+
+export async function assertThrowsAsync<E extends Error = Error>(
   fn: () => Promise<unknown>,
   errorClassOrMsg?: // deno-lint-ignore no-explicit-any
   (new (...args: any[]) => E) | string,

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -36,9 +36,8 @@ export function assertThrowsAsync<E extends Error = Error>(
   // deno-lint-ignore no-explicit-any
   ErrorClass: new (...args: any[]) => E,
   msgIncludes?: string,
-  msg?: string,
+  msg?: string
 ): Promise<E>;
-
 export async function assertThrowsAsync<E extends Error = Error>(
   fn: () => Promise<unknown>,
   errorClassOrMsg?: // deno-lint-ignore no-explicit-any

--- a/assert/assert_throws_async.ts
+++ b/assert/assert_throws_async.ts
@@ -1,0 +1,87 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assertIsError } from "./assert_is_error.ts";
+import { AssertionError } from "./assertion_error.ts";
+
+/**
+ * Executes a function, expecting it to throw. If it does not, then it
+ * throws.
+ *
+ * @example
+ * ```ts
+ * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ *
+ * assertThrows(() => { throw new TypeError("hello world!"); }); // Doesn't throw
+ * assertThrows(() => console.log("hello world!")); // Throws
+ * ```
+ */
+export function assertThrows(
+  fn: () => Promise<unknown>,
+  msg?: string
+): Promise<unknown>;
+/**
+ * Executes a function, expecting it to throw. If it does not, then it
+ * throws. An error class and a string that should be included in the
+ * error message can also be asserted.
+ *
+ * @example
+ * ```ts
+ * import { assertThrows } from "https://deno.land/std@$STD_VERSION/assert/assert_throws.ts";
+ *
+ * assertThrows(() => { throw new TypeError("hello world!"); }, TypeError); // Doesn't throw
+ * assertThrows(() => { throw new TypeError("hello world!"); }, RangeError); // Throws
+ * ```
+ */
+export function assertThrows<E extends Error = Error>(
+  fn: () => Promise<unknown>,
+  // deno-lint-ignore no-explicit-any
+  ErrorClass: new (...args: any[]) => E,
+  msgIncludes?: string,
+  msg?: string
+): Promise<E>;
+export async function assertThrows<E extends Error = Error>(
+  fn: () => Promise<unknown>,
+  errorClassOrMsg?: // deno-lint-ignore no-explicit-any
+  (new (...args: any[]) => E) | string,
+  msgIncludesOrMsg?: string,
+  msg?: string
+): Promise<E | Error | unknown> {
+  // deno-lint-ignore no-explicit-any
+  let ErrorClass: (new (...args: any[]) => E) | undefined = undefined;
+  let msgIncludes: string | undefined = undefined;
+  let err;
+
+  if (typeof errorClassOrMsg !== "string") {
+    if (
+      errorClassOrMsg === undefined ||
+      errorClassOrMsg.prototype instanceof Error ||
+      errorClassOrMsg.prototype === Error.prototype
+    ) {
+      // deno-lint-ignore no-explicit-any
+      ErrorClass = errorClassOrMsg as new (...args: any[]) => E;
+      msgIncludes = msgIncludesOrMsg;
+    } else {
+      msg = msgIncludesOrMsg;
+    }
+  } else {
+    msg = errorClassOrMsg;
+  }
+  let doesThrow = false;
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  try {
+    await fn();
+  } catch (error) {
+    if (ErrorClass) {
+      if (error instanceof Error === false) {
+        throw new AssertionError(`A non-Error object was thrown${msgSuffix}`);
+      }
+      assertIsError(error, ErrorClass, msgIncludes, msg);
+    }
+    err = error;
+    doesThrow = true;
+  }
+  if (!doesThrow) {
+    msg = `Expected function to throw${msgSuffix}`;
+    throw new AssertionError(msg);
+  }
+  return err;
+}

--- a/assert/assert_throws_async_test.ts
+++ b/assert/assert_throws_async_test.ts
@@ -21,13 +21,13 @@ Deno.test(
             });
           },
           TypeError,
-          "Failed assertion: foo"
+          "Failed assertion: foo",
         );
       },
       AssertionError,
-      `Expected error to be instance of "TypeError", but was "AssertionError"`
+      `Expected error to be instance of "TypeError", but was "AssertionError"`,
     );
-  }
+  },
 );
 
 Deno.test("assertThrows() changes its return type by parameter", async () => {
@@ -50,18 +50,18 @@ Deno.test(
             });
           },
           Error,
-          "Panic!"
+          "Panic!",
         );
       },
       AssertionError,
-      "A non-Error object was thrown."
+      "A non-Error object was thrown.",
     );
-  }
+  },
 );
 
 Deno.test("assertThrows() matches thrown non-error value", async () => {
   await await assertThrowsAsync(async () => {
-    return new Promise(() => {
+    return await new Promise(() => {
       throw "Panic!";
     });
   });
@@ -89,9 +89,9 @@ Deno.test(
         });
       },
       Error,
-      "foo"
+      "foo",
     );
-  }
+  },
 );
 
 Deno.test("assertThrows() matches and returns thrown error value", async () => {
@@ -145,6 +145,6 @@ Deno.test("assertThrows() matches subclass of expected error", async () => {
       });
     },
     Error,
-    "Fail!"
+    "Fail!",
   );
 });

--- a/assert/assert_throws_async_test.ts
+++ b/assert/assert_throws_async_test.ts
@@ -1,0 +1,150 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import {
+  assert,
+  assertEquals,
+  AssertionError,
+  assertThrowsAsync,
+  fail,
+} from "./mod.ts";
+
+Deno.test(
+  "assertThrowsAsync() throws when thrown error class does not match expected",
+  async () => {
+    await assertThrowsAsync(
+      async () => {
+        //This next assertThrows will throw an AssertionError due to the wrong
+        //expected error class
+        await assertThrowsAsync(
+          async () => {
+            return await new Promise(() => {
+              fail("foo");
+            });
+          },
+          TypeError,
+          "Failed assertion: foo"
+        );
+      },
+      AssertionError,
+      `Expected error to be instance of "TypeError", but was "AssertionError"`
+    );
+  }
+);
+
+Deno.test("assertThrows() changes its return type by parameter", async () => {
+  await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw new Error();
+    });
+  });
+});
+
+Deno.test(
+  "assertThrows() throws when error class is expected but non-error value is thrown",
+  async () => {
+    await assertThrowsAsync(
+      async () => {
+        await assertThrowsAsync(
+          async () => {
+            return await new Promise(() => {
+              throw "Panic!";
+            });
+          },
+          Error,
+          "Panic!"
+        );
+      },
+      AssertionError,
+      "A non-Error object was thrown."
+    );
+  }
+);
+
+Deno.test("assertThrows() matches thrown non-error value", async () => {
+  await await assertThrowsAsync(async () => {
+    return new Promise(() => {
+      throw "Panic!";
+    });
+  });
+
+  await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw null;
+    });
+  });
+
+  await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw undefined;
+    });
+  });
+});
+
+Deno.test(
+  "assertThrows() matches thrown error with given error class",
+  async () => {
+    await assertThrowsAsync(
+      async () => {
+        return await new Promise(() => {
+          throw new Error("foo");
+        });
+      },
+      Error,
+      "foo"
+    );
+  }
+);
+
+Deno.test("assertThrows() matches and returns thrown error value", async () => {
+  const error = await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw new Error("foo");
+    });
+  });
+  assert(error instanceof Error);
+  assertEquals(error.message, "foo");
+});
+
+Deno.test("assertThrows() matches and returns thrown non-error", async () => {
+  const stringError = await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw "Panic!";
+    });
+  });
+  assert(typeof stringError === "string");
+  assertEquals(stringError, "Panic!");
+
+  const numberError = await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw 1;
+    });
+  });
+  assert(typeof numberError === "number");
+  assertEquals(numberError, 1);
+
+  const nullError = await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw null;
+    });
+  });
+  assert(nullError === null);
+
+  const undefinedError = await assertThrowsAsync(async () => {
+    return await new Promise(() => {
+      throw undefined;
+    });
+  });
+  assert(typeof undefinedError === "undefined");
+  assertEquals(undefinedError, undefined);
+});
+
+Deno.test("assertThrows() matches subclass of expected error", async () => {
+  await assertThrowsAsync(
+    async () => {
+      return await new Promise(() => {
+        throw new AssertionError("Fail!");
+      });
+    },
+    Error,
+    "Fail!"
+  );
+});

--- a/assert/mod.ts
+++ b/assert/mod.ts
@@ -31,6 +31,7 @@ export * from "./assert_rejects.ts";
 export * from "./assert_strict_equals.ts";
 export * from "./assert_string_includes.ts";
 export * from "./assert_throws.ts";
+export * from "./assert_throws_async.ts";
 export * from "./assert.ts";
 export * from "./assertion_error.ts";
 export * from "./equal.ts";


### PR DESCRIPTION
We ran into a use case where we need to be able to assert throws from an async function. I was unable to figure out how to do this with existing assert throws, so added this implementation.