### PR TITLE
refactor(assert,internal): rename `diffstr()` to `diffStr()`

### DIFF
--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 import { equal } from "./equal.ts";
-import { buildMessage, diff, diffstr, format } from "@std/internal";
+import { buildMessage, diff, diffStr, format } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
 
 /**
@@ -39,7 +39,7 @@ export function assertEquals<T>(
   const stringDiff = (typeof actual === "string") &&
     (typeof expected === "string");
   const diffResult = stringDiff
-    ? diffstr(actual as string, expected as string)
+    ? diffStr(actual as string, expected as string)
     : diff(actualString.split("\n"), expectedString.split("\n"));
   const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
   message = `${message}\n${diffMsg}`;

--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
-import { buildMessage, diff, diffstr, format, red } from "@std/internal";
+import { buildMessage, diff, diffStr, format, red } from "@std/internal";
 import { AssertionError } from "./assertion_error.ts";
 
 /**
@@ -48,7 +48,7 @@ export function assertStrictEquals<T>(
     const stringDiff = (typeof actual === "string") &&
       (typeof expected === "string");
     const diffResult = stringDiff
-      ? diffstr(actual as string, expected as string)
+      ? diffStr(actual as string, expected as string)
       : diff(actualString.split("\n"), expectedString.split("\n"));
     const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
     message = `Values are not strictly equal${msgSuffix}\n${diffMsg}`;

--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { buildMessage, diff, diffstr, format } from "@std/internal";
+import { buildMessage, diff, diffStr, format } from "@std/internal";
 import type { EqualOptions } from "./_types.ts";
 
 type EqualErrorMessageOptions = Pick<
@@ -26,7 +26,7 @@ export function buildEqualErrorMessage<T>(
 
   const stringDiff = isString(actual) && isString(expected);
   const diffResult = stringDiff
-    ? diffstr(actual, expected)
+    ? diffStr(actual, expected)
     : diff(actualString.split("\n"), expectedString.split("\n"));
   const diffMsg = buildMessage(diffResult, { stringDiff }).join("\n");
   message = `${message}\n${diffMsg}`;

--- a/internal/build_message.ts
+++ b/internal/build_message.ts
@@ -69,9 +69,9 @@ export interface BuildMessageOptions {
  *
  * @example Usage
  * ```ts
- * import { diffstr, buildMessage } from "@std/internal";
+ * import { diffStr, buildMessage } from "@std/internal";
  *
- * const diffResult = diffstr("Hello, world!", "Hello, world");
+ * const diffResult = diffStr("Hello, world!", "Hello, world");
  *
  * console.log(buildMessage(diffResult));
  * // [

--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -109,10 +109,10 @@ function createDetails(
  *
  * @example Usage
  * ```ts
- * import { diffstr } from "@std/internal/diff-str";
+ * import { diffStr } from "@std/internal/diff-str";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * assertEquals(diffstr("Hello!", "Hello"), [
+ * assertEquals(diffStr("Hello!", "Hello"), [
  *   {
  *     type: "removed",
  *     value: "Hello!\n",
@@ -133,7 +133,7 @@ function createDetails(
  * ]);
  * ```
  */
