### PR TITLE
refactor(crypto): cleanup `crypto.subtle.digest[Sync]()` logic

### DIFF
--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -137,17 +137,16 @@ const webCrypto = ((crypto) => ({
   },
 }))(globalThis.crypto);
 
-const toUint8Array = (data: BufferSource | unknown) => {
-  let bytes: Uint8Array | undefined;
+function toUint8Array(data: unknown): Uint8Array | undefined {
   if (data instanceof Uint8Array) {
-    bytes = data;
+    return data;
   } else if (ArrayBuffer.isView(data)) {
-    bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
   } else if (data instanceof ArrayBuffer) {
-    bytes = new Uint8Array(data);
+    return new Uint8Array(data);
   }
-  return bytes;
-};
+  return undefined;
+}
 
 /** Extensions to the web standard `SubtleCrypto` interface. */
 export interface StdSubtleCrypto extends SubtleCrypto {
@@ -320,17 +319,7 @@ function normalizeAlgorithm(algorithm: DigestAlgorithm) {
 }
 
 function isBufferSource(obj: unknown): obj is BufferSource {
-  return obj instanceof ArrayBuffer ||
-    obj instanceof DataView ||
-    obj instanceof Int8Array ||
-    obj instanceof Uint8Array ||
-    obj instanceof Uint8ClampedArray ||
-    obj instanceof Int16Array ||
-    obj instanceof Uint16Array ||
-    obj instanceof Int32Array ||
-    obj instanceof Uint32Array ||
-    obj instanceof Float32Array ||
-    obj instanceof Float64Array;
+  return obj instanceof ArrayBuffer || ArrayBuffer.isView(obj);
 }
 
 function isIterable<T>(obj: unknown): obj is Iterable<T> {

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -1701,6 +1701,15 @@ for (const algorithm of DIGEST_ALGORITHM_NAMES) {
   });
 }
 
+Deno.test("digest() throws on invalid algorithm", async () => {
+  await assertRejects(
+    // @ts-ignore Algorithm name is invalid on purpose
+    async () => await stdCrypto.subtle.digest("invalid", new Uint8Array(0)),
+    DOMException,
+    "Unrecognized algorithm name",
+  );
+});
+
 /**
  * This is one of many methods of `crypto` for which we don't have our own
  * implementation, and just pass calls through to the native implementation.


### PR DESCRIPTION
This PR bumps test coverage of `crypto/crypto.ts` to 100% and aims to improve logic and readability.

This might interest you, @mbhrznr.