### PR TITLE
docs(bytes): update API doc of lastIndexOfNeedle

### DIFF
--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -10,7 +10,7 @@
  * @param source Source array to check.
  * @param needle Needle array to check for.
  * @param start Start index in the source array to begin the search. Defaults to
- * the end of the array.
+ * `source.length - 1`.
  * @returns Index of the last occurrence of the needle array in the source
  * array, or -1 if it is not present.
  *
@@ -34,7 +34,7 @@
  * const needle = new Uint8Array([1, 2]);
  *
  * lastIndexOfNeedle(source, needle, 2); // 1
- * lastIndexOfNeedle(source, needle, 6); // 3
+ * lastIndexOfNeedle(source, needle, 6); // 5
  * ```
  * Defining a start index will begin the search at the specified index in the
  * source array.


### PR DESCRIPTION
- Clarifies the description of the default value of `start` param (`lastIndexOfNeedle`)
- Fixes an example return value