### PR TITLE
feat(cache): add memoize and LruCache

### DIFF
--- a/cache/_serialize_arg_list_test.ts
+++ b/cache/_serialize_arg_list_test.ts
@@ -1,0 +1,136 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "@std/assert";
+import { _serializeArgList } from "./memoize.ts";
+import { delay } from "@std/async";
+
+Deno.test("_serializeArgList() serializes simple numbers", () => {
+  const getKey = _serializeArgList(new Map());
+  assertEquals(getKey(1), "undefined,1");
+  assertEquals(getKey(1, 2), "undefined,1,2");
+  assertEquals(getKey(1, 2, 3), "undefined,1,2,3");
+});
+
+Deno.test("_serializeArgList() serializes primitive types", () => {
+  const getKey = _serializeArgList(new Map());
+  assertEquals(
+    getKey(1, "2", 3n, null, undefined, true, Symbol.for("xyz")),
+    'undefined,1,"2",3n,null,undefined,true,Symbol.for("xyz")',
+  );
+});
+
+Deno.test("_serializeArgList() serializes reference types", () => {
+  const getKey = _serializeArgList(new Map());
+  const obj = {};
+  const arr: [] = [];
+  const sym = Symbol("xyz");
+
+  assertEquals(getKey(obj), "undefined,{0}");
+  assertEquals(getKey(obj, obj), "undefined,{0},{0}");
+
+  assertEquals(getKey(arr), "undefined,{1}");
+  assertEquals(getKey(sym), "undefined,{2}");
+  assertEquals(
+    getKey(obj, arr, sym),
+    "undefined,{0},{1},{2}",
+  );
+});
+
+Deno.test("_serializeArgList() discriminates on `this` arg", () => {
+  const getKey = _serializeArgList(new Map());
+  const obj1 = {};
+  const obj2 = {};
+
+  assertEquals(getKey(), "undefined");
+  assertEquals(getKey.call(obj1), "{0}");
+  assertEquals(getKey.call(obj2), "{1}");
+  assertEquals(getKey.call(obj1, obj2), "{0},{1}");
+});
+
+Deno.test("_serializeArgList() allows garbage collection for weak keys", async () => {
+  // @ts-expect-error - Triggering true garbage collection is only available
+  // with `--v8-flags="--expose-gc"`, so we mock `FinalizationRegistry` with
+  // `using` and some `Symbol.dispose` trickery if it's not available. Run this
+  // test with `deno test --v8-flags="--expose-gc"` to test actual gc behavior
+  // (however, even calling `globalThis.gc` doesn't _guarantee_ garbage
+  // collection, so this may be flaky between v8 versions etc.)
+  const gc = globalThis.gc as undefined | (() => void);
+
+  class MockFinalizationRegistry<T> extends FinalizationRegistry<T> {
+    #cleanupCallback: (heldValue: T) => void;
+
+    constructor(cleanupCallback: (heldValue: T) => void) {
+      super(cleanupCallback);
+      this.#cleanupCallback = cleanupCallback;
+    }
+
+    override register(target: WeakKey, heldValue: T) {
+      Object.assign(target, {
+        onCleanup: () => {
+          this.#cleanupCallback(heldValue);
+        },
+      });
+    }
+  }
+
+  function makeRegisterableObject() {
+    const onCleanup = null as (() => void) | null;
+    return {
+      onCleanup,
+      [Symbol.dispose]() {
+        this.onCleanup?.();
+      },
+    };
+  }
+
+  const OriginalFinalizationRegistry = FinalizationRegistry;
+
+  try {
+    if (!gc) {
+      globalThis.FinalizationRegistry = MockFinalizationRegistry;
+    }
+
+    const cache = new Map();
+    const getKey = _serializeArgList(cache);
+
+    using outerScopeObj = makeRegisterableObject();
+
+    const k1 = getKey(outerScopeObj);
+    const k2 = getKey(globalThis);
+    const k3 = getKey("primitive");
+    const k4 = getKey(globalThis, "primitive");
+    const k5 = getKey(globalThis, "primitive", outerScopeObj);
+
+    const persistentKeys = new Set([k1, k2, k3, k4, k5]);
+
+    await (async () => {
+      using obj1 = makeRegisterableObject();
+      using obj2 = makeRegisterableObject();
+
+      const k6 = getKey(obj1);
+      const k7 = getKey(obj2);
+      const k8 = getKey(obj1, obj2);
+      const k9 = getKey(obj1, globalThis);
+      const k10 = getKey(obj1, "primitive");
+      const k11 = getKey(obj1, outerScopeObj);
+
+      const ephemeralKeys = new Set([k6, k7, k8, k9, k10, k11]);
+
+      const keys = new Set([...ephemeralKeys, ...persistentKeys]);
+      for (const [idx, key] of [...keys].entries()) {
+        cache.set(key, idx + 1);
+      }
+
+      gc?.();
+      // wait for gc to run
+      await delay(0);
+      assertEquals(cache.size, keys.size);
+    })();
+
+    gc?.();
+    // wait for gc to run
+    await delay(0);
+    assertEquals(cache.size, persistentKeys.size);
+  } finally {
+    globalThis.FinalizationRegistry = OriginalFinalizationRegistry;
+  }
+});

