### PR TITLE
fix(path): export private types used in public API

### DIFF
--- a/path/parse.ts
+++ b/path/parse.ts
@@ -6,6 +6,8 @@ import type { ParsedPath } from "./_interface.ts";
 import { parse as posixParse } from "./posix/parse.ts";
 import { parse as windowsParse } from "./windows/parse.ts";
 
+export type { ParsedPath } from "./_interface.ts";
+
 /**
  * Return a `ParsedPath` object of the `path`. Use `format` to reverse the result.
  *

--- a/path/posix/parse.ts
+++ b/path/posix/parse.ts
@@ -7,6 +7,8 @@ import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts
 import { assertPath } from "../_common/assert_path.ts";
 import { isPosixPathSeparator } from "./_util.ts";
 
+export type { ParsedPath } from "../_interface.ts";
+
 /**
  * Return a `ParsedPath` object of the `path`.
  * @param path to process

--- a/path/windows/parse.ts
+++ b/path/windows/parse.ts
@@ -6,6 +6,8 @@ import type { ParsedPath } from "../_interface.ts";
 import { assertPath } from "../_common/assert_path.ts";
 import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 
+export type { ParsedPath } from "../_interface.ts";
+
 /**
  * Return a `ParsedPath` object of the `path`.
  * @param path to process


### PR DESCRIPTION
The `ParsedPath` type is used as the return type for the function [`parse`](https://github.com/denoland/deno_std/blob/0.223.0/path/parse.ts#L25), which is part of the public API… yet it is only exported from the "private" module [`_interface.ts`](https://github.com/denoland/deno_std/blob/0.223.0/path/_interface.ts#L19). Item number 4 in the [Recommended Usage](https://github.com/denoland/deno_std/tree/0.223.0#recommended-usage) states this…

> Do not import modules with a directory or filename prefixed by an underscore (they're not intended for public use).

…which means that it's currently impossible to import the type in a recommended way. This PR re-exports the type from the `parse` modules which use it so that the `parse` function and the `ParsedPath` type can now be imported together:

```ts
import { parse, type ParsedPath } from "@std/path/parse";
```