### PR TITLE
fix(collections): correct error class when `chunk()` throws

### DIFF
--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -39,7 +39,7 @@
  */
 export function chunk<T>(array: readonly T[], size: number): T[][] {
   if (size <= 0 || !Number.isInteger(size)) {
-    throw new Error(
+    throw new RangeError(
       `Expected size to be an integer greater than 0 but found ${size}`,
     );
   }

--- a/collections/chunk_test.ts
+++ b/collections/chunk_test.ts
@@ -27,11 +27,31 @@ Deno.test({
 Deno.test({
   name: "chunk() throws on non naturals",
   fn() {
-    assertThrows(() => chunk([], +.5));
-    assertThrows(() => chunk([], -4.7));
-    assertThrows(() => chunk([], -2));
-    assertThrows(() => chunk([], +0));
-    assertThrows(() => chunk([], -0));
+    assertThrows(
+      () => chunk([], +.5),
+      RangeError,
+      "Expected size to be an integer greater than 0 but found 0.5",
+    );
+    assertThrows(
+      () => chunk([], -4.7),
+      RangeError,
+      "Expected size to be an integer greater than 0 but found -4.7",
+    );
+    assertThrows(
+      () => chunk([], -2),
+      RangeError,
+      "Expected size to be an integer greater than 0 but found -2",
+    );
+    assertThrows(
+      () => chunk([], +0),
+      RangeError,
+      "Expected size to be an integer greater than 0 but found 0",
+    );
+    assertThrows(
+      () => chunk([], -0),
+      RangeError,
+      "Expected size to be an integer greater than 0 but found 0",
+    );
   },
 });
 


### PR DESCRIPTION
This is a more fitting error class for when `size` is incorrectly defined.