### PR TITLE
docs(csv,encoding,http,json,media-types,uuid): use `rfc-editor.org` for RFC links

### DIFF
--- a/csv/csv_parse_stream.ts
+++ b/csv/csv_parse_stream.ts
@@ -64,7 +64,7 @@ export type RowType<T> = T extends undefined ? string[]
  * for columns.
  *
  * A `CsvParseStream` expects input conforming to
- * {@link https://tools.ietf.org/html/rfc4180 | RFC 4180}.
+ * {@link https://www.rfc-editor.org/rfc/rfc4180.html | RFC 4180}.
  *
  * @example
  * ```ts

--- a/csv/mod.ts
+++ b/csv/mod.ts
@@ -4,7 +4,7 @@
 /** Reads and writes comma-separated values (CSV) files.
  *
  * There are many kinds of CSV files; this module supports the format described
- * in {@link https://tools.ietf.org/html/rfc4180 | RFC 4180}.
+ * in {@link https://www.rfc-editor.org/rfc/rfc4180.html | RFC 4180}.
  *
  * A csv file contains zero or more records of one or more fields per record.
  * Each record is separated by the newline character. The final record may

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -12,7 +12,7 @@
  * and not adding any delimiter. However, there are three more standards
  * supported - btoa (different delimiter and additional compression of 4 bytes
  * equal to 32), {@link https://rfc.zeromq.org/spec/32/ | Z85} and
- * {@link https://tools.ietf.org/html/rfc1924 | RFC 1924}. It's possible to use a
+ * {@link https://www.rfc-editor.org/rfc/rfc1924.html | RFC 1924}. It's possible to use a
  * different encoding by specifying it in `options` object as a second parameter.
  *
  * Similarly, it's possible to make `encode` add a delimiter (`<~` and `~>` for

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -4,7 +4,7 @@
 
 /**
  * Utilities for
- * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-6 | base32}
+ * {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-6 | base32}
  * encoding and decoding.
  *
  * Modified from {@link https://github.com/beatgammit/base64-js}.
@@ -59,7 +59,7 @@ function _byteLength(validLen: number, placeHoldersLen: number): number {
 /**
  * Decodes a base32-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-6}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-6}
  *
  * @param b32 The base32-encoded string to decode.
  * @returns The decoded data.
@@ -165,7 +165,7 @@ function encodeChunk(uint8: Uint8Array, start: number, end: number): string {
 /**
  * Converts data into a base32-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-6}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-6}
  *
  * @param data The data to encode.
  * @returns The base32-encoded string.

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -3,7 +3,7 @@
 
 /**
  * Utilities for
- * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-4 | base64}
+ * {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-4 | base64}
  * encoding and decoding.
  *
  * This module is browser compatible.
@@ -94,7 +94,7 @@ const base64abc = [
 /**
  * Converts data into a base64-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-4}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-4}
  *
  * @param data The data to encode.
  * @returns The base64-encoded string.
@@ -146,7 +146,7 @@ export function encodeBase64(data: ArrayBuffer | Uint8Array | string): string {
 /**
  * Decodes a base64-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-4}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-4}
  *
  * @param b64 The base64-encoded string to decode.
  * @returns The decoded data.

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -3,7 +3,7 @@
 
 /**
  * Utilities for
- * {@link https://datatracker.ietf.org/doc/html/rfc4648#section-5 | base64url}
+ * {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-5 | base64url}
  * encoding and decoding.
  *
  * This module is browser compatible.
@@ -47,7 +47,7 @@ function convertBase64ToBase64url(b64: string) {
 /**
  * Convert data into a base64url-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-5}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-5}
  *
  * @param data The data to encode.
  * @returns The base64url-encoded string.
@@ -68,7 +68,7 @@ export function encodeBase64Url(
 /**
  * Decodes a given base64url-encoded string.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc4648#section-5}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc4648.html#section-5}
  *
  * @param b64url The base64url-encoded string to decode.
  * @returns The decoded data.

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -8,7 +8,7 @@ import { assert } from "@std/assert/assert";
 /**
  * Represents an HTTP Cookie.
  *
- * @see {@link https://tools.ietf.org/html/rfc6265#section-4.1.1}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-4.2.1}
  */
 export interface Cookie {
   /** Name of the cookie. */
@@ -72,7 +72,7 @@ function toString(cookie: Cookie): string {
   out.push(`${cookie.name}=${cookie.value}`);
 
   // Fallback for invalid Set-Cookie
-  // ref: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00#section-3.1
+  // ref: https://www.rfc-editor.org/rfc/rfc6265.html#section-3.1
   if (cookie.name.startsWith("__Secure")) {
     cookie.secure = true;
   }
@@ -129,7 +129,7 @@ function validateName(name: string | undefined | null) {
 
 /**
  * Validate Path Value.
- * See {@link https://tools.ietf.org/html/rfc6265#section-4.1.2.4}.
+ * See {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.2.4}.
  * @param path Path value.
  */
 function validatePath(path: string | null) {
@@ -151,7 +151,7 @@ function validatePath(path: string | null) {
 
 /**
  * Validate Cookie Value.
- * See {@link https://tools.ietf.org/html/rfc6265#section-4.1}.
+ * See {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1}.
  * @param value Cookie value.
  */
 function validateValue(name: string, value: string | null) {
@@ -178,7 +178,7 @@ function validateValue(name: string, value: string | null) {
 
 /**
  * Validate Cookie Domain.
- * See {@link https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3}.
+ * See {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.2.3}.
  * @param domain Cookie domain.
  */
 function validateDomain(domain: string) {
@@ -247,7 +247,7 @@ export function getCookies(headers: Headers): Record<string, string> {
  */
 export function setCookie(headers: Headers, cookie: Cookie) {
   // Parsing cookie headers to make consistent set-cookie header
-  // ref: https://tools.ietf.org/html/rfc6265#section-4.1.1
+  // ref: https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1
   const v = toString(cookie);
   if (v) {
     headers.append("Set-Cookie", v);

--- a/json/json_parse_stream.ts
+++ b/json/json_parse_stream.ts
@@ -12,7 +12,9 @@ function isBrankString(str: string) {
 /**
  * Parse each chunk as JSON.
  *
- * This can be used to parse {@link https://jsonlines.org/ | JSON lines}, {@link http://ndjson.org/ | NDJSON} and {@link https://datatracker.ietf.org/doc/html/rfc7464 | JSON Text Sequences}.
+ * This can be used to parse {@link https://jsonlines.org/ | JSON lines},
+ * {@link http://ndjson.org/ | NDJSON} and
+ * {@link https://www.rfc-editor.org/rfc/rfc7464.html | JSON Text Sequences}.
  * Chunks consisting of spaces, tab characters, or newline characters will be ignored.
  *
  * @example

--- a/json/json_stringify_stream.ts
+++ b/json/json_stringify_stream.ts
@@ -34,7 +34,7 @@ export interface StringifyStreamOptions {
  *
  * This can be used to stringify {@link https://jsonlines.org/ | JSON lines},
  * {@link https://ndjson.org/ | NDJSON},
- * {@link https://datatracker.ietf.org/doc/html/rfc7464 | JSON Text Sequences},
+ * {@link https://www.rfc-editor.org/rfc/rfc7464.html | JSON Text Sequences},
  * and {@link https://en.wikipedia.org/wiki/JSON_streaming#Concatenated_JSON | Concatenated JSON}.
  *
  * You can optionally specify a prefix and suffix for each chunk. The default prefix is `""` and the default suffix is `"\n"`.
@@ -53,7 +53,7 @@ export interface StringifyStreamOptions {
  * ```
  *
  * @example
- * To convert to [JSON Text Sequences](https://datatracker.ietf.org/doc/html/rfc7464), set the
+ * To convert to [JSON Text Sequences](https://www.rfc-editor.org/rfc/rfc7464.html), set the
  * prefix to the delimiter "\x1E" as options.
  * ```ts
  * import { JsonStringifyStream } from "@std/json/json-stringify-stream";

--- a/media_types/format_media_type.ts
+++ b/media_types/format_media_type.ts
@@ -5,8 +5,8 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
 
 /**
  * Serializes the media type and the optional parameters as a media type
- * conforming to {@link https://www.ietf.org/rfc/rfc2045.txt | RFC 2045} and
- * {@link https://www.ietf.org/rfc/rfc2616.txt | RFC 2616}.
+ * conforming to {@link https://www.rfc-editor.org/rfc/rfc2045.html | RFC 2045} and
+ * {@link https://www.rfc-editor.org/rfc/rfc2616.html | RFC 2616}.
  *
  * The type and parameter names are written in lower-case.
  *

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -5,7 +5,7 @@ import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
 
 /**
  * Parses the media type and any optional parameters, per
- * {@link https://datatracker.ietf.org/doc/html/rfc1521 | RFC 1521}.
+ * {@link https://www.rfc-editor.org/rfc/rfc1521.html | RFC 1521}.
  *
  * Media types are the values in `Content-Type` and `Content-Disposition`
  * headers. On success the function returns a tuple where the first element is

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -6,7 +6,8 @@
  *
  * Use {@linkcode crypto.randomUUID} for v4 generating v4 UUIDs.
  *
- * Based on https://github.com/kelektiv/node-uuid -> https://www.ietf.org/rfc/rfc4122.txt
+ * Based on {@linkcode https://www.npmjs.com/package/uuid | npm:uuid}, which is
+ * based on {@link https://www.rfc-editor.org/rfc/rfc4122.html | RFC 4122}.
  *
  * Support for RFC4122 version 1, 3, 4, and 5 UUIDs
  *


### PR DESCRIPTION
`www.rfc-editor.org` seems the most official place for hosting RFCs. I think we should always use `www.rfc-editor.org` urls for the references of RFCs

ref:
- https://en.wikipedia.org/wiki/Request_for_Comments#Obtaining_RFCs
- github discussion discussing various RFC urls https://github.com/ietf-tools/datatracker/discussions/7259