### PR TITLE
chore(log): format test names

### DIFF
--- a/log/base_handler_test.ts
+++ b/log/base_handler_test.ts
@@ -18,7 +18,7 @@ class TestHandler extends BaseHandler {
   }
 }
 
-Deno.test("BaseHandler() handles default setup", function () {
+Deno.test("BaseHandler handles default setup", function () {
   const cases = new Map<LogLevel, string[]>([
     [
       LogLevels.DEBUG,
@@ -69,7 +69,7 @@ Deno.test("BaseHandler() handles default setup", function () {
   }
 });
 
-Deno.test("BaseHandler() handles formatter with empty msg", function () {
+Deno.test("BaseHandler handles formatter with empty msg", function () {
   const handler = new TestHandler("DEBUG", {
     formatter: ({ levelName, msg }) => `test ${levelName} ${msg}`,
   });
@@ -86,7 +86,7 @@ Deno.test("BaseHandler() handles formatter with empty msg", function () {
   assertEquals(handler.messages, ["test DEBUG "]);
 });
 
-Deno.test("BaseHandler() handles formatter", function () {
+Deno.test("BaseHandler handles formatter", function () {
   const handler = new TestHandler("DEBUG", {
     formatter: (logRecord): string =>
       `fn formatter ${logRecord.levelName} ${logRecord.msg}`,

--- a/log/base_handler_test.ts
+++ b/log/base_handler_test.ts
@@ -18,7 +18,7 @@ class TestHandler extends BaseHandler {
   }
 }
 
-Deno.test("simpleHandler", function () {
+Deno.test("BaseHandler() handles default setup", function () {
   const cases = new Map<LogLevel, string[]>([
     [
       LogLevels.DEBUG,
@@ -69,7 +69,7 @@ Deno.test("simpleHandler", function () {
   }
 });
 
-Deno.test("testFormatterWithEmptyMsg", function () {
+Deno.test("BaseHandler() handles formatter with empty msg", function () {
   const handler = new TestHandler("DEBUG", {
     formatter: ({ levelName, msg }) => `test ${levelName} ${msg}`,
   });
@@ -86,7 +86,7 @@ Deno.test("testFormatterWithEmptyMsg", function () {
   assertEquals(handler.messages, ["test DEBUG "]);
 });
 
-Deno.test("testFormatterAsFunction", function () {
+Deno.test("BaseHandler() handles formatter", function () {
   const handler = new TestHandler("DEBUG", {
     formatter: (logRecord): string =>
       `fn formatter ${logRecord.levelName} ${logRecord.msg}`,

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -7,7 +7,7 @@ import { LogRecord } from "./logger.ts";
 const LOG_FILE = "./file_handler_test_log.file";
 
 Deno.test({
-  name: "FileHandler Shouldn't Have Broken line",
+  name: "FileHandler() doesn't have broken line",
   fn() {
     class TestFileHandler extends FileHandler {
       override flush() {
@@ -44,7 +44,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler with mode 'w' will wipe clean existing log file",
+  name: "FileHandler() wipes existing log file clean with mode 'w'",
   async fn() {
     const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -81,7 +81,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler with mode 'x' will throw if log file already exists",
+  name: "FileHandler() throws if log file already exists with mode 'x'",
   fn() {
     using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -98,7 +98,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Window unload flushes buffer",
+  name: "FileHandler() flushes buffer on unload",
   async fn() {
     const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -124,7 +124,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler: Critical logs trigger immediate flush",
+  name: "FileHandler() triggers immediate flush on critical logs",
   async fn() {
     using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -7,7 +7,7 @@ import { LogRecord } from "./logger.ts";
 const LOG_FILE = "./file_handler_test_log.file";
 
 Deno.test({
-  name: "FileHandler() doesn't have broken line",
+  name: "FileHandler doesn't have broken line",
   fn() {
     class TestFileHandler extends FileHandler {
       override flush() {
@@ -44,7 +44,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler() wipes existing log file clean with mode 'w'",
+  name: "FileHandler wipes existing log file clean with mode 'w'",
   async fn() {
     const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -81,7 +81,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler() throws if log file already exists with mode 'x'",
+  name: "FileHandler throws if log file already exists with mode 'x'",
   fn() {
     using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -98,7 +98,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler() flushes buffer on unload",
+  name: "FileHandler flushes buffer on unload",
   async fn() {
     const fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,
@@ -124,7 +124,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "FileHandler() triggers immediate flush on critical logs",
+  name: "FileHandler triggers immediate flush on critical logs",
   async fn() {
     using fileHandler = new FileHandler("WARN", {
       filename: LOG_FILE,

--- a/log/formatters_test.ts
+++ b/log/formatters_test.ts
@@ -12,7 +12,7 @@ const log = (msg: string, args: unknown[] = []) =>
     loggerName: "user-logger",
   });
 
-Deno.test("jsonFormatter with just a message", function () {
+Deno.test("jsonFormatter handles messages without arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(
@@ -21,7 +21,7 @@ Deno.test("jsonFormatter with just a message", function () {
   );
 });
 
-Deno.test("jsonFormatter with one argument", function () {
+Deno.test("jsonFormatter handles messages with one arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(
@@ -30,7 +30,7 @@ Deno.test("jsonFormatter with one argument", function () {
   );
 });
 
-Deno.test("jsonFormatter with many arguments", function () {
+Deno.test("jsonFormatter handles messages with many arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(

--- a/log/formatters_test.ts
+++ b/log/formatters_test.ts
@@ -12,7 +12,7 @@ const log = (msg: string, args: unknown[] = []) =>
     loggerName: "user-logger",
   });
 
-Deno.test("jsonFormatter handles messages without arguments", function () {
+Deno.test("jsonFormatter() handles messages without arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(
@@ -21,7 +21,7 @@ Deno.test("jsonFormatter handles messages without arguments", function () {
   );
 });
 
-Deno.test("jsonFormatter handles messages with one arguments", function () {
+Deno.test("jsonFormatter() handles messages with one arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(
@@ -30,7 +30,7 @@ Deno.test("jsonFormatter handles messages with one arguments", function () {
   );
 });
 
-Deno.test("jsonFormatter handles messages with many arguments", function () {
+Deno.test("jsonFormatter() handles messages with many arguments", function () {
   using _time = new FakeTime(1);
 
   assertEquals(

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -19,7 +19,7 @@ class TestHandler extends BaseHandler {
 }
 
 Deno.test({
-  name: "Logger names can be output in logs",
+  name: "Logger() handles formatter option",
   fn() {
     const handlerNoName = new TestHandler("DEBUG");
     const handlerWithLoggerName = new TestHandler("DEBUG", {
@@ -36,7 +36,7 @@ Deno.test({
   },
 });
 
-Deno.test("simpleLogger", function () {
+Deno.test("Logger() handles handlers option", () => {
   const handler = new TestHandler("DEBUG");
   let logger = new Logger("default", "DEBUG");
 
@@ -49,7 +49,7 @@ Deno.test("simpleLogger", function () {
   assertEquals(logger.handlers, [handler]);
 });
 
-Deno.test("customHandler", function () {
+Deno.test("Logger() handles custom handler", () => {
   const handler = new TestHandler("DEBUG");
   const logger = new Logger("default", "DEBUG", { handlers: [handler] });
 
@@ -65,7 +65,7 @@ Deno.test("customHandler", function () {
   assertEquals(inlineData!, "foo");
 });
 
-Deno.test("logFunctions", function () {
+Deno.test("Logger() handles log functions", () => {
   const doLog = (level: LevelName): TestHandler => {
     const handler = new TestHandler(level);
     const logger = new Logger("default", level, { handlers: [handler] });
@@ -116,8 +116,8 @@ Deno.test("logFunctions", function () {
 });
 
 Deno.test(
-  "String resolver fn will not execute if msg will not be logged",
-  function () {
+  "Logger() handles function argument without resolution",
+  () => {
     const handler = new TestHandler("ERROR");
     const logger = new Logger("default", "ERROR", { handlers: [handler] });
     let called = false;
@@ -137,7 +137,7 @@ Deno.test(
   },
 );
 
-Deno.test("String resolver fn resolves as expected", function () {
+Deno.test("Logger() handles function argument with resolution", () => {
   const handler = new TestHandler("ERROR");
   const logger = new Logger("default", "ERROR", { handlers: [handler] });
   const expensiveFunction = (x: number): string => {
@@ -151,8 +151,8 @@ Deno.test("String resolver fn resolves as expected", function () {
 });
 
 Deno.test(
-  "All types map correctly to log strings and are returned as is",
-  function () {
+  "Logger() handles log function return types",
+  () => {
     const handler = new TestHandler("DEBUG");
     const logger = new Logger("default", "DEBUG", { handlers: [handler] });
     const sym = Symbol();

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -19,7 +19,7 @@ class TestHandler extends BaseHandler {
 }
 
 Deno.test({
-  name: "Logger() handles formatter option",
+  name: "Logger handles formatter option",
   fn() {
     const handlerNoName = new TestHandler("DEBUG");
     const handlerWithLoggerName = new TestHandler("DEBUG", {
@@ -36,7 +36,7 @@ Deno.test({
   },
 });
 
-Deno.test("Logger() handles handlers option", () => {
+Deno.test("Logger handles handlers option", () => {
   const handler = new TestHandler("DEBUG");
   let logger = new Logger("default", "DEBUG");
 
@@ -49,7 +49,7 @@ Deno.test("Logger() handles handlers option", () => {
   assertEquals(logger.handlers, [handler]);
 });
 
-Deno.test("Logger() handles custom handler", () => {
+Deno.test("Logger handles custom handler", () => {
   const handler = new TestHandler("DEBUG");
   const logger = new Logger("default", "DEBUG", { handlers: [handler] });
 
@@ -65,7 +65,7 @@ Deno.test("Logger() handles custom handler", () => {
   assertEquals(inlineData!, "foo");
 });
 
-Deno.test("Logger() handles log functions", () => {
+Deno.test("Logger handles log functions", () => {
   const doLog = (level: LevelName): TestHandler => {
     const handler = new TestHandler(level);
     const logger = new Logger("default", level, { handlers: [handler] });
@@ -116,7 +116,7 @@ Deno.test("Logger() handles log functions", () => {
 });
 
 Deno.test(
-  "Logger() handles function argument without resolution",
+  "Logger handles function argument without resolution",
   () => {
     const handler = new TestHandler("ERROR");
     const logger = new Logger("default", "ERROR", { handlers: [handler] });
@@ -137,7 +137,7 @@ Deno.test(
   },
 );
 
-Deno.test("Logger() handles function argument with resolution", () => {
+Deno.test("Logger handles function argument with resolution", () => {
   const handler = new TestHandler("ERROR");
   const logger = new Logger("default", "ERROR", { handlers: [handler] });
   const expensiveFunction = (x: number): string => {
@@ -151,7 +151,7 @@ Deno.test("Logger() handles function argument with resolution", () => {
 });
 
 Deno.test(
-  "Logger() handles log function return types",
+  "Logger handles log function return types",
   () => {
     const handler = new TestHandler("DEBUG");
     const logger = new Logger("default", "DEBUG", { handlers: [handler] });

--- a/log/mod_test.ts
+++ b/log/mod_test.ts
@@ -31,7 +31,7 @@ try {
   // Pass
 }
 
-Deno.test("logger is initialized", function () {
+Deno.test("getLogger() initializes logger", function () {
   assert(logger instanceof Logger);
 });
 
@@ -60,7 +60,7 @@ Deno.test("default loggers work as expected", function () {
 });
 
 Deno.test({
-  name: "Logging config works as expected with logger names",
+  name: "setup() logging config works as expected with logger names",
   async fn() {
     const consoleHandler = new TestHandler("DEBUG");
     const anotherConsoleHandler = new TestHandler("DEBUG", {
@@ -94,7 +94,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Loggers have level and levelName to get/set loglevels",
+  name: "setup() loggers have level and levelName to get and set loglevels",
   async fn() {
     const testHandler = new TestHandler("DEBUG");
     await setup({
@@ -149,7 +149,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Loggers have loggerName to get logger name",
+  name: "setup() checks loggerName of loggers",
   async fn() {
     const testHandler = new TestHandler("DEBUG");
     await setup({
@@ -177,7 +177,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Logger has mutable handlers",
+  name: "setup() checks if logger has mutable handlers",
   async fn() {
     const testHandlerA = new TestHandler("DEBUG");
     const testHandlerB = new TestHandler("DEBUG");

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -14,7 +14,7 @@ const LOG_FILE = "./rotating_file_handler_test_log.file";
 
 Deno.test({
   name:
-    "RotatingFileHandler() wipes existing log file clean and removes others with mode 'w'",
+    "RotatingFileHandler wipes existing log file clean and removes others with mode 'w'",
   async fn() {
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("hello world"));
     Deno.writeFileSync(
@@ -50,7 +50,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "RotatingFileHandler() throws if any log file already exists with mode 'x'",
+    "RotatingFileHandler throws if any log file already exists with mode 'x'",
   fn() {
     Deno.writeFileSync(
       LOG_FILE + ".3",
@@ -76,7 +76,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler() handles first rollover, monitor step by step",
+  name: "RotatingFileHandler handles first rollover, monitor step by step",
   async fn() {
     using fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
@@ -125,7 +125,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler() handles first rollover, check all at once",
+  name: "RotatingFileHandler handles first rollover, check all at once",
   async fn() {
     const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
@@ -171,7 +171,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler() handles all backups rollover",
+  name: "RotatingFileHandler handles all backups rollover",
   fn() {
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("original log file"));
     Deno.writeFileSync(
@@ -228,7 +228,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler() handles maxBytes less than 1",
+  name: "RotatingFileHandler handles maxBytes less than 1",
   fn() {
     assertThrows(
       () => {
@@ -266,7 +266,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler() rotates on byte length, not msg length",
+  name: "RotatingFileHandler rotates on byte length, not msg length",
   async fn() {
     const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -14,7 +14,7 @@ const LOG_FILE = "./rotating_file_handler_test_log.file";
 
 Deno.test({
   name:
-    "RotatingFileHandler with mode 'w' will wipe clean existing log file and remove others",
+    "RotatingFileHandler() wipes existing log file clean and removes others with mode 'w'",
   async fn() {
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("hello world"));
     Deno.writeFileSync(
@@ -50,7 +50,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "RotatingFileHandler with mode 'x' will throw if any log file already exists",
+    "RotatingFileHandler() throws if any log file already exists with mode 'x'",
   fn() {
     Deno.writeFileSync(
       LOG_FILE + ".3",
@@ -76,7 +76,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler with first rollover, monitor step by step",
+  name: "RotatingFileHandler() handles first rollover, monitor step by step",
   async fn() {
     using fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
@@ -125,7 +125,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler with first rollover, check all at once",
+  name: "RotatingFileHandler() handles first rollover, check all at once",
   async fn() {
     const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,
@@ -171,7 +171,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler with all backups rollover",
+  name: "RotatingFileHandler() handles all backups rollover",
   fn() {
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("original log file"));
     Deno.writeFileSync(
@@ -228,7 +228,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler maxBytes cannot be less than 1",
+  name: "RotatingFileHandler() handles maxBytes less than 1",
   fn() {
     assertThrows(
       () => {
@@ -247,7 +247,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler maxBackupCount cannot be less than 1",
+  name: "RotatingFileHandler handles maxBackupCount less than 1",
   fn() {
     assertThrows(
       () => {
@@ -266,7 +266,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "RotatingFileHandler: rotate on byte length, not msg length",
+  name: "RotatingFileHandler() rotates on byte length, not msg length",
   async fn() {
     const fileHandler = new RotatingFileHandler("WARN", {
       filename: LOG_FILE,

--- a/log/test.ts
+++ b/log/test.ts
@@ -17,7 +17,7 @@ class TestHandler extends log.BaseHandler {
   }
 }
 
-Deno.test("defaultHandlers", async function () {
+Deno.test("setup() handles default handlers", async function () {
   const loggers: {
     [key: string]: (msg: string, ...args: unknown[]) => void;
   } = {
@@ -55,7 +55,7 @@ Deno.test("defaultHandlers", async function () {
   }
 });
 
-Deno.test("getLogger", async function () {
+Deno.test("getLogger()", async function () {
   const handler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -76,7 +76,7 @@ Deno.test("getLogger", async function () {
   assertEquals(logger.handlers, [handler]);
 });
 
-Deno.test("getLoggerWithName", async function () {
+Deno.test("getLogger() handles name", async function () {
   const fooHandler = new TestHandler("DEBUG");
 
   await log.setup({
@@ -97,7 +97,7 @@ Deno.test("getLoggerWithName", async function () {
   assertEquals(logger.handlers, [fooHandler]);
 });
 
-Deno.test("getLoggerUnknown", async function () {
+Deno.test("getLogger() habndles unknown", async function () {
   await log.setup({
     handlers: {},
     loggers: {},
@@ -109,7 +109,7 @@ Deno.test("getLoggerUnknown", async function () {
   assertEquals(logger.handlers, []);
 });
 
-Deno.test("getInvalidLoggerLevels", function () {
+Deno.test("getLogger() handles invalid level", function () {
   assertThrows(() => getLevelByName("FAKE_LOG_LEVEL" as LevelName));
   assertThrows(() => getLevelName(5000 as LogLevel));
 });


### PR DESCRIPTION
Ref: https://github.com/denoland/deno_std/issues/3754

**Note**
`mod_test.ts` seems to be more or less tests for `setup()`. Maybe it should be renamed to `setup_test.ts`.
There is one test called `"default loggers work as expected"` which checks `debug()`, `info()`, `warn()`, `error()`, `critical()` at the same time and would probably make more sense to split them in individual tests and maybe put them into separate test files as well.