### PR TITLE
[unstable] BREAKING(semver): remove deprecated operators

### DIFF
--- a/semver/_constants.ts
+++ b/semver/_constants.ts
@@ -4,11 +4,8 @@
  * @deprecated (will be removed in 0.219.0) `"=="`, `"==="`, `"!=="` and `""` operators are deprecated. Use `"="`, `"!="` or `undefined` instead.
  */
 export const OPERATORS = [
-  "",
+  undefined,
   "=",
-  "==",
-  "===",
-  "!==",
   "!=",
   ">",
   ">=",

--- a/semver/_constants.ts
+++ b/semver/_constants.ts
@@ -1,8 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-/**
- * @deprecated (will be removed in 0.219.0) `"=="`, `"==="`, `"!=="` and `""` operators are deprecated. Use `"="`, `"!="` or `undefined` instead.
- */
 export const OPERATORS = [
   undefined,
   "=",

--- a/semver/constants.ts
+++ b/semver/constants.ts
@@ -66,7 +66,7 @@ export const ANY: SemVer = {
  * A comparator which will span all valid semantic versions
  */
 export const ALL: Comparator = {
-  operator: "",
+  operator: undefined,
   ...ANY,
   semver: ANY,
 };

--- a/semver/parse_range_test.ts
+++ b/semver/parse_range_test.ts
@@ -473,7 +473,7 @@ Deno.test("parseRange() parses ranges with x", () => {
     ["*", [
       [
         {
-          operator: "",
+          operator: undefined,
           major: NaN,
           minor: NaN,
           patch: NaN,

--- a/semver/range_intersects.ts
+++ b/semver/range_intersects.ts
@@ -11,12 +11,12 @@ function comparatorIntersects(
   const op0 = c0.operator;
   const op1 = c1.operator;
 
-  if (op0 === "" || op0 === undefined) {
+  if (op0 === undefined) {
     // if c0 is empty comparator, then returns true
     if (isWildcardComparator(c0)) return true;
     return testRange(c0, [[c1]]);
   }
-  if (op1 === "" || op1 === undefined) {
+  if (op1 === undefined) {
     if (isWildcardComparator(c1)) return true;
     return testRange(c1, [[c0]]);
   }

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -9,13 +9,9 @@ function comparatorMax(comparator: Comparator): SemVer {
   if (semver === ANY) return MAX;
   switch (comparator.operator) {
     case "!=":
-    case "!==":
     case ">":
     case ">=":
       return MAX;
-    case "":
-    case "==":
-    case "===":
     case undefined:
     case "=":
     case "<=":

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -15,17 +15,13 @@ function comparatorMin(comparator: Comparator): SemVer {
         ? increment(semver, "pre")
         : increment(semver, "patch");
     case "!=":
-    case "!==":
     case "<=":
     case "<":
       // The min(<0.0.0) is MAX
       return greaterThan(semver, MIN) ? MIN : MAX;
     case ">=":
     case undefined:
-    case "":
     case "=":
-    case "==":
-    case "===":
       return {
         major: semver.major,
         minor: semver.minor,

--- a/semver/test_range.ts
+++ b/semver/test_range.ts
@@ -9,15 +9,11 @@ function testComparator(version: SemVer, comparator: Comparator): boolean {
   }
   const cmp = compare(version, comparator.semver ?? comparator);
   switch (comparator.operator) {
-    case "":
     case "=":
-    case "==":
-    case "===":
     case undefined: {
       return cmp === 0;
     }
-    case "!=":
-    case "!==": {
+    case "!=": {
       return cmp !== 0;
     }
     case ">": {

--- a/semver/types.ts
+++ b/semver/types.ts
@@ -18,7 +18,6 @@ export type ReleaseType =
 
 /**
  * SemVer comparison operators.
- * @deprecated (will be removed in 0.219.0) `"=="`, `"==="`, `"!=="` and `""` operators are deprecated. Use `"="`, `"!="` or `undefined` instead.
  */
 export type Operator = typeof OPERATORS[number];
 


### PR DESCRIPTION
This change removes deprecated operators `""`, `==`, `===` and `!==` in favor of `undefined`, `=` and `!=`, respectively.