### PR TITLE
chore: update `title.yml`

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -33,7 +33,7 @@ jobs:
             ci
             chore
             revert
-          # This should be kept up-to-date with the packages in the Standard
+          # This should be kept up-to-date with the current packages list
           scopes: |
             archive
             assert

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -34,24 +34,23 @@ jobs:
             chore
             revert
           # This should be kept up-to-date with the packages in the Standard
-          # Library (except `_tools`).
           scopes: |
-            _tools
             archive
             assert
             async
             bytes
+            cache
             cli
             collections
             crypto
             csv
-            data_structures
+            data-structures
             datetime
             dotenv
             encoding
             expect
             fmt
-            front_matter
+            front-matter
             fs
             html
             http
@@ -61,7 +60,7 @@ jobs:
             json
             jsonc
             log
-            media_types
+            media-types
             msgpack
             net
             path


### PR DESCRIPTION
- Changed snake_case names to kebab-case for scope names. [The version upgrade tool](https://github.com/denoland/bump-workspaces) assumes these match with JSR package name.
- Removed `_tools` scope as it's not jsr package. I think we should use non-scoped `chore:` for tool updates.
- Added `cache` to make #4725 CI green.