### PR TITLE
chore: exclude test files from being published to JSR

### DIFF
--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -231,8 +231,10 @@ for (const pkg of packages) {
     version: VERSION,
     exports,
     exclude: [
-      "**/test.{ts,js}",
-      "**/*_test.{ts,js}",
+      "**/test.ts",
+      "**/test.js",
+      "**/*_test.ts",
+      "**/*_test.js",
       "**/testdata/**",
     ],
   };

--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -231,7 +231,8 @@ for (const pkg of packages) {
     version: VERSION,
     exports,
     exclude: [
-      "**/*_test.ts",
+      "**/test.{ts,js}",
+      "**/*_test.{ts,js}",
       "**/testdata/**",
     ],
   };

--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -230,6 +230,10 @@ for (const pkg of packages) {
     name: `@std/${fixPackageName(pkg)}`,
     version: VERSION,
     exports,
+    exclude: [
+      "**/*_test.ts",
+      "**/testdata/**",
+    ],
   };
   /** @see {@link https://github.com/denoland/deno/issues/22317} */
   if (pkg === "crypto") {


### PR DESCRIPTION
This change prevents many unnecessary files from being published and reduces the number of warnings from `deno publish --dry-run`.