### PR TITLE
chore: update deprecation notices and check

### DIFF
--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -13,8 +13,6 @@ const FAIL_FAST = Deno.args.includes("--fail-fast");
 
 const DEPRECATION_IN_FORMAT_REGEX =
   /^\(will be removed in (?<version>\d+\.\d+\.\d+)\)/;
-const DEPRECATION_AFTER_FORMAT_REGEX =
-  /^\(will be removed after (?<version>\d+\.\d+\.\d+)\)/;
 
 let shouldFail = false;
 
@@ -76,29 +74,10 @@ for await (
               if (FAIL_FAST) Deno.exit(1);
               continue;
             }
-            const { version: afterVersion } =
-              DEPRECATION_AFTER_FORMAT_REGEX.exec(message)?.groups || {};
 
-            if (afterVersion) {
-              if (
-                semver.lessThan(
-                  semver.parse(afterVersion),
-                  semver.parse(VERSION),
-                )
-              ) {
-                console.warn(
-                  colors.yellow("Warn"),
-                  `${
-                    colors.bold("@deprecated")
-                  } tag is expired and export should be removed: ${path}:${d.location.line}`,
-                );
-              }
-              continue;
-            }
-
-            const { version: inVersion } =
+            const { version } =
               DEPRECATION_IN_FORMAT_REGEX.exec(message)?.groups || {};
