### PR TITLE
feat(testing): add `after`, `before`, `test` aliases

### DIFF
--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -597,7 +597,7 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>) {
 
 it.skip = it.ignore;
 
-/** Alias of {@link it} */
+/** Alias of {@linkcode it} */
 export const test = it;
 
 function addHook<T>(
@@ -626,7 +626,7 @@ export function beforeAll<T>(
   addHook("beforeAll", fn);
 }
 
-/** Alias of {@link beforeAll} */
+/** Alias of {@linkcode beforeAll} */
 export const before = beforeAll;
 
 /** Run some shared teardown after all of the tests in the suite. */
@@ -636,7 +636,7 @@ export function afterAll<T>(
   addHook("afterAll", fn);
 }
 
-/** Alias of {@link afterAll} */
+/** Alias of {@linkcode afterAll} */
 export const after = afterAll;
 
 /** Run some shared setup before each test in the suite. */

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -597,6 +597,9 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>) {
 
 it.skip = it.ignore;
 
+/** Alias of {@link it} */
+export const test = it;
+
 function addHook<T>(
   name: HookNames,
   fn: (this: T) => void | Promise<void>,
@@ -623,12 +626,18 @@ export function beforeAll<T>(
   addHook("beforeAll", fn);
 }
 
+/** Alias of {@link beforeAll} */
+export const before = beforeAll;
+
 /** Run some shared teardown after all of the tests in the suite. */
 export function afterAll<T>(
   fn: (this: T) => void | Promise<void>,
 ) {
   addHook("afterAll", fn);
 }
+
+/** Alias of {@link afterAll} */
+export const after = afterAll;
 
 /** Run some shared setup before each test in the suite. */
 export function beforeEach<T>(


### PR DESCRIPTION
Mocha and `node:test` use `after` and `before` instead of `afterAll` and `beforeEach`. This PR adds some aliased exports to make switching to Deno easier.