### PR TITLE
test(cli): reduce flakiness of spinner test

### DIFF
--- a/cli/spinner_test.ts
+++ b/cli/spinner_test.ts
@@ -33,7 +33,7 @@ Deno.test("Spinner constructor accepts spinner", async () => {
   ]);
   const actual = normalizeString(text);
 
-  assert(actual.startsWith("0 1 2 3 4 5 6"));
+  assertStringIncludes(actual, "0 1 2 3 4 5 6");
 });
 
 Deno.test("Spinner constructor accepts message", async () => {

--- a/cli/spinner_test.ts
+++ b/cli/spinner_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertGreater, assertLess } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertLess,
+  assertStringIncludes,
+} from "@std/assert";
 import { Spinner } from "./spinner.ts";
 
 async function spawnDeno(args: string[], opts?: Deno.CommandOptions) {
@@ -130,7 +136,7 @@ Deno.test("Spinner.color can set each color", async () => {
     `${LINE_CLEAR}\u001b[31m⠙${COLOR_RESET} ` + // Red
     `${LINE_CLEAR}\u001b[32m⠹${COLOR_RESET} `; // Green
 
-  assertEquals(text, expectedStr);
+  assertStringIncludes(text, expectedStr);
 });
 
 Deno.test("Spinner.color can get each color", () => {

--- a/cli/testdata/spinner_cases/set_color.ts
+++ b/cli/testdata/spinner_cases/set_color.ts
@@ -8,4 +8,4 @@ spinner.color = "black";
 setTimeout(() => spinner.color = "red", 125); // 150
 setTimeout(() => spinner.color = "green", 200); // 225
 
-setTimeout(spinner.stop, 250);
+setTimeout(spinner.stop, 350);


### PR DESCRIPTION
Updates spinner test. Now the test case waits longer time (350ms) to make sure green text appearing

closes #4734 