### PR TITLE
chore: fix permissions for version_bump.yml

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,4 +1,6 @@
 name: version_bump
+permissions:
+  contents: write
 on: workflow_dispatch
 jobs:
   build:


### PR DESCRIPTION
The workflow run failed with missing permission for denobot token. https://github.com/denoland/deno_std/actions/runs/8982982654/job/24671741490

This change could solve the issue (`permissions` was there before the change https://github.com/denoland/deno_std/pull/4687)

