### PR TITLE
chore: exclude `testdata` directories from being published

### DIFF
--- a/archive/deno.json
+++ b/archive/deno.json
@@ -5,5 +5,10 @@
     ".": "./mod.ts",
     "./tar": "./tar.ts",
     "./untar": "./untar.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/crypto/deno.json
+++ b/crypto/deno.json
@@ -9,5 +9,10 @@
   },
   "exclude": [
     "_wasm/target"
-  ]
+  ],
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
+  }
 }

--- a/csv/deno.json
+++ b/csv/deno.json
@@ -7,5 +7,10 @@
     "./csv-stringify-stream": "./csv_stringify_stream.ts",
     "./parse": "./parse.ts",
     "./stringify": "./stringify.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/dotenv/deno.json
+++ b/dotenv/deno.json
@@ -6,5 +6,10 @@
     "./load": "./load.ts",
     "./parse": "./parse.ts",
     "./stringify": "./stringify.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/front_matter/deno.json
+++ b/front_matter/deno.json
@@ -9,5 +9,10 @@
     "./test": "./test.ts",
     "./toml": "./toml.ts",
     "./yaml": "./yaml.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -14,5 +14,10 @@
     "./expand-glob": "./expand_glob.ts",
     "./move": "./move.ts",
     "./walk": "./walk.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/http/deno.json
+++ b/http/deno.json
@@ -12,5 +12,10 @@
     "./status": "./status.ts",
     "./unstable-signed-cookie": "./unstable_signed_cookie.ts",
     "./user-agent": "./user_agent.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/io/deno.json
+++ b/io/deno.json
@@ -27,5 +27,10 @@
     "./to-writable-stream": "./to_writable_stream.ts",
     "./types": "./types.ts",
     "./write-all": "./write_all.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/json/deno.json
+++ b/json/deno.json
@@ -7,5 +7,10 @@
     "./concatenated-json-parse-stream": "./concatenated_json_parse_stream.ts",
     "./json-parse-stream": "./json_parse_stream.ts",
     "./json-stringify-stream": "./json_stringify_stream.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/jsonc/deno.json
+++ b/jsonc/deno.json
@@ -4,5 +4,10 @@
   "exports": {
     ".": "./mod.ts",
     "./parse": "./parse.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/msgpack/deno.json
+++ b/msgpack/deno.json
@@ -5,5 +5,10 @@
     ".": "./mod.ts",
     "./decode": "./decode.ts",
     "./encode": "./encode.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }

--- a/toml/deno.json
+++ b/toml/deno.json
@@ -5,5 +5,10 @@
     ".": "./mod.ts",
     "./parse": "./parse.ts",
     "./stringify": "./stringify.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./testdata"
+    ]
   }
 }


### PR DESCRIPTION
Avoids [some warnings](https://github.com/denoland/deno_std/actions/runs/8826423794/job/24238408524) we get when publishing.