### PR TITLE
deprecation(permissions): update removal time for `std/permissions`

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -51,6 +51,7 @@ for await (
       /_tools$/,
       /_util$/,
       /docs$/,
+      /permissions/,
     ],
   })
 ) {

--- a/permissions/mod.ts
+++ b/permissions/mod.ts
@@ -1,8 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 /**
  * Helpers for interacting with Deno's permissions system.
+ *
+ * @deprecated Use the
+ * {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API}
+ * directly instead. This module will be removed once the Standard Library
+ * migrates to {@link https://jsr.io/ | JSR}.
+ *
  * @module
- * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
  */
 
 const { PermissionDenied } = Deno.errors;
@@ -47,7 +52,10 @@ function getPermissionString(descriptors: Deno.PermissionDescriptor[]): string {
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions.
  *
- * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
+ * @deprecated Use the
+ * {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API}
+ * directly instead. This module will be removed once the Standard Library
+ * migrates to {@link https://jsr.io/ | JSR}.
  */
 export async function grant(
   ...descriptors: Deno.PermissionDescriptor[]
@@ -68,7 +76,10 @@ export async function grant(
  * If one of the permissions requires a prompt, the function will attempt to
  * prompt for it.  The function resolves with all of the granted permissions.
  *
- * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
+ * @deprecated Use the
+ * {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API}
+ * directly instead. This module will be removed once the Standard Library
+ * migrates to {@link https://jsr.io/ | JSR}.
  */
 export async function grant(
   descriptors: Deno.PermissionDescriptor[],
@@ -105,7 +116,10 @@ export async function grant(
  * permission that is denied.  If all permissions are granted, the function
  * will resolve.
  *
- * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
+ * @deprecated Use the
+ * {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API}
+ * directly instead. This module will be removed once the Standard Library
+ * migrates to {@link https://jsr.io/ | JSR}.
  */
 export async function grantOrThrow(
   ...descriptors: Deno.PermissionDescriptor[]
@@ -122,7 +136,10 @@ export async function grantOrThrow(
  * the denied permissions.  If all permissions are granted, the function will
  * resolve.
  *
- * @deprecated (will be removed in 1.0.0) Use the {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API} directly instead.
+ * @deprecated Use the
+ * {@link https://deno.land/api?s=Deno.Permissions | Deno Permissions API}
+ * directly instead. This module will be removed once the Standard Library
+ * migrates to {@link https://jsr.io/ | JSR}.
  */
 export async function grantOrThrow(
   descriptors: Deno.PermissionDescriptor[],


### PR DESCRIPTION
This PR updates the removal version of `std/permissions` to be when `std` migrates to JSR, as `std/permissions` will never reach v1.