### PR TITLE
feat(http): file server prints local network address

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -807,7 +807,7 @@ function main() {
   const useTls = !!(keyFile && certFile);
 
   function onListen({ port }: { port: number }) {
-    const networkAddress = getNewtowrkAddress();
+    const networkAddress = getNetworkAddress();
     const protocol = useTls ? "https" : "http";
     let message =
       `Serving static files!\nlocal: ${protocol}://localhost:${port}`;
@@ -839,7 +839,7 @@ function main() {
  * inspired by the util of the same name in `npm:serve`
  * https://github.com/vercel/serve/blob/1ea55b1b5004f468159b54775e4fb3090fedbb2b/source/utilities/http.ts#L33
  */
-function getNewtowrkAddress() {
+function getNetworkAddress() {
   for (const { family, address } of Deno.networkInterfaces()) {
     if (family === "IPv4" && !address.startsWith("127.")) {
       return address;

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -810,7 +810,7 @@ function main() {
     const networkAddress = getNetworkAddress();
     const protocol = useTls ? "https" : "http";
     let message = `Listening on:\n- Local: ${protocol}://${hostname}:${port}`;
-    if (networkAddress) {
+    if (networkAddress && !DENO_DEPLOYMENT_ID) {
       message += `\n- Network: ${protocol}://${networkAddress}:${port}`;
     }
     console.log(message);

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -806,13 +806,12 @@ function main() {
 
   const useTls = !!(keyFile && certFile);
 
-  function onListen({ port }: { port: number }) {
+  function onListen({ port, hostname }: { port: number; hostname: string }) {
     const networkAddress = getNetworkAddress();
     const protocol = useTls ? "https" : "http";
-    let message =
-      `Serving static files!\nlocal: ${protocol}://localhost:${port}`;
+    let message = `Listening on:\n- local: ${protocol}://${hostname}:${port}`;
     if (networkAddress) {
-      message += `\nnetwork: ${protocol}://${networkAddress}:${port}`;
+      message += `\n- network: ${protocol}://${networkAddress}:${port}`;
     }
     console.log(message);
   }

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -806,10 +806,22 @@ function main() {
 
   const useTls = !!(keyFile && certFile);
 
+  function onListen({ port }: { port: number }) {
+    const networkAddress = getNewtowrkAddress();
+    const protocol = useTls ? "https" : "http";
+    let message =
+      `Serving static files!\nlocal: ${protocol}://localhost:${port}`;
+    if (networkAddress) {
+      message += `\nnetwork: ${protocol}://${networkAddress}:${port}`;
+    }
+    console.log(message);
+  }
+
   if (useTls) {
     Deno.serve({
       port,
       hostname: host,
+      onListen,
       cert: Deno.readTextFileSync(certFile),
       key: Deno.readTextFileSync(keyFile),
     }, handler);
@@ -817,7 +829,21 @@ function main() {
     Deno.serve({
       port,
       hostname: host,
+      onListen,
     }, handler);
+  }
+}
+
+/**
+ * Gets the network address of the machine,
+ * inspired by the util of the same name in `npm:serve`
+ * https://github.com/vercel/serve/blob/1ea55b1b5004f468159b54775e4fb3090fedbb2b/source/utilities/http.ts#L33
+ */
+function getNewtowrkAddress() {
+  for (const { family, address } of Deno.networkInterfaces()) {
+    if (family === "IPv4" && !address.startsWith("127.")) {
+      return address;
+    }
   }
 }
 

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -809,9 +809,9 @@ function main() {
   function onListen({ port, hostname }: { port: number; hostname: string }) {
     const networkAddress = getNetworkAddress();
     const protocol = useTls ? "https" : "http";
-    let message = `Listening on:\n- local: ${protocol}://${hostname}:${port}`;
+    let message = `Listening on:\n- Local: ${protocol}://${hostname}:${port}`;
     if (networkAddress) {
-      message += `\n- network: ${protocol}://${networkAddress}:${port}`;
+      message += `\n- Network: ${protocol}://${networkAddress}:${port}`;
     }
     console.log(message);
   }

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -983,6 +983,8 @@ Deno.test("file_server prints local and network urls", async () => {
       "--allow-net",
       "--allow-read",
       "--allow-sys=networkInterfaces",
+      "--config",
+      "deno.json",
       "http/file_server.ts",
       "--port",
       `${port}`,

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -975,42 +975,87 @@ Deno.test(
 
 Deno.test("file_server prints local and network urls", async () => {
   const port = await getAvailablePort();
+  const process = spawnDeno([
+    "--allow-net",
+    "--allow-read",
+    "--allow-sys=networkInterfaces",
+    "http/file_server.ts",
+    "--port",
+    `${port}`,
+  ]);
+  const output = await readUntilMatch(process.stdout, "Network:");
+  const networkAdress = Deno.networkInterfaces().find((i) =>
+    i.family === "IPv4" && !i.address.startsWith("127")
+  )?.address;
+  assertEquals(
+    output,
+    `Listening on:\n- Local: http://localhost:${port}\n- Network: http://${networkAdress}:${port}\n`,
+  );
+  process.stdout.cancel();
+  process.stderr.cancel();
+  process.kill();
+  await process.status;
+});
+
+Deno.test("file_server prints only local address on Deploy", async () => {
+  const port = await getAvailablePort();
+  const process = spawnDeno([
+    "--allow-net",
+    "--allow-read",
+    "--allow-sys=networkInterfaces",
+    "--allow-env=DENO_DEPLOYMENT_ID",
+    "http/file_server.ts",
+    "--port",
+    `${port}`,
+  ], {
+    env: {
+      DENO_DEPLOYMENT_ID: "abcdef",
+    },
+  });
+  const output = await readUntilMatch(process.stdout, "Local:");
+  console.log(output);
+  assertEquals(
+    output,
+    `Listening on:\n- Local: http://localhost:${port}\n`,
+  );
+  process.stdout.cancel();
+  process.stderr.cancel();
+  process.kill();
+  await process.status;
+});
+
+/** Spawn deno child process with the options convenient for testing */
+function spawnDeno(args: string[], opts?: Deno.CommandOptions) {
   const cmd = new Deno.Command(Deno.execPath(), {
     args: [
       "run",
       "--no-lock",
       "--quiet",
-      "--allow-net",
-      "--allow-read",
-      "--allow-sys=networkInterfaces",
       "--config",
       "deno.json",
-      "http/file_server.ts",
-      "--port",
-      `${port}`,
+      ...args,
     ],
     stdout: "piped",
+    stderr: "piped",
+    ...opts,
   });
-  const process = cmd.spawn();
-  const reader = process.stdout.getReader();
+  return cmd.spawn();
+}
+
+async function readUntilMatch(
+  source: ReadableStream,
+  match: string,
+) {
+  const reader = source.getReader();
   let buf = new Uint8Array(0);
   const dec = new TextDecoder();
-  while (!dec.decode(buf).includes("Network:")) {
+  while (!dec.decode(buf).includes(match)) {
     const { value } = await reader.read();
     if (!value) {
       break;
     }
     buf = concat([buf, value]);
   }
-  const networkAdress = Deno.networkInterfaces().find((i) =>
-    i.family === "IPv4" && !i.address.startsWith("127")
-  )?.address;
-  assertEquals(
-    dec.decode(buf),
-    `Listening on:\n- Local: http://localhost:${port}\n- Network: http://${networkAdress}:${port}\n`,
-  );
-
-  reader.cancel();
-  process.kill();
-  await process.status;
-});
+  reader.releaseLock();
+  return dec.decode(buf);
+}


### PR DESCRIPTION
closes #4597

This PR updates `onListen` hook of file_server to show the local network IP address. The scripts shows 2 urls like the below (Updated):

```shellsession
$ deno run -A http/file_server.ts 
Listening on:
- Local: http://localhost:4507
- Network: http://192.168.79.163:4507
```

Suggestions to the output format are welcome

---

Note: `npm:serve` chooses non internal IPv4 address as the network address. This implementation follows it. ref. https://github.com/vercel/serve/blob/1ea55b1b5004f468159b54775e4fb3090fedbb2b/source/utilities/http.ts#L40

Note: Deno's [NetworkInterfaceInfo](https://deno.land/api@v1.42.4?s=Deno.NetworkInterfaceInfo) object doesn't have `internal` field, but it's polyfilled as `address.startsWith("127")` in the node compat layer https://github.com/denoland/deno/blob/9acbf90b06bf79dd6e4cf2428b3566da009bed65/ext/node/polyfills/os.ts#L232-L234. This implementation follows it as well.