### PR TITLE
chore: ignore more test files from being published

### DIFF
--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -233,8 +233,8 @@ for (const pkg of packages) {
     exclude: [
       "**/test.ts",
       "**/test.js",
-      "**/*_test.ts",
-      "**/*_test.js",
+      "**/*_test*.ts",
+      "**/*_test*.js",
       "**/testdata/**",
     ],
   };

--- a/_tools/convert_to_workspace.ts
+++ b/_tools/convert_to_workspace.ts
@@ -231,8 +231,6 @@ for (const pkg of packages) {
     version: VERSION,
     exports,
     exclude: [
-      "**/test.ts",
-      "**/test.js",
       "**/*_test*.ts",
       "**/*_test*.js",
       "**/testdata/**",


### PR DESCRIPTION
This change:
1. Includes `**/*test.{ts,js}` files to be published, as there's https://github.com/denoland/deno_std/blob/main/front_matter/test.ts that is part of the non-testing, public API.
2. Adds further test files, like `io/_test_common.ts` to be excluded from publishing.