### PR TITLE
chore(log): sync `level` and `levelName` in BaseHandler

### DIFF
--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -11,7 +11,7 @@ export interface BaseHandlerOptions {
 }
 
 export class BaseHandler {
-  #logLevel: LevelName;
+  #levelName: LevelName;
   #level: LogLevel;
   formatter: FormatterFunction;
 
@@ -19,7 +19,7 @@ export class BaseHandler {
     levelName: LevelName,
     { formatter = DEFAULT_FORMATTER }: BaseHandlerOptions = {},
   ) {
-    this.#logLevel = levelName;
+    this.#levelName = levelName;
     this.#level = getLevelByName(levelName);
     this.formatter = formatter;
   }
@@ -29,14 +29,14 @@ export class BaseHandler {
   }
   set level(level: LogLevel) {
     this.#level = level;
-    this.#logLevel = getLevelName(level);
+    this.#levelName = getLevelName(level);
   }
 
   get levelName() {
-    return this.#logLevel;
+    return this.#levelName;
   }
   set levelName(levelName: LevelName) {
-    this.#logLevel = levelName;
+    this.#levelName = levelName;
     this.#level = getLevelByName(levelName);
   }
 

--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -11,22 +11,33 @@ export interface BaseHandlerOptions {
 }
 
 export class BaseHandler {
-  level: LogLevel;
+  #logLevel: LevelName;
+  #level: LogLevel;
   formatter: FormatterFunction;
 
   constructor(
     levelName: LevelName,
     { formatter = DEFAULT_FORMATTER }: BaseHandlerOptions = {},
   ) {
-    this.level = getLevelByName(levelName);
+    this.#logLevel = levelName;
+    this.#level = getLevelByName(levelName);
     this.formatter = formatter;
   }
 
-  get levelName() {
-    return getLevelName(this.level);
+  get level() {
+    return this.#level;
   }
-  set levelName(value: LevelName) {
-    this.level = getLevelByName(value);
+  set level(level: LogLevel) {
+    this.#level = level;
+    this.#logLevel = getLevelName(level);
+  }
+
+  get levelName() {
+    return this.#logLevel;
+  }
+  set levelName(levelName: LevelName) {
+    this.#logLevel = levelName;
+    this.#level = getLevelByName(levelName);
   }
 
   handle(logRecord: LogRecord) {

--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { getLevelByName, LevelName } from "./levels.ts";
+import { getLevelByName, getLevelName, LevelName, LogLevel } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 
 export type FormatterFunction = (logRecord: LogRecord) => string;
@@ -11,14 +11,22 @@ export interface BaseHandlerOptions {
 }
 
 export class BaseHandler {
-  level: number;
-  levelName: LevelName;
+  level: LogLevel;
   formatter: FormatterFunction;
 
-  constructor(levelName: LevelName, options: BaseHandlerOptions = {}) {
+  constructor(
+    levelName: LevelName,
+    { formatter = DEFAULT_FORMATTER }: BaseHandlerOptions = {},
+  ) {
     this.level = getLevelByName(levelName);
-    this.levelName = levelName;
-    this.formatter = options.formatter || DEFAULT_FORMATTER;
+    this.formatter = formatter;
+  }
+
+  get levelName() {
+    return getLevelName(this.level);
+  }
+  set levelName(value: LevelName) {
+    this.level = getLevelByName(value);
   }
 
   handle(logRecord: LogRecord) {


### PR DESCRIPTION
**Changes**
- makes `levelName` a getter and setter so it stays in sync with `level`.
- small cleanup with `options` in `constructor()`.

**Reasons**
- makes `levelName` and `level` should never get out of sync.
- avoids `||` operator by setting default formatter value.