### PR TITLE
chore: update version_bump.yml

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,21 +1,5 @@
 name: version_bump
-
-permissions:
-  contents: write
-
-on:
-  workflow_dispatch:
-    inputs:
-      releaseKind:
-        description: 'Kind of version bump'
-        default: 'minor'
-        type: choice
-        options:
-        - patch
-        - minor
-        - major
-        required: true
-
+on: workflow_dispatch
 jobs:
   build:
     name: version bump
@@ -31,14 +15,9 @@ jobs:
 
       - name: Run version bump
         run: |
-          git remote add upstream https://github.com/denoland/deno_std
-          ./_tools/release/01_bump_version.ts --${{github.event.inputs.releaseKind}}
-
-      - name: Create PR
+          git fetch --unshallow origin
+          deno run -A jsr:@deno/bump-workspaces@0.1.12/cli
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
-          GH_WORKFLOW_ACTOR: ${{ github.actor }}
-        run: |
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git config user.name "${{ github.actor }}"
-          ./_tools/release/02_create_pr.ts
+          GIT_USER_NAME: ${{ github.actor }}
+          GIT_USER_EMAIL: ${{ github.actor}}@users.noreply.github.com

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run version bump
         run: |
           git fetch --unshallow origin
-          deno run -A jsr:@deno/bump-workspaces@0.1.12/cli
+          deno run -A jsr:@deno/bump-workspaces@0.1.13/cli
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
           GIT_USER_NAME: ${{ github.actor }}


### PR DESCRIPTION
This PR sets up new version upgrade flow to the repo using [jsr:@deno/bump-workspaces](https://jsr.io/@deno/bump-workspaces) tool

The new release steps:
- A maintainer trigger `version_bump` action
- @denobot creates a PR like [this](https://github.com/kt3k/deno_std/pull/34)
  - the tool automatically calculates the necessary version upgrades.
- A maintainer review PR, and update it if necessary
- A maintainer land the PR.
- A maintainer tag it with something like `release-YYY-MM-DD` (can be automated in the future)
- A maintainer publish the tag from github UI
- `workspace publish` action is triggered by the above and new versions will be published
- That's all