### PR TITLE
fix(bytes): `equals()` works with subarrays while performant

### DIFF
--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -28,8 +28,8 @@ function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
 function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   const len = a.length;
   const compressible = Math.floor(len / 4);
-  const compressedA = new Uint32Array(a, 0, compressible);
-  const compressedB = new Uint32Array(b, 0, compressible);
+  const compressedA = new Uint32Array(a.buffer, 0, compressible);
+  const compressedB = new Uint32Array(b.buffer, 0, compressible);
   for (let i = compressible * 4; i < len; i++) {
     if (a[i] !== b[i]) return false;
   }
@@ -62,5 +62,7 @@ export function equals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) {
     return false;
   }
-  return a.length < 1000 ? equalsNaive(a, b) : equals32Bit(a, b);
+  return (a.length >= 1_000 && (a.byteOffset % 4 === b.byteOffset % 4))
+    ? equals32Bit(a, b)
+    : equalsNaive(a, b);
 }


### PR DESCRIPTION
```ts
import { equals } from "./bytes/equals.ts";

const a999 = new Uint8Array(999);
const b999 = new Uint8Array(999);

const a1k = new Uint8Array(1000);
const b1k = new Uint8Array(1000);

Deno.bench("999", () => {
  equals(a999, b999);
});

Deno.bench("1k", () => {
  equals(a1k, b1k);
});
```
`jsr:@std/bytes@0.223.0`:
```
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
999           586.88 ns/iter   1,703,926.1 (582.75 ns … 637.45 ns) 586.29 ns 637.45 ns 637.45 ns
1k            275.05 ns/iter   3,635,740.2 (271.04 ns … 317.88 ns) 276.6 ns 302.93 ns 317.88 ns
```

#4630:
```
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
999           588.67 ns/iter   1,698,746.7 (582.78 ns … 634.95 ns) 590.95 ns 634.95 ns 634.95 ns
1k              1.96 µs/iter     509,263.8     (1.84 µs … 2.56 µs) 1.99 µs 2.56 µs 2.56 µs
```

This PR:
```
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
999           593.17 ns/iter   1,685,844.6 (583.09 ns … 645.91 ns) 589.8 ns 645.91 ns 645.91 ns
1k            292.53 ns/iter   3,418,431.8 (286.61 ns … 406.19 ns) 293.77 ns 324.35 ns 406.19 ns
```
CC @0f-0b and @tjjfvi

Fixes https://github.com/denoland/deno_std/pull/4630#issuecomment-2072109408