### PR TITLE
test(net): improve test coverage

### DIFF
--- a/net/get_available_port_test.ts
+++ b/net/get_available_port_test.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getAvailablePort } from "./get_available_port.ts";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals, assertThrows } from "@std/assert";
+import { stub } from "@std/testing/mock";
 
 /** Helper function to see if a port is indeed available for listening (race-y) */
 async function testWithPort(port: number) {
@@ -20,10 +21,32 @@ async function testWithPort(port: number) {
 
 Deno.test("getAvailablePort() gets an available port", async () => {
   const port = getAvailablePort();
+  assertEquals(typeof port, "number");
   await testWithPort(port);
 });
 
 Deno.test("getAvailablePort() gets an available port with a preferred port", async () => {
-  const port = getAvailablePort({ preferredPort: 9563 });
+  const preferredPort = 9563;
+  const port = getAvailablePort({ preferredPort });
+  assertEquals(port, preferredPort);
   await testWithPort(port);
+});
+
+Deno.test("getAvailablePort() falls back to another port if preferred port is in use", async () => {
+  const preferredPort = 9563;
+  const server = Deno.serve(
+    { port: preferredPort, onListen: () => {} },
+    () => new Response("hello"),
+  );
+  const port = getAvailablePort({ preferredPort });
+  assertEquals(typeof port, "number");
+  assertNotEquals(port, preferredPort);
+  server.shutdown();
+  await server.finished;
+});
+
+Deno.test("getAvailablePort() throws if error is not AddrInUse", () => {
+  using _ = stub(Deno, "listen", () => new Error());
+  const preferredPort = 9563;
+  assertThrows(() => getAvailablePort({ preferredPort }), Error);
 });

--- a/net/get_available_port_test.ts
+++ b/net/get_available_port_test.ts
@@ -46,7 +46,9 @@ Deno.test("getAvailablePort() falls back to another port if preferred port is in
 });
 
 Deno.test("getAvailablePort() throws if error is not AddrInUse", () => {
-  using _ = stub(Deno, "listen", () => { throw new Error() });
+  using _ = stub(Deno, "listen", () => {
+    throw new Error();
+  });
   const preferredPort = 9563;
   assertThrows(() => getAvailablePort({ preferredPort }), Error);
 });

--- a/net/get_available_port_test.ts
+++ b/net/get_available_port_test.ts
@@ -46,7 +46,7 @@ Deno.test("getAvailablePort() falls back to another port if preferred port is in
 });
 
 Deno.test("getAvailablePort() throws if error is not AddrInUse", () => {
-  using _ = stub(Deno, "listen", () => new Error());
+  using _ = stub(Deno, "listen", () => { throw new Error() });
   const preferredPort = 9563;
   assertThrows(() => getAvailablePort({ preferredPort }), Error);
 });


### PR DESCRIPTION
working towards https://github.com/denoland/deno_std/issues/3713.
pushes code coverage of the `net` sub-module to 100%.
