### PR TITLE
chore(assert): revert "handle `assertStrictEquals(-0, +0)` correctly"

### DIFF
--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -26,15 +26,10 @@ export function assertStrictEquals<T>(
   expected: T,
   msg?: string,
 ): asserts actual is T {
-  if (actual === expected) {
+  if (Object.is(actual, expected)) {
     return;
   }
-  if (
-    typeof actual === "number" && typeof expected === "number" &&
-    isNaN(actual) && isNaN(expected)
-  ) {
-    return;
-  }
+
   const msgSuffix = msg ? `: ${msg}` : ".";
   let message: string;
 

--- a/assert/assert_strict_equals_test.ts
+++ b/assert/assert_strict_equals_test.ts
@@ -8,7 +8,6 @@ Deno.test({
     assertStrictEquals(10, 10);
     assertStrictEquals("abc", "abc");
     assertStrictEquals(NaN, NaN);
-    assertStrictEquals(+0, -0);
 
     const xs = [1, false, "foo"];
     const ys = xs;


### PR DESCRIPTION
See https://github.com/denoland/deno_std/issues/4714#issuecomment-2106423300