### PR TITLE
BREAKING(streams): replace rest params of `mergeReadableStreams()` with a single array param

### DIFF
--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -13,11 +13,11 @@
  * const stream2 = ReadableStream.from(["a", "b", "c"]);
  *
  * // ["2", "c", "a", "b", "3", "1"]
- * await Array.fromAsync(mergeReadableStreams(stream1, stream2));
+ * await Array.fromAsync(mergeReadableStreams([stream1, stream2]));
  * ```
  */
 export function mergeReadableStreams<T>(
-  ...streams: ReadableStream<T>[]
+  streams: ReadableStream<T>[]
 ): ReadableStream<T> {
   const resolvePromises = streams.map(() => Promise.withResolvers<void>());
   return new ReadableStream<T>({

--- a/streams/merge_readable_streams_test.ts
+++ b/streams/merge_readable_streams_test.ts
@@ -17,7 +17,7 @@ Deno.test("mergeReadableStreams()", async () => {
   ]);
 
   const buf = await Array.fromAsync(
-    mergeReadableStreams(textStream, textStream2),
+    mergeReadableStreams([textStream, textStream2]),
   );
 
   assertEquals(buf.sort(), [
@@ -37,7 +37,7 @@ Deno.test("mergeReadableStreams() handles errors", async () => {
 
   const buf = [];
   try {
-    for await (const s of mergeReadableStreams(textStream, textStream2)) {
+    for await (const s of mergeReadableStreams([textStream, textStream2])) {
       buf.push(s);
       if (s === "2") {
         throw new Error("error");


### PR DESCRIPTION
- This makes it consistent with `concat()` of the bytes submodule.
- It is also slightly more performant.