### PR TITLE
chore: Add a root module (`mod.ts`) to `@std/encoding`

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -1,9 +1,0 @@
-Utilities for encoding and decoding common formats like hex, base64, and varint.
-
-This module is browser compatible.
-
-```ts
-import { encodeBase64 } from "@std/encoding/base64";
-
-encodeBase64("foobar"); // "Zm9vYmFy"
-```

--- a/encoding/deno.json
+++ b/encoding/deno.json
@@ -2,6 +2,7 @@
   "name": "@std/encoding",
   "version": "0.224.1",
   "exports": {
+    ".": "./mod.ts",
     "./ascii85": "./ascii85.ts",
     "./base32": "./base32.ts",
     "./base58": "./base58.ts",

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -6,6 +6,7 @@ export * from "./base58.ts";
 export * from "./base64.ts";
 export * from "./base64url.ts";
 export * from "./hex.ts";
+// TODO: change to * after varint decode/encode functions are removed
 export {
   decodeVarint,
   decodeVarint32,

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -1,5 +1,21 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+/**
+ * Utilities for encoding and decoding common formats like hex, base64, and varint.
+ *
+ * This module is browser compatible.
+ *
+ * ```ts
+ * import { encodeBase64, decodeBase64 } from "@std/encoding";
+ * import { assertEquals } from "@std/assert/assert-equals";
+ *
+ * assertEquals(encodeBase64("foobar"), "Zm9vYmFy");
+ * assertEquals(decodeBase64("Zm9vYmFy"), "foobar");
+ * ```
+ *
+ * @module
+ */
+
 export * from "./ascii85.ts";
 export * from "./base32.ts";
 export * from "./base58.ts";

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -9,8 +9,9 @@
  * import { encodeBase64, decodeBase64 } from "@std/encoding";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * assertEquals(encodeBase64("foobar"), "Zm9vYmFy");
- * assertEquals(decodeBase64("Zm9vYmFy"), "foobar");
+ * const foobar = new TextEncoder().encode("foobar");
+ * assertEquals(encodeBase64(foobar), "Zm9vYmFy");
+ * assertEquals(decodeBase64("Zm9vYmFy"), foobar);
  * ```
  *
  * @module

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -1,0 +1,16 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+export * from "./ascii85.ts";
+export * from "./base32.ts";
+export * from "./base58.ts";
+export * from "./base64.ts";
+export * from "./base64url.ts";
+export * from "./hex.ts";
+export {
+  decodeVarint,
+  decodeVarint32,
+  encodeVarint,
+  MaxUInt64,
+  MaxVarIntLen32,
+  MaxVarIntLen64,
+} from "./varint.ts";


### PR DESCRIPTION
Currently the `@std/encoding` package is one of the few without a root module that re-exports the public symbols.

This PR adds a `mod.ts` file that re-exports the submodules in `encoding`. I diverged a bit from convention by not re-exporting _all_ public symbols, leaving out the `encode` and `decode` functions from `@std/encoding/varint`. Those functions are deprecated, and it seemed confusing to have them exported from the root.