### PR TITLE
chore: skip yanked versions

### DIFF
--- a/assert/deno.json
+++ b/assert/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/assert",
-  "version": "0.224.0",
+  "version": "0.225.0",
   "exports": {
     ".": "./mod.ts",
     "./assert": "./assert.ts",

--- a/fmt/deno.json
+++ b/fmt/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fmt",
-  "version": "0.224.0",
+  "version": "0.225.0",
   "exports": {
     "./bytes": "./bytes.ts",
     "./colors": "./colors.ts",

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fs",
-  "version": "0.224.0",
+  "version": "0.229.0",
   "exports": {
     ".": "./mod.ts",
     "./copy": "./copy.ts",

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/internal",
-  "version": "0.224.0",
+  "version": "0.225.0",
   "exports": {
     ".": "./mod.ts",
     "./diff": "./diff.ts",

--- a/path/deno.json
+++ b/path/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/path",
-  "version": "0.224.0",
+  "version": "0.225.0",
   "exports": {
     ".": "./mod.ts",
     "./basename": "./basename.ts",


### PR DESCRIPTION
These versions are used & yanked in JSR by accident. Let's move forward the versions to skip them in the next release.