### PR TITLE
chore: latest verbatim-module-syntax fixes

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -41,7 +41,7 @@ import { Buffer } from "../io/buffer.ts";
 import { assert } from "../assert/assert.ts";
 import { HEADER_LENGTH } from "./_common.ts";
 
-export { type TarInfo, type TarMeta, type TarOptions };
+export type { TarInfo, TarMeta, TarOptions };
 
 const USTAR_MAGIC_HEADER = "ustar\u000000";
 

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -14,7 +14,12 @@ import {
 } from "./_io.ts";
 import { assert } from "../assert/assert.ts";
 
-export { ParseError, type ParseResult, type ReadOptions, type RecordWithColumn };
+export {
+  ParseError,
+  type ParseResult,
+  type ReadOptions,
+  type RecordWithColumn,
+};
 
 const BYTE_ORDER_MARK = "\ufeff";
 

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -14,7 +14,7 @@ import {
 } from "./_io.ts";
 import { assert } from "../assert/assert.ts";
 
-export { ParseError, type ParseResult, ReadOptions, type RecordWithColumn };
+export { ParseError, type ParseResult, type ReadOptions, type RecordWithColumn };
 
 const BYTE_ORDER_MARK = "\ufeff";
 

--- a/semver/_is_comparator_test.ts
+++ b/semver/_is_comparator_test.ts
@@ -3,7 +3,7 @@ import { assert } from "../assert/mod.ts";
 import { INVALID, MIN } from "./constants.ts";
 import { isComparator } from "./_is_comparator.ts";
 import { formatComparator } from "./_format_comparator.ts";
-import { Comparator } from "./types.ts";
+import type { Comparator } from "./types.ts";
 
 Deno.test({
   name: "isComparator()",

--- a/semver/is_range_test.ts
+++ b/semver/is_range_test.ts
@@ -3,7 +3,7 @@ import { assert } from "../assert/mod.ts";
 import { ALL } from "./constants.ts";
 import { formatRange } from "./format_range.ts";
 import { isRange } from "./is_range.ts";
-import { Range } from "./types.ts";
+import type { Range } from "./types.ts";
 
 Deno.test({
   name: "isRange()",


### PR DESCRIPTION
Going to do a release in a few minutes, so here's the latest fixes for verbatim-module-syntax (we'll have this landed as a lint rule in deno std in a bit)