--- a/cache/deno.json
+++ b/cache/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@std/cache",
+  "version": "0.224.1",
+  "exports": {
+    ".": "./mod.ts",
+    "./lru-cache": "./lru_cache.ts",
+    "./memoize": "./memoize.ts"
+  }
+}

--- a/cache/lru_cache.ts
+++ b/cache/lru_cache.ts
@@ -1,0 +1,56 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import type { MemoizationCache } from "./memoize.ts";
+
+/**
+ * [Least-recently-used](
+ * 	https://en.wikipedia.org/wiki/Cache_replacement_policies#LRU
+ * ) cache.
+ *
+ * Automatically removes entries above the max size based on when they were
+ * last accessed with `get`, `set`, or `has`.
+ */
+export class LruCache<K, V> extends Map<K, V>
+  implements MemoizationCache<K, V> {
+  constructor(public maxSize: number) {
+    super();
+  }
+
+  #setMostRecentlyUsed(key: K, value: V): void {
+    // delete then re-add to ensure most recently accessed elements are last
+    super.delete(key);
+    super.set(key, value);
+  }
+
+  #pruneToMaxSize(): void {
+    if (this.size > this.maxSize) {
+      this.delete(this.keys().next().value);
+    }
+  }
+
+  override has(key: K): boolean {
+    const exists = super.has(key);
+
+    if (exists) {
+      this.#setMostRecentlyUsed(key, super.get(key)!);
+    }
+
+    return exists;
+  }
+
+  override get(key: K): V | undefined {
+    if (super.has(key)) {
+      const value = super.get(key)!;
+      this.#setMostRecentlyUsed(key, value);
+      return value;
+    }
+
+    return undefined;
+  }
+
+  override set(key: K, value: V): this {
+    this.#setMostRecentlyUsed(key, value);
+    this.#pruneToMaxSize();
+
+    return this;
+  }
+}

--- a/cache/lru_cache_test.ts
+++ b/cache/lru_cache_test.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assert, assertEquals } from "@std/assert";
+import { LruCache } from "./lru_cache.ts";
+
+Deno.test("LruCache deletes least-recently-used", () => {
+  const cache = new LruCache(3);
+
+  cache.set(1, "!");
+  cache.set(2, "!");
+  cache.set(1, "updated");
+  cache.set(3, "!");
+  cache.set(4, "!");
+
+  assertEquals(cache.size, 3);
+  assert(!cache.has(2));
+  assertEquals([...cache.keys()], [1, 3, 4]);
+  assertEquals(cache.get(3), "!");
+  assertEquals(cache.get(1), "updated");
+
+  cache.delete(3);
+  assertEquals(cache.size, 2);
+});

