### PR TITLE
chore: fix lint error in canary

### DIFF
--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -86,7 +86,6 @@ function parseHeader(buffer: Uint8Array): TarHeader {
 }
 
 /** Tar entry */
-// deno-lint-ignore no-empty-interface
 export interface TarEntry extends TarMetaWithLinkName {}
 
 /** Contains tar header metadata and a reader to the entry's body. */


### PR DESCRIPTION
Future versions of Deno don't require an ignore comment around empty `interfaces` that extend another type. Previous Deno versions required that.

```ts
// Deno <=1.41.3
// deno-lint-ignore no-empty-interface
export interface TarEntry extends TarMetaWithLinkName {}
```

Canary + Future Deno versions don't need that comment.

```ts
export interface TarEntry extends TarMetaWithLinkName {}
```

This change to the linter in Deno was done in https://github.com/denoland/deno_lint/pull/1250

