### PR TITLE
test(bytes): add test for negative `start` index for `indexOfNeedle()`

### DIFF
--- a/bytes/index_of_needle_test.ts
+++ b/bytes/index_of_needle_test.ts
@@ -62,3 +62,22 @@ Deno.test("indexOfNeedle() handles start index less than 0", () => {
     -1,
   );
 });
+
+Deno.test("indexOfNeedle() handles negative start index", () => {
+  assertEquals(
+    indexOfNeedle(
+      new Uint8Array([0, 1, 2, 0, 1, 2]),
+      new Uint8Array([0, 1]),
+      -3,
+    ),
+    3,
+  );
+  assertEquals(
+    indexOfNeedle(
+      new Uint8Array([0, 1, 2, 1, 1, 2]),
+      new Uint8Array([0, 1]),
+      -3,
+    ),
+    -1,
+  );
+});


### PR DESCRIPTION
Addresses https://github.com/denoland/deno_std/pull/4746#discussion_r1605477633