### PR TITLE
test(encoding): improve test coverage

### DIFF
--- a/encoding/base32_test.ts
+++ b/encoding/base32_test.ts
@@ -110,6 +110,7 @@ Deno.test({
   fn() {
     assertThrows(
       () => decodeBase32("OOOO=="),
+      Error,
       "Invalid string. Length must be a multiple of 8",
     );
   },
@@ -119,7 +120,8 @@ Deno.test({
   name: "decodeBase32() throws on bad padding",
   fn() {
     assertThrows(
-      () => decodeBase32("OOOO=="),
+      () => decodeBase32("5HXR334AQYAAAA=="),
+      Error,
       "Invalid pad length",
     );
   },

--- a/encoding/base58_test.ts
+++ b/encoding/base58_test.ts
@@ -67,6 +67,7 @@ Deno.test("decodeBase58() decodes binary", () => {
 Deno.test("decodeBase58() throws on invalid input", () => {
   assertThrows(
     () => decodeBase58("+2NEpo7TZRRrLZSi2U"),
+    Error,
     `Invalid base58 char at index 0 with value +`,
   );
 });


### PR DESCRIPTION
The `encoding` sub-module is now fully covered.

Towards: #3713