### PR TITLE
deprecation: move `@std/fmt/colors` to `@std/cli/styles`

### DIFF
--- a/_tools/check_circular_package_dependencies.ts
+++ b/_tools/check_circular_package_dependencies.ts
@@ -94,7 +94,7 @@ const ENTRYPOINTS: Record<Mod, string[]> = {
     "varint.ts",
   ],
   expect: ["mod.ts"],
-  fmt: ["bytes.ts", "colors.ts", "duration.ts", "printf.ts"],
+  fmt: ["bytes.ts", "duration.ts", "printf.ts"],
   front_matter: ["mod.ts"],
   fs: ["mod.ts"],
   html: ["mod.ts"],

--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -3,7 +3,7 @@
 import { walk } from "../fs/walk.ts";
 import { relative } from "../path/relative.ts";
 import { dirname } from "../path/dirname.ts";
-import * as colors from "../fmt/colors.ts";
+import * as styles from "../cli/styles.ts";
 import ts from "npm:typescript";
 
 const ROOT = new URL("../", import.meta.url);
@@ -57,7 +57,7 @@ for await (
     if (!exportSpecifiers.has(relativeSpecifier)) {
       console.warn(
         `${
-          colors.yellow("Warn")
+          styles.yellow("Warn")
         } ${modFilePath} does not export '${relativeSpecifier}'.`,
       );
       shouldFail = true;

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -3,7 +3,7 @@
 import { equal } from "./equal.ts";
 import { buildMessage, diff, diffstr, format } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
-import { red } from "@std/fmt/colors";
+import { red } from "@std/cli/styles";
 import { CAN_NOT_DISPLAY } from "./_constants.ts";
 
 /**

--- a/assert/assert_equals_test.ts
+++ b/assert/assert_equals_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, AssertionError, assertThrows } from "./mod.ts";
-import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/fmt/colors";
+import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/cli/styles";
 import { _internals } from "@std/internal";
 import { stub } from "@std/testing/mock";
 

--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 import { AssertionError } from "./assertion_error.ts";
-import { stripAnsiCode } from "@std/fmt/colors";
+import { stripAnsiCode } from "@std/cli/styles";
 
 /**
  * Make an assertion that `error` is an `Error`.

--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -3,7 +3,7 @@
 import { buildMessage, diff, diffstr, format } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
 import { CAN_NOT_DISPLAY } from "./_constants.ts";
-import { red } from "@std/fmt/colors";
+import { red } from "@std/cli/styles";
 
 /**
  * Make an assertion that `actual` and `expected` are strictly equal. If

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -6,6 +6,7 @@
     "./parse-args": "./parse_args.ts",
     "./prompt-secret": "./prompt_secret.ts",
     "./spinner": "./spinner.ts",
+    "./styles": "./styles.ts",
     "./unicode-width": "./unicode_width.ts"
   }
 }

--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -17,4 +17,5 @@
 export * from "./parse_args.ts";
 export * from "./prompt_secret.ts";
 export * from "./spinner.ts";
+export * from "./styles.ts";
 export * from "./unicode_width.ts";

--- a/cli/styles.ts
+++ b/cli/styles.ts
@@ -22,7 +22,7 @@
  *   red,
  *   rgb24,
  *   rgb8,
- * } from "@std/fmt/colors";
+ * } from "@std/cli/styles";
  *
  * console.log(bgBlue(italic(red(bold("Hello, World!")))));
  *
@@ -62,13 +62,7 @@ interface Code {
   regexp: RegExp;
 }
 
-/**
- * RGB 8-bits per channel. Each in range `0->255` or `0x00->0xff`
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
- */
+/** RGB 8-bits per channel. Each in range `0->255` or `0x00->0xff` */
 export interface Rgb {
   /** Red component value */
   r: number;
@@ -83,10 +77,6 @@ let enabled = !noColor;
 /**
  * Set changing text color to enabled or disabled
  * @param value
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function setColorEnabled(value: boolean) {
   if (Deno?.noColor) {
@@ -96,13 +86,7 @@ export function setColorEnabled(value: boolean) {
   enabled = value;
 }
 
-/**
- * Get whether text color change is enabled or disabled.
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
- */
+/** Get whether text color change is enabled or disabled. */
 export function getColorEnabled(): boolean {
   return enabled;
 }
@@ -134,10 +118,6 @@ function run(str: string, code: Code): string {
 /**
  * Reset the text modified.
  * @param str text to reset
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function reset(str: string): string {
   return run(str, code([0], 0));
@@ -146,10 +126,6 @@ export function reset(str: string): string {
 /**
  * Make the text bold.
  * @param str text to make bold
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bold(str: string): string {
   return run(str, code([1], 22));
@@ -161,10 +137,6 @@ export function bold(str: string): string {
  *
  * Warning: Not all terminal emulators support `dim`.
  * For compatibility across all terminals, use {@linkcode gray} or {@linkcode brightBlack} instead.
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function dim(str: string): string {
   return run(str, code([2], 22));
@@ -173,10 +145,6 @@ export function dim(str: string): string {
 /**
  * Make the text italic.
  * @param str text to make italic
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function italic(str: string): string {
   return run(str, code([3], 23));
@@ -185,10 +153,6 @@ export function italic(str: string): string {
 /**
  * Make the text underline.
  * @param str text to underline
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function underline(str: string): string {
   return run(str, code([4], 24));
@@ -197,10 +161,6 @@ export function underline(str: string): string {
 /**
  * Invert background color and text color.
  * @param str text to invert its color
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function inverse(str: string): string {
   return run(str, code([7], 27));
@@ -209,10 +169,6 @@ export function inverse(str: string): string {
 /**
  * Make the text hidden.
  * @param str text to hide
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function hidden(str: string): string {
   return run(str, code([8], 28));
@@ -221,10 +177,6 @@ export function hidden(str: string): string {
 /**
  * Put horizontal line through the center of the text.
  * @param str text to strike through
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function strikethrough(str: string): string {
   return run(str, code([9], 29));
@@ -233,10 +185,6 @@ export function strikethrough(str: string): string {
 /**
  * Set text color to black.
  * @param str text to make black
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function black(str: string): string {
   return run(str, code([30], 39));
@@ -245,10 +193,6 @@ export function black(str: string): string {
 /**
  * Set text color to red.
  * @param str text to make red
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function red(str: string): string {
   return run(str, code([31], 39));
@@ -257,10 +201,6 @@ export function red(str: string): string {
 /**
  * Set text color to green.
  * @param str text to make green
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function green(str: string): string {
   return run(str, code([32], 39));
@@ -269,10 +209,6 @@ export function green(str: string): string {
 /**
  * Set text color to yellow.
  * @param str text to make yellow
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function yellow(str: string): string {
   return run(str, code([33], 39));
@@ -281,10 +217,6 @@ export function yellow(str: string): string {
 /**
  * Set text color to blue.
  * @param str text to make blue
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function blue(str: string): string {
   return run(str, code([34], 39));
@@ -293,10 +225,6 @@ export function blue(str: string): string {
 /**
  * Set text color to magenta.
  * @param str text to make magenta
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function magenta(str: string): string {
   return run(str, code([35], 39));
@@ -305,10 +233,6 @@ export function magenta(str: string): string {
 /**
  * Set text color to cyan.
  * @param str text to make cyan
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function cyan(str: string): string {
   return run(str, code([36], 39));
@@ -317,10 +241,6 @@ export function cyan(str: string): string {
 /**
  * Set text color to white.
  * @param str text to make white
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function white(str: string): string {
   return run(str, code([37], 39));
@@ -329,10 +249,6 @@ export function white(str: string): string {
 /**
  * Set text color to gray.
  * @param str text to make gray
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function gray(str: string): string {
   return brightBlack(str);
@@ -341,10 +257,6 @@ export function gray(str: string): string {
 /**
  * Set text color to bright black.
  * @param str text to make bright-black
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightBlack(str: string): string {
   return run(str, code([90], 39));
@@ -353,10 +265,6 @@ export function brightBlack(str: string): string {
 /**
  * Set text color to bright red.
  * @param str text to make bright-red
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightRed(str: string): string {
   return run(str, code([91], 39));
@@ -365,10 +273,6 @@ export function brightRed(str: string): string {
 /**
  * Set text color to bright green.
  * @param str text to make bright-green
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightGreen(str: string): string {
   return run(str, code([92], 39));
@@ -377,10 +281,6 @@ export function brightGreen(str: string): string {
 /**
  * Set text color to bright yellow.
  * @param str text to make bright-yellow
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightYellow(str: string): string {
   return run(str, code([93], 39));
@@ -389,10 +289,6 @@ export function brightYellow(str: string): string {
 /**
  * Set text color to bright blue.
  * @param str text to make bright-blue
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightBlue(str: string): string {
   return run(str, code([94], 39));
@@ -401,10 +297,6 @@ export function brightBlue(str: string): string {
 /**
  * Set text color to bright magenta.
  * @param str text to make bright-magenta
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightMagenta(str: string): string {
   return run(str, code([95], 39));
@@ -413,10 +305,6 @@ export function brightMagenta(str: string): string {
 /**
  * Set text color to bright cyan.
  * @param str text to make bright-cyan
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightCyan(str: string): string {
   return run(str, code([96], 39));
@@ -425,10 +313,6 @@ export function brightCyan(str: string): string {
 /**
  * Set text color to bright white.
  * @param str text to make bright-white
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function brightWhite(str: string): string {
   return run(str, code([97], 39));
@@ -437,10 +321,6 @@ export function brightWhite(str: string): string {
 /**
  * Set background color to black.
  * @param str text to make its background black
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBlack(str: string): string {
   return run(str, code([40], 49));
@@ -449,10 +329,6 @@ export function bgBlack(str: string): string {
 /**
  * Set background color to red.
  * @param str text to make its background red
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgRed(str: string): string {
   return run(str, code([41], 49));
@@ -461,10 +337,6 @@ export function bgRed(str: string): string {
 /**
  * Set background color to green.
  * @param str text to make its background green
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgGreen(str: string): string {
   return run(str, code([42], 49));
@@ -473,10 +345,6 @@ export function bgGreen(str: string): string {
 /**
  * Set background color to yellow.
  * @param str text to make its background yellow
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgYellow(str: string): string {
   return run(str, code([43], 49));
@@ -485,10 +353,6 @@ export function bgYellow(str: string): string {
 /**
  * Set background color to blue.
  * @param str text to make its background blue
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBlue(str: string): string {
   return run(str, code([44], 49));
@@ -497,10 +361,6 @@ export function bgBlue(str: string): string {
 /**
  *  Set background color to magenta.
  * @param str text to make its background magenta
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgMagenta(str: string): string {
   return run(str, code([45], 49));
@@ -509,10 +369,6 @@ export function bgMagenta(str: string): string {
 /**
  * Set background color to cyan.
  * @param str text to make its background cyan
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgCyan(str: string): string {
   return run(str, code([46], 49));
@@ -521,10 +377,6 @@ export function bgCyan(str: string): string {
 /**
  * Set background color to white.
  * @param str text to make its background white
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgWhite(str: string): string {
   return run(str, code([47], 49));
@@ -533,10 +385,6 @@ export function bgWhite(str: string): string {
 /**
  * Set background color to bright black.
  * @param str text to make its background bright-black
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightBlack(str: string): string {
   return run(str, code([100], 49));
@@ -545,10 +393,6 @@ export function bgBrightBlack(str: string): string {
 /**
  * Set background color to bright red.
  * @param str text to make its background bright-red
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightRed(str: string): string {
   return run(str, code([101], 49));
@@ -557,10 +401,6 @@ export function bgBrightRed(str: string): string {
 /**
  * Set background color to bright green.
  * @param str text to make its background bright-green
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightGreen(str: string): string {
   return run(str, code([102], 49));
@@ -569,10 +409,6 @@ export function bgBrightGreen(str: string): string {
 /**
  * Set background color to bright yellow.
  * @param str text to make its background bright-yellow
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightYellow(str: string): string {
   return run(str, code([103], 49));
@@ -581,10 +417,6 @@ export function bgBrightYellow(str: string): string {
 /**
  * Set background color to bright blue.
  * @param str text to make its background bright-blue
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightBlue(str: string): string {
   return run(str, code([104], 49));
@@ -593,10 +425,6 @@ export function bgBrightBlue(str: string): string {
 /**
  * Set background color to bright magenta.
  * @param str text to make its background bright-magenta
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightMagenta(str: string): string {
   return run(str, code([105], 49));
@@ -605,10 +433,6 @@ export function bgBrightMagenta(str: string): string {
 /**
  * Set background color to bright cyan.
  * @param str text to make its background bright-cyan
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightCyan(str: string): string {
   return run(str, code([106], 49));
@@ -617,10 +441,6 @@ export function bgBrightCyan(str: string): string {
 /**
  * Set background color to bright white.
  * @param str text to make its background bright-white
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgBrightWhite(str: string): string {
   return run(str, code([107], 49));
@@ -643,10 +463,6 @@ function clampAndTruncate(n: number, max = 255, min = 0): number {
  * https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
  * @param str text color to apply paletted 8bit colors to
  * @param color code
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function rgb8(str: string, color: number): string {
   return run(str, code([38, 5, clampAndTruncate(color)], 39));
@@ -657,10 +473,6 @@ export function rgb8(str: string, color: number): string {
  * https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
  * @param str text color to apply paletted 8bit background colors to
  * @param color code
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgRgb8(str: string, color: number): string {
   return run(str, code([48, 5, clampAndTruncate(color)], 49));
@@ -674,17 +486,13 @@ export function bgRgb8(str: string, color: number): string {
  * To produce the color magenta:
  *
  * ```ts
- * import { rgb24 } from "@std/fmt/colors";
+ * import { rgb24 } from "@std/cli/styles";
  *
  * rgb24("foo", 0xff00ff);
  * rgb24("foo", {r: 255, g: 0, b: 255});
  * ```
  * @param str text color to apply 24bit rgb to
  * @param color code
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function rgb24(str: string, color: number | Rgb): string {
   if (typeof color === "number") {
@@ -719,17 +527,13 @@ export function rgb24(str: string, color: number | Rgb): string {
  * To produce the color magenta:
  *
  * ```ts
- * import { bgRgb24 } from "@std/fmt/colors";
+ * import { bgRgb24 } from "@std/cli/styles";
  *
  * bgRgb24("foo", 0xff00ff);
  * bgRgb24("foo", {r: 255, g: 0, b: 255});
  * ```
  * @param str text color to apply 24bit rgb to
  * @param color code
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function bgRgb24(str: string, color: number | Rgb): string {
   if (typeof color === "number") {
@@ -769,9 +573,7 @@ const ANSI_PATTERN = new RegExp(
  * Remove ANSI escape codes from the string.
  * @param string to remove ANSI escape codes from
  *
- * @deprecated Use {@linkcode stripAnsiCode} from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
+ *  @deprecated This will be removed in 1.0.0. Use {@linkcode stripAnsiCode} instead.
  */
 export function stripColor(string: string): string {
   return stripAnsiCode(string);
@@ -781,10 +583,6 @@ export function stripColor(string: string): string {
  * Remove ANSI escape codes from the string.
  *
  * @param string to remove ANSI escape codes from
- *
- * @deprecated Import from
- * {@link https://jsr.io/@std/cli/doc/colors/~ | @std/cli/colors} instead. This
- * will be removed in 1.0.0.
  */
 export function stripAnsiCode(string: string): string {
   return string.replace(ANSI_PATTERN, "");

--- a/cli/styles_test.ts
+++ b/cli/styles_test.ts
@@ -1,210 +1,210 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "@std/assert";
-import * as c from "./styles.ts";
+import * as styles from "./styles.ts";
 
 Deno.test("reset()", function () {
-  assertEquals(c.reset("foo bar"), "[0mfoo bar[0m");
+  assertEquals(styles.reset("foo bar"), "[0mfoo bar[0m");
 });
 
 Deno.test("red() single color", function () {
-  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+  assertEquals(styles.red("foo bar"), "[31mfoo bar[39m");
 });
 
 Deno.test("bgBlue() double color", function () {
-  assertEquals(c.bgBlue(c.red("foo bar")), "[44m[31mfoo bar[39m[49m");
+  assertEquals(styles.bgBlue(styles.red("foo bar")), "[44m[31mfoo bar[39m[49m");
 });
 
 Deno.test("red() replaces close characters", function () {
-  assertEquals(c.red("Hel[39mlo"), "[31mHel[31mlo[39m");
+  assertEquals(styles.red("Hel[39mlo"), "[31mHel[31mlo[39m");
 });
 
 Deno.test("getColorEnabled() handles enabled colors", function () {
-  assertEquals(c.getColorEnabled(), true);
-  c.setColorEnabled(false);
-  assertEquals(c.bgBlue(c.red("foo bar")), "foo bar");
-  c.setColorEnabled(true);
-  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+  assertEquals(styles.getColorEnabled(), true);
+  styles.setColorEnabled(false);
+  assertEquals(styles.bgBlue(styles.red("foo bar")), "foo bar");
+  styles.setColorEnabled(true);
+  assertEquals(styles.red("foo bar"), "[31mfoo bar[39m");
 });
 
 Deno.test("bold()", function () {
-  assertEquals(c.bold("foo bar"), "[1mfoo bar[22m");
+  assertEquals(styles.bold("foo bar"), "[1mfoo bar[22m");
 });
 
 Deno.test("dim()", function () {
-  assertEquals(c.dim("foo bar"), "[2mfoo bar[22m");
+  assertEquals(styles.dim("foo bar"), "[2mfoo bar[22m");
 });
 
 Deno.test("italic()", function () {
-  assertEquals(c.italic("foo bar"), "[3mfoo bar[23m");
+  assertEquals(styles.italic("foo bar"), "[3mfoo bar[23m");
 });
 
 Deno.test("underline()", function () {
-  assertEquals(c.underline("foo bar"), "[4mfoo bar[24m");
+  assertEquals(styles.underline("foo bar"), "[4mfoo bar[24m");
 });
 
 Deno.test("inverse()", function () {
-  assertEquals(c.inverse("foo bar"), "[7mfoo bar[27m");
+  assertEquals(styles.inverse("foo bar"), "[7mfoo bar[27m");
 });
 
 Deno.test("hidden()", function () {
-  assertEquals(c.hidden("foo bar"), "[8mfoo bar[28m");
+  assertEquals(styles.hidden("foo bar"), "[8mfoo bar[28m");
 });
 
 Deno.test("strikethrough()", function () {
-  assertEquals(c.strikethrough("foo bar"), "[9mfoo bar[29m");
+  assertEquals(styles.strikethrough("foo bar"), "[9mfoo bar[29m");
 });
 
 Deno.test("black()", function () {
-  assertEquals(c.black("foo bar"), "[30mfoo bar[39m");
+  assertEquals(styles.black("foo bar"), "[30mfoo bar[39m");
 });
 
 Deno.test("red()", function () {
-  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+  assertEquals(styles.red("foo bar"), "[31mfoo bar[39m");
 });
 
 Deno.test("green()", function () {
-  assertEquals(c.green("foo bar"), "[32mfoo bar[39m");
+  assertEquals(styles.green("foo bar"), "[32mfoo bar[39m");
 });
 
 Deno.test("yellow()", function () {
-  assertEquals(c.yellow("foo bar"), "[33mfoo bar[39m");
+  assertEquals(styles.yellow("foo bar"), "[33mfoo bar[39m");
 });
 
 Deno.test("blue()", function () {
-  assertEquals(c.blue("foo bar"), "[34mfoo bar[39m");
+  assertEquals(styles.blue("foo bar"), "[34mfoo bar[39m");
 });
 
 Deno.test("magenta()", function () {
-  assertEquals(c.magenta("foo bar"), "[35mfoo bar[39m");
+  assertEquals(styles.magenta("foo bar"), "[35mfoo bar[39m");
 });
 
 Deno.test("cyan()", function () {
-  assertEquals(c.cyan("foo bar"), "[36mfoo bar[39m");
+  assertEquals(styles.cyan("foo bar"), "[36mfoo bar[39m");
 });
 
 Deno.test("white()", function () {
-  assertEquals(c.white("foo bar"), "[37mfoo bar[39m");
+  assertEquals(styles.white("foo bar"), "[37mfoo bar[39m");
 });
 
 Deno.test("gray()", function () {
-  assertEquals(c.gray("foo bar"), "[90mfoo bar[39m");
+  assertEquals(styles.gray("foo bar"), "[90mfoo bar[39m");
 });
 
 Deno.test("brightBlack()", function () {
-  assertEquals(c.brightBlack("foo bar"), "[90mfoo bar[39m");
+  assertEquals(styles.brightBlack("foo bar"), "[90mfoo bar[39m");
 });
 
 Deno.test("brightRed()", function () {
-  assertEquals(c.brightRed("foo bar"), "[91mfoo bar[39m");
+  assertEquals(styles.brightRed("foo bar"), "[91mfoo bar[39m");
 });
 
 Deno.test("brightGreen()", function () {
-  assertEquals(c.brightGreen("foo bar"), "[92mfoo bar[39m");
+  assertEquals(styles.brightGreen("foo bar"), "[92mfoo bar[39m");
 });
 
 Deno.test("brightYellow()", function () {
-  assertEquals(c.brightYellow("foo bar"), "[93mfoo bar[39m");
+  assertEquals(styles.brightYellow("foo bar"), "[93mfoo bar[39m");
 });
 
 Deno.test("brightBlue()", function () {
-  assertEquals(c.brightBlue("foo bar"), "[94mfoo bar[39m");
+  assertEquals(styles.brightBlue("foo bar"), "[94mfoo bar[39m");
 });
 
 Deno.test("brightMagenta()", function () {
-  assertEquals(c.brightMagenta("foo bar"), "[95mfoo bar[39m");
+  assertEquals(styles.brightMagenta("foo bar"), "[95mfoo bar[39m");
 });
 
 Deno.test("brightCyan()", function () {
-  assertEquals(c.brightCyan("foo bar"), "[96mfoo bar[39m");
+  assertEquals(styles.brightCyan("foo bar"), "[96mfoo bar[39m");
 });
 
 Deno.test("brightWhite()", function () {
-  assertEquals(c.brightWhite("foo bar"), "[97mfoo bar[39m");
+  assertEquals(styles.brightWhite("foo bar"), "[97mfoo bar[39m");
 });
 
 Deno.test("bgBlack()", function () {
-  assertEquals(c.bgBlack("foo bar"), "[40mfoo bar[49m");
+  assertEquals(styles.bgBlack("foo bar"), "[40mfoo bar[49m");
 });
 
 Deno.test("bgRed()", function () {
-  assertEquals(c.bgRed("foo bar"), "[41mfoo bar[49m");
+  assertEquals(styles.bgRed("foo bar"), "[41mfoo bar[49m");
 });
 
 Deno.test("bgGreen()", function () {
-  assertEquals(c.bgGreen("foo bar"), "[42mfoo bar[49m");
+  assertEquals(styles.bgGreen("foo bar"), "[42mfoo bar[49m");
 });
 
 Deno.test("bgYellow()", function () {
-  assertEquals(c.bgYellow("foo bar"), "[43mfoo bar[49m");
+  assertEquals(styles.bgYellow("foo bar"), "[43mfoo bar[49m");
 });
 
 Deno.test("bgBlue()", function () {
-  assertEquals(c.bgBlue("foo bar"), "[44mfoo bar[49m");
+  assertEquals(styles.bgBlue("foo bar"), "[44mfoo bar[49m");
 });
 
 Deno.test("bgMagenta()", function () {
-  assertEquals(c.bgMagenta("foo bar"), "[45mfoo bar[49m");
+  assertEquals(styles.bgMagenta("foo bar"), "[45mfoo bar[49m");
 });
 
 Deno.test("bgCyan()", function () {
-  assertEquals(c.bgCyan("foo bar"), "[46mfoo bar[49m");
+  assertEquals(styles.bgCyan("foo bar"), "[46mfoo bar[49m");
 });
 
 Deno.test("bgWhite()", function () {
-  assertEquals(c.bgWhite("foo bar"), "[47mfoo bar[49m");
+  assertEquals(styles.bgWhite("foo bar"), "[47mfoo bar[49m");
 });
 
 Deno.test("bgBrightBlack()", function () {
-  assertEquals(c.bgBrightBlack("foo bar"), "[100mfoo bar[49m");
+  assertEquals(styles.bgBrightBlack("foo bar"), "[100mfoo bar[49m");
 });
 
 Deno.test("bgBrightRed()", function () {
-  assertEquals(c.bgBrightRed("foo bar"), "[101mfoo bar[49m");
+  assertEquals(styles.bgBrightRed("foo bar"), "[101mfoo bar[49m");
 });
 
 Deno.test("bgBrightGreen()", function () {
-  assertEquals(c.bgBrightGreen("foo bar"), "[102mfoo bar[49m");
+  assertEquals(styles.bgBrightGreen("foo bar"), "[102mfoo bar[49m");
 });
 
 Deno.test("bgBrightYellow()", function () {
-  assertEquals(c.bgBrightYellow("foo bar"), "[103mfoo bar[49m");
+  assertEquals(styles.bgBrightYellow("foo bar"), "[103mfoo bar[49m");
 });
 
 Deno.test("bgBrightBlue()", function () {
-  assertEquals(c.bgBrightBlue("foo bar"), "[104mfoo bar[49m");
+  assertEquals(styles.bgBrightBlue("foo bar"), "[104mfoo bar[49m");
 });
 
 Deno.test("bgBrightMagenta()", function () {
-  assertEquals(c.bgBrightMagenta("foo bar"), "[105mfoo bar[49m");
+  assertEquals(styles.bgBrightMagenta("foo bar"), "[105mfoo bar[49m");
 });
 
 Deno.test("bgBrightCyan()", function () {
-  assertEquals(c.bgBrightCyan("foo bar"), "[106mfoo bar[49m");
+  assertEquals(styles.bgBrightCyan("foo bar"), "[106mfoo bar[49m");
 });
 
 Deno.test("bgBrightWhite()", function () {
-  assertEquals(c.bgBrightWhite("foo bar"), "[107mfoo bar[49m");
+  assertEquals(styles.bgBrightWhite("foo bar"), "[107mfoo bar[49m");
 });
 
 Deno.test("rgb8() handles clamp", function () {
-  assertEquals(c.rgb8("foo bar", -10), "[38;5;0mfoo bar[39m");
+  assertEquals(styles.rgb8("foo bar", -10), "[38;5;0mfoo bar[39m");
 });
 
 Deno.test("rgb8() handles truncate", function () {
-  assertEquals(c.rgb8("foo bar", 42.5), "[38;5;42mfoo bar[39m");
+  assertEquals(styles.rgb8("foo bar", 42.5), "[38;5;42mfoo bar[39m");
 });
 
 Deno.test("test rgb8", function () {
-  assertEquals(c.rgb8("foo bar", 42), "[38;5;42mfoo bar[39m");
+  assertEquals(styles.rgb8("foo bar", 42), "[38;5;42mfoo bar[39m");
 });
 
 Deno.test("bgRgb8()", function () {
-  assertEquals(c.bgRgb8("foo bar", 42), "[48;5;42mfoo bar[49m");
+  assertEquals(styles.bgRgb8("foo bar", 42), "[48;5;42mfoo bar[49m");
 });
 
 Deno.test("rgb24()", function () {
   assertEquals(
-    c.rgb24("foo bar", {
+    styles.rgb24("foo bar", {
       r: 41,
       g: 42,
       b: 43,
@@ -214,12 +214,12 @@ Deno.test("rgb24()", function () {
 });
 
 Deno.test("rgb24() handles number", function () {
-  assertEquals(c.rgb24("foo bar", 0x070809), "[38;2;7;8;9mfoo bar[39m");
+  assertEquals(styles.rgb24("foo bar", 0x070809), "[38;2;7;8;9mfoo bar[39m");
 });
 
 Deno.test("bgRgb24()", function () {
   assertEquals(
-    c.bgRgb24("foo bar", {
+    styles.bgRgb24("foo bar", {
       r: 41,
       g: 42,
       b: 43,
@@ -229,13 +229,13 @@ Deno.test("bgRgb24()", function () {
 });
 
 Deno.test("bgRgb24() handles number", function () {
-  assertEquals(c.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
+  assertEquals(styles.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
 });
 
 // https://github.com/chalk/strip-ansi/blob/2b8c961e75760059699373f9a69101065c3ded3a/test.js#L4-L6
 Deno.test("stripAnsiCode()", function () {
   assertEquals(
-    c.stripAnsiCode(
+    styles.stripAnsiCode(
       "\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m",
     ),
     "foofoo",

--- a/cli/styles_test.ts
+++ b/cli/styles_test.ts
@@ -1,0 +1,243 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "@std/assert";
+import * as c from "./styles.ts";
+
+Deno.test("reset()", function () {
+  assertEquals(c.reset("foo bar"), "[0mfoo bar[0m");
+});
+
+Deno.test("red() single color", function () {
+  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+});
+
+Deno.test("bgBlue() double color", function () {
+  assertEquals(c.bgBlue(c.red("foo bar")), "[44m[31mfoo bar[39m[49m");
+});
+
+Deno.test("red() replaces close characters", function () {
+  assertEquals(c.red("Hel[39mlo"), "[31mHel[31mlo[39m");
+});
+
+Deno.test("getColorEnabled() handles enabled colors", function () {
+  assertEquals(c.getColorEnabled(), true);
+  c.setColorEnabled(false);
+  assertEquals(c.bgBlue(c.red("foo bar")), "foo bar");
+  c.setColorEnabled(true);
+  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+});
+
+Deno.test("bold()", function () {
+  assertEquals(c.bold("foo bar"), "[1mfoo bar[22m");
+});
+
+Deno.test("dim()", function () {
+  assertEquals(c.dim("foo bar"), "[2mfoo bar[22m");
+});
+
+Deno.test("italic()", function () {
+  assertEquals(c.italic("foo bar"), "[3mfoo bar[23m");
+});
+
+Deno.test("underline()", function () {
+  assertEquals(c.underline("foo bar"), "[4mfoo bar[24m");
+});
+
+Deno.test("inverse()", function () {
+  assertEquals(c.inverse("foo bar"), "[7mfoo bar[27m");
+});
+
+Deno.test("hidden()", function () {
+  assertEquals(c.hidden("foo bar"), "[8mfoo bar[28m");
+});
+
+Deno.test("strikethrough()", function () {
+  assertEquals(c.strikethrough("foo bar"), "[9mfoo bar[29m");
+});
+
+Deno.test("black()", function () {
+  assertEquals(c.black("foo bar"), "[30mfoo bar[39m");
+});
+
+Deno.test("red()", function () {
+  assertEquals(c.red("foo bar"), "[31mfoo bar[39m");
+});
+
+Deno.test("green()", function () {
+  assertEquals(c.green("foo bar"), "[32mfoo bar[39m");
+});
+
+Deno.test("yellow()", function () {
+  assertEquals(c.yellow("foo bar"), "[33mfoo bar[39m");
+});
+
+Deno.test("blue()", function () {
+  assertEquals(c.blue("foo bar"), "[34mfoo bar[39m");
+});
+
+Deno.test("magenta()", function () {
+  assertEquals(c.magenta("foo bar"), "[35mfoo bar[39m");
+});
+
+Deno.test("cyan()", function () {
+  assertEquals(c.cyan("foo bar"), "[36mfoo bar[39m");
+});
+
+Deno.test("white()", function () {
+  assertEquals(c.white("foo bar"), "[37mfoo bar[39m");
+});
+
+Deno.test("gray()", function () {
+  assertEquals(c.gray("foo bar"), "[90mfoo bar[39m");
+});
+
+Deno.test("brightBlack()", function () {
+  assertEquals(c.brightBlack("foo bar"), "[90mfoo bar[39m");
+});
+
+Deno.test("brightRed()", function () {
+  assertEquals(c.brightRed("foo bar"), "[91mfoo bar[39m");
+});
+
+Deno.test("brightGreen()", function () {
+  assertEquals(c.brightGreen("foo bar"), "[92mfoo bar[39m");
+});
+
+Deno.test("brightYellow()", function () {
+  assertEquals(c.brightYellow("foo bar"), "[93mfoo bar[39m");
+});
+
+Deno.test("brightBlue()", function () {
+  assertEquals(c.brightBlue("foo bar"), "[94mfoo bar[39m");
+});
+
+Deno.test("brightMagenta()", function () {
+  assertEquals(c.brightMagenta("foo bar"), "[95mfoo bar[39m");
+});
+
+Deno.test("brightCyan()", function () {
+  assertEquals(c.brightCyan("foo bar"), "[96mfoo bar[39m");
+});
+
+Deno.test("brightWhite()", function () {
+  assertEquals(c.brightWhite("foo bar"), "[97mfoo bar[39m");
+});
+
+Deno.test("bgBlack()", function () {
+  assertEquals(c.bgBlack("foo bar"), "[40mfoo bar[49m");
+});
+
+Deno.test("bgRed()", function () {
+  assertEquals(c.bgRed("foo bar"), "[41mfoo bar[49m");
+});
+
+Deno.test("bgGreen()", function () {
+  assertEquals(c.bgGreen("foo bar"), "[42mfoo bar[49m");
+});
+
+Deno.test("bgYellow()", function () {
+  assertEquals(c.bgYellow("foo bar"), "[43mfoo bar[49m");
+});
+
+Deno.test("bgBlue()", function () {
+  assertEquals(c.bgBlue("foo bar"), "[44mfoo bar[49m");
+});
+
+Deno.test("bgMagenta()", function () {
+  assertEquals(c.bgMagenta("foo bar"), "[45mfoo bar[49m");
+});
+
+Deno.test("bgCyan()", function () {
+  assertEquals(c.bgCyan("foo bar"), "[46mfoo bar[49m");
+});
+
+Deno.test("bgWhite()", function () {
+  assertEquals(c.bgWhite("foo bar"), "[47mfoo bar[49m");
+});
+
+Deno.test("bgBrightBlack()", function () {
+  assertEquals(c.bgBrightBlack("foo bar"), "[100mfoo bar[49m");
+});
+
+Deno.test("bgBrightRed()", function () {
+  assertEquals(c.bgBrightRed("foo bar"), "[101mfoo bar[49m");
+});
+
+Deno.test("bgBrightGreen()", function () {
+  assertEquals(c.bgBrightGreen("foo bar"), "[102mfoo bar[49m");
+});
+
+Deno.test("bgBrightYellow()", function () {
+  assertEquals(c.bgBrightYellow("foo bar"), "[103mfoo bar[49m");
+});
+
+Deno.test("bgBrightBlue()", function () {
+  assertEquals(c.bgBrightBlue("foo bar"), "[104mfoo bar[49m");
+});
+
+Deno.test("bgBrightMagenta()", function () {
+  assertEquals(c.bgBrightMagenta("foo bar"), "[105mfoo bar[49m");
+});
+
+Deno.test("bgBrightCyan()", function () {
+  assertEquals(c.bgBrightCyan("foo bar"), "[106mfoo bar[49m");
+});
+
+Deno.test("bgBrightWhite()", function () {
+  assertEquals(c.bgBrightWhite("foo bar"), "[107mfoo bar[49m");
+});
+
+Deno.test("rgb8() handles clamp", function () {
+  assertEquals(c.rgb8("foo bar", -10), "[38;5;0mfoo bar[39m");
+});
+
+Deno.test("rgb8() handles truncate", function () {
+  assertEquals(c.rgb8("foo bar", 42.5), "[38;5;42mfoo bar[39m");
+});
+
+Deno.test("test rgb8", function () {
+  assertEquals(c.rgb8("foo bar", 42), "[38;5;42mfoo bar[39m");
+});
+
+Deno.test("bgRgb8()", function () {
+  assertEquals(c.bgRgb8("foo bar", 42), "[48;5;42mfoo bar[49m");
+});
+
+Deno.test("rgb24()", function () {
+  assertEquals(
+    c.rgb24("foo bar", {
+      r: 41,
+      g: 42,
+      b: 43,
+    }),
+    "[38;2;41;42;43mfoo bar[39m",
+  );
+});
+
+Deno.test("rgb24() handles number", function () {
+  assertEquals(c.rgb24("foo bar", 0x070809), "[38;2;7;8;9mfoo bar[39m");
+});
+
+Deno.test("bgRgb24()", function () {
+  assertEquals(
+    c.bgRgb24("foo bar", {
+      r: 41,
+      g: 42,
+      b: 43,
+    }),
+    "[48;2;41;42;43mfoo bar[49m",
+  );
+});
+
+Deno.test("bgRgb24() handles number", function () {
+  assertEquals(c.bgRgb24("foo bar", 0x070809), "[48;2;7;8;9mfoo bar[49m");
+});
+
+// https://github.com/chalk/strip-ansi/blob/2b8c961e75760059699373f9a69101065c3ded3a/test.js#L4-L6
+Deno.test("stripAnsiCode()", function () {
+  assertEquals(
+    c.stripAnsiCode(
+      "\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m",
+    ),
+    "foofoo",
+  );
+});

--- a/cli/unicode_width.ts
+++ b/cli/unicode_width.ts
@@ -63,7 +63,7 @@ function charWidth(ch: string) {
  * @example Calculating the unicode width of a color-encoded string
  * ```ts
  * import { unicodeWidth } from "@std/cli/unicode-width";
- * import { stripAnsiCode } from "@std/fmt/colors";
+ * import { stripAnsiCode } from "@std/cli/styles";
  *
  * unicodeWidth(stripAnsiCode("\x1b[36mголубой\x1b[39m")); // 7
  * unicodeWidth(stripAnsiCode("\x1b[31m紅色\x1b[39m")); // 4

--- a/expect/_assert_equals_test.ts
+++ b/expect/_assert_equals_test.ts
@@ -3,7 +3,7 @@
 // This file is copied from `std/assert`.
 
 import { AssertionError, assertThrows } from "@std/assert";
-import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/fmt/colors";
+import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/cli/styles";
 import { assertEquals } from "./_assert_equals.ts";
 
 const createHeader = (): string[] => [

--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { red } from "@std/fmt/colors";
+import { red } from "@std/cli/styles";
 import { CAN_NOT_DISPLAY } from "./_constants.ts";
 import { buildMessage, diff, diffstr, format } from "@std/internal";
 import type { EqualOptions } from "./_types.ts";

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/fmt/colors";
+import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/cli/styles";
 import { AssertionError, assertThrows } from "@std/assert";
 import { expect } from "./expect.ts";
 

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -48,7 +48,7 @@ import {
 } from "./status.ts";
 import { ByteSliceStream } from "@std/streams/byte-slice-stream";
 import { parseArgs } from "@std/cli/parse-args";
-import { red } from "@std/fmt/colors";
+import { red } from "@std/cli/styles";
 import denoConfig from "./deno.json" with { type: "json" };
 import { format as formatBytes } from "@std/fmt/bytes";
 

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { bgGreen, bgRed, bold, gray, green, red, white } from "@std/fmt/colors";
+import { bgGreen, bgRed, bold, gray, green, red, white } from "@std/cli/styles";
 
 interface FarthestPoint {
   y: number;

--- a/internal/format_test.ts
+++ b/internal/format_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { green, red, stripAnsiCode } from "@std/fmt/colors";
+import { green, red, stripAnsiCode } from "@std/cli/styles";
 import { assertEquals, assertThrows } from "@std/assert";
 import { format } from "./format.ts";
 

--- a/log/console_handler.ts
+++ b/log/console_handler.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 import { type LevelName, LogLevels } from "./levels.ts";
 import type { LogRecord } from "./logger.ts";
-import { blue, bold, red, yellow } from "@std/fmt/colors";
+import { blue, bold, red, yellow } from "@std/cli/styles";
 import { BaseHandler, type BaseHandlerOptions } from "./base_handler.ts";
 
 export interface ConsoleHandlerOptions extends BaseHandlerOptions {

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -101,7 +101,7 @@
  * ```ts
  * // example_test.ts
  * import { createAssertSnapshot } from "@std/testing/snapshot";
- * import { stripAnsiCode } from "@std/fmt/colors";
+ * import { stripAnsiCode } from "@std/cli/styles";
  *
  * const assertSnapshot = createAssertSnapshot({
  *   dir: ".snaps",
@@ -141,7 +141,7 @@ import { parse } from "@std/path/parse";
 import { resolve } from "@std/path/resolve";
 import { toFileUrl } from "@std/path/to-file-url";
 import { ensureFile, ensureFileSync } from "@std/fs/ensure-file";
-import { bold, green, red } from "@std/fmt/colors";
+import { bold, green, red } from "@std/cli/styles";
 import { assert } from "@std/assert/assert";
 import { AssertionError } from "@std/assert/assertion-error";
 import { equal } from "@std/assert/equal";

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { stripAnsiCode } from "@std/fmt/colors";
+import { stripAnsiCode } from "@std/cli/styles";
 import { dirname, fromFileUrl, join, toFileUrl } from "@std/path";
 import {
   assert,


### PR DESCRIPTION
Closes #4676