### PR TITLE
chore(cli): remove outdated todo comment

### DIFF
--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -1,8 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// TODO(kt3k): Write test when pty is supported in Deno
-// See: https://github.com/denoland/deno/issues/3994
-
 const encoder = new TextEncoder();
 
 const LINE_CLEAR = encoder.encode("\r\u001b[K"); // From cli/prompt_secret.ts


### PR DESCRIPTION
This todo comment is out-of-date as the test cases of Spinner were added in this PR https://github.com/denoland/deno_std/pull/4713