### PR TITLE
BREAKING(data-structures): hide private internals

### DIFF
--- a/data_structures/_binary_search_tree_internals.ts
+++ b/data_structures/_binary_search_tree_internals.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import type { BinarySearchNode } from "./_binary_search_node.ts";
+import type { Direction } from "./_red_black_node.ts";
+import type { BinarySearchTree } from "./binary_search_tree.ts";
+
+// These are the private methods and properties that are shared between the
+// binary search tree and red-black tree implementations. They are not meant
+// to be used outside of the data structures module.
+export const internals: {
+  /** Returns the root node of the binary search tree. */
+  getRoot<T>(tree: BinarySearchTree<T>): BinarySearchNode<T> | null;
+  /** Sets the root node of the binary search tree. */
+  setRoot<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T> | null,
+  ): void;
+  getCompare<T>(tree: BinarySearchTree<T>): (a: T, b: T) => number;
+  setCompare<T>(
+    tree: BinarySearchTree<T>,
+    compare: (a: T, b: T) => number,
+  ): void;
+  findNode<T>(
+    tree: BinarySearchTree<T>,
+    value: T,
+  ): BinarySearchNode<T> | null;
+  rotateNode<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T>,
+    direction: Direction,
+  ): void;
+  insertNode<T>(
+    tree: BinarySearchTree<T>,
+    Node: typeof BinarySearchNode,
+    value: T,
+  ): BinarySearchNode<T> | null;
+  removeNode<T>(
+    tree: BinarySearchTree<T>,
+    node: BinarySearchNode<T>,
+  ): BinarySearchNode<T> | null;
+} = {} as typeof internals;

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -61,6 +61,7 @@ function getParentIndex(index: number) {
  */
 export class BinaryHeap<T> implements Iterable<T> {
   #data: T[] = [];
+  #compare: (a: T, b: T) => number;
 
   /**
    * Construct an empty binary heap.
@@ -79,7 +80,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    *
    * @param compare A custom comparison function to sort the values in the heap. By default, the values are sorted in descending order.
    */
-  constructor(private compare: (a: T, b: T) => number = descend) {}
+  constructor(compare: (a: T, b: T) => number = descend) {
+    this.#compare = compare;
+  }
 
   /**
    * Returns the underlying cloned array in arbitrary order without sorting.
@@ -188,7 +191,7 @@ export class BinaryHeap<T> implements Iterable<T> {
     let unmappedValues: ArrayLike<T> | Iterable<T> = [];
     if (collection instanceof BinaryHeap) {
       result = new BinaryHeap(
-        options?.compare ?? (collection as unknown as BinaryHeap<U>).compare,
+        options?.compare ?? (collection as unknown as BinaryHeap<U>).#compare,
       );
       if (options?.compare || options?.map) {
         unmappedValues = collection.#data;
@@ -284,10 +287,10 @@ export class BinaryHeap<T> implements Iterable<T> {
     let left: number = right - 1;
     while (left < size) {
       const greatestChild = right === size ||
-          this.compare(this.#data[left]!, this.#data[right]!) <= 0
+          this.#compare(this.#data[left]!, this.#data[right]!) <= 0
         ? left
         : right;
-      if (this.compare(this.#data[greatestChild]!, this.#data[parent]!) < 0) {
+      if (this.#compare(this.#data[greatestChild]!, this.#data[parent]!) < 0) {
         swap(this.#data, parent, greatestChild);
         parent = greatestChild;
       } else {
@@ -323,7 +326,8 @@ export class BinaryHeap<T> implements Iterable<T> {
       let parent: number = getParentIndex(index);
       this.#data.push(value);
       while (
-        index !== 0 && this.compare(this.#data[index]!, this.#data[parent]!) < 0
+        index !== 0 &&
+        this.#compare(this.#data[index]!, this.#data[parent]!) < 0
       ) {
         swap(this.#data, parent, index);
         index = parent;

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -81,6 +81,11 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @param compare A custom comparison function to sort the values in the heap. By default, the values are sorted in descending order.
    */
   constructor(compare: (a: T, b: T) => number = descend) {
+    if (typeof compare !== "function") {
+      throw new TypeError(
+        "compare must be a function, did you mean to use BinaryHeap.from?",
+      );
+    }
     this.#compare = compare;
   }
 

--- a/data_structures/binary_heap_test.ts
+++ b/data_structures/binary_heap_test.ts
@@ -1,8 +1,16 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { BinaryHeap } from "./binary_heap.ts";
 import { ascend, descend } from "./comparators.ts";
 import { type Container, MyMath } from "./_test_utils.ts";
+
+Deno.test("BinaryHeap throws if compare is not a function", () => {
+  assertThrows(
+    () => new BinaryHeap({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
 
 Deno.test("BinaryHeap works with default descend comparator", () => {
   const maxHeap = new BinaryHeap<number>();
@@ -337,6 +345,25 @@ Deno.test("BinaryHeap.toArray()", () => {
   const maxHeap = new BinaryHeap<number>();
   maxHeap.push(...values);
   assert(maxHeap.toArray().every((value) => values.includes(value)));
+});
+
+Deno.test("BinaryHeap.drain()", () => {
+  const values = [2, 4, 3, 5, 1];
+  const expected = [5, 4, 3, 2, 1];
+  const heap = new BinaryHeap<number>();
+  heap.push(...values);
+  assertEquals([...heap.drain()], expected);
+  assertEquals(heap.length, 0);
+});
+
+Deno.test("BinaryHeap drain copy", () => {
+  const values = [2, 4, 3, 5, 1];
+  const expected = [5, 4, 3, 2, 1];
+  const heap = new BinaryHeap<number>();
+  heap.push(...values);
+  const copy = BinaryHeap.from(heap);
+  assertEquals([...copy.drain()], expected);
+  assertEquals(heap.length, 5);
 });
 
 Deno.test("BinaryHeap.clear()", () => {

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -241,7 +241,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    */
   static from<T, U, V = undefined>(
     collection: ArrayLike<T> | Iterable<T> | BinarySearchTree<T>,
-    options?: {
+    options: {
       compare?: (a: U, b: U) => number;
       map: (value: T, index: number) => U;
       thisArg?: V;

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -116,7 +116,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * To create a binary search tree from an array like, an iterable object, or an
    * existing binary search tree, use the {@link BinarySearchTree.from} method.
    *
-   * @param compare A custom comparison function to sort the values in the tree. By default, the values are sorted in ascending order.
+   * @param compare A custom comparison function to sort the values in the tree.
+   * By default, the values are sorted in ascending order.
    */
   constructor(compare: (a: T, b: T) => number = ascend) {
     if (typeof compare !== "function") {

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -3,6 +3,7 @@
 
 import { ascend } from "./comparators.ts";
 import { BinarySearchNode } from "./_binary_search_node.ts";
+import { internals } from "./_binary_search_tree_internals.ts";
 
 type Direction = "left" | "right";
 
@@ -118,7 +119,41 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @param compare A custom comparison function to sort the values in the tree. By default, the values are sorted in ascending order.
    */
   constructor(compare: (a: T, b: T) => number = ascend) {
+    if (typeof compare !== "function") {
+      throw new TypeError(
+        "compare must be a function, did you mean to call BinarySearchTree.from?",
+      );
+    }
     this.#compare = compare;
+  }
+
+  static {
+    internals.getRoot = <T>(tree: BinarySearchTree<T>) => tree.#root;
+    internals.setRoot = <T>(
+      tree: BinarySearchTree<T>,
+      node: BinarySearchNode<T> | null,
+    ) => {
+      tree.#root = node;
+    };
+    internals.getCompare = <T>(tree: BinarySearchTree<T>) => tree.#compare;
+    internals.findNode = <T>(
+      tree: BinarySearchTree<T>,
+      value: T,
+    ): BinarySearchNode<T> | null => tree.#findNode(value);
+    internals.rotateNode = <T>(
+      tree: BinarySearchTree<T>,
+      node: BinarySearchNode<T>,
+      direction: Direction,
+    ) => tree.#rotateNode(node, direction);
+    internals.insertNode = <T>(
+      tree: BinarySearchTree<T>,
+      Node: typeof BinarySearchNode,
+      value: T,
+    ): BinarySearchNode<T> | null => tree.#insertNode(Node, value);
+    internals.removeNode = <T>(
+      tree: BinarySearchTree<T>,
+      node: BinarySearchNode<T>,
+    ): BinarySearchNode<T> | null => tree.#removeNode(node);
   }
 
   /**
@@ -287,7 +322,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
     return this.#size;
   }
 
-  protected findNode(value: T): BinarySearchNode<T> | null {
+  #findNode(value: T): BinarySearchNode<T> | null {
     let node: BinarySearchNode<T> | null = this.#root;
     while (node) {
       const order: number = this.#compare(value as T, node.value);
@@ -298,7 +333,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
     return node;
   }
 
-  protected rotateNode(node: BinarySearchNode<T>, direction: Direction) {
+  #rotateNode(node: BinarySearchNode<T>, direction: Direction) {
     const replacementDirection: Direction = direction === "left"
       ? "right"
       : "left";
@@ -323,7 +358,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
     node.parent = replacement;
   }
 
-  protected insertNode(
+  #insertNode(
     Node: typeof BinarySearchNode,
     value: T,
   ): BinarySearchNode<T> | null {
@@ -350,7 +385,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
   }
 
   /** Removes the given node, and returns the node that was physically removed from the tree. */
-  protected removeNode(
+  #removeNode(
     node: BinarySearchNode<T>,
   ): BinarySearchNode<T> | null {
     /**
@@ -400,7 +435,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @returns `true` if the value was inserted, `false` if the value already exists in the tree.
    */
   insert(value: T): boolean {
-    return !!this.insertNode(BinarySearchNode, value);
+    return !!this.#insertNode(BinarySearchNode, value);
   }
 
   /**
@@ -421,8 +456,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @returns `true` if the value was found and removed, `false` if the value was not found in the tree.
    */
   remove(value: T): boolean {
-    const node: BinarySearchNode<T> | null = this.findNode(value);
-    if (node) this.removeNode(node);
+    const node: BinarySearchNode<T> | null = this.#findNode(value);
+    if (node) this.#removeNode(node);
     return node !== null;
   }
 
@@ -444,7 +479,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @returns The value if it was found, or null if not found.
    */
   find(value: T): T | null {
-    return this.findNode(value)?.value ?? null;
+    return this.#findNode(value)?.value ?? null;
   }
 
   /**

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -19,6 +19,14 @@ interface Container {
   values: number[];
 }
 
+Deno.test("BinarySearchTree throws if compare is not a function", () => {
+  assertThrows(
+    () => new BinarySearchTree({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
+
 Deno.test("BinarySearchTree handles default ascend comparator", () => {
   const trees = [
     new BinarySearchTree(),
@@ -545,15 +553,4 @@ Deno.test("BinarySearchTree.clear()", () => {
   const tree = BinarySearchTree.from([1]);
   tree.clear();
   assert(tree.isEmpty());
-});
-
-Deno.test("BinarySearchTree.rotateNode()", () => {
-  class MyTree<T> extends BinarySearchTree<T> {
-    rotateNode2() {
-      super.rotateNode(this.root!, "right");
-    }
-  }
-  const tree = new MyTree();
-  tree.insert(1);
-  assertThrows(() => tree.rotateNode2());
 });

--- a/data_structures/comparators.ts
+++ b/data_structures/comparators.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
-/** This module is browser compatible. */
 
 /**
  * Compare two values in ascending order using JavaScript's built in comparison

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -112,11 +112,6 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * @param compare A custom comparison function for the values. The default comparison function sorts by ascending order.
    */
   constructor(compare: (a: T, b: T) => number = ascend) {
-    if (typeof compare !== "function") {
-      throw new TypeError(
-        "compare must be a function, did you mean to call RedBlackTree.from?",
-      );
-    }
     super(compare);
   }
 

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -111,9 +111,12 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    *
    * @param compare A custom comparison function for the values. The default comparison function sorts by ascending order.
    */
-  constructor(
-    compare: (a: T, b: T) => number = ascend,
-  ) {
+  constructor(compare: (a: T, b: T) => number = ascend) {
+    if (typeof compare !== "function") {
+      throw new TypeError(
+        "compare must be a function, did you mean to call RedBlackTree.from?",
+      );
+    }
     super(compare);
   }
 
@@ -219,7 +222,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
     let unmappedValues: ArrayLike<T> | Iterable<T> = [];
     if (collection instanceof RedBlackTree) {
       result = new RedBlackTree(
-        options?.compare ?? (collection as unknown as RedBlackTree<U>).compare,
+        options?.compare ?? (collection as unknown as RedBlackTree<U>).#compare,
       );
       if (options?.compare || options?.map) {
         unmappedValues = collection;

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -1,8 +1,16 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import { RedBlackTree } from "./red_black_tree.ts";
 import { ascend, descend } from "./comparators.ts";
 import { type Container, MyMath } from "./_test_utils.ts";
+
+Deno.test("RedBlackTree throws if compare is not a function", () => {
+  assertThrows(
+    () => new RedBlackTree({} as (a: number, b: number) => number),
+    TypeError,
+    "compare must be a function",
+  );
+});
 
 Deno.test("RedBlackTree works as expected with default ascend comparator", () => {
   const trees = [


### PR DESCRIPTION
This commit makes the internals of
`BinarySearchTree` is properly private so that
`BinarySearchNode` is not leaked in public types anymore.

Relands #4794
Towards #4826