### PR TITLE
chore(CI): use `--allow-dirty` for publish action

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Publish (real)
         if: github.event_name == 'release'
-        run: deno publish
+        run: deno publish --allow-dirty


### PR DESCRIPTION
This is needed as CI needs to publish with uncommitted changes. This fixes JSR publishing. See https://github.com/denoland/deno_std/actions/runs/8285101246/job/22672084929