--- a/cache/memoize.ts
+++ b/cache/memoize.ts
@@ -1,0 +1,203 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { LruCache } from "./lru_cache.ts";
+
+export type MemoizationCache<K, V> = {
+  has: (key: K) => boolean;
+  get: (key: K) => V | undefined;
+  set: (key: K, val: V) => unknown;
+  delete: (key: K) => unknown;
+};
+
+export type MemoizationOptions<Fn extends (...args: never[]) => unknown> = {
+  /**
+   * Provide a custom cache for getting previous results. By default, a new
+   * `Map` object is instantiated upon memoization and used as a cache.
+   */
+  cache?: MemoizationCache<unknown, ReturnType<Fn>>;
+  /**
+   * Function to get a unique cache key from the function's arguments. By
+   * default, a composite key is created from all the arguments plus the `this`
+   * value, using reference equality to check for equivalence.
+   *
+   * @example
+   * ```ts
+   * import { memoize } from "@std/cache";
+   * import { assertEquals } from "@std/assert";
+   *
+   * const fn = memoize(({ value }: { cacheKey: number; value: number }) => {
+   *   return value;
+   * }, { getKey: ({ cacheKey }) => cacheKey });
+   *
+   * assertEquals(fn({ cacheKey: 1, value: 2 }), 2);
+   * assertEquals(fn({ cacheKey: 1, value: 99 }), 2);
+   * assertEquals(fn({ cacheKey: 2, value: 99 }), 99);
+   * ```
+   */
+  getKey?: (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) => unknown;
+  /**
+   * Only use args as cache keys up to the `length` property of the function.
+   * Useful for passing unary functions as array callbacks, but should be
+   * avoided for functions with variable argument length (`...rest` or default
+   * params)
+   *
+   * @default false
+   */
+  truncateArgs?: boolean;
+  /**
+   * By default, promises are automatically removed from the cache upon
+   * rejection. If `cacheRejectedPromises` is set to `true`, promises will be
+   * retained in the cache even if rejected.
+   *
+   * @default false
+   */
+  cacheRejectedPromises?: boolean;
+};
+
+// used for memoizing the `memoize` function itself to enable on-the-fly usage
+const _cache: LruCache<unknown, ReturnType<typeof memoize>> = new LruCache(100);
+const _getKey: ReturnType<typeof _serializeArgList> = _serializeArgList(_cache);
+
+/**
+ * Cache the results of a function based on its arguments.
+ *
+ * @param fn - The function to memoize
+ * @param options - Options for memoization
+ *
+ * @example
+ * ```ts
+ * import { memoize } from "@std/cache";
+ * import { assertEquals } from "@std/assert";
+ *
+ * // fibonacci function, which is very slow for n > ~30 if not memoized
+ * const fib = memoize((n: bigint): bigint => {
+ *   return n <= 2n ? 1n : fib(n - 1n) + fib(n - 2n);
+ * });
+ *
+ * assertEquals(fib(100n), 354224848179261915075n);
+ * ```
+ */
+const memoize_: typeof memoize = memoize(memoize, {
+  cache: _cache,
+  getKey(fn, options) {
+    const optionVals = Object.entries(options ?? {})
+      .sort(([a], [b]) => a > b ? 1 : a < b ? -1 : 0)
+      .map(([, v]) => v);
+    return _getKey(fn, ...optionVals);
+  },
+});
+
+export { memoize_ as memoize };
+
+function memoize<Fn extends (...args: never[]) => unknown>(
+  fn: Fn,
+  options?: NoInfer<Partial<MemoizationOptions<Fn>>>,
+): Fn & {
+  cache: MemoizationCache<unknown, ReturnType<Fn>>;
+  getKey: (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) => unknown;
+} {
+  const cache = options?.cache ?? new Map();
+  const getKey = options?.getKey ?? _serializeArgList(cache);
+  const truncateArgs = options?.truncateArgs ?? false;
+  const cacheRejectedPromises = options?.cacheRejectedPromises ?? false;
+
+  const memoized = function (
+    this: ThisParameterType<Fn>,
+    ...args: Parameters<Fn>
+  ): ReturnType<Fn> {
+    if (truncateArgs) args = args.slice(0, fn.length) as Parameters<Fn>;
+
+    const key = getKey.apply(this, args);
+
+    if (cache.has(key)) {
+      return cache.get(key)!;
+    }
+
+    let val = fn.apply(this, args) as ReturnType<Fn>;
+
+    if (val instanceof Promise && !cacheRejectedPromises) {
+      val = val.catch((reason) => {
+        cache.delete(key);
+        throw reason;
+      }) as typeof val;
+    }
+
+    cache.set(key, val);
+
+    return val;
+  } as Fn;
+
+  return Object.defineProperties(Object.assign(memoized, { cache, getKey }), {
+    length: { value: fn.length },
+    name: { value: fn.name },
+  });
+}
+
+/** Default serialization of arguments list for use as cache keys */
+export function _serializeArgList<Return>(
+  cache: MemoizationCache<unknown, Return>,
+): (this: unknown, ...args: unknown[]) => string {
+  const weakKeyToKeySegmentCache = new WeakMap<WeakKey, string>();
+  const weakKeySegmentToKeyCache = new Map<string, string[]>();
+  let i = 0;
+
+  const registry = new FinalizationRegistry<string>((keySegment) => {
+    for (const key of weakKeySegmentToKeyCache.get(keySegment) ?? []) {
+      cache.delete(key);
+    }
+    weakKeySegmentToKeyCache.delete(keySegment);
+  });
+
+  return function (...args) {
+    const weakKeySegments: string[] = [];
+    const keySegments = [this, ...args].map((arg) => {
+      if (typeof arg === "undefined") return "undefined";
+      if (typeof arg === "bigint") return `${arg}n`;
+
+      if (
+        arg === null ||
+        ["string", "boolean", "number", "record", "tuple"].includes(typeof arg)
+      ) {
+        // null, string, boolean, number, or one of the upcoming
+        // [record/tuple](https://github.com/tc39/proposal-record-tuple)
+        // ECMAScript types
+        try {
+          return JSON.stringify(arg);
+        } catch { /* fallthrough to weak cache */ }
+      }
+
+      try {
+        assertWeakKey(arg);
+      } catch (e) {
+        if (typeof arg === "symbol") {
+          return `Symbol.for(${JSON.stringify(arg.description)})`;
+        }
+        throw e;
+      }
+
+      if (!weakKeyToKeySegmentCache.has(arg)) {
+        const keySegment = `{${i++}}`;
+        weakKeySegments.push(keySegment);
+        registry.register(arg, keySegment);
+        weakKeyToKeySegmentCache.set(arg, keySegment);
+      }
+
+      const keySegment = weakKeyToKeySegmentCache.get(arg)!;
+      weakKeySegments.push(keySegment);
+      return keySegment;
+    });
+
+    const key = keySegments.join(",");
+
+    for (const keySegment of weakKeySegments) {
+      const keys = weakKeySegmentToKeyCache.get(keySegment) ?? [];
+      keys.push(key);
+      weakKeySegmentToKeyCache.set(keySegment, keys);
+    }
+
+    return key;
+  };
+}
+
+function assertWeakKey(arg: unknown): asserts arg is WeakKey {
+  new WeakRef(arg as WeakKey);
+}

