### PR TITLE
chore(CI): perform dry-run publish to be done in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,6 @@ jobs:
   publish-dry-run:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    env:
-      DENO_UNSTABLE_WORKSPACES: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,32 @@ jobs:
       - name: Rebuild Wasm and verify it hasn't changed
         if: success() && steps.source.outputs.modified == 'true'
         run: deno task --cwd ${{ matrix.module }} wasmbuild --check
+
+  publish-dry-run:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      DENO_UNSTABLE_WORKSPACES: true
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: canary
+
+      - name: Convert to workspace
+        run: deno run -A ./_tools/convert_to_workspace.ts
+
+      - name: Test
+        run: deno task test
+
+      - name: Publish (dry run)
+        run: deno publish --allow-dirty --dry-run

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Type check
         run: deno task test
 
-      - name: Publish (real)
+      - name: Publish to JSR
         run: deno publish --allow-dirty

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  DENO_UNSTABLE_WORKSPACES: true
-
 jobs:
   publish:
     runs-on: ubuntu-22.04

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -1,8 +1,6 @@
 name: workspace publish
 
 on:
-  push:
-    branches: [main]
   release:
     types: [published]
 
@@ -38,10 +36,5 @@ jobs:
       - name: Type check
         run: deno task test
 
-      - name: Publish (dry run)
-        if: github.event_name == 'push'
-        run: deno publish --allow-dirty --dry-run
-
       - name: Publish (real)
-        if: github.event_name == 'release'
         run: deno publish --allow-dirty

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Format
         run: deno fmt
 
-      - name: Type check
+      - name: Test
         run: deno task test
 
       - name: Publish to JSR

--- a/url/basename.ts
+++ b/url/basename.ts
@@ -31,7 +31,7 @@ import { strip } from "./_strip.ts";
  * @param suffix - optional suffix to remove from extracted name.
  * @returns the last portion of the URL `path`, or the URL origin if there is no path.
  */
-export function basename(url: string | URL, suffix?: string): string {
+export function basename(url: string | URL, suffix?: string) {
   url = new URL(url);
   strip(url);
   return posixBasename(url.href, suffix);

--- a/url/basename.ts
+++ b/url/basename.ts
@@ -31,7 +31,7 @@ import { strip } from "./_strip.ts";
  * @param suffix - optional suffix to remove from extracted name.
  * @returns the last portion of the URL `path`, or the URL origin if there is no path.
  */
-export function basename(url: string | URL, suffix?: string) {
+export function basename(url: string | URL, suffix?: string): string {
   url = new URL(url);
   strip(url);
   return posixBasename(url.href, suffix);


### PR DESCRIPTION
This allows us to catch issues with dry-run publishes before cutting a release.