### PR TITLE
docs: ignore bad snippet examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Check out the documentation [here](https://deno.land/std?doc).
    intended for public use).
 
    Bad:
-   ```ts
+   ```ts, ignore
    import { _format } from "https://deno.land/std@$STD_VERSION/path/_common/format.ts";
    ```
 
@@ -57,7 +57,7 @@ Check out the documentation [here](https://deno.land/std?doc).
    underscore (they're not intended for public use).
 
    Bad:
-   ```ts
+   ```ts, ignore
    import { createLPS } from "https://deno.land/std@$STD_VERSION/streams/_common.ts";
    ```
 


### PR DESCRIPTION
These snippets are deliberately bad and should be ignored.

Fixes https://github.com/denoland/deno_std/actions/runs/8041176789/job/21960124528