### PR TITLE
chore: add `RUST_BACKTRACE=1` to `test` task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/"
   },
   "tasks": {
-    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
+    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env=HOME ./_tools/check_deprecation.ts",


### PR DESCRIPTION
This change aims to improve the debugability of runtime errors.

Related https://github.com/denoland/deno/issues/22719