### PR TITLE
chore: run on Deno v1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         deno:
-          # TODO(kt3k): Enable this when Deno v1.41.1 released
-          # - v1.x
+          - v1.x
           - canary
         os:
           - ubuntu-22.04
@@ -99,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        module: [ crypto/_wasm ]
+        module: [crypto/_wasm]
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Found this while checking the Github Actions workflows and thought about doing this quick fix. Since Deno is now available in 1.41.1 this might be usable now.