### PR TITLE
refactor: make the code work under `verbatimModuleSyntax`

### DIFF
--- a/_tools/check_circular_submodule_dependencies.ts
+++ b/_tools/check_circular_submodule_dependencies.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { createGraph, ModuleGraphJson, ModuleJson } from "deno_graph";
+import { createGraph, type ModuleGraphJson, type ModuleJson } from "deno_graph";
 
 /**
  * Checks for circular dependencies in the std submodules.

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -34,7 +34,7 @@ import {
   HEADER_LENGTH,
   readBlock,
   type TarMeta,
-  UstarFields,
+  type UstarFields,
   ustarStructure,
 } from "./_common.ts";
 import { readAll } from "../io/read_all.ts";

--- a/archive/untar_test.ts
+++ b/archive/untar_test.ts
@@ -5,7 +5,7 @@ import { Tar, type TarMeta } from "./tar.ts";
 import {
   TarEntry,
   type TarHeader,
-  TarMetaWithLinkName,
+  type TarMetaWithLinkName,
   Untar,
 } from "./untar.ts";
 import { Buffer } from "../io/buffer.ts";

--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertStrictEquals } from "../assert/mod.ts";
-import { debounce, DebouncedFunction } from "./debounce.ts";
+import { debounce, type DebouncedFunction } from "./debounce.ts";
 import { delay } from "./delay.ts";
 
 Deno.test("debounce() handles called", async function () {

--- a/cli/parse_args_test.ts
+++ b/cli/parse_args_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { Args, parseArgs, ParseOptions } from "./parse_args.ts";
-import { assertType, IsExact } from "../testing/types.ts";
+import { type Args, parseArgs, type ParseOptions } from "./parse_args.ts";
+import { assertType, type IsExact } from "../testing/types.ts";
 
 // flag boolean true (default all --args to boolean)
 Deno.test("parseArgs() handles true boolean flag", function () {

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -109,7 +109,7 @@
  */
 
 import {
-  DigestAlgorithm as WasmDigestAlgorithm,
+  type DigestAlgorithm as WasmDigestAlgorithm,
   digestAlgorithms as wasmDigestAlgorithms,
   instantiateWasm,
 } from "./_wasm/mod.ts";

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -2,7 +2,7 @@
 import { assert, assertEquals, assertInstanceOf, fail } from "../assert/mod.ts";
 import { crypto as stdCrypto } from "./mod.ts";
 import { repeat } from "../bytes/repeat.ts";
-import { DigestAlgorithm, digestAlgorithms } from "./_wasm/mod.ts";
+import { type DigestAlgorithm, digestAlgorithms } from "./_wasm/mod.ts";
 import { encodeHex } from "../encoding/hex.ts";
 
 const webCrypto = globalThis.crypto;

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -5,7 +5,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals, assertThrows } from "../assert/mod.ts";
-import { parse, ParseError, ParseOptions } from "./parse.ts";
+import { parse, ParseError, type ParseOptions } from "./parse.ts";
 import type { AssertTrue, IsExact } from "../testing/types.ts";
 
 const BYTE_ORDER_MARK = "\ufeff";

