### PR TITLE
fix(assert): don't swallow the original error while creating assertion error

### DIFF
--- a/assert/_constants.ts
+++ b/assert/_constants.ts
@@ -1,2 +1,0 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-export const CAN_NOT_DISPLAY = "[Cannot display]";

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -3,8 +3,6 @@
 import { equal } from "./equal.ts";
 import { buildMessage, diff, diffstr, format } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
-import { red } from "@std/fmt/colors";
-import { CAN_NOT_DISPLAY } from "./_constants.ts";
 
 /**
  * Make an assertion that `actual` and `expected` are equal, deeply. If not
@@ -38,16 +36,12 @@ export function assertEquals<T>(
 
   const actualString = formatter(actual);
   const expectedString = formatter(expected);
-  try {
-    const stringDiff = (typeof actual === "string") &&
-      (typeof expected === "string");
-    const diffResult = stringDiff
-      ? diffstr(actual as string, expected as string)
-      : diff(actualString.split("\n"), expectedString.split("\n"));
-    const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
-    message = `${message}\n${diffMsg}`;
-  } catch {
-    message = `${message}\n${red(CAN_NOT_DISPLAY)} + \n\n`;
-  }
+  const stringDiff = (typeof actual === "string") &&
+    (typeof expected === "string");
+  const diffResult = stringDiff
+    ? diffstr(actual as string, expected as string)
+    : diff(actualString.split("\n"), expectedString.split("\n"));
+  const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
+  message = `${message}\n${diffMsg}`;
   throw new AssertionError(message);
 }

--- a/assert/assert_equals_test.ts
+++ b/assert/assert_equals_test.ts
@@ -1,8 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, AssertionError, assertThrows } from "./mod.ts";
 import { bold, gray, green, red, stripAnsiCode, yellow } from "@std/fmt/colors";
-import { _internals } from "@std/internal";
-import { stub } from "@std/testing/mock";
 
 const createHeader = (): string[] => [
   "",
@@ -148,23 +146,6 @@ Deno.test({
         removed(`-   ${yellow("1")}`),
         added(`+   ${yellow("2")}`),
         "",
-      ].join("\n"),
-    );
-  },
-});
-
-Deno.test({
-  name: "assertEquals() throws with [Cannot display] if diffing fails",
-  fn() {
-    using _ = stub(_internals, "diff", () => {
-      throw new Error();
-    });
-    assertThrows(
-      () => assertEquals("1", "2"),
-      AssertionError,
-      [
-        "Values are not equal.",
-        "[Cannot display]",
       ].join("\n"),
     );
   },

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { CAN_NOT_DISPLAY } from "./_constants.ts";
 import { equal } from "./equal.ts";
 import { AssertionError } from "./assertion_error.ts";
 
@@ -23,18 +22,8 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   if (!equal(actual, expected)) {
     return;
   }
-  let actualString: string;
-  let expectedString: string;
-  try {
-    actualString = String(actual);
-  } catch {
-    actualString = CAN_NOT_DISPLAY;
-  }
-  try {
-    expectedString = String(expected);
-  } catch {
-    expectedString = CAN_NOT_DISPLAY;
-  }
+  const actualString = String(actual);
+  const expectedString = String(expected);
   const msgSuffix = msg ? `: ${msg}` : ".";
   throw new AssertionError(
     `Expected actual: ${actualString} not to be: ${expectedString}${msgSuffix}`,

--- a/assert/assert_not_equals_test.ts
+++ b/assert/assert_not_equals_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { AssertionError, assertNotEquals, assertThrows } from "./mod.ts";
-import { stub } from "@std/testing/mock";
 
 Deno.test("assertNotEquals()", () => {
   assertNotEquals<unknown>({ foo: "bar" }, { bar: "foo" });
@@ -29,18 +28,5 @@ Deno.test("assertNotEquals() throws with custom message", () => {
     },
     AssertionError,
     "Expected actual: foo not to be: foo: CUSTOM MESSAGE",
-  );
-});
-
-Deno.test("assertNotEquals() throws with [Cannot display]", () => {
-  using _ = stub(globalThis, "String", () => {
-    throw new Error();
-  });
-  assertThrows(
-    () => {
-      assertNotEquals("a", "a");
-    },
-    AssertionError,
-    `Expected actual: [Cannot display] not to be: [Cannot display].`,
   );
 });

--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -2,7 +2,6 @@
 // This module is browser compatible.
 import { buildMessage, diff, diffstr, format } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
-import { CAN_NOT_DISPLAY } from "./_constants.ts";
 import { red } from "@std/fmt/colors";
 
 /**
@@ -47,17 +46,13 @@ export function assertStrictEquals<T>(
         red(withOffset)
       }\n`;
   } else {
-    try {
-      const stringDiff = (typeof actual === "string") &&
-        (typeof expected === "string");
-      const diffResult = stringDiff
-        ? diffstr(actual as string, expected as string)
-        : diff(actualString.split("\n"), expectedString.split("\n"));
-      const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
-      message = `Values are not strictly equal${msgSuffix}\n${diffMsg}`;
-    } catch {
-      message = `\n${red(CAN_NOT_DISPLAY)} + \n\n`;
-    }
+    const stringDiff = (typeof actual === "string") &&
+      (typeof expected === "string");
+    const diffResult = stringDiff
+      ? diffstr(actual as string, expected as string)
+      : diff(actualString.split("\n"), expectedString.split("\n"));
+    const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
+    message = `Values are not strictly equal${msgSuffix}\n${diffMsg}`;
   }
 
   throw new AssertionError(message);

--- a/assert/assert_strict_equals_test.ts
+++ b/assert/assert_strict_equals_test.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { AssertionError, assertStrictEquals, assertThrows } from "./mod.ts";
-import { _internals } from "@std/internal";
-import { stub } from "@std/testing/mock";
 
 Deno.test({
   name: "assertStrictEquals()",
@@ -90,20 +88,6 @@ Deno.test({
     {
       a: 1,
     }`,
-    );
-  },
-});
-
-Deno.test({
-  name: "assertStrictEquals() throws with [Cannot display] if diffing fails",
-  fn() {
-    using _ = stub(_internals, "diff", () => {
-      throw new Error();
-    });
-    assertThrows(
-      () => assertStrictEquals("1", "2"),
-      AssertionError,
-      "\n[Cannot display] + \n\n",
     );
   },
 });


### PR DESCRIPTION
This change removes lines that seem unreachable and reduces the dependency on `fmt/colors.ts`. The exact reasons for the changes are the same as in #4700.

Towards #4699