### PR TITLE
chore: fix "Wasm" casing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           declare modifications="$(git diff --name-only HEAD~ -- ${{ matrix.module }})"
           declare modified="$([[ "$modifications" ]] && echo true || echo false)"
           echo "modified=$modified" >> $GITHUB_OUTPUT
-          echo "${{ matrix.module }} WASM source modified in this commit? $modified"
+          echo "${{ matrix.module }} Wasm source modified in this commit? $modified"
           echo "$modifications"
 
       - name: Set up Deno

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -312,8 +312,8 @@ export type FNVAlgorithms = "FNV32" | "FNV32A" | "FNV64" | "FNV64A";
 export type DigestAlgorithmName = WasmDigestAlgorithm | FNVAlgorithms;
 
 /*
- * The largest digest length the current WASM implementation can support. This
- * is the value of `isize::MAX` on 32-bit platforms like WASM, which is the
+ * The largest digest length the current Wasm implementation can support. This
+ * is the value of `isize::MAX` on 32-bit platforms like Wasm, which is the
  * maximum allowed capacity of a Rust `Vec<u8>`.
  */
 const MAX_DIGEST_LENGTH = 0x7FFF_FFFF;


### PR DESCRIPTION
Nit: the correct abbreviation is "Wasm", not "WASM".