### PR TITLE
ci: validate PR titles

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -1,0 +1,72 @@
+name: "Lint PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # This should be kept up-to-date with the packages in the Standard
+          # Library (except `_tools`).
+          scopes: |
+            _tools
+            archive
+            assert
+            async
+            bytes
+            cli
+            collections
+            console
+            crypto
+            csv
+            data_structures
+            datetime
+            dotenv
+            encoding
+            expect
+            flags
+            fmt
+            front_matter
+            fs
+            html
+            http
+            ini
+            io
+            json
+            jsonc
+            log
+            media_types
+            msgpack
+            net
+            path
+            permissions
+            regexp
+            semver
+            streams
+            testing
+            text
+            toml
+            ulid
+            url
+            uuid
+            webgpu
+            yaml
+          # Subject cannot start with an uppercase letter
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.


### PR DESCRIPTION
This allows us to more accurately follow [Conventional Commits](https://www.conventionalcommits.org/), which we already mostly do. The correctness of PR titles will become more important, as we plan to use PR titles in to determine release versions of packages.