### PR TITLE
chore(assert,fmt,fs,internal,path): skip yanked versions manually

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -56,6 +56,7 @@ jobs:
             html
             http
             ini
+            internal
             io
             json
             jsonc

--- a/assert/deno.json
+++ b/assert/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/assert",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "exports": {
     ".": "./mod.ts",
     "./assert": "./assert.ts",

--- a/fmt/deno.json
+++ b/fmt/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fmt",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "exports": {
     "./bytes": "./bytes.ts",
     "./colors": "./colors.ts",

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fs",
-  "version": "0.229.0",
+  "version": "0.229.1",
   "exports": {
     ".": "./mod.ts",
     "./copy": "./copy.ts",

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/internal",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "exports": {
     ".": "./mod.ts",
     "./diff": "./diff.ts",

--- a/path/deno.json
+++ b/path/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/path",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "exports": {
     ".": "./mod.ts",
     "./basename": "./basename.ts",


### PR DESCRIPTION
I updated [the tool](https://jsr.io/@deno/bump-workspaces) for upgrading the versions of packages ([ref](https://github.com/denoland/bump-workspaces/pull/13)), and now the tool always respect the versions which are manually modified (This change was made for supporting manual upgrade of `std/bytes` from `0.224.0` to `1.0.0-rc.1`). Because of this tool update, we need to skip these yanked versions manually.

This unblocks the next release of std packages.