### PR TITLE
deprecation(encoding): make exported function names consistent with `std/encoding`

### DIFF
--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -60,7 +60,7 @@ const U64_VIEW = new BigUint64Array(AB);
  * decode(buf); // [ 300n, 2 ];
  * ```
  *
- * @deprecated (will be removed in 0.224.0) Use {@linkcode decodeVarint} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode decodeVarint} instead.
  */
 export function decode(buf: Uint8Array, offset = 0): [bigint, number] {
   return decodeVarint(buf, offset);
@@ -176,7 +176,7 @@ export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
  * decode32(buf); // [ 300, 2 ];
  * ```
  *
- * @deprecated (will be removed in 0.224.0) Use {@linkcode decodeVarint32}
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode decodeVarint32}
  * instead.
  */
 export function decode32(buf: Uint8Array, offset = 0): [number, number] {
@@ -248,7 +248,7 @@ export function decodeVarint32(buf: Uint8Array, offset = 0): [number, number] {
  * encode(42n, buf); // [ Uint8Array(1) [ 42 ], 1 ];
  * ```
  *
- * @deprecated (will be removed in 0.224.0) Use {@linkcode encodeVarint} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode encodeVarint} instead.
  */
 export function encode(
   num: bigint | number,

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -57,11 +57,41 @@ const U64_VIEW = new BigUint64Array(AB);
  * import { decode } from "https://deno.land/std@$STD_VERSION/encoding/varint.ts";
  *
  * const buf = new Uint8Array([0x8E, 0x02]);
- * decode(buf);
- * // [ 300n, 2 ];
+ * decode(buf); // [ 300n, 2 ];
  * ```
+ *
+ * @deprecated (will be removed in 0.224.0) Use {@linkcode decodeVarint} instead.
  */
 export function decode(buf: Uint8Array, offset = 0): [bigint, number] {
+  return decodeVarint(buf, offset);
+}
+
+/**
+ * Given a non empty `buf`, starting at `offset` (default: 0), begin decoding bytes as
+ * VarInt encoded bytes, for a maximum of 10 bytes (offset + 10). The returned
+ * tuple is of the decoded varint 32-bit number, and the new offset with which
+ * to continue decoding other data.
+ *
+ * If a `bigint` in return is undesired, the `decode32` function will return a
+ * `number`, but this should only be used in cases where the varint is
+ * _assured_ to be 32-bits. If in doubt, use `decode()`.
+ *
+ * To know how many bytes the VarInt took to encode, simply negate `offset`
+ * from the returned new `offset`.
+ *
+ * @param buf The buffer to decode from.
+ * @param offset The offset to start decoding from.
+ * @returns A tuple of the decoded varint 64-bit number, and the new offset.
+ *
+ * @example
+ * ```ts
+ * import { decodeVarint } from "https://deno.land/std@$STD_VERSION/encoding/varint.ts";
+ *
+ * const buf = new Uint8Array([0x8E, 0x02]);
+ * decodeVarint(buf); // [ 300n, 2 ];
+ * ```
+ */
+export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
   // Clear the last result from the Two's complement view
   U64_VIEW[0] = 0n;
 
@@ -143,11 +173,41 @@ export function decode(buf: Uint8Array, offset = 0): [bigint, number] {
  * import { decode32 } from "https://deno.land/std@$STD_VERSION/encoding/varint.ts";
  *
  * const buf = new Uint8Array([0x8E, 0x02]);
- * decode32(buf);
- * // [ 300, 2 ];
+ * decode32(buf); // [ 300, 2 ];
  * ```
+ *
+ * @deprecated (will be removed in 0.224.0) Use {@linkcode decodeVarint32}
+ * instead.
  */
 export function decode32(buf: Uint8Array, offset = 0): [number, number] {
+  return decodeVarint32(buf, offset);
+}
+
+/**
+ * Given a `buf`, starting at `offset` (default: 0), begin decoding bytes as
+ * VarInt encoded bytes, for a maximum of 5 bytes (offset + 5). The returned
+ * tuple is of the decoded varint 32-bit number, and the new offset with which
+ * to continue decoding other data.
+ *
+ * VarInts are _not 32-bit by default_ so this should only be used in cases
+ * where the varint is _assured_ to be 32-bits. If in doubt, use `decode()`.
+ *
+ * To know how many bytes the VarInt took to encode, simply negate `offset`
+ * from the returned new `offset`.
+ *
+ * @param buf The buffer to decode from.
+ * @param offset The offset to start decoding from.
+ * @returns A tuple of the decoded varint 32-bit number, and the new offset.
+ *
+ * @example
+ * ```ts
+ * import { decodeVarint32 } from "https://deno.land/std@$STD_VERSION/encoding/varint.ts";
+ *
+ * const buf = new Uint8Array([0x8E, 0x02]);
+ * decodeVarint32(buf); // [ 300, 2 ];
+ * ```
+ */
+export function decodeVarint32(buf: Uint8Array, offset = 0): [number, number] {
   let shift = 0;
   let decoded = 0;
   for (
@@ -187,8 +247,44 @@ export function decode32(buf: Uint8Array, offset = 0): [number, number] {
  * const buf = new Uint8Array(10);
  * encode(42n, buf); // [ Uint8Array(1) [ 42 ], 1 ];
  * ```
+ *
+ * @deprecated (will be removed in 0.224.0) Use {@linkcode encodeVarint} instead.
  */
 export function encode(
+  num: bigint | number,
+  buf: Uint8Array = new Uint8Array(MaxVarIntLen64),
+  offset = 0,
+): [Uint8Array, number] {
+  return encodeVarint(num, buf, offset);
+}
+
+/**
+ * Takes unsigned number `num` and converts it into a VarInt encoded
+ * `Uint8Array`, returning a tuple consisting of a `Uint8Array` slice of the
+ * encoded VarInt, and an offset where the VarInt encoded bytes end within the
+ * `Uint8Array`.
+ *
+ * If `buf` is not given then a Uint8Array will be created.
+ * `offset` defaults to `0`.
+ *
+ * If passed `buf` then that will be written into, starting at `offset`. The
+ * resulting returned `Uint8Array` will be a slice of `buf`. The resulting
+ * returned number is effectively `offset + bytesWritten`.
+ *
+ * @param num The number to encode.
+ * @param buf The buffer to write into.
+ * @param offset The offset to start writing at.
+ * @returns A tuple of the encoded VarInt `Uint8Array` and the new offset.
+ *
+ * @example
+ * ```ts
+ * import { encodeVarint } from "https://deno.land/std@$STD_VERSION/encoding/varint.ts";
+ *
+ * const buf = new Uint8Array(10);
+ * encodeVarint(42n, buf); // [ Uint8Array(1) [ 42 ], 1 ];
+ * ```
+ */
+export function encodeVarint(
   num: bigint | number,
   buf: Uint8Array = new Uint8Array(MaxVarIntLen64),
   offset = 0,


### PR DESCRIPTION
This PR deprecates:
1. `encode()` in favor of `encodeVarint()`
2. `decode()` in favor of `decodeVarint()`
3. `decode32()` in favor of `decodeVarint32()`