### PR TITLE
chore: cleanup old git submodule settings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,10 +16,6 @@ and [architecture guide](./ARCHITECTURE.md) before contributing.
 
 1. [Install the Deno CLI](https://docs.deno.com/runtime/manual/getting_started/installation).
 1. Fork and clone the repository.
-1. Set up git submodules:
-   ```bash
-   git submodule update --init
-   ```
 1. Create a new branch for your changes.
 1. Make your changes and ensure `deno task ok` passes successfully.
 1. Commit your changes with clear messages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1
@@ -86,8 +84,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: false
           persist-credentials: false
 
       - name: Set up Deno
@@ -119,7 +115,6 @@ jobs:
         with:
           # required to check for changes
           fetch-depth: 2
-          submodules: false
           persist-credentials: false
 
       - name: Check for changes
@@ -160,8 +155,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
           persist-credentials: false
 
       - name: Set up Deno

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1


### PR DESCRIPTION
This codebase no longer contains any git submodules since the Node compatibility layer moved to the runtime repo.