--- a/cache/memoize_test.ts
+++ b/cache/memoize_test.ts
@@ -1,0 +1,662 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertRejects,
+} from "@std/assert";
+import { delay } from "@std/async";
+import { memoize } from "./memoize.ts";
+import { LruCache } from "./lru_cache.ts";
+
+Deno.test(
+  "memoize() memoizes nullary function (lazy/singleton)",
+  async (t) => {
+    await t.step("async function", async () => {
+      let numTimesCalled = 0;
+
+      const db = {
+        connect() {
+          ++numTimesCalled;
+          return Promise.resolve({});
+        },
+      };
+
+      const getConn = memoize(async () => await db.connect());
+      const conn = await getConn();
+      assertEquals(numTimesCalled, 1);
+      const conn2 = await getConn();
+      // equal by reference
+      assert(conn2 === conn);
+      assertEquals(numTimesCalled, 1);
+    });
+
+    await t.step("sync function", async () => {
+      const firstHitDate = memoize(() => new Date());
+
+      const date = firstHitDate();
+
+      await delay(10);
+
+      const date2 = firstHitDate();
+
+      assertEquals(date, date2);
+    });
+  },
+);
+
+Deno.test("memoize() allows simple memoization with primitive arg", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((n: number) => {
+    ++numTimesCalled;
+    return 0 - n;
+  });
+
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(888), -888);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() is performant for expensive fibonacci function", () => {
+  const fib = memoize((n: bigint): bigint =>
+    n <= 2n ? 1n : fib(n - 1n) + fib(n - 2n)
+  );
+
+  const startTime = Date.now();
+  assertEquals(fib(100n), 354224848179261915075n);
+  assertAlmostEquals(Date.now(), startTime, 10);
+});
+
+Deno.test("memoize() allows multiple primitive args", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((a: number, b: number) => {
+    ++numTimesCalled;
+    return a + b;
+  });
+
+  assertEquals(fn(7, 8), 15);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(7, 8), 15);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(7, 9), 16);
+  assertEquals(numTimesCalled, 2);
+  assertEquals(fn(8, 7), 15);
+  assertEquals(numTimesCalled, 3);
+});
+
+Deno.test("memoize() allows ...spread primitive args", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((...ns: number[]) => {
+    ++numTimesCalled;
+    return ns.reduce((total, val) => total + val, 0);
+  });
+
+  assertEquals(fn(), 0);
+  assertEquals(fn(), 0);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(7), 7);
+  assertEquals(fn(7), 7);
+  assertEquals(numTimesCalled, 2);
+  assertEquals(fn(7, 8), 15);
+  assertEquals(fn(7, 8), 15);
+  assertEquals(numTimesCalled, 3);
+  assertEquals(fn(7, 8, 9), 24);
+  assertEquals(fn(7, 8, 9), 24);
+  assertEquals(numTimesCalled, 4);
+});
+
+Deno.test(
+  "memoize() caches unary function by all passed args by default (implicit extra args as array callback)",
+  () => {
+    let numTimesCalled = 0;
+    const fn = memoize((n: number) => {
+      ++numTimesCalled;
+      return 0 - n;
+    });
+
+    assertEquals([1, 1, 2, 2].map(fn), [-1, -1, -2, -2]);
+    assertEquals(numTimesCalled, 4);
+  },
+);
+
+Deno.test(
+  "memoize() caches unary function by single arg if `truncateArgs: true` (even if implicitly passed extra args)",
+  () => {
+    let numTimesCalled = 0;
+    const fn = memoize((n: number) => {
+      ++numTimesCalled;
+      return 0 - n;
+    }, { truncateArgs: true });
+
+    assertEquals([1, 1, 2, 2].map(fn), [-1, -1, -2, -2]);
+    assertEquals(numTimesCalled, 2);
+  },
+);
+
+Deno.test("memoize() preserves `this` binding`", () => {
+  class X {
+    readonly key = "CONSTANT";
+    timesCalled = 0;
+
+    #method() {
+      return 1;
+    }
+
+    method() {
+      ++this.timesCalled;
+      return this.#method();
+    }
+  }
+
+  const x = new X();
+
+  const method = x.method.bind(x);
+
+  const fn = memoize(method);
+  assertEquals(fn(), 1);
+
+  const fn2 = memoize(x.method).bind(x);
+  assertEquals(fn2(), 1);
+});
+
+// based on https://github.com/lodash/lodash/blob/4.17.15/test/test.js#L14704-L14716
+Deno.test("memoize() uses `this` binding of function for `getKey`", () => {
+  type Obj = { b: number; c: number; memoized: (a: number) => number };
+
+  let numTimesCalled = 0;
+
+  const fn = function (this: Obj, a: number) {
+    ++numTimesCalled;
+    return a + this.b + this.c;
+  };
+  const getKey = function (this: Obj, a: number) {
+    return JSON.stringify([a, this.b, this.c]);
+  };
+
+  const memoized = memoize(fn, { getKey });
+
+  const obj: Obj = { memoized, "b": 2, "c": 3 };
+  assertEquals(obj.memoized(1), 6);
+  assertEquals(numTimesCalled, 1);
+
+  assertEquals(obj.memoized(1), 6);
+  assertEquals(numTimesCalled, 1);
+
+  obj.b = 3;
+  obj.c = 5;
+  assertEquals(obj.memoized(1), 9);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() allows reference arg with default caching", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((sym: symbol) => {
+    ++numTimesCalled;
+    return sym;
+  });
+  const sym1 = Symbol();
+  const sym2 = Symbol();
+
+  fn(sym1);
+  assertEquals(numTimesCalled, 1);
+  fn(sym1);
+  assertEquals(numTimesCalled, 1);
+  fn(sym2);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() allows multiple reference args with default caching", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((obj1: unknown, obj2: unknown) => {
+    ++numTimesCalled;
+    return { obj1, obj2 };
+  });
+  const obj1 = {};
+  const obj2 = {};
+
+  fn(obj1, obj1);
+  assertEquals(numTimesCalled, 1);
+  fn(obj1, obj1);
+  assertEquals(numTimesCalled, 1);
+  fn(obj1, obj2);
+  assertEquals(numTimesCalled, 2);
+  fn(obj2, obj2);
+  assertEquals(numTimesCalled, 3);
+  fn(obj2, obj1);
+  assertEquals(numTimesCalled, 4);
+});
+
+Deno.test("memoize() allows non-primitive arg with `getKey`", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((d: Date) => {
+    ++numTimesCalled;
+    return new Date(0 - d.valueOf());
+  }, { getKey: (n) => n.valueOf() });
+  const date1 = new Date(42);
+  const date2 = new Date(888);
+
+  assertEquals(fn(date1), new Date(-42));
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(date1), new Date(-42));
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(date2), new Date(-888));
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() allows non-primitive arg with `getKey`", () => {
+  const fn = memoize(({ value }: { cacheKey: number; value: number }) => {
+    return value;
+  }, { getKey: ({ cacheKey }) => cacheKey });
+
+  assertEquals(fn({ cacheKey: 1, value: 2 }), 2);
+  assertEquals(fn({ cacheKey: 1, value: 99 }), 2);
+  assertEquals(fn({ cacheKey: 2, value: 99 }), 99);
+});
+
+Deno.test(
+  "memoize() allows multiple non-primitive args with `getKey` returning primitive",
+  () => {
+    let numTimesCalled = 0;
+
+    const fn = memoize((...args: { val: number }[]) => {
+      ++numTimesCalled;
+      return args.reduce((total, { val }) => total + val, 0);
+    }, { getKey: (...args) => JSON.stringify(args) });
+
+    assertEquals(fn({ val: 1 }, { val: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ val: 1 }, { val: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ val: 2 }, { val: 1 }), 3);
+    assertEquals(numTimesCalled, 2);
+  },
+);
+
+Deno.test(
+  "memoize() allows multiple non-primitive args with `getKey` returning stringified array of primitives",
+  () => {
+    let numTimesCalled = 0;
+
+    const fn = memoize((...args: { val: number }[]) => {
+      ++numTimesCalled;
+      return args.reduce((total, { val }) => total + val, 0);
+    }, { getKey: (...args) => JSON.stringify(args.map((arg) => arg.val)) });
+
+    assertEquals(fn({ val: 1 }, { val: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ val: 1 }, { val: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ val: 2 }, { val: 1 }), 3);
+    assertEquals(numTimesCalled, 2);
+  },
+);
+
+Deno.test(
+  "memoize() allows multiple non-primitive args of different types, `getKey` returning custom string from props",
+  () => {
+    let numTimesCalled = 0;
+
+    const fn = memoize((one: { one: number }, two: { two: number }) => {
+      ++numTimesCalled;
+      return one.one + two.two;
+    }, { getKey: (one, two) => `${one.one},${two.two}` });
+
+    assertEquals(fn({ one: 1 }, { two: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ one: 1 }, { two: 2 }), 3);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn({ one: 2 }, { two: 1 }), 3);
+    assertEquals(numTimesCalled, 2);
+  },
+);
+
+Deno.test("memoize() allows primitive arg with `getKey`", () => {
+  let numTimesCalled = 0;
+  const fn = memoize((arg: string | number | boolean) => {
+    ++numTimesCalled;
+
+    try {
+      return JSON.parse(String(arg)) as string | number | boolean;
+    } catch {
+      return arg;
+    }
+  }, { getKey: (arg) => String(arg) });
+
+  assertEquals(fn("true"), true);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(true), true);
+  assertEquals(numTimesCalled, 1);
+
+  assertEquals(fn("42"), 42);
+  assertEquals(numTimesCalled, 2);
+  assertEquals(fn(42), 42);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() works with async functions", async () => {
+  // wait time per call of the original (un-memoized) function
+  const DELAY_MS = 100;
+  // max amount of execution time per call of the memoized function
+  const TOLERANCE_MS = 5;
+
+  const startTime = Date.now();
+  const fn = memoize(async (n: number) => {
+    await delay(DELAY_MS);
+    return 0 - n;
+  });
+
+  const nums = [42, 888, 42, 42, 42, 42, 888, 888, 888, 888];
+  const expected = [-42, -888, -42, -42, -42, -42, -888, -888, -888, -888];
+  const results: number[] = [];
+
+  // call in serial to test time elapsed
+  for (const num of nums) {
+    results.push(await fn(num));
+  }
+
+  assertEquals(results, expected);
+
+  const numUnique = new Set(nums).size;
+
+  assertAlmostEquals(
+    Date.now() - startTime,
+    numUnique * DELAY_MS,
+    nums.length * TOLERANCE_MS,
+  );
+});
+
+Deno.test(
+  "memoize() doesn’t cache rejected promises for future function calls",
+  async () => {
+    let rejectNext = true;
+    const fn = memoize(async (n: number) => {
+      await Promise.resolve();
+      const thisCallWillReject = rejectNext;
+      rejectNext = !rejectNext;
+      if (thisCallWillReject) {
+        throw new Error();
+      }
+      return 0 - n;
+    });
+
+    // first call rejects
+    await assertRejects(() => fn(42));
+    // second call succeeds (rejected response is discarded)
+    assertEquals(await fn(42), -42);
+    // subsequent calls also succeed (successful response from cache is used)
+    assertEquals(await fn(42), -42);
+  },
+);
+
+Deno.test(
+  "memoize() caches rejected promises for future function calls if `options.cacheRejectedPromises` is `true`",
+  async () => {
+    let rejectNext = true;
+    const fn = memoize(async (n: number) => {
+      await Promise.resolve();
+      const thisCallWillReject = rejectNext;
+      rejectNext = !rejectNext;
+      if (thisCallWillReject) {
+        throw new Error();
+      }
+      return 0 - n;
+    }, { cacheRejectedPromises: true });
+
+    // first call rejects
+    await assertRejects(() => fn(42));
+    // subsequent calls continue to reject (rejected responses from cache are used)
+    await assertRejects(() => fn(42));
+    await assertRejects(() => fn(42));
+  },
+);
+
+Deno.test(
+  "memoize() causes async functions called in parallel to return the same promise (even if rejected)",
+  async () => {
+    let rejectNext = true;
+    const fn = memoize(async (n: number) => {
+      await Promise.resolve();
+      if (rejectNext) {
+        rejectNext = false;
+        throw new Error(`Rejected ${n}`);
+      }
+      return 0 - n;
+    }, { truncateArgs: true });
+
+    const promises = [42, 42, 888, 888].map(fn);
+
+    const results = await Promise.allSettled(promises);
+
+    assert(promises[1] === promises[0]);
+    assert(results[1]!.status === "rejected");
+    assert(results[1]!.reason.message === "Rejected 42");
+
+    assert(promises[3] === promises[2]);
+    assert(results[3]!.status === "fulfilled");
+    assert(results[3]!.value === -888);
+  },
+);
+
+Deno.test(
+  "memoize() allows manipulating the `cache` property of the memoized function",
+  () => {
+    let numTimesCalled = 0;
+    const fn = memoize((n: number) => {
+      ++numTimesCalled;
+      return 0 - n;
+    });
+
+    assertEquals(fn(42), -42);
+    assertEquals(numTimesCalled, 1);
+    assertEquals(fn(42), -42);
+    assertEquals(numTimesCalled, 1);
+
+    fn.cache.delete(fn.getKey.call(undefined, 42));
+
+    assertEquals(fn(42), -42);
+    assertEquals(numTimesCalled, 2);
+  },
+);
+
+Deno.test("memoize() allows passing a `Map` as a cache", () => {
+  let numTimesCalled = 0;
+  const cache = new Map();
+  const fn = memoize((n: number) => {
+    ++numTimesCalled;
+    return 0 - n;
+  }, { cache });
+
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 1);
+
+  cache.delete(fn.getKey.call(undefined, 42));
+
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() allows passing a custom cache object", () => {
+  let numTimesCalled = 0;
+
+  const uselessCache = {
+    has: () => false,
+    get: () => {
+      throw new Error("`has` is always false, so `get` is never called");
+    },
+    set: () => {},
+    delete: () => {},
+    keys: () => [],
+  };
+
+  const fn = memoize((n: number) => {
+    ++numTimesCalled;
+    return 0 - n;
+  }, { cache: uselessCache });
+
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 1);
+  assertEquals(fn(42), -42);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() deletes stale entries of passed `LruCache`", () => {
+  let numTimesCalled = 0;
+
+  const MAX_SIZE = 5;
+
+  const fn = memoize((n: number) => {
+    ++numTimesCalled;
+    return 0 - n;
+  }, { cache: new LruCache(MAX_SIZE) });
+
+  assertEquals(fn(0), 0);
+  assertEquals(fn(0), 0);
+  assertEquals(numTimesCalled, 1);
+
+  for (let i = 1; i < MAX_SIZE; ++i) {
+    assertEquals(fn(i), 0 - i);
+    assertEquals(fn(i), 0 - i);
+    assertEquals(numTimesCalled, i + 1);
+  }
+
+  assertEquals(fn(MAX_SIZE), 0 - MAX_SIZE);
+  assertEquals(fn(MAX_SIZE), 0 - MAX_SIZE);
+  assertEquals(numTimesCalled, MAX_SIZE + 1);
+
+  assertEquals(fn(0), 0);
+  assertEquals(fn(0), 0);
+  assertEquals(numTimesCalled, MAX_SIZE + 2);
+});
+
+Deno.test("memoize() only caches single latest result with a `LruCache` of maxSize=1", () => {
+  let numTimesCalled = 0;
+
+  const fn = memoize((n: number) => {
+    ++numTimesCalled;
+    return 0 - n;
+  }, { cache: new LruCache(1) });
+
+  assertEquals(fn(0), 0);
+  assertEquals(fn(0), 0);
+  assertEquals(numTimesCalled, 1);
+
+  assertEquals(fn(1), -1);
+  assertEquals(numTimesCalled, 2);
+});
+
+Deno.test("memoize() allows introspecting the cache", () => {
+  const fn = memoize((...args: unknown[]) => args);
+  assertEquals(fn(1), [1]);
+  assertEquals(fn("a"), ["a"]);
+  assertEquals(fn("a", "b"), ["a", "b"]);
+
+  assertEquals(fn.cache.get(fn.getKey.call(undefined, 1)), [1]);
+  assertEquals(fn.cache.get(fn.getKey.call(undefined, "a")), ["a"]);
+  assertEquals(fn.cache.get(fn.getKey.call(undefined, "a", "b")), ["a", "b"]);
+});
+
+Deno.test("memoize() preserves function length", () => {
+  assertEquals(memoize.length, 2);
+
+  assertEquals(memoize(() => {}).length, 0);
+  assertEquals(memoize((_arg) => {}).length, 1);
+  assertEquals(memoize((_1, _2) => {}).length, 2);
+  assertEquals(memoize((..._args) => {}).length, 0);
+  assertEquals(memoize((_1, ..._args) => {}).length, 1);
+});
+
+Deno.test("memoize() preserves function name", () => {
+  assertEquals(memoize.name, "memoize");
+
+  const fn1 = () => {};
+  function fn2() {}
+  const obj = { ["!"]: () => {} };
+
+  assertEquals(memoize(() => {}).name, "");
+  assertEquals(memoize(fn1).name, "fn1");
+  assertEquals(memoize(fn1.bind({})).name, "bound fn1");
+  assertEquals(memoize(fn2).name, "fn2");
+  assertEquals(memoize(function fn3() {}).name, "fn3");
+  assertEquals(memoize(obj["!"]).name, "!");
+});
+
+Deno.test("memoize() allows on-the-fly memoization", () => {
+  let numTimesCalled = 0;
+
+  const fn = (arg?: unknown) => {
+    ++numTimesCalled;
+    return arg;
+  };
+
+  memoize(fn)();
+  assertEquals(numTimesCalled, 1);
+  memoize(fn)();
+  assertEquals(numTimesCalled, 1);
+
+  memoize(fn, {})();
+  assertEquals(numTimesCalled, 1);
+
+  memoize(fn, { cache: new Map() })();
+  assertEquals(numTimesCalled, 2);
+
+  memoize(fn, { cache: new Map() })();
+  assertEquals(numTimesCalled, 3);
+
+  const cache = new Map();
+  memoize(fn, { cache })();
+  assertEquals(numTimesCalled, 4);
+  memoize(fn, { cache })();
+  assertEquals(numTimesCalled, 4);
+});
+
+Deno.test("memoize() has correct TS types", async (t) => {
+  await t.step("simple types", () => {
+    // no need to run, only for type checking
+    void (() => {
+      const fn: (this: number, x: number) => number = (_) => 1;
+      const memoized = memoize(fn);
+
+      const _fn2: typeof fn = memoized;
+      const _fn3: Omit<typeof memoized, "cache" | "getKey"> = fn;
+
+      const _t1: ThisParameterType<typeof fn> = 1;
+      // @ts-expect-error Type 'string' is not assignable to type 'number'.
+      const _t2: ThisParameterType<typeof fn> = "1";
+
+      const _a1: Parameters<typeof fn>[0] = 1;
+      // @ts-expect-error Type 'string' is not assignable to type 'number'.
+      const _a2: Parameters<typeof fn>[0] = "1";
+      // @ts-expect-error Tuple type '[x: number]' of length '1' has no element at index '1'.
+      const _a3: Parameters<typeof fn>[1] = {} as never;
+
+      const _r1: ReturnType<typeof fn> = 1;
+      // @ts-expect-error Type 'string' is not assignable to type 'number'.
+      const _r2: ReturnType<typeof fn> = "1";
+    });
+  });
+
+  await t.step("memoize() correctly preserves generic types", () => {
+    // no need to run, only for type checking
+    void (() => {
+      const fn = <T>(x: T): T => x;
+      const memoized = memoize(fn);
+
+      const _fn2: typeof fn = memoized;
+      const _fn3: Omit<typeof memoized, "cache" | "getKey"> = fn;
+
+      const _r1: number = fn(1);
+      const _r2: string = fn("1");
+      // @ts-expect-error Type 'string' is not assignable to type 'number'.
+      const _r3: number = fn("1");
+
+      const _fn4: typeof fn<number> = (n: number) => n;
+      // @ts-expect-error Type 'string' is not assignable to type 'number'.
+      const _fn5: typeof fn<string> = (n: number) => n;
+    });
+  });
+});

