### PR TITLE
test(webgpu): remove `Deno.resources()` usage

### DIFF
--- a/webgpu/_test_util.ts
+++ b/webgpu/_test_util.ts
@@ -29,14 +29,3 @@ const isLinuxOrMacCI =
 const isWsl = await checkIsWsl();
 
 export const ignore = isWsl || isLinuxOrMacCI;
-
-export function cleanUp(device: GPUDevice) {
-  device.destroy();
-
-  // TODO(lucacasonato): webgpu spec should add a explicit destroy method for
-  // adapters.
-  // @ts-ignore Until WebGPU resources cleanup is automatically handled.
-  const resources = Object.keys(Deno[Deno.internal].core.resources());
-  // @ts-ignore Until WebGPU resources cleanup is automatically handled.
-  Deno[Deno.internal].core.close(Number(resources[resources.length - 1]));
-}

--- a/webgpu/create_capture_test.ts
+++ b/webgpu/create_capture_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "@std/assert";
-import { cleanUp, ignore } from "./_test_util.ts";
+import { ignore } from "./_test_util.ts";
 import { createCapture } from "./create_capture.ts";
 
 Deno.test({
@@ -30,6 +30,6 @@ Deno.test({
       GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
     );
 
-    cleanUp(device);
+    device.destroy();
   },
 });

--- a/webgpu/texture_with_data_test.ts
+++ b/webgpu/texture_with_data_test.ts
@@ -2,7 +2,7 @@
 
 import { assert } from "@std/assert/assert";
 import { createTextureWithData } from "./texture_with_data.ts";
-import { cleanUp, ignore } from "./_test_util.ts";
+import { ignore } from "./_test_util.ts";
 
 Deno.test({
   ignore,

--- a/webgpu/texture_with_data_test.ts
+++ b/webgpu/texture_with_data_test.ts
@@ -22,6 +22,6 @@ Deno.test({
       usage: GPUTextureUsage.COPY_SRC,
     }, new Uint8Array([1, 1, 1, 1, 1, 1, 1]));
 
-    cleanUp(device);
+    device.destroy();
   },
 });


### PR DESCRIPTION
Possible due to https://github.com/denoland/deno/pull/23752