### PR TITLE
perf(bytes): improve performance of `equals()` 

### DIFF
--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -51,6 +51,10 @@ function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   return true;
 }
 
+/**
+ * Threshold for when to use 32-bit comparisons. This was chosen based on
+ * benchmark results.
+ */
 const THRESHOLD_32_BIT = 160;
 
 /**

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -29,8 +29,16 @@ function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   const len = a.length;
   const compactOffset = 3 - ((a.byteOffset + 3) % 4);
   const compactLen = Math.floor((len - compactOffset) / 4);
-  const compactA = new Uint32Array(a.buffer, a.byteOffset + compactOffset, compactLen);
-  const compactB = new Uint32Array(b.buffer, b.byteOffset + compactOffset, compactLen);
+  const compactA = new Uint32Array(
+    a.buffer,
+    a.byteOffset + compactOffset,
+    compactLen,
+  );
+  const compactB = new Uint32Array(
+    b.buffer,
+    b.byteOffset + compactOffset,
+    compactLen,
+  );
   for (let i = 0; i < compactOffset; i++) {
     if (a[i] !== b[i]) return false;
   }
@@ -68,7 +76,8 @@ export function equals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) {
     return false;
   }
-  return a.length >= THRESHOLD_32_BIT && (a.byteOffset % 4) === (b.byteOffset % 4)
+  return a.length >= THRESHOLD_32_BIT &&
+      (a.byteOffset % 4) === (b.byteOffset % 4)
     ? equals32Bit(a, b)
     : equalsNaive(a, b);
 }

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -27,17 +27,23 @@ function equalsNaive(a: Uint8Array, b: Uint8Array): boolean {
  */
 function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
   const len = a.length;
