### PR TITLE
fix(expect): updated error message for toContain

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -417,13 +417,17 @@ export function toContainEqual(
   if (context.isNot) {
     if (doesContain) {
       throw new AssertionError(
-        `The value ${fmtValue} contains the expected item ${fmtExpected}`,
+        `The value contains the expected item.
+Value: ${fmtValue}
+Expected: ${fmtExpected}`,
       );
     }
   } else {
     if (!doesContain) {
       throw new AssertionError(
-        `The value ${fmtValue} doesn't contain the expected item ${fmtExpected}`,
+        `The value doesn't contain the expected item.
+Value: ${fmtValue}
+Expected: ${fmtExpected}`,
       );
     }
   }

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -375,11 +375,15 @@ export function toContain(
 
   if (context.isNot) {
     if (doesContain) {
-      throw new AssertionError("The value contains the expected item");
+      throw new AssertionError(
+        `The value "${context.value}" contains the expected item "${expected}"`,
+      );
     }
   } else {
     if (!doesContain) {
-      throw new AssertionError("The value doesn't contain the expected item");
+      throw new AssertionError(
+        `The value "${context.value}" doesn't contain the expected item "${expected}"`,
+      );
     }
   }
 }

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -35,7 +35,10 @@ export function toEqual(
   const e = expected;
   const equalsOptions = buildEqualOptions({
     ...context,
-    customTesters: [...context.customTesters, iterableEquality],
+    customTesters: [
+      ...context.customTesters,
+      iterableEquality,
+    ],
   });
 
   if (context.isNot) {
@@ -52,7 +55,10 @@ export function toStrictEqual(
   const equalsOptions = buildEqualOptions({
     ...context,
     strictCheck: true,
-    customTesters: [...context.customTesters, iterableEquality],
+    customTesters: [
+      ...context.customTesters,
+      iterableEquality,
+    ],
   });
 
   if (context.isNot) {
@@ -102,34 +108,50 @@ export function toBeDefined(context: MatcherContext): MatchResult {
 
 export function toBeUndefined(context: MatcherContext): MatchResult {
   if (context.isNot) {
-    assertNotStrictEquals(context.value, undefined, context.customMessage);
+    assertNotStrictEquals(
+      context.value,
+      undefined,
+      context.customMessage,
+    );
   } else {
     assertStrictEquals(context.value, undefined, context.customMessage);
   }
 }
 
-export function toBeFalsy(context: MatcherContext): MatchResult {
-  const isFalsy = !context.value;
+export function toBeFalsy(
+  context: MatcherContext,
+): MatchResult {
+  const isFalsy = !(context.value);
   if (context.isNot) {
     if (isFalsy) {
-      throw new AssertionError(`Expected ${context.value} to NOT be falsy`);
+      throw new AssertionError(
+        `Expected ${context.value} to NOT be falsy`,
+      );
     }
   } else {
     if (!isFalsy) {
-      throw new AssertionError(`Expected ${context.value} to be falsy`);
+      throw new AssertionError(
+        `Expected ${context.value} to be falsy`,
+      );
     }
   }
 }
 
-export function toBeTruthy(context: MatcherContext): MatchResult {
-  const isTruthy = !!context.value;
+export function toBeTruthy(
+  context: MatcherContext,
+): MatchResult {
+  const isTruthy = !!(context.value);
   if (context.isNot) {
     if (isTruthy) {
-      throw new AssertionError(`Expected ${context.value} to NOT be truthy`);
+      throw new AssertionError(
+        `Expected ${context.value} to NOT be truthy`,
+      );
     }
   } else {
     if (!isTruthy) {
-      throw new AssertionError(`Expected ${context.value} to be truthy`);
+      throw new AssertionError(
+        `Expected ${context.value} to be truthy`,
+      );
     }
   }
 }
@@ -225,15 +247,23 @@ export function toBeLessThan(
 export function toBeNaN(context: MatcherContext): MatchResult {
   const equalsOptions = buildEqualOptions(context);
   if (context.isNot) {
-    assertNotEquals(isNaN(Number(context.value)), true, {
-      ...equalsOptions,
-      msg: equalsOptions.msg || `Expected ${context.value} to not be NaN`,
-    });
+    assertNotEquals(
+      isNaN(Number(context.value)),
+      true,
+      {
+        ...equalsOptions,
+        msg: equalsOptions.msg || `Expected ${context.value} to not be NaN`,
+      },
+    );
   } else {
-    assertEquals(isNaN(Number(context.value)), true, {
-      ...equalsOptions,
-      msg: equalsOptions.msg || `Expected ${context.value} to be NaN`,
-    });
+    assertEquals(
+      isNaN(Number(context.value)),
+      true,
+      {
+        ...equalsOptions,
+        msg: equalsOptions.msg || `Expected ${context.value} to be NaN`,
+      },
+    );
   }
 }
 
@@ -306,8 +336,7 @@ export function toHaveProperty(
 
   let hasProperty;
   if (v) {
-    hasProperty = current !== undefined &&
-      propPath.length === 0 &&
+    hasProperty = current !== undefined && propPath.length === 0 &&
       equal(current, v, context);
   } else {
     hasProperty = current !== undefined && propPath.length === 0;
@@ -322,9 +351,7 @@ export function toHaveProperty(
     if (hasProperty) {
       throw new AssertionError(
         `Expected the value not to have the property ${
-          propPath.join(
-            ".",
-          )
+          propPath.join(".")
         }${ofValue}, but it does.`,
       );
     }
@@ -332,9 +359,7 @@ export function toHaveProperty(
     if (!hasProperty) {
       throw new AssertionError(
         `Expected the value to have the property ${
-          propPath.join(
-            ".",
-          )
+          propPath.join(".")
         }${ofValue}, but it does not.`,
       );
     }
@@ -419,7 +444,11 @@ export function toMatch(
   expected: RegExp,
 ): MatchResult {
   if (context.isNot) {
-    assertNotMatch(String(context.value), expected, context.customMessage);
+    assertNotMatch(
+      String(context.value),
+      expected,
+      context.customMessage,
+    );
   } else {
     assertMatch(String(context.value), expected, context.customMessage);
   }
@@ -511,9 +540,7 @@ export function toHaveBeenCalledWith(
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected mock function not to be called with ${
-          inspectArgs(
-            expected,
-          )
+          inspectArgs(expected)
         }, but it was`,
       );
     }
@@ -522,16 +549,12 @@ export function toHaveBeenCalledWith(
       let otherCalls = "";
       if (calls.length > 0) {
         otherCalls = `\n  Other calls:\n     ${
-          calls
-            .map((call) => inspectArgs(call.args))
-            .join("\n    ")
+          calls.map((call) => inspectArgs(call.args)).join("\n    ")
         }`;
       }
       throw new AssertionError(
         `Expected mock function to be called with ${
-          inspectArgs(
-            expected,
-          )
+          inspectArgs(expected)
         }, but it was not.${otherCalls}`,
       );
     }
@@ -542,15 +565,14 @@ export function toHaveBeenLastCalledWith(
   ...expected: unknown[]
 ): MatchResult {
   const calls = getMockCalls(context.value);
-  const hasBeenCalled = calls.length > 0 && equal(calls.at(-1)?.args, expected);
+  const hasBeenCalled = calls.length > 0 &&
+    equal(calls.at(-1)?.args, expected);
 
   if (context.isNot) {
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected mock function not to be last called with ${
-          inspectArgs(
-            expected,
-          )
+          inspectArgs(expected)
         }, but it was`,
       );
     }
@@ -560,17 +582,13 @@ export function toHaveBeenLastCalledWith(
       if (!lastCall) {
         throw new AssertionError(
           `Expected mock function to be last called with ${
-            inspectArgs(
-              expected,
-            )
+            inspectArgs(expected)
           }, but it was not.`,
         );
       } else {
         throw new AssertionError(
           `Expected mock function to be last called with ${
-            inspectArgs(
-              expected,
-            )
+            inspectArgs(expected)
           }, but it was last called with ${inspectArgs(lastCall.args)}.`,
         );
       }
@@ -595,9 +613,7 @@ export function toHaveBeenNthCalledWith(
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected the n-th call (n=${nth}) of mock function is not with ${
-          inspectArgs(
-            expected,
-          )
+          inspectArgs(expected)
         }, but it was`,
       );
     }
@@ -607,17 +623,13 @@ export function toHaveBeenNthCalledWith(
       if (!nthCall) {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
-            inspectArgs(
-              expected,
-            )
+            inspectArgs(expected)
           }, but the n-th call does not exist.`,
         );
       } else {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
-            inspectArgs(
-              expected,
-            )
+            inspectArgs(expected)
           }, but it was with ${inspectArgs(nthCall.args)}.`,
         );
       }
@@ -679,9 +691,7 @@ export function toHaveReturnedWith(
     if (returnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did`,
       );
     }
@@ -689,9 +699,7 @@ export function toHaveReturnedWith(
     if (!returnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did not`,
       );
     }
@@ -711,9 +719,7 @@ export function toHaveLastReturnedWith(
     if (lastReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have last returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did`,
       );
     }
@@ -721,9 +727,7 @@ export function toHaveLastReturnedWith(
     if (!lastReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have last returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did not`,
       );
     }
@@ -750,9 +754,7 @@ export function toHaveNthReturnedWith(
     if (nthReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have n-th (n=${nth}) returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did`,
       );
     }
@@ -760,9 +762,7 @@ export function toHaveNthReturnedWith(
     if (!nthReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have n-th (n=${nth}) returned with ${
-          inspectArg(
-            expected,
-          )
+          inspectArg(expected)
         }, but it did not`,
       );
     }

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -348,16 +348,19 @@ export function toContain(
   // deno-lint-ignore no-explicit-any
   const doesContain = (context.value as any)?.includes?.(expected);
 
+  const fmtValue = format(context.value);
+  const fmtExpected = format(expected);
+
   if (context.isNot) {
     if (doesContain) {
       throw new AssertionError(
-        `The value "${context.value}" contains the expected item "${expected}"`,
+        `The value ${fmtValue} contains the expected item ${fmtExpected}`,
       );
     }
   } else {
     if (!doesContain) {
       throw new AssertionError(
-        `The value "${context.value}" doesn't contain the expected item "${expected}"`,
+        `The value ${fmtValue} doesn't contain the expected item ${fmtExpected}`,
       );
     }
   }
@@ -383,24 +386,19 @@ export function toContainEqual(
       .replace(/\"|\n|\t/g, "")
       .slice(0, 100);
 
+  const fmtValue = prettyStringify(context.value);
+  const fmtExpected = prettyStringify(expected);
+
   if (context.isNot) {
     if (doesContain) {
       throw new AssertionError(
-        `The value ${
-          prettyStringify(
-            context.value,
-          )
-        } contains the expected item ${prettyStringify(expected)}`,
+        `The value ${fmtValue} contains the expected item ${fmtExpected}`,
       );
     }
   } else {
     if (!doesContain) {
       throw new AssertionError(
-        `The value ${
-          prettyStringify(
-            context.value,
-          )
-        } doesn't contain the expected item ${prettyStringify(expected)}`,
+        `The value ${fmtValue} doesn't contain the expected item ${fmtExpected}`,
       );
     }
   }

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -35,10 +35,7 @@ export function toEqual(
   const e = expected;
   const equalsOptions = buildEqualOptions({
     ...context,
-    customTesters: [
-      ...context.customTesters,
-      iterableEquality,
-    ],
+    customTesters: [...context.customTesters, iterableEquality],
   });
 
   if (context.isNot) {
@@ -55,10 +52,7 @@ export function toStrictEqual(
   const equalsOptions = buildEqualOptions({
     ...context,
     strictCheck: true,
-    customTesters: [
-      ...context.customTesters,
-      iterableEquality,
-    ],
+    customTesters: [...context.customTesters, iterableEquality],
   });
 
   if (context.isNot) {
@@ -108,50 +102,34 @@ export function toBeDefined(context: MatcherContext): MatchResult {
 
 export function toBeUndefined(context: MatcherContext): MatchResult {
   if (context.isNot) {
-    assertNotStrictEquals(
-      context.value,
-      undefined,
-      context.customMessage,
-    );
+    assertNotStrictEquals(context.value, undefined, context.customMessage);
   } else {
     assertStrictEquals(context.value, undefined, context.customMessage);
   }
 }
 
-export function toBeFalsy(
-  context: MatcherContext,
-): MatchResult {
-  const isFalsy = !(context.value);
+export function toBeFalsy(context: MatcherContext): MatchResult {
+  const isFalsy = !context.value;
   if (context.isNot) {
     if (isFalsy) {
-      throw new AssertionError(
-        `Expected ${context.value} to NOT be falsy`,
-      );
+      throw new AssertionError(`Expected ${context.value} to NOT be falsy`);
     }
   } else {
     if (!isFalsy) {
-      throw new AssertionError(
-        `Expected ${context.value} to be falsy`,
-      );
+      throw new AssertionError(`Expected ${context.value} to be falsy`);
     }
   }
 }
 
-export function toBeTruthy(
-  context: MatcherContext,
-): MatchResult {
-  const isTruthy = !!(context.value);
+export function toBeTruthy(context: MatcherContext): MatchResult {
+  const isTruthy = !!context.value;
   if (context.isNot) {
     if (isTruthy) {
-      throw new AssertionError(
-        `Expected ${context.value} to NOT be truthy`,
-      );
+      throw new AssertionError(`Expected ${context.value} to NOT be truthy`);
     }
   } else {
     if (!isTruthy) {
-      throw new AssertionError(
-        `Expected ${context.value} to be truthy`,
-      );
+      throw new AssertionError(`Expected ${context.value} to be truthy`);
     }
   }
 }
@@ -247,23 +225,15 @@ export function toBeLessThan(
 export function toBeNaN(context: MatcherContext): MatchResult {
   const equalsOptions = buildEqualOptions(context);
   if (context.isNot) {
-    assertNotEquals(
-      isNaN(Number(context.value)),
-      true,
-      {
-        ...equalsOptions,
-        msg: equalsOptions.msg || `Expected ${context.value} to not be NaN`,
-      },
-    );
+    assertNotEquals(isNaN(Number(context.value)), true, {
+      ...equalsOptions,
+      msg: equalsOptions.msg || `Expected ${context.value} to not be NaN`,
+    });
   } else {
-    assertEquals(
-      isNaN(Number(context.value)),
-      true,
-      {
-        ...equalsOptions,
-        msg: equalsOptions.msg || `Expected ${context.value} to be NaN`,
-      },
-    );
+    assertEquals(isNaN(Number(context.value)), true, {
+      ...equalsOptions,
+      msg: equalsOptions.msg || `Expected ${context.value} to be NaN`,
+    });
   }
 }
 
@@ -336,7 +306,8 @@ export function toHaveProperty(
 
   let hasProperty;
   if (v) {
-    hasProperty = current !== undefined && propPath.length === 0 &&
+    hasProperty = current !== undefined &&
+      propPath.length === 0 &&
       equal(current, v, context);
   } else {
     hasProperty = current !== undefined && propPath.length === 0;
@@ -351,7 +322,9 @@ export function toHaveProperty(
     if (hasProperty) {
       throw new AssertionError(
         `Expected the value not to have the property ${
-          propPath.join(".")
+          propPath.join(
+            ".",
+          )
         }${ofValue}, but it does.`,
       );
     }
@@ -359,7 +332,9 @@ export function toHaveProperty(
     if (!hasProperty) {
       throw new AssertionError(
         `Expected the value to have the property ${
-          propPath.join(".")
+          propPath.join(
+            ".",
+          )
         }${ofValue}, but it does not.`,
       );
     }
@@ -403,13 +378,30 @@ export function toContainEqual(
     }
   }
 
+  const prettyStringify = (js: unknown) =>
+    JSON.stringify(js, null, "\t")
+      .replace(/\"|\n|\t/g, "")
+      .slice(0, 100);
+
   if (context.isNot) {
     if (doesContain) {
-      throw new AssertionError("The value contains the expected item");
+      throw new AssertionError(
+        `The value ${
+          prettyStringify(
+            context.value,
+          )
+        } contains the expected item ${prettyStringify(expected)}`,
+      );
     }
   } else {
     if (!doesContain) {
-      throw new AssertionError("The value doesn't contain the expected item");
+      throw new AssertionError(
+        `The value ${
+          prettyStringify(
+            context.value,
+          )
+        } doesn't contain the expected item ${prettyStringify(expected)}`,
+      );
     }
   }
 }
@@ -429,11 +421,7 @@ export function toMatch(
   expected: RegExp,
 ): MatchResult {
   if (context.isNot) {
-    assertNotMatch(
-      String(context.value),
-      expected,
-      context.customMessage,
-    );
+    assertNotMatch(String(context.value), expected, context.customMessage);
   } else {
     assertMatch(String(context.value), expected, context.customMessage);
   }
@@ -525,7 +513,9 @@ export function toHaveBeenCalledWith(
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected mock function not to be called with ${
-          inspectArgs(expected)
+          inspectArgs(
+            expected,
+          )
         }, but it was`,
       );
     }
@@ -534,12 +524,16 @@ export function toHaveBeenCalledWith(
       let otherCalls = "";
       if (calls.length > 0) {
         otherCalls = `\n  Other calls:\n     ${
-          calls.map((call) => inspectArgs(call.args)).join("\n    ")
+          calls
+            .map((call) => inspectArgs(call.args))
+            .join("\n    ")
         }`;
       }
       throw new AssertionError(
         `Expected mock function to be called with ${
-          inspectArgs(expected)
+          inspectArgs(
+            expected,
+          )
         }, but it was not.${otherCalls}`,
       );
     }
@@ -550,14 +544,15 @@ export function toHaveBeenLastCalledWith(
   ...expected: unknown[]
 ): MatchResult {
   const calls = getMockCalls(context.value);
-  const hasBeenCalled = calls.length > 0 &&
-    equal(calls.at(-1)?.args, expected);
+  const hasBeenCalled = calls.length > 0 && equal(calls.at(-1)?.args, expected);
 
   if (context.isNot) {
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected mock function not to be last called with ${
-          inspectArgs(expected)
+          inspectArgs(
+            expected,
+          )
         }, but it was`,
       );
     }
@@ -567,13 +562,17 @@ export function toHaveBeenLastCalledWith(
       if (!lastCall) {
         throw new AssertionError(
           `Expected mock function to be last called with ${
-            inspectArgs(expected)
+            inspectArgs(
+              expected,
+            )
           }, but it was not.`,
         );
       } else {
         throw new AssertionError(
           `Expected mock function to be last called with ${
-            inspectArgs(expected)
+            inspectArgs(
+              expected,
+            )
           }, but it was last called with ${inspectArgs(lastCall.args)}.`,
         );
       }
@@ -598,7 +597,9 @@ export function toHaveBeenNthCalledWith(
     if (hasBeenCalled) {
       throw new AssertionError(
         `Expected the n-th call (n=${nth}) of mock function is not with ${
-          inspectArgs(expected)
+          inspectArgs(
+            expected,
+          )
         }, but it was`,
       );
     }
@@ -608,13 +609,17 @@ export function toHaveBeenNthCalledWith(
       if (!nthCall) {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
-            inspectArgs(expected)
+            inspectArgs(
+              expected,
+            )
           }, but the n-th call does not exist.`,
         );
       } else {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
-            inspectArgs(expected)
+            inspectArgs(
+              expected,
+            )
           }, but it was with ${inspectArgs(nthCall.args)}.`,
         );
       }
@@ -676,7 +681,9 @@ export function toHaveReturnedWith(
     if (returnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did`,
       );
     }
@@ -684,7 +691,9 @@ export function toHaveReturnedWith(
     if (!returnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did not`,
       );
     }
@@ -704,7 +713,9 @@ export function toHaveLastReturnedWith(
     if (lastReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have last returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did`,
       );
     }
@@ -712,7 +723,9 @@ export function toHaveLastReturnedWith(
     if (!lastReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have last returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did not`,
       );
     }
@@ -739,7 +752,9 @@ export function toHaveNthReturnedWith(
     if (nthReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to not have n-th (n=${nth}) returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did`,
       );
     }
@@ -747,7 +762,9 @@ export function toHaveNthReturnedWith(
     if (!nthReturnedWithExpected) {
       throw new AssertionError(
         `Expected the mock function to have n-th (n=${nth}) returned with ${
-          inspectArg(expected)
+          inspectArg(
+            expected,
+          )
         }, but it did not`,
       );
     }

--- a/expect/_to_contain_equal_test.ts
+++ b/expect/_to_contain_equal_test.ts
@@ -14,14 +14,14 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).toContainEqual({ bar: 42 });
     },
     AssertionError,
-    "{bar: 42}",
+    "The value [{foo: 42},{bar: 43},{baz: 44}] doesn't contain the expected item {bar: 42}"
   );
 
   assertThrows(
     () => {
-      expect(arr).toContainEqual({ bar: 42 });
+      expect(arr).not.toContainEqual({ foo: 42 });
     },
     AssertionError,
-    "{foo: 42},{bar: 43},{baz: 44}",
+    "The value [{foo: 42},{bar: 43},{baz: 44}] contains the expected item {foo: 42}"
   );
 });

--- a/expect/_to_contain_equal_test.ts
+++ b/expect/_to_contain_equal_test.ts
@@ -9,11 +9,19 @@ Deno.test("expect().toContainEqual()", () => {
 
   expect(arr).not.toContainEqual({ bar: 42 });
 
-  assertThrows(() => {
-    expect(arr).toContainEqual({ bar: 42 });
-  }, AssertionError);
+  assertThrows(
+    () => {
+      expect(arr).toContainEqual({ bar: 42 });
+    },
+    AssertionError,
+    "{bar: 42}",
+  );
 
-  assertThrows(() => {
-    expect(arr).not.toContainEqual({ bar: 43 });
-  }, AssertionError);
+  assertThrows(
+    () => {
+      expect(arr).toContainEqual({ bar: 42 });
+    },
+    AssertionError,
+    "{foo: 42},{bar: 43},{baz: 44}",
+  );
 });

--- a/expect/_to_contain_equal_test.ts
+++ b/expect/_to_contain_equal_test.ts
@@ -14,7 +14,9 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).toContainEqual({ bar: 42 });
     },
     AssertionError,
-    "The value [{foo: 42},{bar: 43},{baz: 44}] doesn't contain the expected item {bar: 42}",
+    `The value doesn't contain the expected item.
+Value: [{foo: 42},{bar: 43},{baz: 44}]
+Expected: {bar: 42}`,
   );
 
   assertThrows(
@@ -22,6 +24,8 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).not.toContainEqual({ foo: 42 });
     },
     AssertionError,
-    "The value [{foo: 42},{bar: 43},{baz: 44}] contains the expected item {foo: 42}",
+    `The value contains the expected item.
+Value: [{foo: 42},{bar: 43},{baz: 44}]
+Expected: {foo: 42}`,
   );
 });

--- a/expect/_to_contain_equal_test.ts
+++ b/expect/_to_contain_equal_test.ts
@@ -14,7 +14,7 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).toContainEqual({ bar: 42 });
     },
     AssertionError,
-    "The value [{foo: 42},{bar: 43},{baz: 44}] doesn't contain the expected item {bar: 42}"
+    "The value [{foo: 42},{bar: 43},{baz: 44}] doesn't contain the expected item {bar: 42}",
   );
 
   assertThrows(
@@ -22,6 +22,6 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).not.toContainEqual({ foo: 42 });
     },
     AssertionError,
-    "The value [{foo: 42},{bar: 43},{baz: 44}] contains the expected item {foo: 42}"
+    "The value [{foo: 42},{bar: 43},{baz: 44}] contains the expected item {foo: 42}",
   );
 });

--- a/expect/_to_contain_test.ts
+++ b/expect/_to_contain_test.ts
@@ -15,9 +15,20 @@ Deno.test("expect().toContain()", () => {
   assertThrows(() => {
     expect(arr).toContain(4);
   }, AssertionError);
-  assertThrows(() => {
-    expect("foobarbaz").toContain("qux");
-  }, AssertionError);
+  assertThrows(
+    () => {
+      expect("foobarbaz").toContain("qux");
+    },
+    AssertionError,
+    "foobarbaz",
+  );
+  assertThrows(
+    () => {
+      expect("foobarbaz").toContain("qux");
+    },
+    AssertionError,
+    "qux",
+  );
 
   assertThrows(() => {
     expect(arr).not.toContain(2);

--- a/expect/_to_contain_test.ts
+++ b/expect/_to_contain_test.ts
@@ -20,20 +20,17 @@ Deno.test("expect().toContain()", () => {
       expect("foobarbaz").toContain("qux");
     },
     AssertionError,
-    "foobarbaz",
-  );
-  assertThrows(
-    () => {
-      expect("foobarbaz").toContain("qux");
-    },
-    AssertionError,
-    "qux",
+    `The value "foobarbaz" doesn\'t contain the expected item "qux"`,
   );
 
   assertThrows(() => {
     expect(arr).not.toContain(2);
   }, AssertionError);
-  assertThrows(() => {
-    expect("foobarbaz").not.toContain("bar");
-  }, AssertionError);
+  assertThrows(
+    () => {
+      expect("foobarbaz").not.toContain("bar");
+    },
+    AssertionError,
+    `The value "foobarbaz" contains the expected item "bar"`,
+  );
 });

--- a/expect/_to_contain_test.ts
+++ b/expect/_to_contain_test.ts
@@ -20,7 +20,7 @@ Deno.test("expect().toContain()", () => {
       expect("foobarbaz").toContain("qux");
     },
     AssertionError,
-    `The value "foobarbaz" doesn\'t contain the expected item "qux"`,
+    `The value "foobarbaz" doesn't contain the expected item "qux"`
   );
 
   assertThrows(() => {

--- a/expect/_to_contain_test.ts
+++ b/expect/_to_contain_test.ts
@@ -20,7 +20,7 @@ Deno.test("expect().toContain()", () => {
       expect("foobarbaz").toContain("qux");
     },
     AssertionError,
-    `The value "foobarbaz" doesn't contain the expected item "qux"`
+    `The value "foobarbaz" doesn't contain the expected item "qux"`,
   );
 
   assertThrows(() => {
@@ -31,6 +31,6 @@ Deno.test("expect().toContain()", () => {
       expect("foobarbaz").not.toContain("bar");
     },
     AssertionError,
-    'The value "foobarbaz" contains the expected item "bar"'
+    'The value "foobarbaz" contains the expected item "bar"',
   );
 });

--- a/expect/_to_contain_test.ts
+++ b/expect/_to_contain_test.ts
@@ -31,6 +31,6 @@ Deno.test("expect().toContain()", () => {
       expect("foobarbaz").not.toContain("bar");
     },
     AssertionError,
-    `The value "foobarbaz" contains the expected item "bar"`,
+    'The value "foobarbaz" contains the expected item "bar"'
   );
 });


### PR DESCRIPTION
See issue: #4659 

Updated error message `toContain` to include the values from the failed test.

~~Should we also add this to `toContainEqual`?~~

For `toContainEqual` we need to come to an agreement for how to format that.