### PR TITLE
chore: improve doc checker

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -1,11 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 /**
- * This script checks that all exported functions have JSDoc comments with
- * `@param`, `@return`, and `@example` tags, according to the contributing
- * guidelines.
- *
- * @see {@link https://github.com/denoland/deno_std/blob/main/.github/CONTRIBUTING.md#documentation}
+ * This script checks that all public symbols documentation aligns with the
+ * {@link ./CONTRIBUTING.md#documentation | documentation guidelines}.
  *
  * TODO(iuioiua): Add support for classes and methods.
  */
@@ -50,11 +47,6 @@ function isExported(document: DocNodeBase) {
   return document.declarationKind === "export";
 }
 
-/**
- * We only check functions that have JSDocs. We know that exported functions
- * have JSDocs thanks to `deno doc --lint`, which is used in the `lint:docs`
- * task.
- */
 function isFunctionDoc(document: DocNodeBase): document is DocNodeFunction {
   return document.kind === "function" && document.jsDoc !== undefined;
 }

--- a/deno.json
+++ b/deno.json
@@ -19,7 +19,7 @@
     "lint:circular": "deno run --allow-env --allow-read --allow-net=deno.land,jsr.io ./_tools/check_circular_package_dependencies.ts",
     "lint:mod-exports": "deno run --allow-env --allow-read ./_tools/check_mod_exports.ts",
     "lint:tools-types": "deno check _tools/*.ts",
-    "lint:docs": "deno run -A _tools/check_docs.ts && deno doc --lint collections/mod.ts bytes/mod.ts datetime/mod.ts internal/mod.ts media_types/mod.ts url/mod.ts",
+    "lint:docs": "deno doc --lint collections/mod.ts bytes/mod.ts datetime/mod.ts internal/mod.ts media_types/mod.ts url/mod.ts && deno run -A _tools/check_docs.ts",
     "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:circular && deno task lint:deprecations && deno task lint:tools-types && deno task lint:mod-exports && deno task lint:docs",
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",

--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -4,8 +4,6 @@
 import { parseMediaType } from "./parse_media_type.ts";
 import { extensions } from "./_db.ts";
 
-export { extensions };
-
 /**
  * Returns the extensions known to be associated with the media type `type`, or
  * `undefined` if no extensions are found.


### PR DESCRIPTION
This PR:
1. Swaps the command order in the `lint:docs` task so `document.jsDoc` is known to be defined in the doc checker.
2. Simplifies some of the functions in the doc checker by just passing in `document`.
3. Adds the ability for the doc checker to check if the JSDocs for exported variables contain at least one example.