### PR TITLE
refactor(archive): A clean implementation of Tar

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -28,148 +28,15 @@
  * THE SOFTWARE.
  */
 
-import {
-  FileTypes,
-  type TarInfo,
-  type TarMeta,
-  USTAR_STRUCTURE,
-} from "./_common.ts";
-import type { Reader } from "../io/types.ts";
-import { MultiReader } from "../io/multi_reader.ts";
-import { Buffer } from "../io/buffer.ts";
-import { assert } from "../assert/assert.ts";
-import { HEADER_LENGTH } from "./_common.ts";
-
-export type { TarInfo, TarMeta };
-
-/** Options for {@linkcode Tar.append}. */
-export interface TarOptions extends TarInfo {
-  /**
-   * Filepath of the file to append to the archive
-   */
-  filePath?: string;
-
-  /**
-   * A Reader of any arbitrary content to append to the archive
-   */
-  reader?: Reader;
-
-  /**
-   * Size of the content to be appended. This is only required
-   * when passing a reader to the archive.
-   */
-  contentSize?: number;
-}
-
-const USTAR_MAGIC_HEADER = "ustar\u000000" as const;
-
 /**
- * Simple file reader
+ * @param pathname is what you want the file to be called inside the archive.
+ * @param iterable is the source of the file in Uint8Array form.
+ * @param size is the size of the source in bytes. Providing the wrong size can lead to corrupt data.
  */
