### PR TITLE
chore: run `@example` JSDoc code snippets

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -10,12 +10,19 @@
  * TODO(iuioiua): Add support for classes and methods.
  */
 import { doc } from "@deno/doc";
-import type { DocNodeBase, DocNodeFunction, JsDocTag } from "@deno/doc/types";
+import type {
+  DocNodeBase,
+  DocNodeFunction,
+  JsDocTag,
+  JsDocTagDocRequired,
+} from "@deno/doc/types";
 
 const ENTRY_POINTS = [
   "../bytes/mod.ts",
   "../datetime/mod.ts",
 ] as const;
+
+const MD_SNIPPET = /(?<=```ts\n)(\n|.)*(?=\n```)/g;
 
 class ValidationError extends Error {
   constructor(message: string, document: DocNodeBase) {
@@ -74,6 +81,41 @@ function assertHasParamTag(
   );
 }
 
+function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
+  tags = tags.filter((tag) => tag.kind === "example");
+  if (tags.length === 0) {
+    throw new ValidationError("Symbol must have an @example tag", document);
+  }
+  for (const tag of (tags as JsDocTagDocRequired[])) {
+    assert(
+      tag.doc !== undefined,
+      "@example tag must have a description",
+      document,
+    );
+    const snippets = tag.doc.match(MD_SNIPPET);
+    if (snippets === null) {
+      throw new ValidationError(
+        "@example tag must have a code snippet",
+        document,
+      );
+    }
+    for (const snippet of snippets) {
+      const command = new Deno.Command(Deno.execPath(), {
+        args: [
+          "eval",
+          snippet,
+        ],
+      });
+      const { success } = command.outputSync();
+      assert(
+        success,
+        `Example code snippet failed to execute: \n${snippet}\n`,
+        document,
+      );
+    }
+  }
+}
+
 function assertFunctionDocs(document: DocNodeFunction) {
   assert(
     document.jsDoc !== undefined,
@@ -92,7 +134,7 @@ function assertFunctionDocs(document: DocNodeFunction) {
     }
   }
   assertHasTag(tags, "return", document);
-  assertHasTag(tags, "example", document);
+  assertHasExampleTag(tags, document);
 }
 
 async function checkDocs(specifier: string) {

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -81,7 +81,7 @@ function assertHasParamTag(
   );
 }
 
-async function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
+function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
   tags = tags.filter((tag) => tag.kind === "example");
   if (tags.length === 0) {
     throw new ValidationError("Symbol must have an @example tag", document);
@@ -99,25 +99,20 @@ async function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
         document,
       );
     }
-    const promises = [];
     for (const snippet of snippets) {
-      promises.push(async () => {
-        const command = new Deno.Command(Deno.execPath(), {
-          args: [
-            "eval",
-            snippet,
-          ],
-        });
-        console.log(snippet);
-        const { success } = await command.output();
-        assert(
-          success,
-          `Example code snippet failed to execute: \n${snippet}\n`,
-          document,
-        );
+      const command = new Deno.Command(Deno.execPath(), {
+        args: [
+          "eval",
+          snippet,
+        ],
       });
+      const { success } = command.outputSync();
+      assert(
+        success,
+        `Example code snippet failed to execute: \n${snippet}\n`,
+        document,
+      );
     }
-    await Promise.all(promises);
   }
 }
 
@@ -142,7 +137,7 @@ function assertHasTemplateTags(
   );
 }
 
-async function assertFunctionDocs(document: DocNodeFunction) {
+function assertFunctionDocs(document: DocNodeFunction) {
   assert(
     document.jsDoc !== undefined,
     "Symbol must have a JSDoc block",
@@ -163,18 +158,16 @@ async function assertFunctionDocs(document: DocNodeFunction) {
     assertHasTemplateTags(tags, typeParam.name, document);
   }
   assertHasTag(tags, "return", document);
-  await assertHasExampleTag(tags, document);
+  assertHasExampleTag(tags, document);
 }
 
 async function checkDocs(specifier: string) {
   const docs = await doc(specifier);
-  const promises = [];
   for (const document of docs.filter(isExported)) {
     if (isFunctionDoc(document)) {
-      promises.push(assertFunctionDocs(document));
+      assertFunctionDocs(document);
     }
   }
-  await Promise.all(promises);
 }
 
 const promises = [];

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -106,6 +106,7 @@ function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
           snippet,
         ],
       });
