### PR TITLE
fix(csv): remove unused `opt` parameter

### DIFF
--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -319,11 +319,10 @@ export interface ParseOptions extends ReadOptions {
  * ```
  *
  * @param input Input to parse.
- * @param opt options of the parser.
  * @returns If you don't provide `opt.skipFirstRow` and `opt.columns`, it returns `string[][]`.
  *   If you provide `opt.skipFirstRow` or `opt.columns`, it returns `Record<string, unknown>[]`.
  */
-export function parse(input: string, opt?: undefined): string[][];
+export function parse(input: string): string[][];
 /**
  * Csv parse helper to manipulate data.
  * Provides an auto/custom mapper for columns.


### PR DESCRIPTION
This was made according to the issue #4545 inside the file deno_std/csv/parse.ts