### PR TITLE
chore: remove doc test workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Run tests
-        # TODO(kt3k): remove doc-test task when the below issue resolved
-        # https://github.com/denoland/deno/issues/23430
-        run: deno task test && deno task doc-test
+        run: deno task test
 
       - name: Run tests (simulate Deno 2)
         if: matrix.deno == 'canary'

--- a/deno.json
+++ b/deno.json
@@ -12,8 +12,7 @@
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/"
   },
   "tasks": {
-    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --allow-all --parallel --coverage --trace-leaks",
-    "doc-test": "deno task test --doc",
+    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env ./_tools/check_deprecation.ts",


### PR DESCRIPTION
We added doc-test workaround in https://github.com/denoland/deno_std/issues/4606 because of the issue https://github.com/denoland/deno/issues/23430

This PR removes that workaround because the issue https://github.com/denoland/deno/issues/23430 is now resolved in main.