+      // TODO(iuioiua): Use `await command.output()`
       const { success } = command.outputSync();
       assert(
         success,

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -108,6 +108,7 @@ async function assertHasExampleTag(tags: JsDocTag[], document: DocNodeBase) {
             snippet,
           ],
         });
+        console.log(snippet);
         const { success } = await command.output();
         assert(
           success,

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -20,7 +20,7 @@ import { copy } from "./copy.ts";
  *
  * const result = repeat(source, 3);
  *
- * assertEquals(result, new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 3]));
+ * assertEquals(result, new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
  * ```
  *
  * @example Zero count

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -14,14 +14,31 @@ import { copy } from "./copy.ts";
  * @example Basic usage
  * ```ts
  * import { repeat } from "@std/bytes/repeat";
+ * import { assertEquals } from "@std/assert/assert-equals";
  *
  * const source = new Uint8Array([0, 1, 2]);
  *
- * repeat(source, 3); // Uint8Array(9) [0, 1, 2, 0, 1, 2, 0, 1, 2]
+ * assertEquals(repeat(source, 3), new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
+ * ```
  *
- * repeat(source, 0); // Uint8Array(0) []
+ * @example Zero count
+ * ```ts
+ * import { repeat } from "@std/bytes/repeat";
+ * import { assertEquals } from "@std/assert/assert-equals";
  *
- * repeat(source, -1); // Throws `RangeError`
+ * const source = new Uint8Array([0, 1, 2]);
+ *
+ * assertEquals(repeat(source, 0), new Uint8Array());
+ * ```
+ *
+ * @example Invalid count
+ * ```ts
+ * import { repeat } from "@std/bytes/repeat";
+ * import { assertThrows } from "@std/assert/assert-throws";
+ *
+ * const source = new Uint8Array([0, 1, 2]);
+ *
+ * assertThrows(() => repeat(source, -1), RangeError);
  * ```
  */
 export function repeat(source: Uint8Array, count: number): Uint8Array {

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -18,7 +18,9 @@ import { copy } from "./copy.ts";
  *
  * const source = new Uint8Array([0, 1, 2]);
  *
- * assertEquals(repeat(source, 3), new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
+ * const result = repeat(source, 3);
+ *
+ * assertEquals(result, new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
  * ```
  *
  * @example Zero count
@@ -28,17 +30,9 @@ import { copy } from "./copy.ts";
  *
  * const source = new Uint8Array([0, 1, 2]);
  *
- * assertEquals(repeat(source, 0), new Uint8Array());
- * ```
+ * const result = repeat(source, 0);
  *
- * @example Invalid count
- * ```ts
- * import { repeat } from "@std/bytes/repeat";
- * import { assertThrows } from "@std/assert/assert-throws";
- *
- * const source = new Uint8Array([0, 1, 2]);
- *
- * assertThrows(() => repeat(source, -1), RangeError);
+ * assertEquals(result), new Uint8Array());
  * ```
  */
 export function repeat(source: Uint8Array, count: number): Uint8Array {

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -32,7 +32,7 @@ import { copy } from "./copy.ts";
  *
  * const result = repeat(source, 0);
  *
- * assertEquals(result), new Uint8Array());
+ * assertEquals(result, new Uint8Array());
  * ```
  */
 export function repeat(source: Uint8Array, count: number): Uint8Array {

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -20,7 +20,7 @@ import { copy } from "./copy.ts";
  *
  * const result = repeat(source, 3);
  *
- * assertEquals(result, new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
+ * assertEquals(result, new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 3]));
  * ```
  *
  * @example Zero count


### PR DESCRIPTION
This ensures that our code snippets are correct. Once this is merged, we'll have to rewrite some documents to take advantage of assertions.