### PR TITLE
docs(path): add examples for posix basename, dirname and extname

### DIFF
--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -13,6 +13,15 @@ import { isPosixPathSeparator } from "./_util.ts";
  * Return the last portion of a `path`.
  * Trailing directory separators are ignored, and optional suffix is removed.
  *
+ * @example
+ * ```ts
+ * import { basename } from "https://deno.land/std@$STD_VERSION/path/basename.ts";
+ *
+ * console.log(basename("/home/user/Documents/")); // "Documents"
+ * console.log(basename("/home/user/Documents/image.png")); // "image.png"
+ * console.log(basename("/home/user/Documents/image.png", ".png")); // "image"
+ * ```
+ *
  * @param path - path to extract the name from.
  * @param [suffix] - suffix to remove from extracted name.
  */

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -12,8 +12,8 @@ import { isPosixPathSeparator } from "./_util.ts";
  * ```ts
  * import { dirname } from "https://deno.land/std@$STD_VERSION/path/dirname.ts";
  *
- * console.log(dirname("/home/user/Documents/")); // "Documents"
- * console.log(dirname("/home/user/Documents/image.png")); // "Documents"
+ * console.log(dirname("/home/user/Documents/")); // "/home/user"
+ * console.log(dirname("/home/user/Documents/image.png")); // "/home/user/Documents"
  * ```
  *
  * @param path - path to extract the directory from.

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -7,6 +7,15 @@ import { isPosixPathSeparator } from "./_util.ts";
 
 /**
  * Return the directory path of a `path`.
+ *
+ * @example
+ * ```ts
+ * import { dirname } from "https://deno.land/std@$STD_VERSION/path/dirname.ts";
+ *
+ * console.log(dirname("/home/user/Documents/")); // "Documents"
+ * console.log(dirname("/home/user/Documents/image.png")); // "Documents"
+ * ```
+ *
  * @param path - path to extract the directory from.
  */
 export function dirname(path: string): string {

--- a/path/posix/extname.ts
+++ b/path/posix/extname.ts
@@ -7,6 +7,15 @@ import { isPosixPathSeparator } from "./_util.ts";
 
 /**
  * Return the extension of the `path` with leading period.
+ *
+ * @example
+ * ```ts
+ * import { extname } from "https://deno.land/std@$STD_VERSION/path/extname.ts";
+ *
+ * console.log(extname("/home/user/Documents/")); // ""
+ * console.log(extname("/home/user/Documents/image.png")); // ".png"
+ * ```
+ *
  * @param path with extension
  * @returns extension (ex. for `file.ts` returns `.ts`)
  */


### PR DESCRIPTION
Hi

This documentation PR adds JSDoc `@example` for : 

- https://deno.land/std/path/posix/basename.ts?s=basename
- https://deno.land/std/path/posix/dirname.ts?s=dirname
- https://deno.land/std/path/posix/extname.ts?s=extname