### PR TITLE
0.218.2

### DIFF
--- a/version.ts
+++ b/version.ts
@@ -5,4 +5,4 @@
  * the cli's API is stable. In the future when std becomes stable, likely we
  * will match versions with cli as we have in the past.
  */
-export const VERSION = "0.218.0";
+export const VERSION = "0.218.2";


### PR DESCRIPTION
This PR bumps patch version (+2) to publish 0.218.2 with provenance enabled to JSR.