### PR TITLE
BREAKING(data-structures): hide private internals

### DIFF
--- a/data_structures/_binary_search_tree_internals.ts
+++ b/data_structures/_binary_search_tree_internals.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import type { BinarySearchNode } from "./_binary_search_node.ts";
+import type { Direction } from "./_red_black_node.ts";
+import type { BinarySearchTree } from "./binary_search_tree.ts";
+
+// These are the private methods and properties that are shared between the
+// binary search tree and red-black tree implementations. They are not meant
+// to be used outside of the data structures module.
+export const internals: {
+  /** Returns the root node of the binary search tree. */
+  getRoot<T>(tree: BinarySearchTree<T>): BinarySearchNode<T> | null;
+  /** Sets the root node of the binary search tree. */
+  setRoot<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T> | null,
+  ): void;
+  getCompare<T>(tree: BinarySearchTree<T>): (a: T, b: T) => number;
+  setCompare<T>(
+    tree: BinarySearchTree<T>,
+    compare: (a: T, b: T) => number,
+  ): void;
+  findNode<T>(
+    tree: BinarySearchTree<T>,
+    value: T,
+  ): BinarySearchNode<T> | null;
+  rotateNode<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T>,
+    direction: Direction,
+  ): void;
+  insertNode<T>(
+    tree: BinarySearchTree<T>,
+    Node: typeof BinarySearchNode,
+    value: T,
+  ): BinarySearchNode<T> | null;
+  removeNode<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T>,
+  ): BinarySearchNode<T> | null;
+} = {} as typeof internals;

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -59,22 +59,28 @@ function getParentIndex(index: number) {
  */
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
-  constructor(private compare: (a: T, b: T) => number = descend) {}
-  /** Returns the underlying cloned array in arbitrary order without sorting */
+  #compare: (a: T, b: T) => number;
+
+  constructor(compare: (a: T, b: T) => number = descend) {
+    if (typeof compare !== "function") {
+      throw new TypeError(
+        "compare must be a function, did you mean to use BinaryHeap.from?",
+      );
+    }
+    this.#compare = compare;
+  }
+
   toArray(): T[] {
     return Array.from(this.#data);
   }
   /** Creates a new binary heap from an array like or iterable object. */
   static from<T>(
     collection: ArrayLike<T> | Iterable<T> | BinaryHeap<T>,
-  ): BinaryHeap<T>;
-  static from<T>(
-    collection: ArrayLike<T> | Iterable<T> | BinaryHeap<T>,
-    options: {
+    options?: {
       compare?: (a: T, b: T) => number;
     },
   ): BinaryHeap<T>;
-  static from<T, U, V>(
+  static from<T, U, V = undefined>(
     collection: ArrayLike<T> | Iterable<T> | BinaryHeap<T>,
     options: {
       compare?: (a: U, b: U) => number;
@@ -94,7 +100,7 @@ export class BinaryHeap<T> implements Iterable<T> {
     let unmappedValues: ArrayLike<T> | Iterable<T> = [];
     if (collection instanceof BinaryHeap) {
       result = new BinaryHeap(
-        options?.compare ?? (collection as unknown as BinaryHeap<U>).compare,
+        options?.compare ?? (collection as unknown as BinaryHeap<U>).#compare,
       );
       if (options?.compare || options?.map) {
         unmappedValues = collection.#data;
@@ -133,10 +139,10 @@ export class BinaryHeap<T> implements Iterable<T> {
     let left: number = right - 1;
     while (left < size) {
       const greatestChild = right === size ||
-          this.compare(this.#data[left]!, this.#data[right]!) <= 0
+          this.#compare(this.#data[left]!, this.#data[right]!) <= 0
         ? left
         : right;
-      if (this.compare(this.#data[greatestChild]!, this.#data[parent]!) < 0) {
+      if (this.#compare(this.#data[greatestChild]!, this.#data[parent]!) < 0) {
         swap(this.#data, parent, greatestChild);
         parent = greatestChild;
       } else {
@@ -155,7 +161,8 @@ export class BinaryHeap<T> implements Iterable<T> {
       let parent: number = getParentIndex(index);
       this.#data.push(value);
       while (
-        index !== 0 && this.compare(this.#data[index]!, this.#data[parent]!) < 0
+        index !== 0 &&
+        this.#compare(this.#data[index]!, this.#data[parent]!) < 0
       ) {
         swap(this.#data, parent, index);
         index = parent;

--- a/data_structures/binary_heap_test.ts
+++ b/data_structures/binary_heap_test.ts
@@ -1,8 +1,16 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { BinaryHeap } from "./binary_heap.ts";
 import { ascend, descend } from "./comparators.ts";
 import { type Container, MyMath } from "./_test_utils.ts";
+
+Deno.test("BinaryHeap throws if compare is not a function", () => {
+  assertThrows(
+    () => new BinaryHeap({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
 
 Deno.test("BinaryHeap works with default descend comparator", () => {
   const maxHeap = new BinaryHeap<number>();
@@ -337,6 +345,25 @@ Deno.test("BinaryHeap.toArray()", () => {
   const maxHeap = new BinaryHeap<number>();
   maxHeap.push(...values);
   assert(maxHeap.toArray().every((value) => values.includes(value)));
+});
+
+Deno.test("BinaryHeap.drain()", () => {
+  const values = [2, 4, 3, 5, 1];
+  const expected = [5, 4, 3, 2, 1];
+  const heap = new BinaryHeap<number>();
+  heap.push(...values);
+  assertEquals([...heap.drain()], expected);
+  assertEquals(heap.length, 0);
+});
+
+Deno.test("BinaryHeap drain copy", () => {
+  const values = [2, 4, 3, 5, 1];
+  const expected = [5, 4, 3, 2, 1];
+  const heap = new BinaryHeap<number>();
+  heap.push(...values);
+  const copy = BinaryHeap.from(heap);
+  assertEquals([...copy.drain()], expected);
+  assertEquals(heap.length, 5);
 });
 
 Deno.test("BinaryHeap.clear()", () => {

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -19,6 +19,14 @@ interface Container {
   values: number[];
 }
 
+Deno.test("BinarySearchTree throws if compare is not a function", () => {
+  assertThrows(
+    () => new BinarySearchTree({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
+
 Deno.test("BinarySearchTree handles default ascend comparator", () => {
   const trees = [
     new BinarySearchTree(),
@@ -545,15 +553,4 @@ Deno.test("BinarySearchTree.clear()", () => {
   const tree = BinarySearchTree.from([1]);
   tree.clear();
   assert(tree.isEmpty());
-});
-
-Deno.test("BinarySearchTree.rotateNode()", () => {
-  class MyTree<T> extends BinarySearchTree<T> {
-    rotateNode2() {
-      super.rotateNode(this.root!, "right");
-    }
-  }
-  const tree = new MyTree();
-  tree.insert(1);
-  assertThrows(() => tree.rotateNode2());
 });

--- a/data_structures/comparators.ts
+++ b/data_structures/comparators.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
-/** This module is browser compatible. */
 
 /** Compares its two arguments for ascending order using JavaScript's built in comparison operators. */
 export function ascend<T>(a: T, b: T): -1 | 0 | 1 {

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -1,8 +1,16 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import { RedBlackTree } from "./red_black_tree.ts";
 import { ascend, descend } from "./comparators.ts";
 import { type Container, MyMath } from "./_test_utils.ts";
+
+Deno.test("RedBlackTree throws if compare is not a function", () => {
+  assertThrows(
+    () => new RedBlackTree({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
 
 Deno.test("RedBlackTree works as expected with default ascend comparator", () => {
   const trees = [


### PR DESCRIPTION
This commit makes the internals of
`BinarySearchTree` properly private, so that
`BinarySearchNode` is not leaked in public types anymore.
