### PR TITLE
refactor(log): Deprecate `BaseHandler.setup()` and `BaseHandler.destroy()`

### DIFF
--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -58,7 +58,14 @@ export class BaseHandler {
   }
 
   log(_msg: string) {}
+
+  /**
+   * @deprecated (will be removed in 0.220.0)
+   */
   setup() {}
+  /**
+   * @deprecated (will be removed in 0.220.0)
+   */
   destroy() {}
 
   [Symbol.dispose]() {

--- a/log/file_handler_test.ts
+++ b/log/file_handler_test.ts
@@ -18,8 +18,8 @@ Deno.test({
         assertEquals(text.slice(-1), "\n");
       }
 
-      override destroy() {
-        super.destroy();
+      override close() {
+        super.close();
         Deno.removeSync(LOG_FILE);
       }
     }
@@ -28,7 +28,7 @@ Deno.test({
       filename: LOG_FILE,
       mode: "w",
     });
-    testFileHandler.setup();
+    testFileHandler.open();
 
     for (let i = 0; i < 300; i++) {
       testFileHandler.handle(
@@ -51,7 +51,7 @@ Deno.test({
       mode: "w",
     });
 
-    fileHandler.setup();
+    fileHandler.open();
     fileHandler.handle(
       new LogRecord({
         msg: "Hello World",
@@ -60,10 +60,10 @@ Deno.test({
         loggerName: "default",
       }),
     );
-    fileHandler.destroy();
+    fileHandler.close();
     const firstFileSize = (await Deno.stat(LOG_FILE)).size;
 
-    fileHandler.setup();
+    fileHandler.open();
     fileHandler.handle(
       new LogRecord({
         msg: "Hello World",
@@ -72,7 +72,7 @@ Deno.test({
         loggerName: "default",
       }),
     );
-    fileHandler.destroy();
+    fileHandler.close();
     const secondFileSize = (await Deno.stat(LOG_FILE)).size;
 
     assertEquals(secondFileSize, firstFileSize);
@@ -90,7 +90,7 @@ Deno.test({
     Deno.writeFileSync(LOG_FILE, new TextEncoder().encode("hello world"));
 
     assertThrows(() => {
-      fileHandler.setup();
+      fileHandler.open();
     }, Deno.errors.AlreadyExists);
 
     Deno.removeSync(LOG_FILE);
@@ -104,7 +104,7 @@ Deno.test({
       filename: LOG_FILE,
       mode: "w",
     });
-    fileHandler.setup();
+    fileHandler.open();
     fileHandler.handle(
       new LogRecord({
         msg: "AAA",
@@ -130,7 +130,7 @@ Deno.test({
       filename: LOG_FILE,
       mode: "w",
     });
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.handle(
       new LogRecord({
@@ -171,10 +171,10 @@ Deno.test({
       mode: "w",
     });
     const logOverBufferLimit = "A".repeat(4096);
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.log(logOverBufferLimit);
-    fileHandler.destroy();
+    fileHandler.close();
 
     assertEquals(
       Deno.readTextFileSync(LOG_FILE),
@@ -194,12 +194,12 @@ Deno.test({
     });
     const veryLargeLog = "A".repeat(10000);
     const regularLog = "B".repeat(100);
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.log(regularLog);
     fileHandler.log(veryLargeLog);
     fileHandler.log(regularLog);
-    fileHandler.destroy();
+    fileHandler.close();
 
     assertEquals(
       Deno.readTextFileSync(LOG_FILE),

--- a/log/rotating_file_handler.ts
+++ b/log/rotating_file_handler.ts
@@ -58,15 +58,19 @@ export class RotatingFileHandler extends FileHandler {
   }
 
   override setup() {
+    this.open();
+    super.setup();
+  }
+  override open() {
     if (this.#maxBytes < 1) {
-      this.destroy();
+      this.close();
       throw new Error("maxBytes cannot be less than 1");
     }
     if (this.#maxBackupCount < 1) {
-      this.destroy();
+      this.close();
       throw new Error("maxBackupCount cannot be less than 1");
     }
-    super.setup();
+    super.open();
 
     if (this._mode === "w") {
       // Remove old backups too as it doesn't make sense to start with a clean
@@ -84,7 +88,7 @@ export class RotatingFileHandler extends FileHandler {
       // Throw if any backups also exist
       for (let i = 1; i <= this.#maxBackupCount; i++) {
         if (existsSync(this._filename + "." + i)) {
-          this.destroy();
+          this.close();
           throw new Deno.errors.AlreadyExists(
             "Backup log file " + this._filename + "." + i + " already exists",
           );

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -36,8 +36,8 @@ Deno.test({
       maxBackupCount: 3,
       mode: "w",
     });
-    fileHandler.setup();
-    fileHandler.destroy();
+    fileHandler.open();
+    fileHandler.close();
 
     assertEquals((await Deno.stat(LOG_FILE)).size, 0);
     assert(!existsSync(LOG_FILE + ".1"));
@@ -64,7 +64,7 @@ Deno.test({
     });
     assertThrows(
       () => {
-        fileHandler.setup();
+        fileHandler.open();
       },
       Deno.errors.AlreadyExists,
       "Backup log file " + LOG_FILE + ".3 already exists",
@@ -84,7 +84,7 @@ Deno.test({
       maxBackupCount: 3,
       mode: "w",
     });
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.handle(
       new LogRecord({
@@ -133,7 +133,7 @@ Deno.test({
       maxBackupCount: 3,
       mode: "w",
     });
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.handle(
       new LogRecord({
@@ -160,7 +160,7 @@ Deno.test({
       }),
     );
 
-    fileHandler.destroy();
+    fileHandler.close();
 
     assertEquals((await Deno.stat(LOG_FILE)).size, 10);
     assertEquals((await Deno.stat(LOG_FILE + ".1")).size, 20);
@@ -193,7 +193,7 @@ Deno.test({
       maxBackupCount: 3,
       mode: "a",
     });
-    fileHandler.setup();
+    fileHandler.open();
     fileHandler.handle(
       new LogRecord({
         msg: "AAA",
@@ -202,7 +202,7 @@ Deno.test({
         loggerName: "default",
       }),
     ); // 'ERROR AAA\n' = 10 bytes
-    fileHandler.destroy();
+    fileHandler.close();
 
     const decoder = new TextDecoder();
     assertEquals(decoder.decode(Deno.readFileSync(LOG_FILE)), "ERROR AAA\n");
@@ -238,7 +238,7 @@ Deno.test({
           maxBackupCount: 3,
           mode: "w",
         });
-        fileHandler.setup();
+        fileHandler.open();
       },
       Error,
       "maxBytes cannot be less than 1",
@@ -257,7 +257,7 @@ Deno.test({
           maxBackupCount: 0,
           mode: "w",
         });
-        fileHandler.setup();
+        fileHandler.open();
       },
       Error,
       "maxBackupCount cannot be less than 1",
@@ -274,7 +274,7 @@ Deno.test({
       maxBackupCount: 1,
       mode: "w",
     });
-    fileHandler.setup();
+    fileHandler.open();
 
     const msg = "。";
     const msgLength = msg.length;
@@ -286,7 +286,7 @@ Deno.test({
     fileHandler.log(msg); // logs 4 bytes (including '\n')
     fileHandler.log(msg); // max bytes is 7, but this would be 8.  Rollover.
 
-    fileHandler.destroy();
+    fileHandler.close();
 
     const fileSize1 = (await Deno.stat(LOG_FILE)).size;
     const fileSize2 = (await Deno.stat(LOG_FILE + ".1")).size;
@@ -309,10 +309,10 @@ Deno.test({
       maxBackupCount: 10,
     });
     const logOverBufferLimit = "A".repeat(4096);
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.log(logOverBufferLimit);
-    fileHandler.destroy();
+    fileHandler.close();
 
     assertEquals(
       Deno.readTextFileSync(LOG_FILE),
@@ -334,12 +334,12 @@ Deno.test({
     });
     const veryLargeLog = "A".repeat(10000);
     const regularLog = "B".repeat(100);
-    fileHandler.setup();
+    fileHandler.open();
 
     fileHandler.log(regularLog);
     fileHandler.log(veryLargeLog);
     fileHandler.log(regularLog);
-    fileHandler.destroy();
+    fileHandler.close();
 
     assertEquals(
       Deno.readTextFileSync(LOG_FILE),

--- a/log/setup.ts
+++ b/log/setup.ts
@@ -14,6 +14,11 @@ export function setup(config: LogConfig) {
 
   // tear down existing handlers
   state.handlers.forEach((handler) => {
+    /**
+     * replace with
+     * `const close = (handler as FileHandler).close; if (close instanceof Function) close();`
+     * after removal of `BaseHandler.destroy()`
+     */
     handler.destroy();
   });
   state.handlers.clear();
@@ -22,6 +27,11 @@ export function setup(config: LogConfig) {
   const handlers = state.config.handlers || {};
 
   for (const [handlerName, handler] of Object.entries(handlers)) {
+    /**
+     * replace with
+     * `const open = (handler as FileHandler).open; if (open instanceof Function) open();`
+     * after removal of `BaseHandler.setup()`
+     */
     handler.setup();
     state.handlers.set(handlerName, handler);
   }


### PR DESCRIPTION
Ref: https://github.com/denoland/deno_std/issues/4391

**Changes**

- Deprecates `BaseHandler.setup()`
- Deprecates `BaseHandler.destroy()`
- Introduces `FileHandler.open()` to replace `FileHandler.setup()`
- Introduces `FileHandler.close()`to replace `FileHandler.destroy()`
- Adds comments how to make `setup()` function work without `BaseHandler.setup()` and `BaseHandler.destroy()`