-export function diffstr(A: string, B: string): DiffResult<string>[] {
+export function diffStr(A: string, B: string): DiffResult<string>[] {
   // Compute multi-line diff
   const diffResult = diff(
     tokenize(`${unescape(A)}\n`),

--- a/internal/diff_str_test.ts
+++ b/internal/diff_str_test.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { diffstr } from "./diff_str.ts";
+import { diffStr } from "./diff_str.ts";
 import { assertEquals } from "@std/assert/assert-equals";
 
 Deno.test({
-  name: 'diff() "a b c d" vs "a b x d e" (diffstr)',
+  name: 'diff() "a b c d" vs "a b x d e" (diffStr)',
   fn() {
-    const diffResult = diffstr(
+    const diffResult = diffStr(
       [..."abcd"].join("\n"),
       [..."abxde"].join("\n"),
     );
@@ -57,9 +57,9 @@ Deno.test({
 });
 
 Deno.test({
-  name: `diff() "3.14" vs "2.71" (diffstr)`,
+  name: `diff() "3.14" vs "2.71" (diffStr)`,
   fn() {
-    const diffResult = diffstr("3.14", "2.71");
+    const diffResult = diffStr("3.14", "2.71");
     assertEquals(diffResult, [
       {
         type: "removed",
@@ -110,9 +110,9 @@ Deno.test({
 });
 
 Deno.test({
-  name: `diff() single line "a b" vs "c d" (diffstr)`,
+  name: `diff() single line "a b" vs "c d" (diffStr)`,
   fn() {
-    const diffResult = diffstr("a b", "c d");
+    const diffResult = diffStr("a b", "c d");
     assertEquals(diffResult, [
       {
         type: "removed",
@@ -139,9 +139,9 @@ Deno.test({
 });
 
 Deno.test({
-  name: `diff() single line, different word length "a bc" vs "cd e" (diffstr)`,
+  name: `diff() single line, different word length "a bc" vs "cd e" (diffStr)`,
   fn() {
-    const diffResult = diffstr("a bc", "cd e");
+    const diffResult = diffStr("a bc", "cd e");
     assertEquals(diffResult, [
       {
         type: "removed",
@@ -168,9 +168,9 @@ Deno.test({
 });
 
 Deno.test({
-  name: `diff() "\\b\\f\\r\\t\\v\\n" vs "\\r\\n" (diffstr)`,
+  name: `diff() "\\b\\f\\r\\t\\v\\n" vs "\\r\\n" (diffStr)`,
   fn() {
-    const diffResult = diffstr("\b\f\r\t\v\n", "\r\n");
+    const diffResult = diffStr("\b\f\r\t\v\n", "\r\n");
     assertEquals(diffResult, [
       {
         type: "removed",
@@ -211,7 +211,7 @@ Deno.test({
 Deno.test({
   name: "diff() multiline with more removed lines",
   fn() {
-    const diffResult = diffstr("a\na", "e");
+    const diffResult = diffStr("a\na", "e");
     assertEquals(diffResult, [
       {
         type: "removed",

--- a/internal/mod.ts
+++ b/internal/mod.ts
@@ -6,7 +6,7 @@
  * Note: this module is for internal use only and should not be used directly.
  *
  * ```ts
- * import { diff, diffstr, buildMessage } from "@std/internal";
+ * import { diff, diffStr, buildMessage } from "@std/internal";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
  * const a = [1, 2, 3];
@@ -19,7 +19,7 @@
  *   { type: "added", value: 4 },
  * ]);
  *
- * const diffResult = diffstr("Hello, world!", "Hello, world");
+ * const diffResult = diffStr("Hello, world!", "Hello, world");
  *
  * console.log(buildMessage(diffResult));
  * // [

--- a/internal/mod.ts
+++ b/internal/mod.ts
@@ -5,6 +5,35 @@
  *
  * Note: this module is for internal use only and should not be used directly.
  *
+ * ```ts
+ * import { diff, diffstr, buildMessage } from "@std/internal";
+ * import { assertEquals } from "@std/assert/assert-equals";
+ *
+ * const a = [1, 2, 3];
+ * const b = [1, 2, 4];
+ *
+ * assertEquals(diff(a, b), [
+ *   { type: "common", value: 1 },
+ *   { type: "common", value: 2 },
+ *   { type: "removed", value: 3 },
+ *   { type: "added", value: 4 },
+ * ]);
+ *
+ * const diffResult = diffstr("Hello, world!", "Hello, world");
+ *
+ * console.log(buildMessage(diffResult));
+ * // [
+ * //   "",
+ * //   "",
+ * //   "    [Diff] Actual / Expected",
+ * //   "",
+ * //   "",
+ * //   "-   Hello, world!",
+ * //   "+   Hello, world",
+ * //   "",
+ * // ]
+ * ```
+ *
  * @module
  */
 export * from "./build_message.ts";


### PR DESCRIPTION
There's no reason for this function to not adhere to the function naming convention.

Prerequisite #4757