### PR TITLE
fix: use hyphens for jsr package exports

### DIFF
--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -179,7 +179,7 @@ for await (const entry of walk(cwd)) {
     const pkg = target.split("/")[0];
     if (pkg === currentPkg) {
       let newSpecifier = relative(dirname(entry.path), target)
-        .replaceAll( "\\", "/",);
+        .replaceAll("\\", "/");
       if (!newSpecifier.startsWith(".")) {
         newSpecifier = "./" + newSpecifier;
       }

--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -97,20 +97,16 @@ for (const { specifier, dependencies } of graph.modules) {
   const fromPkg = from.split("/")[0];
   for (const dep of dependencies ?? []) {
     if (dep.code) {
-      const to = relative(cwd, fromFileUrl(dep.code.specifier)).replaceAll(
-        "\\",
-        "/",
-      );
+      const to = relative(cwd, fromFileUrl(dep.code.specifier))
+        .replaceAll("\\", "/");
       const toPkg = to.split("/")[0];
       if (fromPkg !== toPkg) {
         pkgDeps.get(fromPkg)!.add(toPkg);
       }
     }
     if (dep.types) {
-      const to = relative(cwd, fromFileUrl(dep.types.specifier)).replaceAll(
-        "\\",
-        "/",
-      );
+      const to = relative(cwd, fromFileUrl(dep.types.specifier))
+        .replaceAll("\\", "/");
       const toPkg = to.split("/")[0];
       if (fromPkg !== toPkg) {
         pkgDeps.get(fromPkg)!.add(toPkg);
@@ -182,10 +178,8 @@ for await (const entry of walk(cwd)) {
     const target = relative(cwd, path).replaceAll("\\", "/");
     const pkg = target.split("/")[0];
     if (pkg === currentPkg) {
-      let newSpecifier = relative(dirname(entry.path), target).replaceAll(
-        "\\",
-        "/",
-      );
+      let newSpecifier = relative(dirname(entry.path), target)
+        .replaceAll( "\\", "/",);
       if (!newSpecifier.startsWith(".")) {
         newSpecifier = "./" + newSpecifier;
       }
@@ -249,9 +243,10 @@ function fixPackageName(pkg: string) {
 function fixPackagePath(path: string) {
   const packageName = /^[^/]+/.exec(path);
   if (packageName) {
-    return path.replace(packageName[0], fixPackageName(packageName[0]));
+    return path.replace(packageName[0], fixPackageName(packageName[0]))
+      .replaceAll("_", "-");
   }
-  return path;
+  return path.replaceAll("_", "-");
 }
 
 // Generate `deno.json` file.

--- a/_tools/packages.ts
+++ b/_tools/packages.ts
@@ -50,7 +50,7 @@ async function discoverExports(pkg: string) {
     if (name.includes("/testdata/")) continue; // testdata files
     if (name.endsWith("/deno.json")) continue; // deno.json files
 
-    const key = "." + name.replace(/\/mod$/, "");
+    const key = "." + name.replace(/\/mod$/, "").replaceAll("_", "-");
     exports.push([key, "." + path]);
   }
   exports.sort((a, b) => a[0].localeCompare(b[0]));


### PR DESCRIPTION
Uses a consistent separator instead of mixing the two: `@std/data-structures/binary_heap` -> `@std/data-structures/binary-heap`