--- a/data_structures/_red_black_node.ts
+++ b/data_structures/_red_black_node.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { BinarySearchNode, Direction } from "./_binary_search_node.ts";
+import { BinarySearchNode, type Direction } from "./_binary_search_node.ts";
 export type { Direction };
 
 export class RedBlackNode<T> extends BinarySearchNode<T> {

--- a/data_structures/binary_heap_test.ts
+++ b/data_structures/binary_heap_test.ts
@@ -2,7 +2,7 @@
 import { assert, assertEquals } from "../assert/mod.ts";
 import { BinaryHeap } from "./binary_heap.ts";
 import { ascend, descend } from "./comparators.ts";
-import { Container, MyMath } from "./_test_utils.ts";
+import { type Container, MyMath } from "./_test_utils.ts";
 
 Deno.test("BinaryHeap works with default descend comparator", () => {
   const maxHeap = new BinaryHeap<number>();

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -3,7 +3,7 @@
 
 import { ascend } from "./comparators.ts";
 import { BinarySearchTree } from "./binary_search_tree.ts";
-import { Direction, RedBlackNode } from "./_red_black_node.ts";
+import { type Direction, RedBlackNode } from "./_red_black_node.ts";
 
 /**
  * A red-black tree. This is a kind of self-balancing binary search tree. The

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, assertStrictEquals } from "../assert/mod.ts";
 import { RedBlackTree } from "./red_black_tree.ts";
 import { ascend, descend } from "./comparators.ts";
-import { Container, MyMath } from "./_test_utils.ts";
+import { type Container, MyMath } from "./_test_utils.ts";
 
 Deno.test("RedBlackTree works as expected with default ascend comparator", () => {
   const trees = [

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,11 @@
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true
   },
+  "lint": {
+    "rules": {
+      "include": ["consistent-type-imports"]
+    }
+  },
   "imports": {
     "https://deno.land/std@$STD_VERSION/": "./",
     "deno_graph": "https://deno.land/x/deno_graph@0.60.0/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -4,11 +4,6 @@
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true
   },
-  "lint": {
-    "rules": {
-      "include": ["consistent-type-imports"]
-    }
-  },
   "imports": {
     "https://deno.land/std@$STD_VERSION/": "./",
     "deno_graph": "https://deno.land/x/deno_graph@0.60.0/mod.ts",

--- a/encoding/ascii85_test.ts
+++ b/encoding/ascii85_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { Ascii85Standard, decodeAscii85, encodeAscii85 } from "./ascii85.ts";
+import { type Ascii85Standard, decodeAscii85, encodeAscii85 } from "./ascii85.ts";
 type TestCases = Partial<{ [index in Ascii85Standard]: string[][] }>;
 const utf8encoder = new TextEncoder();
 const testCasesNoDelimiter: TestCases = {

--- a/encoding/ascii85_test.ts
+++ b/encoding/ascii85_test.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
-import { type Ascii85Standard, decodeAscii85, encodeAscii85 } from "./ascii85.ts";
+import {
+  type Ascii85Standard,
+  decodeAscii85,
+  encodeAscii85,
+} from "./ascii85.ts";
 type TestCases = Partial<{ [index in Ascii85Standard]: string[][] }>;
 const utf8encoder = new TextEncoder();
 const testCasesNoDelimiter: TestCases = {

--- a/expect/_assert_equals.ts
+++ b/expect/_assert_equals.ts
@@ -5,7 +5,7 @@
 import { AssertionError } from "../assert/assertion_error.ts";
 import { buildEqualErrorMessage } from "./_build_message.ts";
 import { equal } from "./_equal.ts";
-import { EqualOptions } from "./_types.ts";
+import type { EqualOptions } from "./_types.ts";
 
 /**
  * Make an assertion that `actual` and `expected` are equal, deeply. If not

--- a/expect/_assert_not_equals.ts
+++ b/expect/_assert_not_equals.ts
@@ -5,7 +5,7 @@
 import { AssertionError } from "../assert/assertion_error.ts";
 import { buildNotEqualErrorMessage } from "./_build_message.ts";
 import { equal } from "./_equal.ts";
-import { EqualOptions } from "./_types.ts";
+import type { EqualOptions } from "./_types.ts";
 
 /**
  * Make an assertion that `actual` and `expected` are not equal, deeply.

--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -4,7 +4,7 @@ import { red } from "../fmt/colors.ts";
 import { CAN_NOT_DISPLAY } from "./_constants.ts";
 import { buildMessage, diff, diffstr } from "./_diff.ts";
 import { format } from "./_format.ts";
-import { EqualOptions } from "./_types.ts";
+import type { EqualOptions } from "./_types.ts";
 
 type EqualErrorMessageOptions = Pick<
   EqualOptions,

--- a/expect/_custom_equality_tester.ts
+++ b/expect/_custom_equality_tester.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { Tester } from "./_types.ts";
+import type { Tester } from "./_types.ts";
 
 const customEqualityTesters: Tester[] = [];
 

--- a/expect/_equal.ts
+++ b/expect/_equal.ts
@@ -2,7 +2,7 @@
 
 // This file is copied from `std/assert`.
 
-import { EqualOptions } from "./_types.ts";
+import type { EqualOptions } from "./_types.ts";
 
 function isKeyedCollection(x: unknown): x is Set<unknown> {
   return [Symbol.iterator, "size"].every((k) => k in (x as Set<unknown>));

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -14,7 +14,7 @@ import { assertEquals } from "./_assert_equals.ts";
 import { assertNotEquals } from "./_assert_not_equals.ts";
 import { equal } from "./_equal.ts";
 import { format } from "./_format.ts";
-import { AnyConstructor, MatcherContext, MatchResult } from "./_types.ts";
+import type { AnyConstructor, MatcherContext, MatchResult } from "./_types.ts";
 import { getMockCalls } from "./_mock_util.ts";
 import { inspectArg, inspectArgs } from "./_inspect_args.ts";
 import { buildEqualOptions } from "./_utils.ts";

--- a/expect/_to_have_returned_with.ts
+++ b/expect/_to_have_returned_with.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { MatcherContext, MatchResult } from "./_types.ts";
+import type { MatcherContext, MatchResult } from "./_types.ts";
 import { AssertionError } from "../assert/assertion_error.ts";
 import { equal } from "../assert/equal.ts";
 import { getMockCalls } from "./_mock_util.ts";

--- a/expect/_utils.ts
+++ b/expect/_utils.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { EqualOptions, EqualOptionUtil } from "./_types.ts";
+import type { EqualOptions, EqualOptionUtil } from "./_types.ts";
 
 export function buildEqualOptions(options: EqualOptionUtil): EqualOptions {
   const { customMessage, customTesters = [], strictCheck } = options || {};

--- a/expect/fn.ts
+++ b/expect/fn.ts
@@ -2,7 +2,7 @@
 // Copyright 2019 Allain Lalonde. All rights reserved. ISC License.
 // deno-lint-ignore-file no-explicit-any ban-types
 
-import { MOCK_SYMBOL, MockCall } from "./_mock_util.ts";
+import { MOCK_SYMBOL, type MockCall } from "./_mock_util.ts";
 
 export function fn(...stubs: Function[]): Function {
   const calls: MockCall[] = [];

--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
+import {
+  createExtractor,
+  type Extractor,
+  type Parser,
+} from "./create_extractor.ts";
 import { parse as parseYAML } from "../yaml/parse.ts";
 import { parse as parseTOML } from "../toml/parse.ts";
 

--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, Parser } from "./create_extractor.ts";
+import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
 import { parse as parseYAML } from "../yaml/parse.ts";
 import { parse as parseTOML } from "../toml/parse.ts";
 

--- a/front_matter/create_extractor_test.ts
+++ b/front_matter/create_extractor_test.ts
@@ -11,7 +11,7 @@ import {
   runExtractYAMLTests1,
   runExtractYAMLTests2,
 } from "./_test_utils.ts";
-import { createExtractor, Parser } from "./create_extractor.ts";
+import { createExtractor, type Parser } from "./create_extractor.ts";
 
 const extractYAML = createExtractor({ "yaml": parseYAML as Parser });
 const extractTOML = createExtractor({ "toml": parseTOML as Parser });

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
+import {
+  createExtractor,
+  type Extractor,
+  type Parser,
+} from "./create_extractor.ts";
 
 export const extract: Extractor = createExtractor({
   json: JSON.parse as Parser,

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, Parser } from "./create_extractor.ts";
+import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
 
 export const extract: Extractor = createExtractor({
   json: JSON.parse as Parser,

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
+import {
+  createExtractor,
+  type Extractor,
+  type Parser,
+} from "./create_extractor.ts";
 import { parse } from "../toml/parse.ts";
 
 export const extract: Extractor = createExtractor({

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, Parser } from "./create_extractor.ts";
+import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
 import { parse } from "../toml/parse.ts";
 
 export const extract: Extractor = createExtractor({

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, Parser } from "./create_extractor.ts";
+import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
 import { parse } from "../yaml/parse.ts";
 
 export const extract: Extractor = createExtractor({

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { createExtractor, type Extractor, type Parser } from "./create_extractor.ts";
+import {
+  createExtractor,
+  type Extractor,
+  type Parser,
+} from "./create_extractor.ts";
 import { parse } from "../yaml/parse.ts";
 
 export const extract: Extractor = createExtractor({

--- a/fs/_get_file_info_type_test.ts
+++ b/fs/_get_file_info_type_test.ts
@@ -3,7 +3,7 @@
 
 import { assertEquals } from "../assert/mod.ts";
 import * as path from "../path/mod.ts";
-import { getFileInfoType, PathType } from "./_get_file_info_type.ts";
+import { getFileInfoType, type PathType } from "./_get_file_info_type.ts";
 import { ensureFileSync } from "./ensure_file.ts";
 import { ensureDirSync } from "./ensure_dir.ts";
 

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -9,7 +9,7 @@ import {
 } from "../path/mod.ts";
 import {
   expandGlob,
-  ExpandGlobOptions,
+  type ExpandGlobOptions,
   expandGlobSync,
 } from "./expand_glob.ts";
 

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { walk, WalkError, WalkOptions, walkSync } from "./walk.ts";
+import { walk, WalkError, type WalkOptions, walkSync } from "./walk.ts";
 import {
   assertArrayIncludes,
   assertEquals,

--- a/http/_negotiation/encoding.ts
+++ b/http/_negotiation/encoding.ts
@@ -29,7 +29,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { compareSpecs, isQuality, Specificity } from "./common.ts";
+import { compareSpecs, isQuality, type Specificity } from "./common.ts";
 
 interface EncodingSpecificity extends Specificity {
   encoding?: string;

--- a/http/_negotiation/language.ts
+++ b/http/_negotiation/language.ts
@@ -29,7 +29,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { compareSpecs, isQuality, Specificity } from "./common.ts";
+import { compareSpecs, isQuality, type Specificity } from "./common.ts";
 
 interface LanguageSpecificity extends Specificity {
   prefix: string;

--- a/http/_negotiation/media_type.ts
+++ b/http/_negotiation/media_type.ts
@@ -29,7 +29,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { compareSpecs, isQuality, Specificity } from "./common.ts";
+import { compareSpecs, isQuality, type Specificity } from "./common.ts";
 
 interface MediaTypeSpecificity extends Specificity {
   type: string;

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -8,7 +8,7 @@ import {
   assertStringIncludes,
 } from "../assert/mod.ts";
 import { stub } from "../testing/mock.ts";
-import { serveDir, ServeDirOptions, serveFile } from "./file_server.ts";
+import { serveDir, type ServeDirOptions, serveFile } from "./file_server.ts";
 import { calculate } from "./etag.ts";
 import {
   basename,

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { type ConnInfo, serve, serveListener, Server, serveTls } from "./server.ts";
+import {
+  type ConnInfo,
+  serve,
+  serveListener,
+  Server,
+  serveTls,
+} from "./server.ts";
 import { mockConn as createMockConn } from "./_mock_conn.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 import { writeAll } from "../io/write_all.ts";

--- a/http/server_test.ts
+++ b/http/server_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { ConnInfo, serve, serveListener, Server, serveTls } from "./server.ts";
+import { type ConnInfo, serve, serveListener, Server, serveTls } from "./server.ts";
 import { mockConn as createMockConn } from "./_mock_conn.ts";
 import { dirname, fromFileUrl, join, resolve } from "../path/mod.ts";
 import { writeAll } from "../io/write_all.ts";

--- a/ini/parse.ts
+++ b/ini/parse.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { IniMap, ParseOptions } from "./ini_map.ts";
+import { IniMap, type ParseOptions } from "./ini_map.ts";
 /** Parse an INI config string into an object. Provide formatting options to override the default assignment operator. */
 export function parse(
   text: string,

--- a/ini/parse_test.ts
+++ b/ini/parse_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { IniMap, parse, ParseOptions } from "./mod.ts";
+import { IniMap, parse, type ParseOptions } from "./mod.ts";
 import {
   assert,
   assertEquals,

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { IniMap, StringifyOptions } from "./ini_map.ts";
+import { IniMap, type StringifyOptions } from "./ini_map.ts";
 
 /** Compile an object into an INI config string. Provide formatting options to modify the output. */
 export function stringify(

--- a/ini/stringify_test.ts
+++ b/ini/stringify_test.ts
@@ -2,7 +2,7 @@
 
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { stringify, StringifyOptions } from "./mod.ts";
+import { stringify, type StringifyOptions } from "./mod.ts";
 import { assertEquals } from "../assert/mod.ts";
 
 function assertValidStringify(

--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { type BufReader } from "./buf_reader.ts";
+import type { BufReader } from "./buf_reader.ts";
 import { readShort } from "./read_short.ts";
 
 /**

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { type Reader } from "./types.ts";
+import type { Reader } from "./types.ts";
 import { BufReader } from "./buf_reader.ts";
 import { concat } from "../bytes/concat.ts";
 

--- a/io/read_long.ts
+++ b/io/read_long.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { type BufReader } from "./buf_reader.ts";
+import type { BufReader } from "./buf_reader.ts";
 import { readInt } from "./read_int.ts";
 
 const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);

--- a/io/read_short.ts
+++ b/io/read_short.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { type BufReader } from "./buf_reader.ts";
+import type { BufReader } from "./buf_reader.ts";
 
 /**
  * Read big endian 16bit short from BufReader

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { type Reader } from "./types.ts";
+import type { Reader } from "./types.ts";
 import { readDelim } from "./read_delim.ts";
 
 /**

--- a/json/json_stringify_stream_test.ts
+++ b/json/json_stringify_stream_test.ts
@@ -3,7 +3,7 @@
 import { assertEquals, assertRejects } from "../assert/mod.ts";
 import {
   JsonStringifyStream,
-  StringifyStreamOptions,
+  type StringifyStreamOptions,
 } from "./json_stringify_stream.ts";
 
 async function assertValidStringify(

--- a/jsonc/mod.ts
+++ b/jsonc/mod.ts
@@ -1,4 +1,24 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+/**
+ * Provides tools for working with JSONC (JSON with comments). Currently, this
+ * module only provides a means of parsing JSONC. JSONC serialization is not
+ * yet supported.
+ *
+ * This module is browser compatible.
+ *
+ * @example
+ * ```ts Parsing JSONC
+ * import { parse } from "https://deno.land/std@$STD_VERSION/jsonc/mod.ts";
+ *
+ * parse('{"foo": "bar", } // comment'); // { foo: "bar" }
+ * parse('{"foo": "bar", } /* comment *\/'); // { foo: "bar" }
+ * parse('{"foo": "bar" } // comment', {
+ *   allowTrailingComma: false,
+ * }); // { foo: "bar" }
+ * ```
+ *
+ * @module
+ */
 export * from "./parse.ts";

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -33,11 +33,11 @@ export interface ParseOptions {
  * ```ts
  * import { parse } from "https://deno.land/std@$STD_VERSION/jsonc/mod.ts";
  *
- * console.log(parse('{"foo": "bar", } // comment')); // { foo: "bar" }
- * console.log(parse('{"foo": "bar", } /* comment *\/')); // { foo: "bar" }
- * console.log(parse('{"foo": "bar" } // comment', {
+ * parse('{"foo": "bar", } // comment'); // { foo: "bar" }
+ * parse('{"foo": "bar", } /* comment *\/'); // { foo: "bar" }
+ * parse('{"foo": "bar" } // comment', {
  *   allowTrailingComma: false,
- * })); // { foo: "bar" }
+ * }); // { foo: "bar" }
  * ```
  *
  * @param text A valid JSONC string.

--- a/log/_config.ts
+++ b/log/_config.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { ConsoleHandler } from "./console_handler.ts";
-import { type LogConfig } from "./logger.ts";
+import type { LogConfig } from "./logger.ts";
 
 export const DEFAULT_LEVEL = "INFO";
 

--- a/log/_state.ts
+++ b/log/_state.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { BaseHandler } from "./base_handler.ts";
+import type { BaseHandler } from "./base_handler.ts";
 import { DEFAULT_CONFIG } from "./_config.ts";
-import { Logger } from "./logger.ts";
+import type { Logger } from "./logger.ts";
 
 export const state = {
   handlers: new Map<string, BaseHandler>(),

--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { getLevelByName, getLevelName, LevelName, LogLevel } from "./levels.ts";
+import { getLevelByName, getLevelName, type LevelName, type LogLevel } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 
 export type FormatterFunction = (logRecord: LogRecord) => string;

--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { getLevelByName, getLevelName, type LevelName, type LogLevel } from "./levels.ts";
+import {
+  getLevelByName,
+  getLevelName,
+  type LevelName,
+  type LogLevel,
+} from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 
 export type FormatterFunction = (logRecord: LogRecord) => string;

--- a/log/base_handler_test.ts
+++ b/log/base_handler_test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "../assert/mod.ts";
 import {
   getLevelByName,
   getLevelName,
-  LogLevel,
+  type LogLevel,
   LogLevelNames,
   LogLevels,
 } from "./levels.ts";

--- a/log/console_handler.ts
+++ b/log/console_handler.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { LevelName, LogLevels } from "./levels.ts";
+import { type LevelName, LogLevels } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 import { blue, bold, red, yellow } from "../fmt/colors.ts";
 import { BaseHandler, type BaseHandlerOptions } from "./base_handler.ts";

--- a/log/critical.ts
+++ b/log/critical.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getLogger } from "./get_logger.ts";
-import { type GenericFunction } from "./logger.ts";
+import type { GenericFunction } from "./logger.ts";
 
 /** Log with critical level, using default logger. */
 export function critical<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/log/debug.ts
+++ b/log/debug.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getLogger } from "./get_logger.ts";
-import { type GenericFunction } from "./logger.ts";
+import type { GenericFunction } from "./logger.ts";
 
 /** Log with debug level, using default logger. */
 export function debug<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/log/error.ts
+++ b/log/error.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getLogger } from "./get_logger.ts";
-import { type GenericFunction } from "./logger.ts";
+import type { GenericFunction } from "./logger.ts";
 
 /** Log with error level, using default logger. */
 export function error<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/log/file_handler.ts
+++ b/log/file_handler.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { LevelName, LogLevels } from "./levels.ts";
+import { type LevelName, LogLevels } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 import { BaseHandler, type BaseHandlerOptions } from "./base_handler.ts";
 

--- a/log/formatters.ts
+++ b/log/formatters.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { LogRecord } from "./logger.ts";
+import type { LogRecord } from "./logger.ts";
 
 export function jsonFormatter(logRecord: LogRecord): string {
   return JSON.stringify({

--- a/log/info.ts
+++ b/log/info.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getLogger } from "./get_logger.ts";
-import { type GenericFunction } from "./logger.ts";
+import type { GenericFunction } from "./logger.ts";
 
 /** Log with info level, using default logger. */
 export function info<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/log/logger_test.ts
+++ b/log/logger_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertMatch } from "../assert/mod.ts";
-import { Logger, LogRecord } from "./logger.ts";
-import { LevelName, LogLevels } from "./levels.ts";
+import { Logger, type LogRecord } from "./logger.ts";
+import { type LevelName, LogLevels } from "./levels.ts";
 import { BaseHandler } from "./base_handler.ts";
 
 class TestHandler extends BaseHandler {

--- a/log/mod_test.ts
+++ b/log/mod_test.ts
@@ -7,7 +7,7 @@ import {
   error,
   getLogger,
   info,
-  LevelName,
+  type LevelName,
   Logger,
   LogLevels,
   setup,

--- a/log/rotating_file_handler.ts
+++ b/log/rotating_file_handler.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { LevelName } from "./levels.ts";
+import type { LevelName } from "./levels.ts";
 import { existsSync } from "../fs/exists.ts";
 import { FileHandler, type FileHandlerOptions } from "./file_handler.ts";
 

--- a/log/setup.ts
+++ b/log/setup.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { BaseHandler } from "./base_handler.ts";
+import type { BaseHandler } from "./base_handler.ts";
 import { DEFAULT_CONFIG, DEFAULT_LEVEL } from "./_config.ts";
 import { type LogConfig, Logger } from "./logger.ts";
 import { state } from "./_state.ts";

--- a/log/test.ts
+++ b/log/test.ts
@@ -4,8 +4,8 @@ import * as log from "./mod.ts";
 import {
   getLevelByName,
   getLevelName,
-  LevelName,
-  LogLevel,
+  type LevelName,
+  type LogLevel,
   LogLevelNames,
 } from "./levels.ts";
 

--- a/log/warn.ts
+++ b/log/warn.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getLogger } from "./get_logger.ts";
-import { type GenericFunction } from "./logger.ts";
+import type { GenericFunction } from "./logger.ts";
 
 /** Log with warning level, using default logger. */
 export function warn<T>(msg: () => T, ...args: unknown[]): T | undefined;

--- a/media_types/_db.ts
+++ b/media_types/_db.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import db from "./vendor/mime-db.v1.52.0.ts";
-import { type DBEntry } from "./_util.ts";
+import type { DBEntry } from "./_util.ts";
 
 export type KeyOfDb = keyof typeof db;
 

--- a/media_types/get_charset.ts
+++ b/media_types/get_charset.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { parseMediaType } from "./parse_media_type.ts";
-import { type DBEntry } from "./_util.ts";
+import type { DBEntry } from "./_util.ts";
 import { db, type KeyOfDb } from "./_db.ts";
 
 /**

--- a/msgpack/decode.ts
+++ b/msgpack/decode.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { ValueType } from "./encode.ts";
+import type { ValueType } from "./encode.ts";
 
 /**
  * Decode a value from the MessagePack binary format.

--- a/path/format.ts
+++ b/path/format.ts
@@ -4,7 +4,7 @@
 import { isWindows } from "./_os.ts";
 import { format as posixFormat } from "./posix/format.ts";
 import { format as windowsFormat } from "./windows/format.ts";
-import { FormatInputPathObject } from "./_interface.ts";
+import type { FormatInputPathObject } from "./_interface.ts";
 
 /**
  * Generate a path from `FormatInputPathObject` object.

--- a/path/glob_to_regexp.ts
+++ b/path/glob_to_regexp.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import type { GlobOptions } from "./_common/glob_to_reg_exp.ts";
-import { isWindows, OSType } from "./_os.ts";
+import { isWindows, type OSType } from "./_os.ts";
 
 import { globToRegExp as posixGlobToRegExp } from "./posix/glob_to_regexp.ts";
 import {

--- a/path/glob_to_regexp_test.ts
+++ b/path/glob_to_regexp_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "../assert/mod.ts";
-import { globToRegExp, GlobToRegExpOptions } from "./glob_to_regexp.ts";
+import { globToRegExp, type GlobToRegExpOptions } from "./glob_to_regexp.ts";
 
 function match(
   glob: string,

--- a/path/posix/glob_to_regexp.ts
+++ b/path/posix/glob_to_regexp.ts
@@ -3,8 +3,8 @@
 
 import {
   _globToRegExp,
-  GlobConstants,
-  GlobToRegExpOptions,
+  type GlobConstants,
+  type GlobToRegExpOptions,
 } from "../_common/glob_to_reg_exp.ts";
 
 const constants: GlobConstants = {

--- a/path/posix/join_globs.ts
+++ b/path/posix/join_globs.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { GlobOptions } from "../_common/glob_to_reg_exp.ts";
+import type { GlobOptions } from "../_common/glob_to_reg_exp.ts";
 import { join } from "./join.ts";
 import { SEPARATOR } from "./constants.ts";
 import { normalizeGlob } from "./normalize_glob.ts";

--- a/path/posix/normalize_glob.ts
+++ b/path/posix/normalize_glob.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { GlobOptions } from "../_common/glob_to_reg_exp.ts";
+import type { GlobOptions } from "../_common/glob_to_reg_exp.ts";
 import { normalize } from "./normalize.ts";
 import { SEPARATOR_PATTERN } from "./constants.ts";
 

--- a/path/posix/parse.ts
+++ b/path/posix/parse.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { CHAR_DOT } from "../_common/constants.ts";
-import { ParsedPath } from "../_interface.ts";
+import type { ParsedPath } from "../_interface.ts";
 import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
 import { assertPath } from "../_common/assert_path.ts";
 import { isPosixPathSeparator } from "./_util.ts";

--- a/path/windows/glob_to_regexp.ts
+++ b/path/windows/glob_to_regexp.ts
@@ -3,8 +3,8 @@
 
 import {
   _globToRegExp,
-  GlobConstants,
-  GlobToRegExpOptions,
+  type GlobConstants,
+  type GlobToRegExpOptions,
 } from "../_common/glob_to_reg_exp.ts";
 
 const constants: GlobConstants = {

--- a/path/windows/join_globs.ts
+++ b/path/windows/join_globs.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { GlobOptions } from "../_common/glob_to_reg_exp.ts";
+import type { GlobOptions } from "../_common/glob_to_reg_exp.ts";
 import { join } from "./join.ts";
 import { SEPARATOR } from "./constants.ts";
 import { normalizeGlob } from "./normalize_glob.ts";

--- a/path/windows/normalize_glob.ts
+++ b/path/windows/normalize_glob.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { globToRegExp as _globToRegExp } from "./glob_to_regexp.ts";
-import { GlobOptions } from "../_common/glob_to_reg_exp.ts";
+import type { GlobOptions } from "../_common/glob_to_reg_exp.ts";
 import { normalize } from "./normalize.ts";
 import { SEPARATOR_PATTERN } from "./constants.ts";
 

--- a/path/windows/parse.ts
+++ b/path/windows/parse.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 import { CHAR_COLON, CHAR_DOT } from "../_common/constants.ts";
-import { ParsedPath } from "../_interface.ts";
+import type { ParsedPath } from "../_interface.ts";
 import { assertPath } from "../_common/assert_path.ts";
 import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 

--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { type Comparator } from "./types.ts";
+import type { Comparator } from "./types.ts";
 
 export function compareNumber(
   a: number,

--- a/semver/comparator_test.ts
+++ b/semver/comparator_test.ts
@@ -6,7 +6,7 @@ import { parse } from "./parse.ts";
 import { testRange } from "./test_range.ts";
 import { parseComparator } from "./_parse_comparator.ts";
 import { formatComparator } from "./_format_comparator.ts";
-import { Comparator } from "./types.ts";
+import type { Comparator } from "./types.ts";
 
 Deno.test({
   name: "comparators",

--- a/semver/difference_test.ts
+++ b/semver/difference_test.ts
@@ -2,7 +2,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../assert/mod.ts";
 import { parse } from "./parse.ts";
-import { ReleaseType } from "./types.ts";
+import type { ReleaseType } from "./types.ts";
 import { difference } from "./difference.ts";
 
 Deno.test("diff", async (t) => {

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../assert/mod.ts";
 import { format } from "./format.ts";
 import { parse } from "./parse.ts";
 import { INVALID, MAX, MIN } from "./constants.ts";
-import { SemVer } from "./types.ts";
+import type { SemVer } from "./types.ts";
 
 Deno.test("format", async (t) => {
   const versions: [string, string][] = [

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { SemVer } from "./types.ts";
+import type { SemVer } from "./types.ts";
 import { parseBuild, parseNumber, parsePrerelease } from "./_shared.ts";
 import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 

--- a/semver/try_parse.ts
+++ b/semver/try_parse.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { SemVer } from "./types.ts";
+import type { SemVer } from "./types.ts";
 import { parse } from "./parse.ts";
 
 /**

--- a/semver/try_parse_range.ts
+++ b/semver/try_parse_range.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { Range } from "./types.ts";
+import type { Range } from "./types.ts";
 import { parseRange } from "./parse_range.ts";
 
 /**

--- a/semver/types.ts
+++ b/semver/types.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { OPERATORS } from "./_constants.ts";
+import type { OPERATORS } from "./_constants.ts";
 
 /**
  * The possible release types are used as an operator for the

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -3,7 +3,7 @@
 
 import { Buffer } from "../io/buffer.ts";
 import { writeAll } from "../io/write_all.ts";
-import { Reader } from "../io/types.ts";
+import type { Reader } from "../io/types.ts";
 
 /**
  * Create a {@linkcode Reader} from an iterable of {@linkcode Uint8Array}s.

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -395,10 +395,10 @@
  */
 
 import {
-  DescribeDefinition,
-  HookNames,
-  ItDefinition,
-  TestSuite,
+  type DescribeDefinition,
+  type HookNames,
+  type ItDefinition,
+  type TestSuite,
   TestSuiteInternal,
 } from "./_test_suite.ts";
 export type { DescribeDefinition, ItDefinition, TestSuite };

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -14,7 +14,7 @@ import {
   it,
 } from "./bdd.ts";
 import { TestSuiteInternal } from "./_test_suite.ts";
-import { assertSpyCall, assertSpyCalls, Spy, spy, stub } from "./mock.ts";
+import { assertSpyCall, assertSpyCalls, type Spy, spy, stub } from "./mock.ts";
 
 Deno.test("global", async (t) => {
   class TestContext implements Deno.TestContext {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -13,7 +13,7 @@ import {
   assertSpyCallArgs,
   assertSpyCallAsync,
   assertSpyCalls,
-  MethodSpy,
+  type MethodSpy,
   MockError,
   mockSession,
   mockSessionAsync,
@@ -23,12 +23,12 @@ import {
   returnsArgs,
   returnsNext,
   returnsThis,
-  Spy,
+  type Spy,
   spy,
-  Stub,
+  type Stub,
   stub,
 } from "./mock.ts";
-import { Point, PointWithExtra, stringifyPoint } from "./_test_utils.ts";
+import { Point, type PointWithExtra, stringifyPoint } from "./_test_utils.ts";
 
 Deno.test("spy default", () => {
   const func = spy();

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -9,7 +9,7 @@ import {
 } from "../assert/mod.ts";
 import { FakeTime, TimeError } from "./time.ts";
 import { _internals } from "./_time.ts";
-import { assertSpyCall, spy, SpyCall } from "./mock.ts";
+import { assertSpyCall, spy, type SpyCall } from "./mock.ts";
 
 function fromNow(): () => number {
   const start: number = Date.now();

--- a/testing/types_test.ts
+++ b/testing/types_test.ts
@@ -3,17 +3,17 @@
 // deno-lint-ignore-file no-explicit-any ban-types
 
 import {
-  Assert,
-  AssertFalse,
-  AssertTrue,
+  type Assert,
+  type AssertFalse,
+  type AssertTrue,
   assertType,
-  Has,
-  IsAny,
-  IsExact,
-  IsNever,
-  IsNullable,
-  IsUnknown,
-  NotHas,
+  type Has,
+  type IsAny,
+  type IsExact,
+  type IsNever,
+  type IsNullable,
+  type IsUnknown,
+  type NotHas,
 } from "./types.ts";
 
 // IsNullable

--- a/ulid/mod.ts
+++ b/ulid/mod.ts
@@ -19,7 +19,7 @@ import {
   RANDOM_LEN,
   TIME_LEN,
   TIME_MAX,
-  ULID,
+  type ULID,
 } from "./_util.ts";
 
 export type { ULID } from "./_util.ts";

--- a/yaml/_dumper/dumper.ts
+++ b/yaml/_dumper/dumper.ts
@@ -6,7 +6,7 @@
 import { YAMLError } from "../_error.ts";
 import type { RepresentFn, StyleVariant, Type } from "../type.ts";
 import * as common from "../_utils.ts";
-import { DumperState, DumperStateOptions } from "./dumper_state.ts";
+import { DumperState, type DumperStateOptions } from "./dumper_state.ts";
 
 type Any = common.Any;
 type ArrayObject<T = Any> = common.ArrayObject<T>;

--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -7,7 +7,7 @@ import { YAMLError } from "../_error.ts";
 import { Mark } from "../_mark.ts";
 import type { Type } from "../type.ts";
 import * as common from "../_utils.ts";
-import { LoaderState, LoaderStateOptions, ResultType } from "./loader_state.ts";
+import { LoaderState, type LoaderStateOptions, type ResultType } from "./loader_state.ts";
 
 type Any = common.Any;
 type ArrayObject<T = Any> = common.ArrayObject<T>;

--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -7,7 +7,11 @@ import { YAMLError } from "../_error.ts";
 import { Mark } from "../_mark.ts";
 import type { Type } from "../type.ts";
 import * as common from "../_utils.ts";
-import { LoaderState, type LoaderStateOptions, type ResultType } from "./loader_state.ts";
+import {
+  LoaderState,
+  type LoaderStateOptions,
+  type ResultType,
+} from "./loader_state.ts";
 
 type Any = common.Any;
 type ArrayObject<T = Any> = common.ArrayObject<T>;

--- a/yaml/_type/float.ts
+++ b/yaml/_type/float.ts
@@ -3,8 +3,8 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { StyleVariant, Type } from "../type.ts";
-import { Any, isNegativeZero } from "../_utils.ts";
+import { type StyleVariant, Type } from "../type.ts";
+import { type Any, isNegativeZero } from "../_utils.ts";
 
 const YAML_FLOAT_PATTERN = new RegExp(
   // 2.5e4, 2.5 and integers

--- a/yaml/_type/int.ts
+++ b/yaml/_type/int.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { Type } from "../type.ts";
-import { Any, isNegativeZero } from "../_utils.ts";
+import { type Any, isNegativeZero } from "../_utils.ts";
 
 function isHexCode(c: number): boolean {
   return (

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { CbFunction, load, loadAll } from "./_loader/loader.ts";
+import { type CbFunction, load, loadAll } from "./_loader/loader.ts";
 import type { LoaderStateOptions } from "./_loader/loader_state.ts";
 
 export type ParseOptions = LoaderStateOptions;


### PR DESCRIPTION
I have an upcoming lint rule to enforce this. Was just testing it out on deno_std.

Read more here: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax