### PR TITLE
fix(path): fix common() results that depend on the order and/or number of input paths

### DIFF
--- a/path/_common/common.ts
+++ b/path/_common/common.ts
@@ -3,24 +3,24 @@
 
 export function _common(paths: string[], sep: string): string {
   const [first = "", ...remaining] = paths;
-  if (first === "" || remaining.length === 0) {
-    return first.substring(0, first.lastIndexOf(sep) + 1);
-  }
   const parts = first.split(sep);
 
   let endOfPrefix = parts.length;
+  let append = "";
   for (const path of remaining) {
     const compare = path.split(sep);
+    if (compare.length <= endOfPrefix) {
+      endOfPrefix = compare.length;
+      append = "";
+    }
+
     for (let i = 0; i < endOfPrefix; i++) {
       if (compare[i] !== parts[i]) {
         endOfPrefix = i;
+        append = i === 0 ? "" : sep;
+        break;
       }
     }
-
-    if (endOfPrefix === 0) {
-      return "";
-    }
   }
-  const prefix = parts.slice(0, endOfPrefix).join(sep);
-  return prefix.endsWith(sep) ? prefix : `${prefix}${sep}`;
+  return parts.slice(0, endOfPrefix).join(sep) + append;
 }

--- a/path/common_test.ts
+++ b/path/common_test.ts
@@ -42,3 +42,45 @@ Deno.test({
     assertEquals(actual, "c:\\deno\\");
   },
 });
+
+Deno.test({
+  name: "common(['', '/'], '/') returns ''",
+  fn() {
+    const actual = common(["", "/"], "/");
+    assertEquals(actual, "");
+  },
+});
+
+Deno.test({
+  name: "common(['/', ''], '/') returns ''",
+  fn() {
+    const actual = common([
+      "/",
+      "",
+    ], "/");
+    assertEquals(actual, "");
+  },
+});
+
+Deno.test({
+  name: "common() returns the first path unmodified when it's the only path",
+  fn() {
+    const actual = common(["./deno/std/path/mod.ts"], "/");
+    assertEquals(actual, "./deno/std/path/mod.ts");
+  },
+});
+
+Deno.test({
+  name: "common() returns the first path unmodified if all paths are equal",
+  fn() {
+    const actual = common(
+      [
+        "./deno/std/path/mod.ts",
+        "./deno/std/path/mod.ts",
+        "./deno/std/path/mod.ts",
+      ],
+      "/",
+    );
+    assertEquals(actual, "./deno/std/path/mod.ts");
+  },
+});


### PR DESCRIPTION
This pull request addresses (and adds tests for) cases where [`common()`](https://deno.land/std@0.217.0/path/mod.ts?s=common) returns different values depending on the order and/or number of the input paths, when different results may not be intended.

For example in this case it's probably expected that both cases return an empty string:

```ts
> common(["/", ""], "/")
'/'
> common(["", "/"], "/")
''
```

In the next case the result depends on the number of paths, even if the paths are all equal. The expected result in both cases is likely `'/foo/bar'`:

```ts
> common(["/foo/bar"], "/")
'/foo/'      // missing 'bar'
> common(["/foo/bar", "/foo/bar"], "/")
'/foo/bar/'  // extra slash at the end
```

This pull request adds a variable (`append`) to track whether a separator should be appended to the end of the result string. Early returns are removed to keep this tracking consistent. The performance doesn't seem to degrade in the following tested case:

```ts
Deno.bench("original common()", () => {
  commonOriginal([
    "./deno/std/path/mod.ts",
    "./deno/std/fs/mod.ts",
  ], "/")
});

Deno.bench("modified common()", () => {
  commonModified([
    "./deno/std/path/mod.ts",
    "./deno/std/fs/mod.ts",
  ], "/")
});
```

Results for Deno v1.41.0, MacOS 14.3.1:

```
benchmark              time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------- -----------------------------
original common()     225.89 ns/iter   4,426,966.2 (219.21 ns … 255.68 ns) 227.8 ns 246.43 ns 247.09 ns
modified common()     196.07 ns/iter   5,100,328.9  (188.82 ns … 217.8 ns) 196.75 ns 216.05 ns 216.22 ns
```