### PR TITLE
chore: enable simulated tests for Deno 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
-      - name: Run tests canary
+      - name: Run tests
+        run: deno task test
+
+      - name: Run tests (simulate Deno 2)
+        if: matrix.deno == 'canary'
         run: deno task test
 
       - name: Run timezone-dependent tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Run tests (simulate Deno 2)
         if: matrix.deno == 'canary'
         run: deno task test
+        env:
+          DENO_FUTURE: 1
 
       - name: Run timezone-dependent tests
         run: |

--- a/webgpu/_test_util.ts
+++ b/webgpu/_test_util.ts
@@ -35,8 +35,8 @@ export function cleanUp(device: GPUDevice) {
 
   // TODO(lucacasonato): webgpu spec should add a explicit destroy method for
   // adapters.
-  // deno-lint-ignore no-deprecated-deno-api
-  const resources = Object.keys(Deno.resources());
+  // @ts-ignore Until WebGPU resources cleanup is automatically handled.
+  const resources = Object.keys(Deno[Deno.internal].core.resources());
   // @ts-ignore Until WebGPU resources cleanup is automatically handled.
   Deno[Deno.internal].core.close(Number(resources[resources.length - 1]));
 }


### PR DESCRIPTION
As expected, this currently fails because [`cleanup()`](https://github.com/denoland/deno_std/blob/main/webgpu/_test_util.ts#L33) calls `Deno.resources()`, which will be removed in Deno 2.

Closes #4517