### PR TITLE
BREAKING(ini): remove internal `Formatting` type

### DIFF
--- a/ini/ini_map_test.ts
+++ b/ini/ini_map_test.ts
@@ -158,7 +158,7 @@ Deno.test({
         });
         assertObjectMatch(IniMap.from("# comment\n\ra =b").formatting, {
           commentChar: "#",
-          lineBreak: "\n\r",
+          lineBreak: "\n",
           pretty: false,
         });
       },


### PR DESCRIPTION
Seems like we should just use `FormattingOptions` here?