### PR TITLE
chore: add `@template` JSDoc tag check

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -74,6 +74,27 @@ function assertHasParamTag(
   );
 }
 
+function assertHasTemplateTags(
+  tags: JsDocTag[],
+  template: string,
+  document: DocNodeBase,
+) {
+  const tag = tags.find((tag) =>
+    tag.kind === "template" && tag.name === template
+  );
+  assert(
+    tag !== undefined,
+    `Symbol must have a @template tag for ${template}`,
+    document,
+  );
+  assert(
+    // @ts-ignore doc is defined
+    tag.doc !== undefined,
+    `@template tag for ${template} must have a description`,
+    document,
+  );
+}
+
 function assertFunctionDocs(document: DocNodeFunction) {
   assert(
     document.jsDoc !== undefined,
@@ -90,6 +111,9 @@ function assertFunctionDocs(document: DocNodeFunction) {
       // @ts-ignore Trust me
       assertHasParamTag(tags, param.left.name, document);
     }
+  }
+  for (const typeParam of document.functionDef.typeParams) {
+    assertHasTemplateTags(tags, typeParam.name, document);
   }
   assertHasTag(tags, "return", document);
   assertHasTag(tags, "example", document);


### PR DESCRIPTION
This change adds the ability for the doc checker to ensure that all functions have a `@template` JSDoc tag for each type argument.