### PR TITLE
refactor(internal): cleanup `diff()`

### DIFF
--- a/internal/_types.ts
+++ b/internal/_types.ts
@@ -1,8 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
 export type DiffType = "removed" | "common" | "added";
 
 export interface DiffResult<T> {
   type: DiffType;
   value: T;
-  details?: Array<DiffResult<T>>;
+  details?: DiffResult<T>[];
 }

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -129,7 +129,7 @@ function createFp(
  *
  * @returns An array of differences between the actual and expected values.
  */
-export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
+export function diff<T>(A: T[], B: T[]): DiffResult<T>[] {
   const prefixCommon = createCommon(A, B);
   const suffixCommon = createCommon(
     A.slice(prefixCommon.length),

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -138,7 +138,7 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
   let ptr = 0;
   let p = -1;
 
-  function createFP(
+  function createFp(
     slide: FarthestPoint | undefined,
     down: FarthestPoint | undefined,
     k: number,
@@ -169,15 +169,15 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
 
   function snake<T>(
     k: number,
-    slide: FarthestPoint | undefined,
-    down: FarthestPoint | undefined,
     A: T[],
     B: T[],
+    slide?: FarthestPoint,
+    down?: FarthestPoint,
   ): FarthestPoint {
     const M = A.length;
     const N = B.length;
     if (k < -N || M < k) return { y: -1, id: -1 };
-    const fp = createFP(slide, down, k, M);
+    const fp = createFp(slide, down, k, M);
     while (fp.y + k < M && fp.y < N && A[fp.y + k] === B[fp.y]) {
       const prev = fp.id;
       ptr++;
@@ -191,26 +191,26 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
 
   let currentFp = fp[delta + offset];
   assertFp(currentFp);
-  while (currentFp && currentFp.y < N) {
+  while (currentFp.y < N) {
     p = p + 1;
     for (let k = -p; k < delta; ++k) {
       fp[k + offset] = snake(
         k,
-        fp[k - 1 + offset],
-        fp[k + 1 + offset],
         A,
         B,
+        fp[k - 1 + offset],
+        fp[k + 1 + offset],
       );
     }
     for (let k = delta + p; k > delta; --k) {
-      fp[k + offset] = snake(k, fp[k - 1 + offset], fp[k + 1 + offset], A, B);
+      fp[k + offset] = snake(k, A, B, fp[k - 1 + offset], fp[k + 1 + offset]);
     }
     fp[delta + offset] = snake(
       delta,
-      fp[delta - 1 + offset],
-      fp[delta + 1 + offset],
       A,
       B,
+      fp[delta - 1 + offset],
+      fp[delta + 1 + offset],
     );
     currentFp = fp[delta + offset];
     assertFp(currentFp);

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -161,7 +161,6 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
   const routes = new Uint32Array((M * N + length + 1) * 2);
   const diffTypesPtrOffset = routes.length / 2;
   let ptr = 0;
-  let p = -1;
 
   function snake<T>(
     k: number,
@@ -188,6 +187,7 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
 
   let currentFp = fp[delta + offset];
   assertFp(currentFp);
+  let p = -1;
   while (currentFp.y < N) {
     p = p + 1;
     for (let k = -p; k < delta; ++k) {

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -88,13 +88,13 @@ function backTrace<T>(
 }
 
 function createFp(
-  slide: FarthestPoint | undefined,
-  down: FarthestPoint | undefined,
   k: number,
   M: number,
   routes: Uint32Array,
   diffTypesPtrOffset: number,
   ptr: number,
+  slide?: FarthestPoint,
+  down?: FarthestPoint,
 ): FarthestPoint {
   if (slide && slide.y === -1 && down && down.y === -1) {
     return { y: 0, id: 0 };
@@ -180,7 +180,7 @@ export function diff<T>(A: T[], B: T[]): Array<DiffResult<T>> {
     const M = A.length;
     const N = B.length;
     if (k < -N || M < k) return { y: -1, id: -1 };
-    const fp = createFp(slide, down, k, M, routes, diffTypesPtrOffset, ptr);
+    const fp = createFp(k, M, routes, diffTypesPtrOffset, ptr, slide, down);
     ptr = fp.id;
     while (fp.y + k < M && fp.y < N && A[fp.y + k] === B[fp.y]) {
       const prev = fp.id;


### PR DESCRIPTION
To improve maintainability. I wasn't able to make `snake()` top-level. Oh well. That can be done some other time.