-  const compressible = Math.floor(len / 4);
-  const compressedA = new Uint32Array(a, 0, compressible);
-  const compressedB = new Uint32Array(b, 0, compressible);
-  for (let i = compressible * 4; i < len; i++) {
+  const compactOffset = 3 - ((a.byteOffset + 3) % 4);
+  const compactLen = Math.floor((len - compactOffset) / 4);
+  const compactA = new Uint32Array(a.buffer, a.byteOffset + compactOffset, compactLen);
+  const compactB = new Uint32Array(b.buffer, b.byteOffset + compactOffset, compactLen);
+  for (let i = 0; i < compactOffset; i++) {
     if (a[i] !== b[i]) return false;
   }
-  for (let i = 0; i < compressedA.length; i++) {
-    if (compressedA[i] !== compressedB[i]) return false;
+  for (let i = 0; i < compactA.length; i++) {
+    if (compactA[i] !== compactB[i]) return false;
+  }
+  for (let i = compactOffset + compactLen * 4; i < len; i++) {
+    if (a[i] !== b[i]) return false;
   }
   return true;
 }
+
+const THRESHOLD_32_BIT = 160;
 
 /**
  * Check whether byte slices are equal to each other.
@@ -62,5 +68,7 @@ export function equals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) {
     return false;
   }
-  return a.length < 1000 ? equalsNaive(a, b) : equals32Bit(a, b);
+  return a.length >= THRESHOLD_32_BIT && (a.byteOffset % 4) === (b.byteOffset % 4)
+    ? equals32Bit(a, b)
+    : equalsNaive(a, b);
 }

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -52,8 +52,10 @@ function equals32Bit(a: Uint8Array, b: Uint8Array): boolean {
 }
 
 /**
- * Threshold for when to use 32-bit comparisons. This was chosen based on
- * benchmark results.
+ * Byte length threshold for when to use 32-bit comparisons, based on
+ * benchmarks.
+ *
+ * @see {@link https://github.com/denoland/deno_std/pull/4635}
  */
 const THRESHOLD_32_BIT = 160;
 


### PR DESCRIPTION
See https://github.com/denoland/deno_std/pull/4630 for prior history

cc @iuioiua @0f-0b

The `THRESHOLD_32_BIT` value was based off of the following benchmark:
```ts
import { equals32Bit, equalsNaive } from "./equals.ts";

let n = 0;
for(let l = 0; l < 300; l += 10) {
  const len = l;
  const a = crypto.getRandomValues(new Uint8Array(len));
  const b = new Uint8Array(a);
  Deno.bench(`naive ${len}`, () => {
    n += +equalsNaive(a, b)
  })
  Deno.bench(`32-bit ${len}`, () => {
    n += +equals32Bit(a, b)
  })
}
```
```
benchmark       time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------- -----------------------------
naive 0          3.94 ns/iter 253,808,039.2     (3.75 ns … 9.02 ns)   4.07 ns   4.83 ns   5.12 ns
32-bit 0        64.53 ns/iter  15,497,682.7   (59.45 ns … 80.91 ns)     66 ns  70.62 ns  71.62 ns
naive 10         9.92 ns/iter 100,796,680.6     (9.59 ns … 14.1 ns)  10.03 ns  11.83 ns  12.18 ns
32-bit 10          74 ns/iter  13,513,318.1   (61.51 ns … 85.97 ns)  75.88 ns  83.55 ns  84.47 ns
naive 20           14 ns/iter  71,445,190.6   (13.66 ns … 17.52 ns)  13.99 ns  15.58 ns  15.97 ns
32-bit 20       69.86 ns/iter  14,315,212.4   (65.78 ns … 78.87 ns)  71.53 ns  75.33 ns  76.92 ns
naive 30        19.65 ns/iter  50,878,970.5   (18.63 ns … 25.76 ns)     20 ns  23.67 ns  25.02 ns
32-bit 30       77.06 ns/iter  12,976,293.8   (70.39 ns … 89.66 ns)  78.78 ns   82.7 ns  83.86 ns
naive 40         31.2 ns/iter  32,056,228.0   (24.43 ns … 39.78 ns)  35.06 ns  36.83 ns  37.16 ns
32-bit 40       71.46 ns/iter  13,993,469.7    (62.2 ns … 82.64 ns)  73.08 ns  77.49 ns  80.04 ns
naive 50        30.66 ns/iter  32,614,108.4   (29.26 ns … 35.28 ns)  30.87 ns  33.43 ns  34.19 ns
32-bit 50        78.8 ns/iter  12,689,984.0   (64.42 ns … 92.75 ns)  80.88 ns  85.34 ns  85.74 ns
naive 60        36.71 ns/iter  27,240,234.2   (32.87 ns … 54.51 ns)  37.08 ns  51.85 ns  53.46 ns
32-bit 60        74.7 ns/iter  13,386,740.0     (69.4 ns … 81.8 ns)  76.47 ns  80.59 ns  80.95 ns
naive 70        57.75 ns/iter  17,316,174.7   (39.39 ns … 63.83 ns)  58.91 ns  61.45 ns  62.07 ns
32-bit 70       82.13 ns/iter  12,176,062.2    (77.81 ns … 90.5 ns)  84.05 ns  86.36 ns   86.6 ns
naive 80        66.42 ns/iter  15,056,538.7   (61.52 ns … 82.38 ns)  66.68 ns   71.1 ns  75.35 ns
32-bit 80       76.43 ns/iter  13,083,971.9   (68.79 ns … 87.87 ns)  77.94 ns   83.6 ns  87.42 ns
naive 90        62.63 ns/iter  15,966,559.5   (62.17 ns … 72.21 ns)  62.75 ns  65.84 ns  66.67 ns
32-bit 90       82.67 ns/iter  12,096,982.3   (73.95 ns … 95.72 ns)  84.45 ns  91.05 ns     92 ns
naive 100       57.43 ns/iter  17,413,021.4   (53.12 ns … 64.73 ns)  57.44 ns  60.24 ns  61.23 ns
32-bit 100      79.85 ns/iter  12,523,307.3   (69.97 ns … 90.94 ns)  81.43 ns  84.39 ns  85.28 ns
naive 110       63.57 ns/iter  15,731,369.2   (62.36 ns … 80.27 ns)  63.71 ns  79.71 ns  79.84 ns
32-bit 110      86.38 ns/iter  11,576,624.8   (81.38 ns … 99.84 ns)  88.19 ns  94.22 ns  96.29 ns
naive 120       85.69 ns/iter  11,670,324.6   (64.5 ns … 115.42 ns)  98.24 ns 105.28 ns  108.9 ns
32-bit 120      84.88 ns/iter  11,780,757.1  (76.03 ns … 102.23 ns)  87.02 ns   97.7 ns  98.88 ns
naive 130       76.49 ns/iter  13,072,948.8  (70.17 ns … 114.62 ns)  76.49 ns  83.08 ns  86.79 ns
32-bit 130       87.3 ns/iter  11,454,961.9  (80.67 ns … 101.41 ns)  89.01 ns  94.28 ns  95.43 ns
naive 140       82.47 ns/iter  12,125,236.6   (81.57 ns … 88.81 ns)  82.97 ns  86.13 ns  87.06 ns
32-bit 140      87.86 ns/iter  11,381,266.9    (76.94 ns … 98.2 ns)  89.77 ns  95.85 ns  97.72 ns
naive 150       91.09 ns/iter  10,978,752.3   (90.1 ns … 106.04 ns)  91.37 ns  98.33 ns  99.79 ns
32-bit 150      90.87 ns/iter  11,004,962.1  (86.17 ns … 106.46 ns)   92.5 ns  97.36 ns  98.83 ns
naive 160       99.39 ns/iter  10,061,375.9  (97.39 ns … 125.92 ns)  99.53 ns 124.47 ns 124.65 ns
32-bit 160      88.17 ns/iter  11,342,244.1   (76.62 ns … 109.4 ns)  89.73 ns  96.12 ns  96.69 ns
naive 170      122.77 ns/iter   8,145,632.0 (121.53 ns … 132.62 ns)  123.1 ns 129.71 ns 130.87 ns
32-bit 170      94.61 ns/iter  10,570,031.8  (88.51 ns … 122.26 ns)  96.23 ns 106.49 ns 115.35 ns
naive 180      108.63 ns/iter   9,205,290.3 (107.94 ns … 117.53 ns) 108.85 ns 112.77 ns 114.65 ns
32-bit 180      90.76 ns/iter  11,017,883.9   (81.1 ns … 101.09 ns)  92.34 ns  97.12 ns  99.72 ns
naive 190      120.18 ns/iter   8,320,621.9 (106.11 ns … 169.32 ns) 117.29 ns  165.7 ns 166.28 ns
32-bit 190       97.9 ns/iter  10,214,101.9   (83.62 ns … 123.5 ns)  99.58 ns 113.24 ns 118.75 ns
naive 200      151.83 ns/iter   6,586,237.9 (120.84 ns … 188.43 ns) 173.21 ns 185.51 ns  187.6 ns
32-bit 200      93.56 ns/iter  10,687,828.9  (85.49 ns … 109.41 ns)  95.23 ns 102.01 ns 102.33 ns
```