### PR TITLE
chore: add `--allow-dirty` flag to publish dry run

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Publish (dry run)
         if: github.event_name == 'push'
-        run: deno publish --dry-run
+        run: deno publish --allow-dirty --dry-run
 
       - name: Publish (real)
         if: github.event_name == 'release'


### PR DESCRIPTION
Now `--allow-dirty` flag seems necessary even with dry run.