### PR TITLE
chore: update `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,9 @@
 root = true
 
-[*.{ts,js}]
+[*.{ts,js,yml}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 2
-
-[*.yml]
-indent_style = space
-trim_trailing_whitespace = true
 indent_size = 2


### PR DESCRIPTION
This PR updates .editorconfig. Now it enforces `charset = utf-8` `end_of_line = lf` `insert_final_newline = true` to `.yml` files, which should reduce the whitespace diffs in PRs.