### PR TITLE
fix(fs): `SubdirectoryMoveError` extends `Error` correctly

### DIFF
--- a/fs/move.ts
+++ b/fs/move.ts
@@ -14,6 +14,7 @@ export class SubdirectoryMoveError extends Error {
     super(
       `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
     );
+    this.name = this.constructor.name;
   }
 }
 

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -22,7 +22,7 @@ export class WalkError extends Error {
       `${cause instanceof Error ? cause.message : cause} for path "${root}"`,
     );
     this.cause = cause;
-    this.name = "WalkError";
+    this.name = this.constructor.name;
     this.root = root;
   }
 }


### PR DESCRIPTION
The name of a custom error should have the same name as its constructor name. This ensures that for `SubdirectoryMoveError` and `WalkError`.