### PR TITLE
feat(html): add `normalize` function for HTML entities (#4523)

### DIFF
--- a/html/entities_test.ts
+++ b/html/entities_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { escape, unescape } from "./entities.ts";
+import { escape, normalize, unescape } from "./entities.ts";
 import { assertEquals } from "../assert/mod.ts";
 import entityList from "./named_entity_list.json" with { type: "json" };
 
@@ -18,6 +18,43 @@ Deno.test("escape()", async (t) => {
     "doesn't escape other characters, even if they have named entities",
     () => {
       assertEquals(escape("þð"), "þð");
+    },
+  );
+  await t.step(
+    "doesn't escape non-ascii text by default",
+    () => {
+      assertEquals(escape("两只小蜜蜂 🐝🐝"), "两只小蜜蜂 🐝🐝");
+    },
+  );
+  await t.step(
+    "doesn't escape non-ascii text when `form` is `readability`",
+    () => {
+      assertEquals(
+        escape("两只小蜜蜂 🐝🐝", { form: "readability" }),
+        "两只小蜜蜂 🐝🐝",
+      );
+    },
+  );
+  await t.step(
+    "escapes non-ascii text when `form` is `compatibility`",
+    () => {
+      assertEquals(
+        escape("两只小蜜蜂 🐝🐝", { form: "compatibility" }),
+        "&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702; &#x1f41d;&#x1f41d;",
+      );
+      assertEquals(escape("þð", { form: "compatibility" }), "&#xfe;&#xf0;");
+    },
+  );
+  await t.step(
+    "escapes control chars when `form` is `compatibility`",
+    () => {
+      assertEquals(escape("\x03", { form: "compatibility" }), "&#x3;");
+    },
+  );
+  await t.step(
+    "doesn't escape ASCII whitespace chars when `form` is `compatibility`",
+    () => {
+      assertEquals(escape(" \r\n\t", { form: "compatibility" }), " \r\n\t");
     },
   );
 });
@@ -107,4 +144,77 @@ Deno.test("unescape()", async (t) => {
       },
     );
   });
+});
+
+Deno.test("normalize()", async (t) => {
+  await t.step(
+    "normalizes unnecessarily escaped non-ascii chars by default",
+    () => {
+      assertEquals(
+        normalize("&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702;"),
+        "两只小蜜蜂",
+      );
+      assertEquals(normalize("两只小蜜蜂"), "两只小蜜蜂");
+    },
+  );
+  await t.step(
+    "normalizes unnecessarily escaped non-ascii chars if `form` is `readability`",
+    () => {
+      assertEquals(
+        normalize("&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702;", {
+          form: "readability",
+        }),
+        "两只小蜜蜂",
+      );
+      assertEquals(
+        normalize("两只小蜜蜂", { form: "readability" }),
+        "两只小蜜蜂",
+      );
+    },
+  );
+  await t.step(
+    "normalizes non-ascii chars to escaped form if `form` is `compatibility`",
+    () => {
+      assertEquals(
+        normalize("两只小蜜蜂", { form: "compatibility" }),
+        "&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702;",
+      );
+      assertEquals(
+        normalize("&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702;", {
+          form: "compatibility",
+        }),
+        "&#x4e24;&#x53ea;&#x5c0f;&#x871c;&#x8702;",
+      );
+    },
+  );
+  await t.step("leaves markup untouched", () => {
+    const markup = `<tag attr1="dbl" attr2='sgl' />`;
+    assertEquals(normalize(markup), markup);
+    assertEquals(normalize(markup, { form: "readability" }), markup);
+    assertEquals(normalize(markup, { form: "compatibility" }), markup);
+  });
+  await t.step("normalizes unescaped & to &amp;", () => {
+    assertEquals(normalize("a&b"), "a&amp;b");
+    assertEquals(normalize("a&b", { form: "readability" }), "a&amp;b");
+    assertEquals(normalize("a&b", { form: "compatibility" }), "a&amp;b");
+  });
+  await t.step("normalizes other forms of entities to a canonical form", () => {
+    assertEquals(normalize("&#62;&#x3e;&gt;"), "&gt;&gt;&gt;");
+    assertEquals(
+      normalize("&#62;&#x3e;&gt;", { form: "readability" }),
+      "&gt;&gt;&gt;",
+    );
+    assertEquals(
+      normalize("&#62;&#x3e;&gt;", { form: "compatibility" }),
+      "&gt;&gt;&gt;",
+    );
+  });
+  await t.step(
+    "normalizes &apos; to &#39; (for compliance with HTML 4.01 Strict)",
+    () => {
+      assertEquals(normalize("&apos;"), "&#39;");
+      assertEquals(normalize("&apos;", { form: "readability" }), "&#39;");
+      assertEquals(normalize("&apos;", { form: "compatibility" }), "&#39;");
+    },
+  );
 });


### PR DESCRIPTION
Fixes #4523

Various bikeshedding things:
* Given its dual use for XML, should the top-level dir have its name changed from `html`? If so, to what?
  - `xml` suffers the same issue but in reverse
  - `html_and_xml` is pretty gross
  - `markup` seems overly vague
  - `sgml_like` might be technically correct, but would the average web developer think to look there?
* Is it worth exporting `escapeAllCharsAsHex`? Could be useful for users wanting finer-grained control than the 2 normalization forms, but it's a very simple function to replicate
* Is the name `NormalizationForm` OK or is it too confusing with Unicode normalization forms (NFC, NFD, etc?)