### PR TITLE
deprecation(semver): deprecate `rangeMax()` and `rangeMin()`

### DIFF
--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -44,7 +44,7 @@ function comparatorMax(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers. The maximum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or {@linkcode lessThanRange} for comparing ranges and semvers. The maximum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
  *
  * The maximum valid SemVer for a given range or INVALID
  * @param range The range to calculate the max for

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -44,7 +44,11 @@ function comparatorMax(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or {@linkcode lessThanRange} for comparing ranges and semvers. The maximum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or
+ * {@linkcode lessThanRange} for comparing ranges and semvers. The maximum
+ * version of a range is often not well defined, and therefore this API
+ * shouldn't be used. See
+ * {@link https://github.com/denoland/deno_std/issues/4365} for details.
  *
  * The maximum valid SemVer for a given range or INVALID
  * @param range The range to calculate the max for

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -44,7 +44,7 @@ function comparatorMax(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers.
+ * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers. The maximum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
  *
  * The maximum valid SemVer for a given range or INVALID
  * @param range The range to calculate the max for

--- a/semver/range_max.ts
+++ b/semver/range_max.ts
@@ -44,6 +44,8 @@ function comparatorMax(comparator: Comparator): SemVer {
 }
 
 /**
+ * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers.
+ *
  * The maximum valid SemVer for a given range or INVALID
  * @param range The range to calculate the max for
  * @returns A valid SemVer or INVALID

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -35,7 +35,11 @@ function comparatorMin(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or {@linkcode lessThanRange} for comparing ranges and semvers. The minimum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or
+ * {@linkcode lessThanRange} for comparing ranges and semvers. The minimum
+ * version of a range is often not well defined, and therefore this API
+ * shouldn't be used. See
+ * {@link https://github.com/denoland/deno_std/issues/4365} for details.
  *
  * The minimum valid SemVer for a given range or INVALID
  * @param range The range to calculate the min for

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -35,6 +35,8 @@ function comparatorMin(comparator: Comparator): SemVer {
 }
 
 /**
+ * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers.
+ *
  * The minimum valid SemVer for a given range or INVALID
  * @param range The range to calculate the min for
  * @returns A valid SemVer or INVALID

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -35,7 +35,7 @@ function comparatorMin(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers.
+ * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers. The minimum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
  *
  * The minimum valid SemVer for a given range or INVALID
  * @param range The range to calculate the min for

--- a/semver/range_min.ts
+++ b/semver/range_min.ts
@@ -35,7 +35,7 @@ function comparatorMin(comparator: Comparator): SemVer {
 }
 
 /**
- * @deprecated (will be removed in 1.0.0) use greaterThanRange or lessThanRange for comparing ranges and semvers. The minimum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode greaterThanRange} or {@linkcode lessThanRange} for comparing ranges and semvers. The minimum version of a range is often not well defined, and therefore this API shouldn't be used. See https://github.com/denoland/deno_std/issues/4365 for details.
  *
  * The minimum valid SemVer for a given range or INVALID
  * @param range The range to calculate the min for


### PR DESCRIPTION
closes #4365