### PR TITLE
test(csv): fix type error in `csv/parse_test.ts`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Run tests
-        run: deno task test
+        # TODO(kt3k): remove doc-test task when the below issue resolved
+        # https://github.com/denoland/deno/issues/23430
+        run: deno task test && deno task doc-test
 
       - name: Run tests (simulate Deno 2)
         if: matrix.deno == 'canary'
@@ -172,7 +174,9 @@ jobs:
         run: deno run -A ./_tools/convert_to_workspace.ts
 
       - name: Test
-        run: deno task test
+        # TODO(kt3k): remove doc-test task when the below issue resolved
+        # https://github.com/denoland/deno/issues/23430
+        run: deno task test && deno task doc-test
 
       - name: Publish (dry run)
         run: deno publish --allow-dirty --dry-run

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -825,7 +825,7 @@ Deno.test({
       type _ = AssertTrue<IsExact<typeof parsed, string[][]>>;
     }
     {
-      const parsed = parse("a\nb", undefined);
+      const parsed = parse("a\nb");
       type _ = AssertTrue<IsExact<typeof parsed, string[][]>>;
     }
     {

--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,8 @@
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/"
   },
   "tasks": {
-    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
+    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --allow-all --parallel --coverage --trace-leaks",
+    "doc-test": "deno task test --doc",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env ./_tools/check_deprecation.ts",


### PR DESCRIPTION
This PR fixes the type error in `csv/parse_test.ts`. This also adds workaround in tasks. Now `deno task test` type check the codebase correctly, and we check the doc types with a separate task `deno task doc-test`.

closes #4606