### PR TITLE
deprecation(crypto): rename an export to match style guide, deprecating original and two other obsolete imports

### DIFF
--- a/crypto/_benches/bench.ts
+++ b/crypto/_benches/bench.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env -S deno bench
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import {
-  crypto as stdCrypto,
-  wasmDigestAlgorithms as DIGEST_ALGORITHM_NAMES,
-} from "../mod.ts";
+import { crypto as stdCrypto, DIGEST_ALGORITHM_NAMES } from "../mod.ts";
 
 import nodeCrypto from "node:crypto";
 

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -297,21 +297,21 @@ const stdCrypto: StdCrypto = ((x) => x)({
 /**
  * A FNV (Fowler/Noll/Vo) digest algorithm name supported by std/crypto.
  *
- * @deprecated (will be removed in 0.224.0)
+ * @deprecated (will be removed in 1.0.0)
  */
 export type FNVAlgorithms = "FNV32" | "FNV32A" | "FNV64" | "FNV64A";
 
 /**
  * Digest algorithm names supported by std/crypto with a Wasm implementation.
  *
- * @deprecated (will be removed in 0.224.0) Consider using {@linkcode DIGEST_ALGORITHM_NAMES} instead.
+ * @deprecated (will be removed in 1.0.0) Consider using {@linkcode DIGEST_ALGORITHM_NAMES} instead.
  */
 export const wasmDigestAlgorithms = DIGEST_ALGORITHM_NAMES;
 
 /**
  * A digest algorithm name supported by std/crypto with a Wasm implementation.
  *
- * @deprecated (will be removed in 0.224.0) Consider using {@linkcode DigestAlgorithmName} instead.
+ * @deprecated (will be removed in 1.0.0) Consider using {@linkcode DigestAlgorithmName} instead.
  */
 export type WasmDigestAlgorithm = DigestAlgorithmName;
 

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -107,12 +107,12 @@
  * @module
  */
 import {
-  DIGEST_ALGORITHM_NAMES as wasmDigestAlgorithms,
-  type DigestAlgorithmName as WasmDigestAlgorithm,
+  DIGEST_ALGORITHM_NAMES,
+  type DigestAlgorithmName,
   instantiateWasm,
 } from "./_wasm/mod.ts";
 
-export { type WasmDigestAlgorithm, wasmDigestAlgorithms };
+export { DIGEST_ALGORITHM_NAMES, type DigestAlgorithmName };
 
 /** Digest algorithms supported by WebCrypto. */
 const WEB_CRYPTO_DIGEST_ALGORITHM_NAMES = [
@@ -219,7 +219,7 @@ const stdCrypto: StdCrypto = ((x) => x)({
         bytes
       ) {
         return webCrypto.subtle.digest(algorithm, bytes);
-      } else if (wasmDigestAlgorithms.includes(name as WasmDigestAlgorithm)) {
+      } else if (DIGEST_ALGORITHM_NAMES.includes(name as DigestAlgorithmName)) {
         if (bytes) {
           // Otherwise, we use our bundled Wasm implementation via digestSync
           // if it supports the algorithm.
@@ -294,11 +294,26 @@ const stdCrypto: StdCrypto = ((x) => x)({
   },
 });
 
-/** FNV (Fowler/Noll/Vo) algorithms names. */
+/**
+ * A FNV (Fowler/Noll/Vo) digest algorithm name supported by std/crypto.
+ *
+ * @deprecated (will be removed in 0.224.0)
+ */
 export type FNVAlgorithms = "FNV32" | "FNV32A" | "FNV64" | "FNV64A";
 
-/** Extended digest algorithm names. */
-export type DigestAlgorithmName = WasmDigestAlgorithm | FNVAlgorithms;
+/**
+ * Digest algorithm names supported by std/crypto with a Wasm implementation.
+ *
+ * @deprecated (will be removed in 0.224.0) Consider using {@linkcode DIGEST_ALGORITHM_NAMES} instead.
+ */
+export const wasmDigestAlgorithms = DIGEST_ALGORITHM_NAMES;
+
+/**
+ * A digest algorithm name supported by std/crypto with a Wasm implementation.
+ *
+ * @deprecated (will be removed in 0.224.0) Consider using {@linkcode DigestAlgorithmName} instead.
+ */
+export type WasmDigestAlgorithm = DigestAlgorithmName;
 
 /*
  * The largest digest length the current Wasm implementation can support. This

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -2,8 +2,8 @@
 import { assert, assertEquals, assertInstanceOf, fail } from "../assert/mod.ts";
 import {
   crypto as stdCrypto,
+  DIGEST_ALGORITHM_NAMES,
   type DigestAlgorithmName,
-  wasmDigestAlgorithms as DIGEST_ALGORITHM_NAMES,
 } from "./mod.ts";
 import { repeat } from "../bytes/repeat.ts";
 import { encodeHex } from "../encoding/hex.ts";


### PR DESCRIPTION
(Originally part of #4515, broken into separate PR as [suggested by iuioiua](https://github.com/denoland/deno_std/pull/4515#pullrequestreview-1956667727).) 

This PR renames `crypto.ts`'s exported `const` `wasmDigestAlgorithms` to `DIGEST_ALGORITHM_NAMES`, to match Deno's style guide and reflect the fact that it includes all algorithm names supported by the digest function, not just a subset. The old name is maintained as a deprecated alias for now. The exported `WasmDigestAlgorithm` type is deprecated, as it's redundant with the existing `DigestAlgorithmName` export (all algorithms are available in Wasm, and if that changes in the future it should probably just be an internal implementation detail, not part of the public interface). The `FNVAlgorithms` export is similarly deprecated (they were previously a special case that was not included in Wasm).