-class FileReader implements Reader {
-  #file?: Deno.FsFile;
-
-  constructor(private filePath: string) {}
-
-  public async read(p: Uint8Array): Promise<number | null> {
-    if (!this.#file) {
-      this.#file = await Deno.open(this.filePath, { read: true });
-    }
-    const res = await this.#file.read(p);
-    if (res === null) {
-      this.#file.close();
-      this.#file = undefined;
-    }
-    return res;
-  }
-}
-
-/**
- * Pads a number with leading zeros to a specified number of bytes.
- *
- * @param num The number to pad.
- * @param bytes The number of bytes to pad the number to.
- * @returns The padded number as a string.
- */
-function pad(num: number, bytes: number): string {
-  return num.toString(8).padStart(bytes, "0");
-}
-
-/**
- * Formats the header data for a tar file entry.
- *
- * @param data The data object containing the values for the tar header fields.
- * @returns The formatted header data as a Uint8Array.
- */
-function formatHeader(data: TarData): Uint8Array {
-  const encoder = new TextEncoder();
-  const buffer = new Uint8Array(HEADER_LENGTH);
-  let offset = 0;
-  for (const { field, length } of USTAR_STRUCTURE) {
-    const entry = encoder.encode(data[field as keyof TarData] || "");
-    buffer.set(entry, offset);
-    offset += length;
-  }
-  return buffer;
-}
-
-/** Base interface for {@linkcode TarDataWithSource}. */
-export interface TarData {
-  /** Name of the file, excluding directory names (if any). */
-  fileName?: string;
-  /** Directory names preceding the file name (if any). */
-  fileNamePrefix?: string;
-  /**
-   * The underlying raw `st_mode` bits that contain the standard Unix
-   * permissions for this file/directory.
-   */
-  fileMode?: string;
-  /**
-   * Numeric user ID of the file owner. This is ignored if the operating system
-   * does not support numeric user IDs.
-   */
-  uid?: string;
-  /**
-   * Numeric group ID of the file owner. This is ignored if the operating
-   * system does not support numeric group IDs.
-   */
-  gid?: string;
-  /**
-   * The size of the file in bytes; for archive members that are symbolic or
-   * hard links to another file, this field is specified as zero.
-   */
-  fileSize?: string;
-  /**
-   * Data modification time of the file at the time it was archived. It
-   * represents the integer number of seconds since January 1, 1970, 00:00 UTC.
-   */
-  mtime?: string;
-  /** The simple sum of all bytes in the header block */
-  checksum?: string;
-  /**
-   * The type of file archived.
-   *
-   * @see {@linkcode FileTypes}
-   */
-  type?: string;
-  /** Ustar magic header */
-  ustar?: string;
-  /** The name of the file owner. */
-  owner?: string;
-  /** The group that the file owner belongs to. */
-  group?: string;
-}
-
-/** Tar data interface for {@linkcode Tar.data}. */
-export interface TarDataWithSource extends TarData {
-  /**
-   * Path of the file to read.
-   */
-  filePath?: string;
-  /**
-   * Buffer reader.
-   */
-  reader?: Reader;
+export type TarFile = {
+  pathname: string,
+  iterable: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  size: number
 }
 
 /**
@@ -178,214 +45,177 @@ export interface TarDataWithSource extends TarData {
  * single file (called an archive, or sometimes a tarball).  These archives typically
  * have the '.tar' extension.
  *
- * ### Usage
+ * # Usage
  * The workflow is to create a Tar instance, append files to it, and then write the
- * tar archive to the filesystem (or other output stream).  See the worked example
- * below for details.
- *
- * ### Compression
- * Tar archives are not compressed by default.  If you want to compress the archive,
- * you may compress the tar archive after creation, but this capability is not provided
- * here.
+ * tar archive to the filesystem (or other output stream).  See the worked example below for details.
  *
  * ### File format and limitations
- *
- * The ustar file format is used for creating the archive file.
+ * The ustar file format used for creating the archive file.
  * While this format is compatible with most tar readers,
  * the format has several limitations, including:
- * * Files must be smaller than 8GiB
- * * Filenames (including path) must be shorter than 256 characters
- * * Filenames (including path) cannot contain non-ASCII characters
- * * Sparse files are not supported
+ * * File sizes can be at most 8 GiBs.
+ * * Filenames (including path) must be shorter than 256 characters.
+ * * Sparse files are not supported.
+ * This implementation does support decoding tarballs with files up to 64 GiBs, and can create them
+ * via setting `sizeExtension` to true in the `append` method, but doing so may limit its compatibility
+ * with older tar implementations.
  *
  * @example
  * ```ts
- * import { Tar } from "https://deno.land/std@$STD_VERSION/archive/tar.ts";
- * import { Buffer } from "https://deno.land/std@$STD_VERSION/io/buffer.ts";
- * import { copy } from "https://deno.land/std@$STD_VERSION/io/copy.ts";
+ * import { Tar } from '@std/archive'
  *
  * const tar = new Tar();
- *
- * // Now that we've created our tar, let's add some files to it:
- *
- * const content = new TextEncoder().encode("Some arbitrary content");
- * await tar.append("deno.txt", {
- *   reader: new Buffer(content),
- *   contentSize: content.byteLength,
+ * tar.append({
+ *   pathname: 'deno.txt',
+ *   size: (await Deno.stat('deno.txt')).size,
+ *   iterable: (await Deno.open('deno.txt')).readable
  * });
- *
- * // This file is sourced from the filesystem (and renamed in the archive)
- * await tar.append("filename_in_archive.txt", {
- *   filePath: "./filename_on_filesystem.txt",
+ * tar.append({
+ *   pathname: 'filename_in_archive.txt',
+ *   size: (await Deno.stat('filename_in_archive.txt')).size,
+ *   iterable: (await Deno.open('filename_in_archive.txt')).readable
  * });
+ * tar.close();
  *
- * // Now let's write the tar (with it's two files) to the filesystem
- * // use tar.getReader() to read the contents.
+ * await tar.pipeTo((await Deno.create('./out.tar')).writable);
+ * ```
  *
- * const writer = await Deno.open("./out.tar", { write: true, create: true });
- * await copy(tar.getReader(), writer);
- * writer.close();
+ * ### Compression
+ * Tar archives are not compressed by default, but if you want to compress the archive,
+ * you may pipe the archive through a compression stream like `gzip` before writing it to disk.
+ *
+ * @example
+ * ```ts
+ * import { Tar } from '@std/archive'
+ *
+ * const tar = new Tar();
+ * tar.append({
+ *   pathname: 'deno.txt',
+ *   size: (await Deno.stat('deno.txt')).size,
+ *   iterable: (await Deno.open('deno.txt')).readable
+ * });
+ * tar.append({
+ *   pathname: 'filename_in_archive.txt',
+ *   size: (await Deno.stat('filename_in_archive.txt')).size,
+ *   iterable: (await Deno.open('filename_in_archive.txt')).readable
+ * });
+ * tar.close();
+ *
+ * await tar
+ *   .pipeThrough(new CompressionStream('gzip'))
+ *   .pipeTo((await Deno.create('./out.tar.gz')).writable);
  * ```
  */
 export class Tar {
-  /** Tar data. */
-  data: TarDataWithSource[];
-
-  /** Constructs a new instance. */
+  #files: { prefix: Uint8Array, name: Uint8Array, iterable: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, size: number, sizeExtension: boolean }[] = []
+  #readable: ReadableStream<Uint8Array>
+  #finishedAppending: boolean = false
+  /**
+   * Constructs a new instance.
+   */
   constructor() {
-    this.data = [];
+    const gen = (async function* (tar) {
+      while (
+        (!tar.#finishedAppending || tar.#files.length)
+        && await new Promise<true>(a => setTimeout(() => a(true), 0))
+      ) {
+        if (tar.#files.length) {
+          const file = tar.#files.shift()!
+          const encoder = new TextEncoder()
+          const header = new Uint8Array(512)
+
+          header.set(file.name) // name
+          header.set(encoder.encode(
+            '000644 \0' // mode
+            + '000000 \0' // uid
+            + '000000 \0' // gid
+            + file.size.toString(8).padStart(file.sizeExtension ? 12 : 11) + (file.sizeExtension ? '' : ' ') // size
+            + '00000000000 ' // mtime
+            + '        ' // checksum | Needs to be updated
+            + '0' // typeflag
+            + '\0'.repeat(100) // linkname
+            + 'ustar\0' // magic
+            + '00' // version
+            + '\0'.repeat(32 + 32 + 8 + 8) // uname, gname, devmajor, devminor
+          ), 100)
+          header.set(file.prefix, 345) // prefix
+
+          header.set(encoder.encode(header.reduce((x, y) => x + y).toString(8).padStart(6, '0') + '\0'), 148)
+          yield header
+
+          for await (const x of file.iterable)
+            yield x
+          yield encoder.encode('\0'.repeat(512 - file.size % 512))
+        }
+      }
+      yield new TextEncoder().encode('\0'.repeat(1024))
+    })(this)
+    this.#readable = new ReadableStream({
+      async pull(controller) {
+        const { done, value } = await gen.next()
+        if (done)
+          controller.close()
+        else
+          controller.enqueue(value)
+      }
+    })
   }
 
   /**
-   * Append a file or reader of arbitrary content to this tar archive. Directories
-   * appended to the archive append only the directory itself to the archive, not
-   * its contents.  To add a directory and its contents, recursively append the
-   * directory's contents.  Directories and subdirectories will be created automatically
-   * in the archive as required.
-   *
-   * @param filenameInArchive File name of the content in the archive. E.g.
-   * `test.txt`. Use slash for directory separators.
-   * @param source Details of the source of the content including the
-   * reference to the content itself and potentially any related metadata.
+   * Append a file to the archive. This method will throw if you provide an incompatible
+   * size or pathname, or have already called the `close` method.
+   * @param file Details of the TarFile being appended to the archive.
+   * @param [sizeExtension=false] Enable up to 64 GiB files in the archive instead of 8 GiBs.
    */
-  async append(filenameInArchive: string, source: TarOptions) {
-    if (typeof filenameInArchive !== "string") {
-      throw new Error("file name not specified");
-    }
-    let fileName = filenameInArchive;
+  append(file: TarFile, sizeExtension = false): void {
+    if (this.#finishedAppending)
+      throw new Error('This Tar instance has already be closed.')
 
-    /**
-     * Ustar format has a limitation of file name length. Specifically:
-     * 1. File names can contain at most 255 bytes.
-     * 2. File names longer than 100 bytes must be split at a directory separator in two parts,
-     * the first being at most 155 bytes long. So, in most cases file names must be a bit shorter
-     * than 255 bytes.
-     */
-    // separate file name into two parts if needed
-    let fileNamePrefix: string | undefined;
-    if (fileName.length > 100) {
-      let i = fileName.length;
-      while (i >= 0) {
-        i = fileName.lastIndexOf("/", i);
-        if (i <= 155) {
-          fileNamePrefix = fileName.slice(0, i);
-          fileName = fileName.slice(i + 1);
-          break;
-        }
-        i--;
-      }
-      const errMsg =
-        "ustar format does not allow a long file name (length of [file name" +
-        "prefix] + / + [file name] must be shorter than 256 bytes)";
-      if (i < 0 || fileName.length > 100) {
-        throw new Error(errMsg);
-      } else {
-        assert(fileNamePrefix !== undefined);
-        if (fileNamePrefix.length > 155) {
-          throw new Error(errMsg);
+    // Validate size provided.
+    if (file.size < 0 || Math.pow(8, sizeExtension ? 12 : 11) < file.size)
+      throw new Error('Invalid File Size: Up to 8 GiBs allowed or 64 GiBs if `sizeExtension` is enabled.')
+
+    file.pathname = file.pathname.split('/').filter(x => x).join('/')
+    if (file.pathname.startsWith('./'))
+      file.pathname = file.pathname.slice(2)
+
+    // Validating the path provided.
+    const pathname = new TextEncoder().encode(file.pathname)
+    if (pathname.length > 256)
+      throw new Error('Provided pathname is too long. Max 256 bytes.')
+
+    let i = Math.max(0, pathname.lastIndexOf(47))
+    if (pathname.slice(i).length > 100)
+      throw new Error('Filename in pathname is too long. Filename can be at most 100 bytes.')
+
+    if (pathname.length <= 100)
+      i = 0
+    else
+      for (; i > 0; --i) {
+        i = pathname.lastIndexOf(47, i)
+        if (pathname.slice(i).length > 100) {
+          i = Math.max(0, pathname.indexOf(47, ++i))
+          break
         }
       }
-    }
 
-    source = source || {};
-
-    // set meta data
-    let info: Deno.FileInfo | undefined;
-    if (source.filePath) {
-      info = await Deno.stat(source.filePath);
-      if (info.isDirectory) {
-        info.size = 0;
-        source.reader = new Buffer();
-      }
-    }
-
-    const mode = source.fileMode || (info && info.mode) ||
-      parseInt("777", 8) & 0xfff /* 511 */;
-    const mtime = Math.floor(
-      source.mtime ?? (info?.mtime ?? new Date()).valueOf() / 1000,
-    );
-    const uid = source.uid || 0;
-    const gid = source.gid || 0;
-
-    if (typeof source.owner === "string" && source.owner.length >= 32) {
-      throw new Error(
-        "ustar format does not allow owner name length >= 32 bytes",
-      );
-    }
-    if (typeof source.group === "string" && source.group.length >= 32) {
-      throw new Error(
-        "ustar format does not allow group name length >= 32 bytes",
-      );
-    }
-
-    const fileSize = info?.size ?? source.contentSize;
-    assert(fileSize !== undefined, "fileSize must be set");
-
-    const type = source.type
-      ? FileTypes[source.type as keyof typeof FileTypes]
-      : (info?.isDirectory ? FileTypes.directory : FileTypes.file);
-    const tarData: TarDataWithSource = {
-      fileName,
-      fileNamePrefix,
-      fileMode: pad(mode, 7),
-      uid: pad(uid, 7),
-      gid: pad(gid, 7),
-      fileSize: pad(fileSize, 11),
-      mtime: pad(mtime, 11),
-      checksum: "        ",
-      type: type.toString(),
-      ustar: USTAR_MAGIC_HEADER,
-      owner: source.owner || "",
-      group: source.group || "",
-      filePath: source.filePath,
-      reader: source.reader,
-    };
-
-    // calculate the checksum
-    let checksum = 0;
-    const encoder = new TextEncoder();
-    Object.keys(tarData)
-      .filter((key): boolean => ["filePath", "reader"].indexOf(key) < 0)
-      .forEach(function (key) {
-        checksum += encoder
-          .encode(tarData[key as keyof TarData])
-          .reduce((p, c): number => p + c, 0);
-      });
-
-    tarData.checksum = pad(checksum, 6) + "\u0000 ";
-    this.data.push(tarData);
+    const prefix = pathname.slice(0, i++)
+    if (prefix.length > 155)
+      throw new Error('Provided pathname cannot be split into [155, 100] segments along a forward slash separator.')
+    this.#files.push({ name: prefix.length ? pathname.slice(i) : pathname, prefix, iterable: file.iterable, size: file.size, sizeExtension })
   }
 
   /**
-   * Get a Reader instance for this tar archive.
+   * Closes the tar archive from accepting more files. Must be called for tar archive to be properly created.
    */
-  getReader(): Reader {
-    const readers: Reader[] = [];
-    this.data.forEach((tarData) => {
-      let { reader } = tarData;
-      const { filePath } = tarData;
-      const headerArr = formatHeader(tarData);
-      readers.push(new Buffer(headerArr));
-      if (!reader) {
-        assert(filePath !== undefined);
-        reader = new FileReader(filePath);
-      }
-      readers.push(reader);
+  close(): void {
+    this.#finishedAppending = true
+  }
 
-      // to the nearest multiple of recordSize
-      assert(tarData.fileSize !== undefined, "fileSize must be set");
-      readers.push(
-        new Buffer(
-          new Uint8Array(
-            HEADER_LENGTH -
-              (parseInt(tarData.fileSize, 8) % HEADER_LENGTH || HEADER_LENGTH),
-          ),
-        ),
-      );
-    });
-
-    // append 2 empty records
-    readers.push(new Buffer(new Uint8Array(HEADER_LENGTH * 2)));
-    return new MultiReader(readers);
+  /**
+   * A Readable Stream of the archive.
+   */
+  get readable(): ReadableStream<Uint8Array> {
+    return this.#readable
   }
 }

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -35,34 +35,34 @@
  * @param readable is the contents of the file.
  */
 export type TarEntry = {
-  pathname: string,
-  header: TarHeader,
-  readable: ReadableStream<Uint8Array>
-}
+  pathname: string;
+  header: TarHeader;
+  readable: ReadableStream<Uint8Array>;
+};
 
 /**
  * The header of a file decoded into an object, where `pad` is the remaining bytes of the header.
  * The `pad` will be larger if the optional properties are missing.
  */
 export type TarHeader = {
-  name: string
-  mode: string
-  uid: string
-  gid: string
-  size: number
-  mtime: string
-  checksum: string
-  typeflag: string
-  linkname: string
-  magic?: string
-  version?: string
-  uname?: string
-  gname?: string
-  devmajor?: number
-  devminor?: number
-  prefix?: string
-  pad: Uint8Array
-}
+  name: string;
+  mode: string;
+  uid: string;
+  gid: string;
+  size: number;
+  mtime: string;
+  checksum: string;
+  typeflag: string;
+  linkname: string;
+  magic?: string;
+  version?: string;
+  uname?: string;
+  gname?: string;
+  devmajor?: number;
+  devminor?: number;
+  prefix?: string;
+  pad: Uint8Array;
+};
 
 /**
  * ### Overview
@@ -83,6 +83,8 @@ export type TarHeader = {
  *
  * @example
  * ```ts
+ * import { UnTar } from '@std/archive'
+ *
  * for await (
  *   const entry of new UnTar((await Deno.open('./out.tar.gz')).readable)
  * ) {
@@ -97,6 +99,8 @@ export type TarHeader = {
  *
  * @example
  * ```ts
+ * import { UnTar } from '@std/archive'
+ *
  * for await (
  *   const entry of new UnTar(
  *     (await Deno.open('./out.tar.gz'))
@@ -114,105 +118,142 @@ export class UnTar extends ReadableStream<TarEntry> {
    * Constructs a new instance.
    */
   constructor(readable: ReadableStream<Uint8Array>) {
-    const reader = readable.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
-      push: new Uint8Array(0),
-      transform(chunk, controller) {
-        const x = new Uint8Array(this.push.length + chunk.length)
-        x.set(this.push)
-        x.set(chunk, this.push.length)
-        for (let i = 512; i <= x.length; i += 512)
-          controller.enqueue(x.slice(i - 512, i))
-        this.push = x.length % 512 ? x.slice(-x.length % 512) : new Uint8Array(0)
-      },
-      flush(controller) {
-        if (this.push.length) // This should always be zero!
-          controller.enqueue(this.push)
-      }
-    } as Transformer<Uint8Array, Uint8Array> & { push: Uint8Array })).getReader()
-
-    let header: TarHeader | undefined
-    super({
-      cancelled: false,
-      async pull(controller) {
-        while (header !== undefined)
-          await new Promise(a => setTimeout(a, 0))
-
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done || value.reduce((x, y) => x + y) === 0)
-            return controller.close()
-
-          const decoder = new TextDecoder()
-          header = {
-            name: decoder.decode(value.slice(0, 100)).replaceAll('\0', ''),
-            mode: decoder.decode(value.slice(100, 108 - 2)),
-            uid: decoder.decode(value.slice(108, 116 - 2)),
-            gid: decoder.decode(value.slice(116, 124 - 2)),
-            size: parseInt(decoder.decode(value.slice(124, 136)).trimEnd(), 8), // Support tarballs with files up to 64 GiBs.
-            mtime: decoder.decode(value.slice(136, 148 - 1)),
-            checksum: decoder.decode(value.slice(148, 156 - 2)),
-            typeflag: decoder.decode(value.slice(156, 157)),
-            linkname: decoder.decode(value.slice(157, 257)).replaceAll('\0', ''),
-            pad: value.slice(257)
-          }
-          if ([117, 115, 116, 97, 114, 0, 48, 48].every((byte, i) => value[i + 257] === byte))
-            header = {
-              ...header,
-              magic: decoder.decode(value.slice(257, 263)),
-              version: decoder.decode(value.slice(263, 265)),
-              uname: decoder.decode(value.slice(265, 297)).replaceAll('\0', ''),
-              gname: decoder.decode(value.slice(297, 329)).replaceAll('\0', ''),
-              devmajor: value.slice(329, 337).reduce((x, y) => x + y),
-              devminor: value.slice(337, 345).reduce((x, y) => x + y),
-              prefix: decoder.decode(value.slice(345, 500)).replaceAll('\0', ''),
-              pad: value.slice(500)
+    const reader = readable.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>(
+        {
+          push: new Uint8Array(0),
+          transform(chunk, controller) {
+            const x = new Uint8Array(this.push.length + chunk.length);
+            x.set(this.push);
+            x.set(chunk, this.push.length);
+            for (let i = 512; i <= x.length; i += 512) {
+              controller.enqueue(x.slice(i - 512, i));
             }
-          if (header.typeflag !== '0' && header.typeflag !== '\0')
-            continue
+            this.push = x.length % 512
+              ? x.slice(-x.length % 512)
+              : new Uint8Array(0);
+          },
+          flush(controller) {
+            if (this.push.length) { // This should always be zero!
+              controller.enqueue(this.push);
+            }
+          },
+        } as Transformer<Uint8Array, Uint8Array> & { push: Uint8Array },
+      ),
+    ).getReader();
 
-          const size = header.size
-          let i = Math.ceil(size / 512)
-          const isCancelled = () => this.cancelled
+    let header: TarHeader | undefined;
+    super(
+      {
+        cancelled: false,
+        async pull(controller) {
+          while (header !== undefined) {
+            await new Promise((a) => setTimeout(a, 0));
+          }
 
-          controller.enqueue({
-            pathname: (header.prefix ? header.prefix + '/' : '') + header.name,
-            header,
-            readable: new ReadableStream<Uint8Array>({
-              async pull(controller) {
-                if (i > 0) {
-                  const { done, value } = await reader.read()
-                  if (done) {
-                    header = undefined
-                    return controller.close()
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done || value.reduce((x, y) => x + y) === 0) {
+              return controller.close();
+            }
+
+            const decoder = new TextDecoder();
+            header = {
+              name: decoder.decode(value.slice(0, 100)).replaceAll("\0", ""),
+              mode: decoder.decode(value.slice(100, 108 - 2)),
+              uid: decoder.decode(value.slice(108, 116 - 2)),
+              gid: decoder.decode(value.slice(116, 124 - 2)),
+              size: parseInt(
+                decoder.decode(value.slice(124, 136)).trimEnd(),
+                8,
+              ), // Support tarballs with files up to 64 GiBs.
+              mtime: decoder.decode(value.slice(136, 148 - 1)),
+              checksum: decoder.decode(value.slice(148, 156 - 2)),
+              typeflag: decoder.decode(value.slice(156, 157)),
+              linkname: decoder.decode(value.slice(157, 257)).replaceAll(
+                "\0",
+                "",
+              ),
+              pad: value.slice(257),
+            };
+            if (
+              [117, 115, 116, 97, 114, 0, 48, 48].every((byte, i) =>
+                value[i + 257] === byte
+              )
+            ) {
+              header = {
+                ...header,
+                magic: decoder.decode(value.slice(257, 263)),
+                version: decoder.decode(value.slice(263, 265)),
+                uname: decoder.decode(value.slice(265, 297)).replaceAll(
+                  "\0",
+                  "",
+                ),
+                gname: decoder.decode(value.slice(297, 329)).replaceAll(
+                  "\0",
+                  "",
+                ),
+                devmajor: value.slice(329, 337).reduce((x, y) => x + y),
+                devminor: value.slice(337, 345).reduce((x, y) => x + y),
+                prefix: decoder.decode(value.slice(345, 500)).replaceAll(
+                  "\0",
+                  "",
+                ),
+                pad: value.slice(500),
+              };
+            }
+            if (header.typeflag !== "0" && header.typeflag !== "\0") {
+              continue;
+            }
+
+            const size = header.size;
+            let i = Math.ceil(size / 512);
+            const isCancelled = () => this.cancelled;
+
+            controller.enqueue({
+              pathname: (header.prefix ? header.prefix + "/" : "") +
+                header.name,
+              header,
+              readable: new ReadableStream<Uint8Array>({
+                async pull(controller) {
+                  if (i > 0) {
+                    const { done, value } = await reader.read();
+                    if (done) {
+                      header = undefined;
+                      return controller.close();
+                    }
+                    controller.enqueue(
+                      i-- === 1 ? value.slice(0, size % 512) : value,
+                    );
+                  } else {
+                    header = undefined;
+                    if (isCancelled()) {
+                      reader.cancel();
+                    }
+                    controller.close();
                   }
-                  controller.enqueue(i-- === 1 ? value.slice(0, size % 512) : value)
-                }
-                else {
-                  header = undefined
-                  if (isCancelled())
-                    reader.cancel()
-                  controller.close()
-                }
-              },
-              async cancel() {
-                if (i !== 1)
-                  while (i-- > 0) {
-                    const { done } = await reader.read()
-                    if (done)
-                      break
+                },
+                async cancel() {
+                  if (i !== 1) {
+                    while (i-- > 0) {
+                      const { done } = await reader.read();
+                      if (done) {
+                        break;
+                      }
+                    }
                   }
-                header = undefined
-              }
-            })
-          })
-          break
-        }
-      },
-      cancel() {
-        this.cancelled = true
-      }
-    } as UnderlyingSource & { cancelled: boolean }
-    )
+                  header = undefined;
+                },
+              }),
+            });
+            break;
+          }
+        },
+        cancel() {
+          this.cancelled = true;
+        },
+      } as UnderlyingSource & { cancelled: boolean },
+    );
   }
 }
 