-            if (!inVersion) {
+            if (!version) {
               console.error(
                 colors.red("Error"),
                 `${
@@ -112,7 +91,7 @@ for await (
 
             if (
               !semver.greaterThan(
-                semver.parse(inVersion),
+                semver.parse(version),
                 semver.parse(VERSION),
               )
             ) {

--- a/http/server.ts
+++ b/http/server.ts
@@ -19,7 +19,7 @@ const MAX_ACCEPT_BACKOFF_DELAY = 1000;
 /**
  * Information about the connection a request arrived on.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeHandlerInfo} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeHandlerInfo} instead.
  */
 export interface ConnInfo {
   /** The local address of the connection. */
@@ -36,7 +36,7 @@ export interface ConnInfo {
  * of the error is isolated to the individual request. It will catch the error
  * and close the underlying connection.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeHandler} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeHandler} instead.
  */
 export type Handler = (
   request: Request,
@@ -46,7 +46,7 @@ export type Handler = (
 /**
  * Options for running an HTTP server.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeInit} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeInit} instead.
  */
 export interface ServerInit extends Partial<Deno.ListenOptions> {
   /** The handler to invoke for individual HTTP requests. */
@@ -63,7 +63,7 @@ export interface ServerInit extends Partial<Deno.ListenOptions> {
 /**
  * Used to construct an HTTP server.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.serve} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.serve} instead.
  */
 export class Server {
   #port?: number;
@@ -501,7 +501,7 @@ export class Server {
 /**
  * Additional serve options.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeInit} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeInit} instead.
  */
 export interface ServeInit extends Partial<Deno.ListenOptions> {
   /** An AbortSignal to close the server and all connections. */
@@ -517,7 +517,7 @@ export interface ServeInit extends Partial<Deno.ListenOptions> {
 /**
  * Additional serve listener options.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeOptions} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeOptions} instead.
  */
 export interface ServeListenerOptions {
   /** An AbortSignal to close the server and all connections. */
@@ -554,7 +554,7 @@ export interface ServeListenerOptions {
  * @param handler The handler for individual HTTP requests.
  * @param options Optional serve options.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.serve} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.serve} instead.
  */
 export async function serveListener(
   listener: Deno.Listener,
@@ -622,7 +622,7 @@ function hostnameForDisplay(hostname: string) {
  * @param handler The handler for individual HTTP requests.
  * @param options The options. See `ServeInit` documentation for details.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.serve} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.serve} instead.
  */
 export async function serve(
   handler: Handler,
@@ -667,7 +667,7 @@ export async function serve(
 /**
  * Initialization parameters for {@linkcode serveTls}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.ServeTlsOptions} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.ServeTlsOptions} instead.
  */
 export interface ServeTlsInit extends ServeInit {
   /** Server private key in PEM format */
@@ -742,7 +742,7 @@ export interface ServeTlsInit extends ServeInit {
  * @param options The options. See `ServeTlsInit` documentation for details.
  * @returns
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode Deno.serve} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode Deno.serve} instead.
  */
 export async function serveTls(
   handler: Handler,

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -12,7 +12,7 @@ const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufferFullError extends Error {
   override name = "BufferFullError";
@@ -22,7 +22,7 @@ export class BufferFullError extends Error {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class PartialReadError extends Error {
   override name = "PartialReadError";
@@ -35,7 +35,7 @@ export class PartialReadError extends Error {
 /**
  * Result type returned by of BufReader.readLine().
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export interface ReadLineResult {
   line: Uint8Array;
@@ -43,7 +43,7 @@ export interface ReadLineResult {
 }
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufReader implements Reader {
   #buf!: Uint8Array;

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -40,7 +40,7 @@ abstract class AbstractBufBase {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.Writer.
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufWriter extends AbstractBufBase implements Writer {
   #writer: Writer;
@@ -133,7 +133,7 @@ export class BufWriter extends AbstractBufBase implements Writer {
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.WriterSync.
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufWriterSync extends AbstractBufBase implements WriterSync {
   #writer: WriterSync;

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -12,7 +12,7 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param dest Writer
  * @param size Read size
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function copyN(
   r: Reader,

--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -10,7 +10,7 @@
 import type { Reader } from "./types.ts";
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class LimitedReader implements Reader {
   constructor(public reader: Reader, public limit: number) {}

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -6,7 +6,7 @@ import type { Reader } from "./types.ts";
 /**
  * Reader utility for combining multiple readers
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class MultiReader implements Reader {
   readonly #readers: Reader[];

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -28,7 +28,7 @@ function createLPS(pat: Uint8Array): Uint8Array {
 /**
  * Read delimited bytes from a Reader.
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readDelim(
   reader: Reader,

--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -7,7 +7,7 @@ import { readShort } from "./read_short.ts";
  * Read big endian 32bit integer from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readInt(buf: BufReader): Promise<number | null> {
   const high = await readShort(buf);

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -21,7 +21,7 @@ import { concat } from "../bytes/concat.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readLines(
   reader: Reader,

--- a/io/read_long.ts
+++ b/io/read_long.ts
@@ -9,7 +9,7 @@ const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
  * Read big endian 64bit long from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readLong(buf: BufReader): Promise<number | null> {
   const high = await readInt(buf);

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -7,7 +7,7 @@ import type { Reader, ReaderSync } from "./types.ts";
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 
 /**
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export interface ByteRange {
   /** The 0 based index of the start byte for a range. */
@@ -32,7 +32,7 @@ export interface ByteRange {
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readRange(
   r: Reader & Deno.Seeker,
@@ -72,7 +72,7 @@ export async function readRange(
  * assertEquals(bytes.length, 10);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export function readRangeSync(
   r: ReaderSync & Deno.SeekerSync,

--- a/io/read_short.ts
+++ b/io/read_short.ts
@@ -6,7 +6,7 @@ import type { BufReader } from "./buf_reader.ts";
  * Read big endian 16bit short from BufReader
  * @param buf
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readShort(buf: BufReader): Promise<number | null> {
   const high = await buf.readByte();

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -20,7 +20,7 @@ import { readDelim } from "./read_delim.ts";
  * }
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function* readStringDelim(
   reader: Reader,

--- a/io/slice_long_to_bytes.ts
+++ b/io/slice_long_to_bytes.ts
@@ -6,7 +6,7 @@
  * @param d The number to be sliced
  * @param dest The sliced array
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export function sliceLongToBytes(
   d: number,

--- a/io/string_reader.ts
+++ b/io/string_reader.ts
@@ -32,7 +32,7 @@ import { Buffer } from "./buffer.ts";
  * abcdef
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class StringReader extends Buffer {
   constructor(s: string) {

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -35,7 +35,7 @@ const decoder = new TextDecoder();
  * base0123456789
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated (will be removed in 1.0.0) Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class StringWriter implements Writer, WriterSync {
   #chunks: Uint8Array[] = [];

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -37,10 +37,10 @@
 import * as _windows from "./windows/mod.ts";
 import * as _posix from "./posix/mod.ts";
 
-/** @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/path/windows/mod.ts} instead. */
+/** @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/path/windows/mod.ts} instead. */
 export const win32: typeof _windows = _windows;
 
-/** @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/path/posix/mod.ts} instead. */
+/** @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/path/posix/mod.ts} instead. */
 export const posix: typeof _posix = _posix;
 
 export * from "./basename.ts";

--- a/streams/readable_stream_from_reader.ts
+++ b/streams/readable_stream_from_reader.ts
@@ -8,7 +8,7 @@ export type { Closer };
 /**
  * Options for {@linkcode readableStreamFromReader}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode toReadableStream} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode toReadableStream} instead.
  */
 export interface ReadableStreamFromReaderOptions {
   /** If the `reader` is also a `Closer`, automatically close the `reader`
@@ -43,7 +43,7 @@ export interface ReadableStreamFromReaderOptions {
  * const fileStream = readableStreamFromReader(file);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode toReadableStream} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode toReadableStream} instead.
  */
 export function readableStreamFromReader(
   reader: Reader | (Reader & Closer),

--- a/streams/reader_from_iterable.ts
+++ b/streams/reader_from_iterable.ts
@@ -23,7 +23,7 @@ import type { Reader } from "../io/types.ts";
  * await copy(reader, file);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode ReadableStream.from} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode ReadableStream.from} instead.
  */
 export function readerFromIterable(
   iterable: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,

--- a/streams/writable_stream_from_writer.ts
+++ b/streams/writable_stream_from_writer.ts
@@ -7,7 +7,7 @@ import { toWritableStream } from "../io/to_writable_stream.ts";
 /**
  * Options for {@linkcode writableStreamFromWriter}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode toWritableStream} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode toWritableStream} instead.
  */
 export interface WritableStreamFromWriterOptions {
   /**
@@ -22,7 +22,7 @@ export interface WritableStreamFromWriterOptions {
 /**
  * Create a {@linkcode WritableStream} from a {@linkcode Writer}.
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode toWritableStream} instead.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode toWritableStream} instead.
  */
 export function writableStreamFromWriter(
   writer: Writer,

--- a/streams/writer_from_stream_writer.ts
+++ b/streams/writer_from_stream_writer.ts
@@ -22,7 +22,7 @@ import type { Writer } from "../io/types.ts";
  * await copy(file, writer);
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Use {@linkcode WritableStreamDefaultWriter} directly.
+ * @deprecated (will be removed in 1.0.0) Use {@linkcode WritableStreamDefaultWriter} directly.
  */
 export function writerFromStreamWriter(
   streamWriter: WritableStreamDefaultWriter<Uint8Array>,

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -8,7 +8,7 @@
  * This module is browser compatible, but do not rely on good formatting of
  * values for AssertionError messages in browsers.
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/mod.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/mod.ts} instead.
  *
  * @module
  */
@@ -30,7 +30,7 @@ import * as asserts from "../assert/mod.ts";
  * assertAlmostEquals(0.1 + 0.2, 0.3, 1e-17); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_almost_equals.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_almost_equals.ts} instead.
  */
 export function assertAlmostEquals(
   actual: number,
@@ -44,7 +44,7 @@ export function assertAlmostEquals(
 /**
  * An array-like object (`Array`, `Uint8Array`, `NodeList`, etc.) that is not a string.
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_array_includes.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_array_includes.ts} instead.
  */
 export type ArrayLikeArg<T> = ArrayLike<T> & object;
 
@@ -63,7 +63,7 @@ export type ArrayLikeArg<T> = ArrayLike<T> & object;
  * assertArrayIncludes([1, 2], [3]); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_array_includes.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_array_includes.ts} instead.
  */
 export function assertArrayIncludes<T>(
   actual: ArrayLikeArg<T>,
@@ -90,7 +90,7 @@ export function assertArrayIncludes<T>(
  *
  * Note: formatter option is experimental and may be removed in the future.
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_equals.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_equals.ts} instead.
  */
 export function assertEquals<T>(
   actual: T,
@@ -113,7 +113,7 @@ export function assertEquals<T>(
  * assertExists(undefined); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_exists.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_exists.ts} instead.
  */
 export function assertExists<T>(
   actual: T,
@@ -125,7 +125,7 @@ export function assertExists<T>(
 /**
  * Assertion condition for {@linkcode assertFalse}.
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_false.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_false.ts} instead.
  */
 export type Falsy = false | 0 | 0n | "" | null | undefined;
 
@@ -140,7 +140,7 @@ export type Falsy = false | 0 | 0n | "" | null | undefined;
  * assertFalse(true); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_false.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_false.ts} instead.
  */
 export function assertFalse(expr: unknown, msg = ""): asserts expr is Falsy {
   asserts.assertFalse(expr, msg);
@@ -159,7 +159,7 @@ export function assertFalse(expr: unknown, msg = ""): asserts expr is Falsy {
  * assertGreaterOrEqual(0, 1); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_greater_or_equal.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_greater_or_equal.ts} instead.
  */
 export function assertGreaterOrEqual<T>(
   actual: T,
@@ -182,7 +182,7 @@ export function assertGreaterOrEqual<T>(
  * assertGreater(0, 1); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_greater.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_greater.ts} instead.
  */
 export function assertGreater<T>(actual: T, expected: T, msg?: string) {
   asserts.assertGreater<T>(actual, expected, msg);
@@ -191,13 +191,13 @@ export function assertGreater<T>(actual: T, expected: T, msg?: string) {
 /**
  * Any constructor
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
  */
 // deno-lint-ignore no-explicit-any
 export type AnyConstructor = new (...args: any[]) => any;
 /** Gets constructor type
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
  */
 export type GetConstructorType<T extends AnyConstructor> = T extends // deno-lint-ignore no-explicit-any
 new (...args: any) => infer C ? C
@@ -215,7 +215,7 @@ new (...args: any) => infer C ? C
  * assertInstanceOf(new Date(), Number); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_instance_of.ts} instead.
  */
 export function assertInstanceOf<T extends AnyConstructor>(
   actual: unknown,
@@ -242,7 +242,7 @@ export function assertInstanceOf<T extends AnyConstructor>(
  * assertIsError(new RangeError("Out of range"), SyntaxError, "Within range"); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_is_error.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_is_error.ts} instead.
  */
 export function assertIsError<E extends Error = Error>(
   error: unknown,
@@ -267,7 +267,7 @@ export function assertIsError<E extends Error = Error>(
  * assertLessOrEqual(1, 0); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_less_or_equal.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_less_or_equal.ts} instead.
  */
 export function assertLessOrEqual<T>(
   actual: T,
@@ -289,7 +289,7 @@ export function assertLessOrEqual<T>(
  * assertLess(2, 1); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_less.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_less.ts} instead.
  */
 export function assertLess<T>(actual: T, expected: T, msg?: string) {
   asserts.assertLess<T>(actual, expected, msg);
@@ -307,7 +307,7 @@ export function assertLess<T>(actual: T, expected: T, msg?: string) {
  * assertMatch("Denosaurus", RegExp(/Raptor/)); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_match.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_match.ts} instead.
  */
 export function assertMatch(
   actual: string,
@@ -331,7 +331,7 @@ export function assertMatch(
  * assertNotEquals(1, 1); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_equals.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_equals.ts} instead.
  */
 export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   asserts.assertNotEquals<T>(actual, expected, msg);
@@ -349,7 +349,7 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
  * assertNotInstanceOf(new Date(), Date); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_instance_of.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_instance_of.ts} instead.
  */
 export function assertNotInstanceOf<A, T>(
   actual: A,
@@ -372,7 +372,7 @@ export function assertNotInstanceOf<A, T>(
  * assertNotMatch("Raptor", RegExp(/Raptor/)); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_match.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_match.ts} instead.
  */
 export function assertNotMatch(
   actual: string,
@@ -394,7 +394,7 @@ export function assertNotMatch(
  * assertNotStrictEquals(1, 2); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_strict_equals.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_not_strict_equals.ts} instead.
  */
 export function assertNotStrictEquals<T>(
   actual: T,
@@ -416,7 +416,7 @@ export function assertNotStrictEquals<T>(
  * assertObjectMatch({ foo: "bar" }, { foo: "baz" }); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_object_match.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_object_match.ts} instead.
  */
 export function assertObjectMatch(
   // deno-lint-ignore no-explicit-any
@@ -438,7 +438,7 @@ export function assertObjectMatch(
  * await assertRejects(async () => console.log("Hello world")); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_rejects.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_rejects.ts} instead.
  */
 export function assertRejects(
   fn: () => PromiseLike<unknown>,
@@ -457,7 +457,7 @@ export function assertRejects(
  * await assertRejects(async () => Promise.reject(new Error()), SyntaxError); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_rejects.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_rejects.ts} instead.
  */
 export function assertRejects<E extends Error = Error>(
   fn: () => PromiseLike<unknown>,
@@ -501,7 +501,7 @@ export async function assertRejects<E extends Error = Error>(
  * assertStrictEquals(c, d); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_strict_equals.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_strict_equals.ts} instead.
  */
 export function assertStrictEquals<T>(
   actual: unknown,
@@ -523,7 +523,7 @@ export function assertStrictEquals<T>(
  * assertStringIncludes("Hello", "world"); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_string_includes.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_string_includes.ts} instead.
  */
 export function assertStringIncludes(
   actual: string,
@@ -545,7 +545,7 @@ export function assertStringIncludes(
  * assertThrows(() => console.log("hello world!")); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_throws.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_throws.ts} instead.
  */
 export function assertThrows(
   fn: () => unknown,
@@ -564,7 +564,7 @@ export function assertThrows(
  * assertThrows(() => { throw new TypeError("hello world!"); }, RangeError); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert_throws.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert_throws.ts} instead.
  */
 export function assertThrows<E extends Error = Error>(
   fn: () => unknown,
@@ -602,7 +602,7 @@ export function assertThrows<E extends Error = Error>(
  * assert("hello".includes("world")); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assert.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assert.ts} instead.
  */
 export function assert(expr: unknown, msg = ""): asserts expr {
   asserts.assert(expr, msg);
@@ -618,7 +618,7 @@ export function assert(expr: unknown, msg = ""): asserts expr {
  * throw new AssertionError("Assertion failed");
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/assertion_error.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/assertion_error.ts} instead.
  */
 export class AssertionError extends Error {
   /** Constructs a new instance. */
@@ -641,7 +641,7 @@ export class AssertionError extends Error {
  * equal({ foo: "bar" }, { foo: "baz" }); // Returns `false
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/equal.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/equal.ts} instead.
  */
 export function equal(c: unknown, d: unknown): boolean {
   return asserts.equal(c, d);
@@ -657,7 +657,7 @@ export function equal(c: unknown, d: unknown): boolean {
  * fail("Deliberately failed!"); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/fail.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/fail.ts} instead.
  */
 export function fail(msg?: string): never {
   asserts.fail(msg);
@@ -673,7 +673,7 @@ export function fail(msg?: string): never {
  * unimplemented(); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/unimplemented.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/unimplemented.ts} instead.
  */
 export function unimplemented(msg?: string): never {
   asserts.unimplemented(msg);
@@ -689,7 +689,7 @@ export function unimplemented(msg?: string): never {
  * unreachable(); // Throws
  * ```
  *
- * @deprecated (will be removed after 1.0.0) Import from {@link https://deno.land/std/assert/unreachable.ts} instead.
+ * @deprecated (will be removed in 1.0.0) Import from {@link https://deno.land/std/assert/unreachable.ts} instead.
  */
 export function unreachable(): never {
   asserts.unreachable();


### PR DESCRIPTION
Having a deprecation notice containing "will be removed after..." can be a little confusing as it suggests that there's no definitive time/version when an API will be removed.