### PR TITLE
fix(_tools): update `check_deprecation` path exclusion to recognize Windows directory separators

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -7,22 +7,6 @@ import { doc } from "deno_doc";
 import { walk } from "../fs/walk.ts";
 import { toFileUrl } from "../path/mod.ts";
 
-const EXTENSIONS = [".mjs", ".js", ".ts"];
-const EXCLUDED_PATHS = [
-  ".git",
-  "dotenv/testdata",
-  "fs/testdata",
-  "http/testdata",
-  "http/_negotiation",
-  "crypto/_wasm",
-  "crypto/_fnv",
-  "encoding/_yaml",
-  "encoding/_toml",
-  "_tools",
-  "_util",
-  "docs",
-];
-
 const ROOT = new URL("../", import.meta.url);
 
 const FAIL_FAST = Deno.args.includes("--fail-fast");
@@ -52,8 +36,21 @@ const DEPRECATION_IN_FORMAT =
 for await (
   const { path } of walk(ROOT, {
     includeDirs: false,
-    exts: EXTENSIONS,
-    skip: EXCLUDED_PATHS.map((path) => new RegExp(path + "$")),
+    exts: [".mjs", ".js", ".ts"],
+    skip: [
+      /\.git$/,
+      /dotenv(\/|\\)testdata$/,
+      /fs(\/|\\)testdata$/,
+      /http(\/|\\)testdata$/,
+      /http(\/|\\)_negotiation$/,
+      /crypto(\/|\\)_benches$/,
+      /crypto(\/|\\)_wasm$/,
+      /encoding(\/|\\)_yaml$/,
+      /encoding(\/|\\)_toml$/,
+      /_tools$/,
+      /_util$/,
+      /docs$/,
+    ],
   })
 ) {
   // deno_doc only takes urls.

--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -35,7 +35,7 @@ for await (
 
   for await (
     const { path: filePath } of walk(dirname(modFilePath), {
-      exts: ["ts"],
+      exts: [".ts"],
       includeDirs: false,
       maxDepth: 1,
       skip: [


### PR DESCRIPTION
PR #4503 updated the `lint` action to run on all platforms, not just Linux, and updated the path-exclusion logic in `_tools/check_mod_exports.ts` to use a regex that matches both Linux and Windows directory separators. However, `_tools/check_deprecation.ts` was not updated and the path exclusion logic is not working correctly on Windows. This doesn't break anything that's currently on `main`, but it breaks my PR #4515 which was relying on one of those path exclusions to avoid crashing on an `node:` import in my benchmark script which is unsupported by `/x/deno_doc`. (The exclusion does **not** apply to any actual library code, so I think it's reasonable to use it and skip the check, since the benchmark is only used manually by developers working on this repository.)

This PR attempts to update the path exclusion logic in `check_deprecation` in the same way as the logic for `check_mod_exports` was updated in #4503. It also fixes the `exts` argument to `walk()` in `check_mod_exports` to specify the file extension as `.ts` instead of `ts` because from the implementation it looks like it's just a suffix match, so the dot isn't implied.

(I'm not entirely sure if this is the right change to make, feel free to close this PR if not, but I wanted to take a stab at fixing the issue before pulling the offending code out of my other PR.)