@@ -221,6 +262,8 @@ export class UnTar extends ReadableStream<TarEntry> {
  *
  * @example
  * ```ts
+ * import { UnTarStream } from '@std/archive'
+ *
  * await Deno.mkdir('out/')
  * for await (
  *   const entry of (await Deno.open('./out.tar.gz'))
@@ -233,29 +276,32 @@ export class UnTar extends ReadableStream<TarEntry> {
  * ```
  */
 export class UnTarStream {
-  #readable: ReadableStream<TarEntry>
-  #writable: WritableStream<Uint8Array>
+  #readable: ReadableStream<TarEntry>;
+  #writable: WritableStream<Uint8Array>;
   /**
    * Creates an instance.
    */
   constructor() {
-    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
-    const unTar = new UnTar(readable)
-    this.#readable = unTar
-    this.#writable = writable
+    const { readable, writable } = new TransformStream<
+      Uint8Array,
+      Uint8Array
+    >();
+    const unTar = new UnTar(readable);
+    this.#readable = unTar;
+    this.#writable = writable;
   }
 
   /**
    * Returns a ReadableStream of the files in the archive.
    */
   get readable(): ReadableStream<TarEntry> {
-    return this.#readable
+    return this.#readable;
   }
 
   /**
    * Returns a WritableStream for the archive to be expanded.
    */
   get writable(): WritableStream<Uint8Array> {
-    return this.#writable
+    return this.#writable;
   }
 }

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -35,9 +35,9 @@
  * @param readable is the contents of the file.
  */
 export type TarEntry = {
-	pathname: string,
-	header: TarHeader,
-	readable: ReadableStream<Uint8Array>
+  pathname: string,
+  header: TarHeader,
+  readable: ReadableStream<Uint8Array>
 }
 
 /**
@@ -45,23 +45,23 @@ export type TarEntry = {
  * The `pad` will be larger if the optional properties are missing.
  */
 export type TarHeader = {
-	name: string
-	mode: string
-	uid: string
-	gid: string
-	size: number
-	mtime: string
-	checksum: string
-	typeflag: string
-	linkname: string
-	magic?: string
-	version?: string
-	uname?: string
-	gname?: string
-	devmajor?: number
-	devminor?: number
-	prefix?: string
-	pad: Uint8Array
+  name: string
+  mode: string
+  uid: string
+  gid: string
+  size: number
+  mtime: string
+  checksum: string
+  typeflag: string
+  linkname: string
+  magic?: string
+  version?: string
+  uname?: string
+  gname?: string
+  devmajor?: number
+  devminor?: number
+  prefix?: string
+  pad: Uint8Array
 }
 
 /**
@@ -110,108 +110,108 @@ export type TarHeader = {
  * ```
  */
 export class UnTar extends ReadableStream<TarEntry> {
-	/**
-	 * Constructs a new instance.
-	 */
-	constructor(readable: ReadableStream<Uint8Array>) {
-		const reader = readable.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
-			push: new Uint8Array(0),
-			transform(chunk, controller) {
-				const x = new Uint8Array(this.push.length + chunk.length)
-				x.set(this.push)
-				x.set(chunk, this.push.length)
-				for (let i = 0; i < x.length; i += 512)
-					controller.enqueue(x.slice(i, i + 512))
-				this.push = x.slice(x.length % 512)
-			},
-			flush(controller) {
-				if (this.push.length) // This should always be zero!
-					controller.enqueue(this.push)
-			}
-		} as Transformer<Uint8Array, Uint8Array> & { push: Uint8Array })).getReader()
+  /**
+   * Constructs a new instance.
+   */
+  constructor(readable: ReadableStream<Uint8Array>) {
+    const reader = readable.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+      push: new Uint8Array(0),
+      transform(chunk, controller) {
+        const x = new Uint8Array(this.push.length + chunk.length)
+        x.set(this.push)
+        x.set(chunk, this.push.length)
+        for (let i = 0; i < x.length; i += 512)
+          controller.enqueue(x.slice(i, i + 512))
+        this.push = x.slice(x.length % 512)
+      },
+      flush(controller) {
+        if (this.push.length) // This should always be zero!
+          controller.enqueue(this.push)
+      }
+    } as Transformer<Uint8Array, Uint8Array> & { push: Uint8Array })).getReader()
 
