### PR TITLE
chore: update `jsr:@deno/bump-workspaces`

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run version bump
         run: |
           git fetch --unshallow origin
-          deno run -A jsr:@deno/bump-workspaces@0.1.13/cli
+          deno run -A jsr:@deno/bump-workspaces@^0.1/cli
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
           GIT_USER_NAME: ${{ github.actor }}


### PR DESCRIPTION
This PR updates the dependency version of `@deno/bump-workspaces` to `^0.1` to automatically include the fixes in the upstream.

#4689 revealed a few bugs in the tool and they are fixed in v0.1.14: https://github.com/denoland/bump-workspaces/releases/tag/v0.1.14