### PR TITLE
refactor(collections): improve implementation signatures

### DIFF
--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -91,13 +91,9 @@ export function maxBy<T>(
   array: Iterable<T>,
   selector: (el: T) => Date,
 ): T | undefined;
-export function maxBy<T>(
+export function maxBy<T, S extends (number | string | bigint | Date)>(
   array: Iterable<T>,
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => S,
 ): T | undefined {
   let max: T | undefined = undefined;
   let maxValue: ReturnType<typeof selector> | undefined = undefined;

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -51,14 +51,14 @@ export function maxOf<T>(
   array: Iterable<T>,
   selector: (el: T) => bigint,
 ): bigint | undefined;
-export function maxOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function maxOf<T, S extends (number | bigint)>(
   array: Iterable<T>,
-  selector: S,
-): ReturnType<S> | undefined {
-  let maximumValue: ReturnType<S> | undefined = undefined;
+  selector: (el: T) => S,
+): S | undefined {
+  let maximumValue: S | undefined = undefined;
 
   for (const i of array) {
-    const currentValue = selector(i) as ReturnType<S>;
+    const currentValue = selector(i);
 
     if (maximumValue === undefined || currentValue > maximumValue) {
       maximumValue = currentValue;

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -91,16 +91,12 @@ export function minBy<T>(
   array: Iterable<T>,
   selector: (el: T) => Date,
 ): T | undefined;
-export function minBy<T>(
+export function minBy<T, S extends (number | string | bigint | Date)>(
   array: Iterable<T>,
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => S,
 ): T | undefined {
   let min: T | undefined = undefined;
-  let minValue: ReturnType<typeof selector> | undefined = undefined;
+  let minValue: S | undefined = undefined;
 
   for (const current of array) {
     const currentValue = selector(current);

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -49,14 +49,14 @@ export function minOf<T>(
   array: Iterable<T>,
   selector: (el: T) => bigint,
 ): bigint | undefined;
-export function minOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function minOf<T, S extends (number | bigint)>(
   array: Iterable<T>,
-  selector: S,
-): ReturnType<S> | undefined {
-  let minimumValue: ReturnType<S> | undefined = undefined;
+  selector: (el: T) => S,
+): S | undefined {
+  let minimumValue: S | undefined = undefined;
 
   for (const i of array) {
-    const currentValue = selector(i) as ReturnType<S>;
+    const currentValue = selector(i);
 
     if (minimumValue === undefined || currentValue < minimumValue) {
       minimumValue = currentValue;

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -112,18 +112,14 @@ export function sortBy<T>(
   selector: (el: T) => Date,
   options?: SortByOptions,
 ): T[];
-export function sortBy<T>(
+export function sortBy<T, S extends (number | string | bigint | Date)>(
   array: readonly T[],
-  selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+  selector: (el: T) => S,
   options?: SortByOptions,
 ): T[] {
   const len = array.length;
   const indexes = new Array<number>(len);
-  const selectors = new Array<ReturnType<typeof selector> | null>(len);
+  const selectors = new Array<S | null>(len);
   const order = options?.order ?? "asc";
 
   array.forEach((item, idx) => {


### PR DESCRIPTION
This PR simplifies the implementation signatures of some functions within `std/collections`.

Previously, `selector` parameters were written in a manner that was a little more complicated than needed, also resulting in having to rely on `ReturnType<typeof selector>` within function bodies. The return type of `selector` parameters are now defined within a second type argument, `S`.

This change is non-breaking as it adds a new type argument. The aim of this change is to make implementation signatures of these functions easier to understand, and hopefully avoid the need for overload signatures for these functions.