### PR TITLE
fix(csv): do not print empty header line when no columns are given in `stringify()`

### DIFF
--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -303,7 +303,7 @@ export function stringify(
     output += BYTE_ORDER_MARK;
   }
 
-  if (headers) {
+  if (headers && normalizedColumns.length > 0) {
     output += normalizedColumns
       .map((column) => getEscapedString(column.header, sep))
       .join(sep);

--- a/csv/stringify_test.ts
+++ b/csv/stringify_test.ts
@@ -106,7 +106,7 @@ Deno.test({
         fn() {
           const columns: string[] = [];
           const data: string[][] = [];
-          const output = CRLF;
+          const output = "";
           assertEquals(stringify(data, { columns }), output);
         },
       },
@@ -505,7 +505,7 @@ Deno.test({
       name: "Valid data, no columns",
       fn() {
         const data = [[1, 2, 3], [4, 5, 6]];
-        const output = `${CRLF}1,2,3${CRLF}4,5,6${CRLF}`;
+        const output = `1,2,3${CRLF}4,5,6${CRLF}`;
 
         assertEquals(stringify(data), output);
       },


### PR DESCRIPTION
closes #4546