-		let header: TarHeader | undefined
-		super({
-			cancelled: false,
-			async pull(controller) {
-				while (header !== undefined)
-					await new Promise(a => setTimeout(a, 0))
+    let header: TarHeader | undefined
+    super({
+      cancelled: false,
+      async pull(controller) {
+        while (header !== undefined)
+          await new Promise(a => setTimeout(a, 0))
 
-				while (true) {
-					const { done, value } = await reader.read()
-					if (done || value.reduce((x, y) => x + y) === 0)
-						return controller.close()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done || value.reduce((x, y) => x + y) === 0)
+            return controller.close()
 
-					const decoder = new TextDecoder()
-					header = {
-						name: decoder.decode(value.slice(0, 100)).replaceAll('\0', ''),
-						mode: decoder.decode(value.slice(100, 108 - 2)),
-						uid: decoder.decode(value.slice(108, 116 - 2)),
-						gid: decoder.decode(value.slice(116, 124 - 2)),
-						size: parseInt(decoder.decode(value.slice(124, 136)).trimEnd(), 8), // Support tarballs with files up to 64 GiBs.
-						mtime: decoder.decode(value.slice(136, 148 - 1)),
-						checksum: decoder.decode(value.slice(148, 156 - 2)),
-						typeflag: decoder.decode(value.slice(156, 157)),
-						linkname: decoder.decode(value.slice(157, 257)).replaceAll('\0', ''),
-						pad: value.slice(257)
-					}
-					if ([117, 115, 116, 97, 114, 0, 48, 48].every((byte, i) => value[i + 257] === byte))
-						header = {
-							...header,
-							magic: decoder.decode(value.slice(257, 263)),
-							version: decoder.decode(value.slice(263, 265)),
-							uname: decoder.decode(value.slice(265, 297)).replaceAll('\0', ''),
-							gname: decoder.decode(value.slice(297, 329)).replaceAll('\0', ''),
-							devmajor: value.slice(329, 337).reduce((x, y) => x + y),
-							devminor: value.slice(337, 345).reduce((x, y) => x + y),
-							prefix: decoder.decode(value.slice(345, 500)).replaceAll('\0', ''),
-							pad: value.slice(500)
-						}
-					if (header.typeflag !== '0' && header.typeflag !== '\0')
-						continue
+          const decoder = new TextDecoder()
+          header = {
+            name: decoder.decode(value.slice(0, 100)).replaceAll('\0', ''),
+            mode: decoder.decode(value.slice(100, 108 - 2)),
+            uid: decoder.decode(value.slice(108, 116 - 2)),
+            gid: decoder.decode(value.slice(116, 124 - 2)),
+            size: parseInt(decoder.decode(value.slice(124, 136)).trimEnd(), 8), // Support tarballs with files up to 64 GiBs.
+            mtime: decoder.decode(value.slice(136, 148 - 1)),
+            checksum: decoder.decode(value.slice(148, 156 - 2)),
+            typeflag: decoder.decode(value.slice(156, 157)),
+            linkname: decoder.decode(value.slice(157, 257)).replaceAll('\0', ''),
+            pad: value.slice(257)
+          }
+          if ([117, 115, 116, 97, 114, 0, 48, 48].every((byte, i) => value[i + 257] === byte))
+            header = {
+              ...header,
+              magic: decoder.decode(value.slice(257, 263)),
+              version: decoder.decode(value.slice(263, 265)),
+              uname: decoder.decode(value.slice(265, 297)).replaceAll('\0', ''),
+              gname: decoder.decode(value.slice(297, 329)).replaceAll('\0', ''),
+              devmajor: value.slice(329, 337).reduce((x, y) => x + y),
+              devminor: value.slice(337, 345).reduce((x, y) => x + y),
+              prefix: decoder.decode(value.slice(345, 500)).replaceAll('\0', ''),
+              pad: value.slice(500)
+            }
+          if (header.typeflag !== '0' && header.typeflag !== '\0')
+            continue
 
-					const size = header.size
-					let i = Math.ceil(size / 512)
-					const isCancelled = () => this.cancelled
+          const size = header.size
+          let i = Math.ceil(size / 512)
+          const isCancelled = () => this.cancelled
 
-					controller.enqueue({
-						pathname: (header.prefix ? header.prefix + '/' : '') + header.name,
-						header,
-						readable: new ReadableStream<Uint8Array>({
-							async pull(controller) {
-								if (i > 0) {
-									const { done, value } = await reader.read()
-									if (done) {
-										header = undefined
-										return controller.close()
-									}
-									controller.enqueue(i === 1 ? value.slice(0, size % 512) : value)
-									--i
-								}
-								else {
-									header = undefined
-									if (isCancelled())
-										reader.cancel()
-									controller.close()
-								}
-							},
-							async cancel() {
-								while (i-- > 0) {
-									const { done } = await reader.read()
-									if (done)
-										break
-								}
-								header = undefined
-							}
-						})
-					})
-					break
-				}
-			},
-			cancel() {
-				this.cancelled = true
-			}
-		} as UnderlyingSource & { cancelled: boolean }
-		)
-	}
+          controller.enqueue({
+            pathname: (header.prefix ? header.prefix + '/' : '') + header.name,
+            header,
+            readable: new ReadableStream<Uint8Array>({
+              async pull(controller) {
+                if (i > 0) {
+                  const { done, value } = await reader.read()
+                  if (done) {
+                    header = undefined
+                    return controller.close()
+                  }
+                  controller.enqueue(i === 1 ? value.slice(0, size % 512) : value)
+                  --i
+                }
+                else {
+                  header = undefined
+                  if (isCancelled())
+                    reader.cancel()
+                  controller.close()
+                }
+              },
+              async cancel() {
+                while (i-- > 0) {
+                  const { done } = await reader.read()
+                  if (done)
+                    break
+                }
+                header = undefined
+              }
+            })
+          })
+          break
+        }
+      },
+      cancel() {
+        this.cancelled = true
+      }
+    } as UnderlyingSource & { cancelled: boolean }
+    )
+  }
 }


