### PR TITLE
docs(http): fix default algorithm for etag in docs

### DIFF
--- a/http/etag.ts
+++ b/http/etag.ts
@@ -40,7 +40,7 @@ export interface ETagOptions {
   /**
    * A digest algorithm to use to calculate the etag.
    *
-   * @default {"FNV32A"}
+   * @default {"SHA-256"}
    */
   algorithm?: AlgorithmIdentifier;
 


### PR DESCRIPTION
The default algorithm for etag is not FNV32A, but SHA-256. This PR fixes the doc for it.