### PR TITLE
deprecation(expect): rename `addSnapshotSerializers` to `addSnapshotSerializer`

### DIFF
--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -199,7 +199,11 @@ export function expect(value: unknown, customMessage?: string): Expected {
 }
 
 expect.addEqualityTesters = addCustomEqualityTesters;
+/**
+ * @deprecated (will be removed in 0.226.0) Use {@linkcode expect.addSnapshotSerializer} instead.
+ */
 expect.addSnapshotSerializers = addSerializer;
+expect.addSnapshotSerializer = addSerializer;
 expect.extend = setExtendMatchers;
 
 expect.anything = anything;


### PR DESCRIPTION
This PR renames `expect.addSnapshotSerializers` to `expect.addSnapshotSerializer` to match [Jest's naming](https://github.com/jestjs/jest/blob/v29.7.0/docs/ExpectAPI.md#expectaddsnapshotserializerserializer).