### PR TITLE
chore: run `deno task test` after workspace conversion

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: deno fmt
 
       - name: Type check
-        run: deno test --no-run --doc
+        run: deno task test
 
       - name: Publish (dry run)
         if: github.event_name == 'push'


### PR DESCRIPTION
This is a more complete means of testing after the workspaces conversion script has run.

Depends on #4346 being closed.