### PR DESCRIPTION
Nobody asked for this, but since `@std/archive` was still listed as unstable; I thought I'd have a go at rewriting it based off [this spec](https://man.freebsd.org/cgi/man.cgi?query=tar&apropos=0&sektion=5&manpath=FreeBSD+15.0-CURRENT&arch=default&format=html). The tests for this new implementation will need to be written to accommodate the changes, but I thought I wouldn't have a crack at that unless you actually want this. 

## Notes
Some things to note about this implementation.
1. At the moment it only supports untar-ing files. Anything else will be skipped over.
2. Unlike the current implementation on JSR, the ustar spec doesn't actually require names and prefixes to only be ASCII letters, and so this implementation also does support non-ASCII letters.
3. While the default file limit is at 8 GiBs, many modern implementations do support unarchiving files up to 64 GiBs. This implementation not only also supports that, but also supports creating them provided the user provide an extra argument.
4. This rewrite has no dependencies and is several lines less than the existing one. The code is also completely original and not a fork of somebody else's. _I noticed in the license that the current one was a fork._
5. This implementation doesn't allow the user to only provide a path to the current file on the system. Instead it required the user give an `Iterable` or `AsyncIterable` to it. This design choice was to allow the implementation to work in other environments besides Deno, like the browser for instance.

