### PR TITLE
chore: drop lint in macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macOS-12
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It seems enough to check lint in linux (posix) and windows. I'd suggest drop lint ci in macos.