### PR TITLE
chore: release `@std/internal@1.0.0`

### DIFF
--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/internal",
-  "version": "0.225.1",
+  "version": "1.0.0",
   "exports": {
     ".": "./mod.ts",
     "./build-message": "./build_message.ts",


### PR DESCRIPTION
related #4739 

Retry of #4741. We reverted #4741 in #4753 to fix internal dependency issue.