### PR TITLE
chore: update `check_deprecation.ts`

### DIFF
--- a/_tools/check_circular_package_dependencies.ts
+++ b/_tools/check_circular_package_dependencies.ts
@@ -5,6 +5,7 @@ import {
   type ModuleGraphJson,
   type ModuleJson,
 } from "@deno/graph";
+import { resolveWorkspaceSpecifiers } from "./utils.ts";
 
 /**
  * Checks for circular dependencies in the std packages.
@@ -177,15 +178,7 @@ async function check(
   for (const path of paths) {
     const entrypoint = new URL(`../${submod}/${path}`, import.meta.url).href;
     const graph = await createGraph(entrypoint, {
-      resolve(specifier, referrer) {
-        if (specifier.startsWith("../") || specifier.startsWith("./")) {
-          return new URL(specifier, referrer).href;
-        } else if (specifier.startsWith("@std/")) {
-          return new URL(specifier.replace("@std", ".."), import.meta.url).href;
-        } else {
-          return new URL(specifier).href;
-        }
-      },
+      resolve: resolveWorkspaceSpecifiers,
     });
 
     for (

--- a/_tools/check_deprecation.ts
+++ b/_tools/check_deprecation.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 /**
- * TODO(kt3k): This stopped working after JSR migration. Enable this check.
- *
  * Checks whether all deprecated tags have a message.
  *
  * @example
@@ -13,7 +11,7 @@
 import { doc } from "@deno/doc";
 import { walk } from "../fs/walk.ts";
 import { toFileUrl } from "../path/to_file_url.ts";
-import { join } from "../path/join.ts";
+import { resolveWorkspaceSpecifiers } from "./utils.ts";
 
 const ROOT = new URL("../", import.meta.url);
 
@@ -29,41 +27,9 @@ const iter = walk(ROOT, {
   ],
 });
 
-const workspaces = JSON.parse(await Deno.readTextFile("deno.json"))
-  .workspaces as string[];
-// deno-lint-ignore no-explicit-any
-const denoConfig = {} as Record<string, any>;
-for (const workspace of workspaces) {
-  const config = JSON.parse(
-    await Deno.readTextFile(join(workspace, "deno.json")),
-  );
-  denoConfig[config.name.replace("@std/", "")] = config;
-}
-
 for await (const entry of iter) {
   const url = toFileUrl(entry.path);
-  const docs = await doc(url.href, {
-    resolve(specifier, referrer) {
-      if (specifier.startsWith("../") || specifier.startsWith("./")) {
-        return new URL(specifier, referrer).href;
-      } else if (specifier.startsWith("@std/")) {
-        let [_std, pkg, exp] = specifier.split("/");
-        if (exp === undefined) {
-          exp = ".";
-        } else {
-          exp = "./" + exp;
-        }
-        const pkgPath = "../" + pkg!.replaceAll("-", "_") + "/";
-        const config = denoConfig[pkg!];
-        if (typeof config.exports === "string") {
-          return new URL(pkgPath + config.exports, import.meta.url).href;
-        }
-        return new URL(pkgPath + config.exports[exp], import.meta.url).href;
-      } else {
-        return new URL(specifier).href;
-      }
-    },
-  });
+  const docs = await doc(url.href, { resolve: resolveWorkspaceSpecifiers });
   for (const document of docs) {
     const tags = document.jsDoc?.tags;
     if (!tags) continue;

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -9,12 +9,8 @@
  *
  * TODO(iuioiua): Add support for classes and methods.
  */
-import { doc } from "deno_doc/mod.ts";
-import type {
-  DocNodeBase,
-  DocNodeFunction,
-  JsDocTag,
-} from "deno_doc/types.d.ts";
+import { doc } from "@deno/doc";
+import type { DocNodeBase, DocNodeFunction, JsDocTag } from "@deno/doc/types";
 
 const ENTRY_POINTS = [
   "../bytes/mod.ts",

--- a/_tools/utils.ts
+++ b/_tools/utils.ts
@@ -1,15 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { join } from "../path/join.ts";
-
 const workspaces = JSON.parse(await Deno.readTextFile("deno.json"))
   .workspaces as string[];
 // deno-lint-ignore no-explicit-any
 const denoConfig = {} as Record<string, any>;
 for (const workspace of workspaces) {
-  const config = JSON.parse(
-    await Deno.readTextFile(join(workspace, "deno.json")),
-  );
+  const { default: config } = await import("../" + workspace + "/deno.json", {
+    with: { type: "json" },
+  });
   denoConfig[config.name.replace("@std/", "")] = config;
 }
 

--- a/_tools/utils.ts
+++ b/_tools/utils.ts
@@ -1,0 +1,38 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { join } from "../path/join.ts";
+
+const workspaces = JSON.parse(await Deno.readTextFile("deno.json"))
+  .workspaces as string[];
+// deno-lint-ignore no-explicit-any
+const denoConfig = {} as Record<string, any>;
+for (const workspace of workspaces) {
+  const config = JSON.parse(
+    await Deno.readTextFile(join(workspace, "deno.json")),
+  );
+  denoConfig[config.name.replace("@std/", "")] = config;
+}
+
+export function resolveWorkspaceSpecifiers(
+  specifier: string,
+  referrer: string,
+) {
+  if (specifier.startsWith("../") || specifier.startsWith("./")) {
+    return new URL(specifier, referrer).href;
+  } else if (specifier.startsWith("@std/")) {
+    let [_std, pkg, exp] = specifier.split("/");
+    if (exp === undefined) {
+      exp = ".";
+    } else {
+      exp = "./" + exp;
+    }
+    const pkgPath = "../" + pkg!.replaceAll("-", "_") + "/";
+    const config = denoConfig[pkg!];
+    if (typeof config.exports === "string") {
+      return new URL(pkgPath + config.exports, import.meta.url).href;
+    }
+    return new URL(pkgPath + config.exports[exp], import.meta.url).href;
+  } else {
+    return new URL(specifier).href;
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
   },
   "imports": {
     "@deno/graph": "jsr:@deno/graph@^0.74",
-    "deno_doc/": "https://deno.land/x/deno_doc@0.123.1/",
+    "@deno/doc": "jsr:@deno/doc@0.128.1",
     "npm:/typescript": "npm:typescript@5.4.4",
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/"
   },

--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
     "lint:mod-exports": "deno run --allow-env --allow-read ./_tools/check_mod_exports.ts",
     "lint:tools-types": "deno check _tools/*.ts",
     "lint:docs": "deno run -A _tools/check_docs.ts && deno doc --lint bytes/mod.ts datetime/mod.ts url/mod.ts",
-    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:circular && deno task lint:tools-types && deno task lint:mod-exports && deno task lint:docs",
+    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:circular && deno task lint:deprecations && deno task lint:tools-types && deno task lint:mod-exports && deno task lint:docs",
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.17.1 --js-ext mjs --sync",


### PR DESCRIPTION
We disabled `check_deprecation.ts` in #4650. This PR re-enables it by providing appropriate resolver to `@deno/doc`. Also shares the same resolver with `check_circular_package_dependencies.ts`.