### PR TITLE
refactor(front_matter): cleanup `_formats.ts`

### DIFF
--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -2,23 +2,21 @@
 
 type Delimiter = string | [begin: string, end: string];
 
-const { isArray } = Array;
-
 function getBeginToken(delimiter: Delimiter): string {
-  return isArray(delimiter) ? delimiter[0] : delimiter;
+  return Array.isArray(delimiter) ? delimiter[0] : delimiter;
 }
 
 function getEndToken(delimiter: Delimiter): string {
-  return isArray(delimiter) ? delimiter[1] : delimiter;
+  return Array.isArray(delimiter) ? delimiter[1] : delimiter;
 }
 
-function createRegExp(...dv: Delimiter[]): [RegExp, RegExp] {
-  const beginPattern = "(" + dv.map(getBeginToken).join("|") + ")";
+function createRegExps(delimiters: Delimiter[]): [RegExp, RegExp] {
+  const beginPattern = "(" + delimiters.map(getBeginToken).join("|") + ")";
   const pattern = "^(" +
     "\\ufeff?" + // Maybe byte order mark
     beginPattern +
     "$([\\s\\S]+?)" +
-    "^(?:" + dv.map(getEndToken).join("|") + ")\\s*" +
+    "^(?:" + delimiters.map(getEndToken).join("|") + ")\\s*" +
     "$" +
     (globalThis?.Deno?.build?.os === "windows" ? "\\r?" : "") +
     "(?:\\n)?)";
@@ -29,29 +27,35 @@ function createRegExp(...dv: Delimiter[]): [RegExp, RegExp] {
   ];
 }
 
-const [RX_RECOGNIZE_YAML, RX_YAML] = createRegExp(
-  ["---yaml", "---"],
-  "= yaml =",
-  "---",
+const [RECOGNIZE_YAML_REGEXP, EXTRACT_YAML_REGEXP] = createRegExps(
+  [
+    ["---yaml", "---"],
+    "= yaml =",
+    "---",
+  ],
 );
-const [RX_RECOGNIZE_TOML, RX_TOML] = createRegExp(
-  ["---toml", "---"],
-  "\\+\\+\\+",
-  "= toml =",
+const [RECOGNIZE_TOML_REGEXP, EXTRACT_TOML_REGEXP] = createRegExps(
+  [
+    ["---toml", "---"],
+    "\\+\\+\\+",
+    "= toml =",
+  ],
 );
-const [RX_RECOGNIZE_JSON, RX_JSON] = createRegExp(
-  ["---json", "---"],
-  "= json =",
+const [RECOGNIZE_JSON_REGEXP, EXTRACT_JSON_REGEXP] = createRegExps(
+  [
+    ["---json", "---"],
+    "= json =",
+  ],
 );
 
-export const MAP_FORMAT_TO_RECOGNIZER_RX = {
-  yaml: RX_RECOGNIZE_YAML,
-  toml: RX_RECOGNIZE_TOML,
-  json: RX_RECOGNIZE_JSON,
+export const RECOGNIZE_REGEXP_MAP = {
+  yaml: RECOGNIZE_YAML_REGEXP,
+  toml: RECOGNIZE_TOML_REGEXP,
+  json: RECOGNIZE_JSON_REGEXP,
 } as const;
 
-export const MAP_FORMAT_TO_EXTRACTOR_RX = {
-  yaml: RX_YAML,
-  toml: RX_TOML,
-  json: RX_JSON,
+export const EXTRACT_REGEXP_MAP = {
+  yaml: EXTRACT_YAML_REGEXP,
+  toml: EXTRACT_TOML_REGEXP,
+  json: EXTRACT_JSON_REGEXP,
 } as const;

--- a/front_matter/create_extractor.ts
+++ b/front_matter/create_extractor.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import {
-  MAP_FORMAT_TO_EXTRACTOR_RX,
-  MAP_FORMAT_TO_RECOGNIZER_RX,
-} from "./_formats.ts";
+import { EXTRACT_REGEXP_MAP, RECOGNIZE_REGEXP_MAP } from "./_formats.ts";
 
 type Format = "yaml" | "toml" | "json" | "unknown";
 
@@ -56,7 +53,7 @@ function _extract<T>(
  */
 function recognize(str: string, formats?: Format[]): Format {
   if (!formats) {
-    formats = Object.keys(MAP_FORMAT_TO_RECOGNIZER_RX) as Format[];
+    formats = Object.keys(RECOGNIZE_REGEXP_MAP) as Format[];
   }
 
   const [firstLine] = str.split(/(\r?\n)/) as [string];
@@ -66,7 +63,7 @@ function recognize(str: string, formats?: Format[]): Format {
       continue;
     }
 
-    if (MAP_FORMAT_TO_RECOGNIZER_RX[format].test(firstLine)) {
+    if (RECOGNIZE_REGEXP_MAP[format].test(firstLine)) {
       return format;
     }
   }
@@ -133,6 +130,6 @@ export function createExtractor(
       throw new TypeError(`Unsupported front matter format`);
     }
 
-    return _extract(str, MAP_FORMAT_TO_EXTRACTOR_RX[format], parser);
+    return _extract(str, EXTRACT_REGEXP_MAP[format], parser);
   };
 }

--- a/front_matter/test.ts
+++ b/front_matter/test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { MAP_FORMAT_TO_EXTRACTOR_RX } from "./_formats.ts";
+import { EXTRACT_REGEXP_MAP } from "./_formats.ts";
 
 type Format = "yaml" | "toml" | "json" | "unknown";
 
@@ -26,7 +26,7 @@ export function test(
   formats?: ("yaml" | "toml" | "json" | "unknown")[],
 ): boolean {
   if (!formats) {
-    formats = Object.keys(MAP_FORMAT_TO_EXTRACTOR_RX) as Format[];
+    formats = Object.keys(EXTRACT_REGEXP_MAP) as Format[];
   }
 
   for (const format of formats) {
@@ -34,7 +34,7 @@ export function test(
       throw new TypeError("Unable to test for unknown front matter format");
     }
 
-    const match = MAP_FORMAT_TO_EXTRACTOR_RX[format].exec(str);
+    const match = EXTRACT_REGEXP_MAP[format].exec(str);
     if (match?.index === 0) {
       return true;
     }


### PR DESCRIPTION
**Changes**
- renames constants in `_formats.ts`, uses conventional name format.
- removes `Array` destructuring.
- renames `createRegExp()` to `createRegExps()` as it returns multiple regexps.
- removes `createRegExps()` spread arguments in favour of an array.