### PR TITLE
fix(media-types): do not expose vendored json file as public API

### DIFF
--- a/media_types/deno.json
+++ b/media_types/deno.json
@@ -9,7 +9,6 @@
     "./format-media-type": "./format_media_type.ts",
     "./get-charset": "./get_charset.ts",
     "./parse-media-type": "./parse_media_type.ts",
-    "./type-by-extension": "./type_by_extension.ts",
-    "./vendor/mime-db.v1.52.0": "./vendor/mime-db.v1.52.0.ts"
+    "./type-by-extension": "./type_by_extension.ts"
   }
 }


### PR DESCRIPTION
Currently [vendor/mime-db.v1.52.0](https://jsr.io/@std/media-types/doc/vendor/mime-db.v1.52.0/~/) is exposed as a public API, but I believe this is an error.

related https://github.com/denoland/deno_std/pull/4744/ https://github.com/denoland/deno_std/issues/4730