### PR TITLE
chore: enable `camelcase` lint rule

### DIFF
--- a/_tools/check_circular_submodule_dependencies.ts
+++ b/_tools/check_circular_submodule_dependencies.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file camelcase
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { createGraph, type ModuleGraphJson, type ModuleJson } from "deno_graph";
 

--- a/deno.json
+++ b/deno.json
@@ -36,5 +36,12 @@
     "front_matter/testdata",
     "coverage",
     "docs"
-  ]
+  ],
+  "lint": {
+    "rules": {
+      "include": [
+        "camelcase"
+      ]
+    }
+  }
 }

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -9,10 +9,10 @@ type LineParseResult = {
 
 type CharactersMap = { [key: string]: string };
 
-const RE_KeyValue =
+const RE_KEY_VALUE =
   /^\s*(?:export\s+)?(?<key>[a-zA-Z_]+[a-zA-Z0-9_]*?)\s*=[\ \t]*('\n?(?<notInterpolated>(.|\n)*?)\n?'|"\n?(?<interpolated>(.|\n)*?)\n?"|(?<unquoted>[^\n#]*)) *#*.*$/gm;
 
-const RE_ExpandValue =
+const RE_EXPAND_VALUE =
   /(\${(?<inBrackets>.+?)(\:-(?<inBracketsDefault>.+))?}|(?<!\\)\$(?<notInBrackets>\w+)(\:-(?<notInBracketsDefault>.+))?)/g;
 
 function expandCharacters(str: string): string {
@@ -29,9 +29,9 @@ function expandCharacters(str: string): string {
 }
 
 function expand(str: string, variablesMap: { [key: string]: string }): string {
-  if (RE_ExpandValue.test(str)) {
+  if (RE_EXPAND_VALUE.test(str)) {
     return expand(
-      str.replace(RE_ExpandValue, function (...params) {
+      str.replace(RE_EXPAND_VALUE, function (...params) {
         const {
           inBrackets,
           inBracketsDefault,
@@ -71,7 +71,7 @@ export function parse(rawDotenv: string): Record<string, string> {
   let match;
   const keysForExpandCheck = [];
 
-  while ((match = RE_KeyValue.exec(rawDotenv)) !== null) {
+  while ((match = RE_KEY_VALUE.exec(rawDotenv)) !== null) {
     const { key, interpolated, notInterpolated, unquoted } = match
       ?.groups as LineParseResult;
 

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -61,12 +61,12 @@ export function encodeBase58(data: ArrayBuffer | Uint8Array | string): string {
     let carry = byte;
 
     for (
-      let reverse_iterator = size - 1;
-      (carry > 0 || i < length) && reverse_iterator !== -1;
-      reverse_iterator--, i++
+      let reverseIterator = size - 1;
+      (carry > 0 || i < length) && reverseIterator !== -1;
+      reverseIterator--, i++
     ) {
-      carry += (b58Encoding[reverse_iterator] || 0) * 256;
-      b58Encoding[reverse_iterator] = Math.round(carry % 58);
+      carry += (b58Encoding[reverseIterator] || 0) * 256;
+      b58Encoding[reverseIterator] = Math.round(carry % 58);
       carry = Math.floor(carry / 58);
     }
 
@@ -127,12 +127,12 @@ export function decodeBase58(b58: string): Uint8Array {
     }
 
     for (
-      let reverse_iterator = size - 1;
-      (carry > 0 || i < length) && reverse_iterator !== -1;
-      reverse_iterator--, i++
+      let reverseIterator = size - 1;
+      (carry > 0 || i < length) && reverseIterator !== -1;
+      reverseIterator--, i++
     ) {
-      carry += 58 * (output[reverse_iterator] || 0);
-      output[reverse_iterator] = Math.round(carry % 256);
+      carry += 58 * (output[reverseIterator] || 0);
+      output[reverseIterator] = Math.round(carry % 256);
       carry = Math.floor(carry / 256);
     }
 

--- a/url/basename_test.ts
+++ b/url/basename_test.ts
@@ -13,7 +13,7 @@ const TESTSUITE: [[string | URL, string?], string][] = [
 ];
 
 Deno.test("basename()", function () {
-  for (const [[test_url, suffix], expected] of TESTSUITE) {
-    assertEquals(url.basename(test_url, suffix), expected);
+  for (const [[testUrl, suffix], expected] of TESTSUITE) {
+    assertEquals(url.basename(testUrl, suffix), expected);
   }
 });

--- a/url/dirname_test.ts
+++ b/url/dirname_test.ts
@@ -27,7 +27,7 @@ const TESTSUITE = [
 ] as const;
 
 Deno.test("dirname()", function () {
-  for (const [test_url, expected] of TESTSUITE) {
-    assertEquals(url.dirname(test_url), expected);
+  for (const [testUrl, expected] of TESTSUITE) {
+    assertEquals(url.dirname(testUrl), expected);
   }
 });

--- a/url/extname_test.ts
+++ b/url/extname_test.ts
@@ -13,7 +13,7 @@ const TESTSUITE = [
 ] as const;
 
 Deno.test("extname()", function () {
-  for (const [test_url, expected] of TESTSUITE) {
-    assertEquals(url.extname(test_url), expected);
+  for (const [testUrl, expected] of TESTSUITE) {
+    assertEquals(url.extname(testUrl), expected);
   }
 });

--- a/url/join_test.ts
+++ b/url/join_test.ts
@@ -23,7 +23,7 @@ const TESTSUITE: [[string | URL, ...string[]], URL][] = [
 ];
 
 Deno.test("join()", function () {
-  for (const [[test_url, ...paths], expected] of TESTSUITE) {
-    assertEquals(url.join(test_url, ...paths), expected);
+  for (const [[testUrl, ...paths], expected] of TESTSUITE) {
+    assertEquals(url.join(testUrl, ...paths), expected);
   }
 });

--- a/url/normalize_test.ts
+++ b/url/normalize_test.ts
@@ -31,7 +31,7 @@ const TESTSUITE = [
 ] as const;
 
 Deno.test("normalize()", function () {
-  for (const [test_url, expected] of TESTSUITE) {
-    assertEquals(url.normalize(test_url), expected);
+  for (const [testUrl, expected] of TESTSUITE) {
+    assertEquals(url.normalize(testUrl), expected);
   }
 });


### PR DESCRIPTION
IMO, this should be enabled by default.

Closes #4322