--- a/cache/mod.ts
+++ b/cache/mod.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+export * from "./memoize.ts";
+export * from "./lru_cache.ts";

--- a/deno.json
+++ b/deno.json
@@ -52,6 +52,7 @@
     "./assert",
     "./async",
     "./bytes",
+    "./cache",
     "./cli",
     "./collections",
     "./crypto",


### PR DESCRIPTION
Closes https://github.com/denoland/deno_std/issues/4608

Some questions:

* Which methods should count as accessing/using an entry stored in an `LruCache`? Currently, all three of `get`, `set`, and `has` are tracked. In other words, when deleting the "least-recently-used", it means deleting the entry that was least-recently touched by any of `get`, `set`, or `has`.
* Is "on-the-fly" usage even worth supporting? It adds a small amount of complexity to the implementation and allows `memoize(fn)(arg)` to be memoized, with the following gotcha:
```js
// ✅ reference to function
const fn1 = memoize(fn)
const result1 = fn1(42)

// ✅ function literal
const fn2 = memoize((n: number) => n + 1)
const result2 = fn1(42)

// ✅ on-the-fly with reference to function
const result3 = memoize(fn)(42)

// ⚠️ on-the-fly with function literal - fails to memoize
const result4 = memoize((n: number) => n + 1)(42)
```