### PR TITLE
fix(log): don't discard bytes >4096 in `FileHandler`

### DIFF
--- a/log/file_handler.ts
+++ b/log/file_handler.ts
@@ -2,6 +2,7 @@
 import { type LevelName, LogLevels } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
 import { BaseHandler, type BaseHandlerOptions } from "./base_handler.ts";
+import { writeAllSync } from "../io/write_all.ts";
 
 const PAGE_SIZE = 4096;
 export type LogMode = "a" | "w" | "x";
@@ -76,8 +77,12 @@ export class FileHandler extends BaseHandler {
     if (bytes.byteLength > this._buf.byteLength - this._pointer) {
       this.flush();
     }
-    this._buf.set(bytes, this._pointer);
-    this._pointer += bytes.byteLength;
+    if (bytes.byteLength > this._buf.byteLength) {
+      writeAllSync(this._file!, bytes);
+    } else {
+      this._buf.set(bytes, this._pointer);
+      this._pointer += bytes.byteLength;
+    }
   }
 
   flush() {

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -202,9 +202,8 @@ Deno.test({
     fileHandler.log(regularLog);
     fileHandler.destroy();
 
-    const decoder = new TextDecoder();
     assertEquals(
-      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      Deno.readTextFileSync(LOG_FILE),
       `${regularLog}\n${veryLargeLog}\n${regularLog}\n`,
     );
 

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -176,9 +176,8 @@ Deno.test({
     fileHandler.log(logOverBufferLimit);
     fileHandler.destroy();
 
-    const decoder = new TextDecoder();
     assertEquals(
-      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      Deno.readTextFileSync(LOG_FILE),
       `${logOverBufferLimit}\n`,
     );
 

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -162,3 +162,52 @@ Deno.test({
     Deno.removeSync(LOG_FILE);
   },
 });
+
+Deno.test({
+  name: "FileHandler handles strings larger than the buffer",
+  fn() {
+    const fileHandler = new FileHandler("WARN", {
+      filename: LOG_FILE,
+      mode: "w",
+    });
+    const logOverBufferLimit = "A".repeat(4096);
+    fileHandler.setup();
+
+    fileHandler.log(logOverBufferLimit);
+    fileHandler.destroy();
+
+    const decoder = new TextDecoder();
+    assertEquals(
+      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      `${logOverBufferLimit}\n`,
+    );
+
+    Deno.removeSync(LOG_FILE);
+  },
+});
+
+Deno.test({
+  name: "FileHandler handles a mixture of string sizes",
+  fn() {
+    const fileHandler = new FileHandler("WARN", {
+      filename: LOG_FILE,
+      mode: "w",
+    });
+    const veryLargeLog = "A".repeat(10000);
+    const regularLog = "B".repeat(100);
+    fileHandler.setup();
+
+    fileHandler.log(regularLog);
+    fileHandler.log(veryLargeLog);
+    fileHandler.log(regularLog);
+    fileHandler.destroy();
+
+    const decoder = new TextDecoder();
+    assertEquals(
+      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      `${regularLog}\n${veryLargeLog}\n${regularLog}\n`,
+    );
+
+    Deno.removeSync(LOG_FILE);
+  },
+});

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -342,9 +342,8 @@ Deno.test({
     fileHandler.log(regularLog);
     fileHandler.destroy();
 
-    const decoder = new TextDecoder();
     assertEquals(
-      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      Deno.readTextFileSync(LOG_FILE),
       `${regularLog}\n${veryLargeLog}\n${regularLog}\n`,
     );
 

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -298,3 +298,56 @@ Deno.test({
     Deno.removeSync(LOG_FILE + ".1");
   },
 });
+
+Deno.test({
+  name: "RotatingFileHandler handles strings larger than the buffer",
+  fn() {
+    const fileHandler = new RotatingFileHandler("WARN", {
+      filename: LOG_FILE,
+      mode: "w",
+      maxBytes: 4000000,
+      maxBackupCount: 10,
+    });
+    const logOverBufferLimit = "A".repeat(4096);
+    fileHandler.setup();
+
+    fileHandler.log(logOverBufferLimit);
+    fileHandler.destroy();
+
+    const decoder = new TextDecoder();
+    assertEquals(
+      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      `${logOverBufferLimit}\n`,
+    );
+
+    Deno.removeSync(LOG_FILE);
+  },
+});
+
+Deno.test({
+  name: "RotatingFileHandler handles a mixture of string sizes",
+  fn() {
+    const fileHandler = new RotatingFileHandler("WARN", {
+      filename: LOG_FILE,
+      mode: "w",
+      maxBytes: 4000000,
+      maxBackupCount: 10,
+    });
+    const veryLargeLog = "A".repeat(10000);
+    const regularLog = "B".repeat(100);
+    fileHandler.setup();
+
+    fileHandler.log(regularLog);
+    fileHandler.log(veryLargeLog);
+    fileHandler.log(regularLog);
+    fileHandler.destroy();
+
+    const decoder = new TextDecoder();
+    assertEquals(
+      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      `${regularLog}\n${veryLargeLog}\n${regularLog}\n`,
+    );
+
+    Deno.removeSync(LOG_FILE);
+  },
+});

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -314,9 +314,8 @@ Deno.test({
     fileHandler.log(logOverBufferLimit);
     fileHandler.destroy();
 
-    const decoder = new TextDecoder();
     assertEquals(
-      decoder.decode(Deno.readFileSync(LOG_FILE)),
+      Deno.readTextFileSync(LOG_FILE),
       `${logOverBufferLimit}\n`,
     );
 


### PR DESCRIPTION
Fixes the bug https://github.com/denoland/deno_std/issues/4411
Bug introduced in https://github.com/denoland/deno_std/pull/4021

TLDR; Attempting to log 4096 or more bytes in a single call to the logger would throw an error and the log would not be written.

Note this PR appears to introduce a new dependency between std/log and std/io. If this is not acceptable then we can find a workaround but the solution will be more verbose.