### PR TITLE
chore: use `--trace-leaks` instead of `--trace-ops`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/"
   },
   "tasks": {
-    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-ops",
+    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env=HOME ./_tools/check_deprecation.ts",


### PR DESCRIPTION
`--trace-ops` has been deprecated in favour of `--trace-leaks`. See https://github.com/denoland/deno/pull/22598.