### PR TITLE
docs(cli): improve spinner.message document

### DIFF
--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -98,7 +98,7 @@ export class Spinner {
    * }
    *
    * spinner.stop();
-   * spinner.message = "Done!";
+   * console.log("Done!");
    * ```
    */
   message: string = "";

--- a/cli/spinner_test.ts
+++ b/cli/spinner_test.ts
@@ -188,3 +188,16 @@ Deno.test("Spinner.message can be updated", async () => {
   assertStringIncludes(actual, "One dino 🦕");
   assertStringIncludes(actual, "Two dinos 🦕🦕");
 });
+
+Deno.test("Spinner.message returns the current value when updated", () => {
+  const spinner = new Spinner();
+
+  spinner.message = "Step 1";
+  assertEquals(spinner.message, "Step 1");
+
+  spinner.message = "Step 2";
+  assertEquals(spinner.message, "Step 2");
+
+  spinner.message = "Step 3";
+  assertEquals(spinner.message, "Step 3");
+});


### PR DESCRIPTION
This makes the `Spinner` in `@std/cli` expose a `message` property to be consistent with the existing `color` property. It also adds doc comments and an examples for both `message` and `color `

_NOTE: I noticed another issue while making this change. The `Color` type also includes `Ansi` which is defined as a string. However, the actual code in the set `color` property will never let you set this to anything other then a valid `COLORS` value._