### PR TITLE
fix(media-types): remove `extensions` export

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 /**
- * This script checks that all exported functions have JSDoc comments with
- * `@param`, `@return`, and `@example` tags, according to the contributing
- * guidelines.
+ * This script checks that all public symbols documentation aligns with the
+ * {@link ./CONTRIBUTING.md#documentation | documentation guidelines}.
  *
  * @see {@link https://github.com/denoland/deno_std/blob/main/.github/CONTRIBUTING.md#documentation}
  *
@@ -46,11 +45,6 @@ function assert(
   }
 }
 
-/**
- * We only check functions that have JSDocs. We know that exported functions
- * have JSDocs thanks to `deno doc --lint`, which is used in the `lint:docs`
- * task.
- */
 function isFunctionDoc(document: DocNodeBase): document is DocNodeFunction {
   return document.kind === "function" && document.jsDoc !== undefined;
 }

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -1,8 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 /**
- * This script checks that all public symbols documentation aligns with the
- * {@link ./CONTRIBUTING.md#documentation | documentation guidelines}.
+ * This script checks that all exported functions have JSDoc comments with
+ * `@param`, `@return`, and `@example` tags, according to the contributing
+ * guidelines.
  *
  * @see {@link https://github.com/denoland/deno_std/blob/main/.github/CONTRIBUTING.md#documentation}
  *
@@ -45,6 +46,11 @@ function assert(
   }
 }
 
+/**
+ * We only check functions that have JSDocs. We know that exported functions
+ * have JSDocs thanks to `deno doc --lint`, which is used in the `lint:docs`
+ * task.
+ */
 function isFunctionDoc(document: DocNodeBase): document is DocNodeFunction {
   return document.kind === "function" && document.jsDoc !== undefined;
 }

--- a/media_types/extensions_by_type.ts
+++ b/media_types/extensions_by_type.ts
@@ -4,8 +4,6 @@
 import { parseMediaType } from "./parse_media_type.ts";
 import { extensions } from "./_db.ts";
 
-export { extensions };
-
 /**
  * Returns the extensions known to be associated with the media type `type`, or
  * `undefined` if no extensions are found.


### PR DESCRIPTION
Like #4776, it looks like this variable is exported accidently.