### PR TITLE
chore(expect): fix future `no-slow-type` lint errors with expando properties

### DIFF
--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -53,14 +53,7 @@ import {
 } from "./_matchers.ts";
 import { addSerializer } from "./_snapshot_serializer.ts";
 import { isPromiseLike } from "./_utils.ts";
-import {
-  any,
-  anything,
-  arrayContaining,
-  closeTo,
-  stringContaining,
-  stringMatching,
-} from "./_asymmetric_matchers.ts";
+import * as asymetricMatchers from "./_asymmetric_matchers.ts";
 
 const matchers: Record<MatcherKey, Matcher> = {
   lastCalledWith: toHaveBeenLastCalledWith,
@@ -206,9 +199,9 @@ expect.addSnapshotSerializers = addSerializer;
 expect.addSnapshotSerializer = addSerializer;
 expect.extend = setExtendMatchers;
 
-expect.anything = anything;
-expect.any = any;
-expect.arrayContaining = arrayContaining;
-expect.closeTo = closeTo;
-expect.stringContaining = stringContaining;
-expect.stringMatching = stringMatching;
+expect.anything = asymetricMatchers.anything;
+expect.any = asymetricMatchers.any;
+expect.arrayContaining = asymetricMatchers.arrayContaining;
+expect.closeTo = asymetricMatchers.closeTo;
+expect.stringContaining = asymetricMatchers.stringContaining;
+expect.stringMatching = asymetricMatchers.stringMatching;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -53,7 +53,7 @@ import {
 } from "./_matchers.ts";
 import { addSerializer } from "./_snapshot_serializer.ts";
 import { isPromiseLike } from "./_utils.ts";
-import * as asymetricMatchers from "./_asymmetric_matchers.ts";
+import * as asymmetricMatchers from "./_asymmetric_matchers.ts";
 
 const matchers: Record<MatcherKey, Matcher> = {
   lastCalledWith: toHaveBeenLastCalledWith,
@@ -199,9 +199,9 @@ expect.addSnapshotSerializers = addSerializer;
 expect.addSnapshotSerializer = addSerializer;
 expect.extend = setExtendMatchers;
 
-expect.anything = asymetricMatchers.anything;
-expect.any = asymetricMatchers.any;
-expect.arrayContaining = asymetricMatchers.arrayContaining;
-expect.closeTo = asymetricMatchers.closeTo;
-expect.stringContaining = asymetricMatchers.stringContaining;
-expect.stringMatching = asymetricMatchers.stringMatching;
+expect.anything = asymmetricMatchers.anything;
+expect.any = asymmetricMatchers.any;
+expect.arrayContaining = asymmetricMatchers.arrayContaining;
+expect.closeTo = asymmetricMatchers.closeTo;
+expect.stringContaining = asymmetricMatchers.stringContaining;
+expect.stringMatching = asymmetricMatchers.stringMatching;

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -579,7 +579,7 @@ export function it<T>(...args: ItArgs<T>) {
   }
 }
 
-it.only = function itOnly<T>(...args: ItArgs<T>) {
+it.only = function itOnly<T>(...args: ItArgs<T>): void {
   const options = itDefinition(...args);
   return it({
     ...options,
@@ -587,7 +587,7 @@ it.only = function itOnly<T>(...args: ItArgs<T>) {
   });
 };
 
-it.ignore = function itIgnore<T>(...args: ItArgs<T>) {
+it.ignore = function itIgnore<T>(...args: ItArgs<T>): void {
   const options = itDefinition(...args);
   return it({
     ...options,


### PR DESCRIPTION
Fast check will be getting a bit smarter at analyzing expando properties.

```
error[missing-explicit-return-type]: missing explicit return type in the public API
   --> V:\deno_std\testing\bdd.ts:582:11
    |
582 | it.only = function itOnly<T>(...args: ItArgs<T>) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
583 |   const options = itDefinition(...args);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
584 |   return it({
    | ^^^^^^^^^^^^^
585 |     ...options,
    | ^^^^^^^^^^^^^^^
586 |     only: true,
    | ^^^^^^^^^^^^^^^
587 |   });
    | ^^^^^
588 | };
    | ^ this function is missing an explicit return type
    = hint: add an explicit return type to the function

  info: all functions in the public API must have an explicit return type
  docs: https://jsr.io/go/slow-type-missing-explicit-return-type

error[missing-explicit-return-type]: missing explicit return type in the public API
   --> V:\deno_std\testing\bdd.ts:590:13
    |
590 | it.ignore = function itIgnore<T>(...args: ItArgs<T>) {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
591 |   const options = itDefinition(...args);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
592 |   return it({
    | ^^^^^^^^^^^^^
593 |     ...options,
    | ^^^^^^^^^^^^^^^
594 |     ignore: true,
    | ^^^^^^^^^^^^^^^^^
595 |   });
    | ^^^^^
596 | };
    | ^ this function is missing an explicit return type
    = hint: add an explicit return type to the function

  info: all functions in the public API must have an explicit return type
  docs: https://jsr.io/go/slow-type-missing-explicit-return-type

error[unsupported-expando-property]: expando property referencing 'anything' conflicts with 'expect.anything'
   --> V:\deno_std\expect\expect.ts:209:19
    |
209 | expect.anything = anything;
    |                   ^^^^^^^^
    = hint: rename 'anything' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property

error[unsupported-expando-property]: expando property referencing 'any' conflicts with 'expect.any'
   --> V:\deno_std\expect\expect.ts:210:14
    |
210 | expect.any = any;
    |              ^^^
    = hint: rename 'any' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property

error[unsupported-expando-property]: expando property referencing 'arrayContaining' conflicts with 'expect.arrayContaining'
   --> V:\deno_std\expect\expect.ts:211:26
    |
211 | expect.arrayContaining = arrayContaining;
    |                          ^^^^^^^^^^^^^^^
    = hint: rename 'arrayContaining' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property

error[unsupported-expando-property]: expando property referencing 'closeTo' conflicts with 'expect.closeTo'
   --> V:\deno_std\expect\expect.ts:212:18
    |
212 | expect.closeTo = closeTo;
    |                  ^^^^^^^
    = hint: rename 'closeTo' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property

error[unsupported-expando-property]: expando property referencing 'stringContaining' conflicts with 'expect.stringContaining'
   --> V:\deno_std\expect\expect.ts:213:27
    |
213 | expect.stringContaining = stringContaining;
    |                           ^^^^^^^^^^^^^^^^
    = hint: rename 'stringContaining' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property

error[unsupported-expando-property]: expando property referencing 'stringMatching' conflicts with 'expect.stringMatching'
   --> V:\deno_std\expect\expect.ts:214:25
    |
214 | expect.stringMatching = stringMatching;
    |                         ^^^^^^^^^^^^^^
    = hint: rename 'stringMatching' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference

  info: expando properties get converted to a namespace and the reference conflicts with a namespace export
  docs: https://jsr.io/go/slow-type-unsupported-expando-property
```