### PR TITLE
fix(cli): spinner support NO_COLOR

### DIFF
--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -135,12 +135,15 @@ export class Spinner {
     if (this.#active || Deno.stdout.writable.locked) return;
     this.#active = true;
     let i = 0;
+    const noColor = Deno.noColor;
     // Updates the spinner after the given interval.
     const updateFrame = () => {
       const color = this.#color ?? "";
       Deno.stdout.writeSync(LINE_CLEAR);
       const frame = encoder.encode(
-        color + this.#spinner[i] + COLOR_RESET + " " + this.message,
+        noColor
+          ? this.#spinner[i] + " " + this.message
+          : color + this.#spinner[i] + COLOR_RESET + " " + this.message,
       );
       Deno.stdout.writeSync(frame);
       i = (i + 1) % this.#spinner.length;


### PR DESCRIPTION
This may change `fmt/colors` in the future, but please support this first.