## Usage Examples
### Creating a Tarball
The piping of the readable stream can happen at any stage here. calling `tar.close()` must happen when the user is finished appending files to the instance.
```ts
const tar = new Tar()

tar.append({
    pathname: 'deno.json',
    size: (await Deno.stat('deno.json')).size,
    iterable: (await Deno.open('deno.json')).readable
})
tar.close()

tar.readable
    .pipeThrough(new CompressionStream('gzip'))
    .pipeTo((await Deno.create('archive.tar.gz')).writable)
```

### Extracting a Tarball
It is important to note for when unarchiving, one must decide to either consume the entirety of the ReadableStream or call cancel (`entry.readable.cancel()`) on it before the next entry will be resolved.
```ts
await Deno.mkdir('archive/')
for await (const entry of new UnTar(
    (await Deno.open('archive.tar.gz'))
        .readable
        .pipeThrough(new DecompressionStream('gzip'))
)) {
    entry.readable.pipeTo((await Deno.create('archive/' + entry.pathname)).writable)
}
```
It should also be noted here that while compression is optional, it is very easy for the user to implement in their system. This implementation does allow the user to stream their creation and extraction of tarballs all without it ever hitting the file system or creating memory spikes. _Granted that the size of each iterable is known._

Anyway, I'd like to know what you think. What you do and don't like.

## Edit
### TarStream
```ts
await ReadableStream.from([
    {
        pathname: './data.csv',
        size: (await Deno.stat('./data.csv')).size,
        iterable: (await Deno.open('./data.csv')).readable
    },
    {
        pathname: './deno.json',
        size: (await Deno.stat('./deno.json')).size,
        iterable: (await Deno.open('./deno.json')).readable
    },
    {
        pathname: './deno.lock',
        size: (await Deno.stat('./deno.lock')).size,
        iterable: (await Deno.open('./deno.lock')).readable
    }
])
    .pipeThrough(new TarStream())
    .pipeThrough(new CompressionStream('gzip'))
    .pipeTo((await Deno.create('archive.tar.gz')).writable)
```
### UnTarStream
```ts
await Deno.mkdir('archive/')
for await (
    const entry of (await Deno.open('archive.tar.gz'))
        .readable
        .pipeThrough(new DecompressionStream('gzip'))
        .pipeThrough(new UnTarStream())
)
    await entry.readable.pipeTo((await Deno.create('archive/' + entry.pathname)).writable)
```