### PR TITLE
chore: enable Codecov comments in PRs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,3 @@
-comment: false
 codecov:
   require_ci_to_pass: true
 coverage:
@@ -9,5 +8,3 @@ coverage:
     patch:
       default:
         informational: true
-ignore:
-  - examples


### PR DESCRIPTION
This change enables Codecov comments. I find myself having to manually look up test coverage changes on commits in the Codecov UI. Having this presented within PR feeds would help a lot. We can re-evaluate if it becomes too noisy.