### PR TITLE
fix(msgpack): error on early end of data

### DIFF
--- a/msgpack/decode.ts
+++ b/msgpack/decode.ts
@@ -37,9 +37,13 @@ function decodeString(
   pointer: { consumed: number },
 ) {
   pointer.consumed += size;
-  return decoder.decode(
-    uint8.subarray(pointer.consumed - size, pointer.consumed),
-  );
+  const u8 = uint8.subarray(pointer.consumed - size, pointer.consumed);
+  if (u8.length !== size) {
+    throw new EvalError(
+      "Messagepack decode reached end of array prematurely",
+    );
+  }
+  return decoder.decode(u8);
 }
 
 function decodeArray(
@@ -101,6 +105,9 @@ function decodeSlice(
   dataView: DataView,
   pointer: { consumed: number },
 ): ValueType {
+  if (pointer.consumed >= uint8.length) {
+    throw new EvalError("Messagepack decode reached end of array prematurely");
+  }
   const type = dataView.getUint8(pointer.consumed);
   pointer.consumed++;
 
@@ -139,23 +146,53 @@ function decodeSlice(
     case 0xc3: // true
       return true;
     case 0xc4: { // bin 8 - small Uint8Array
+      if (pointer.consumed >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint8(pointer.consumed);
       pointer.consumed++;
       const u8 = uint8.subarray(pointer.consumed, pointer.consumed + length);
+      if (u8.length !== length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       pointer.consumed += length;
       return u8;
     }
     case 0xc5: { // bin 16 - medium Uint8Array
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint16(pointer.consumed);
       pointer.consumed += 2;
       const u8 = uint8.subarray(pointer.consumed, pointer.consumed + length);
+      if (u8.length !== length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       pointer.consumed += length;
       return u8;
     }
     case 0xc6: { // bin 32 - large Uint8Array
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint32(pointer.consumed);
       pointer.consumed += 4;
       const u8 = uint8.subarray(pointer.consumed, pointer.consumed + length);
+      if (u8.length !== length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       pointer.consumed += length;
       return u8;
     }
@@ -164,51 +201,101 @@ function decodeSlice(
     case 0xc9: // ext 32 - large extension type
       throw new Error("ext not implemented yet");
     case 0xca: { // float 32
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getFloat32(pointer.consumed);
       pointer.consumed += 4;
       return value;
     }
     case 0xcb: { // float 64
+      if (pointer.consumed + 7 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getFloat64(pointer.consumed);
       pointer.consumed += 8;
       return value;
     }
     case 0xcc: { // uint 8
+      if (pointer.consumed >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getUint8(pointer.consumed);
       pointer.consumed += 1;
       return value;
     }
     case 0xcd: { // uint 16
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getUint16(pointer.consumed);
       pointer.consumed += 2;
       return value;
     }
     case 0xce: { // uint 32
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getUint32(pointer.consumed);
       pointer.consumed += 4;
       return value;
     }
     case 0xcf: { // uint 64
+      if (pointer.consumed + 7 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getBigUint64(pointer.consumed);
       pointer.consumed += 8;
       return value;
     }
     case 0xd0: { // int 8
+      if (pointer.consumed >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getInt8(pointer.consumed);
       pointer.consumed += 1;
       return value;
     }
     case 0xd1: { // int 16
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getInt16(pointer.consumed);
       pointer.consumed += 2;
       return value;
     }
     case 0xd2: { // int 32
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getInt32(pointer.consumed);
       pointer.consumed += 4;
       return value;
     }
     case 0xd3: { // int 64
+      if (pointer.consumed + 7 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const value = dataView.getBigInt64(pointer.consumed);
       pointer.consumed += 8;
       return value;
@@ -220,36 +307,71 @@ function decodeSlice(
     case 0xd8: // fixext 16 - 16 byte extension type
       throw new Error("fixext not implemented yet");
     case 0xd9: { // str 8 - small string
+      if (pointer.consumed >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint8(pointer.consumed);
       pointer.consumed += 1;
       return decodeString(uint8, length, pointer);
     }
     case 0xda: { // str 16 - medium string
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint16(pointer.consumed);
       pointer.consumed += 2;
       return decodeString(uint8, length, pointer);
     }
     case 0xdb: { // str 32 - large string
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint32(pointer.consumed);
       pointer.consumed += 4;
       return decodeString(uint8, length, pointer);
     }
     case 0xdc: { // array 16 - medium array
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint16(pointer.consumed);
       pointer.consumed += 2;
       return decodeArray(uint8, dataView, length, pointer);
     }
     case 0xdd: { // array 32 - large array
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint32(pointer.consumed);
       pointer.consumed += 4;
       return decodeArray(uint8, dataView, length, pointer);
     }
     case 0xde: { // map 16 - medium map
+      if (pointer.consumed + 1 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint16(pointer.consumed);
       pointer.consumed += 2;
       return decodeMap(uint8, dataView, length, pointer);
     }
     case 0xdf: { // map 32 - large map
+      if (pointer.consumed + 3 >= uint8.length) {
+        throw new EvalError(
+          "Messagepack decode reached end of array prematurely",
+        );
+      }
       const length = dataView.getUint32(pointer.consumed);
       pointer.consumed += 4;
       return decodeMap(uint8, dataView, length, pointer);

--- a/msgpack/decode_test.ts
+++ b/msgpack/decode_test.ts
@@ -150,3 +150,64 @@ Deno.test("decode() handles negative fixint", () => {
     assertEquals(decode(Uint8Array.of(i)), i);
   }
 });
+
+const EARLY_EOF_CASES: Record<string, number[]> = {
+  "empty input is invalid": [],
+  "fixmap with one entry, no data": [0b1000_0001],
+  "fixarray with one entry, no data": [0b1001_0001],
+  "fixstr with length 1, no data": [0b1011_0001],
+  "bin 8 with no length": [0xc4],
+  "bin 8 with length 1, no data": [0xc4, 1],
+  "bin 16 with no length": [0xc5],
+  "bin 16 with too short length": [0xc5, 0],
+  "bin 16 with length 1, no data": [0xc5, 0, 1],
+  "bin 32 with no length": [0xc6],
+  "bin 32 with too short length": [0xc6, 0, 0],
+  "bin 32 with length 1, no data": [0xc6, 0, 0, 0, 1],
+  "float 32 with no data": [0xca],
+  "float 32 with too short data": [0xca, 0x43, 0xd2, 0x58],
+  "float 64 with no data": [0xcb],
+  "float 64 with too short data": [0xcb, 0x40, 0x09, 0x21, 0xFB, 0x54],
+  "uint 8 with no data": [0xcc],
+  "uint 16 with no data": [0xcd],
+  "uint 16 with too short data": [0xcd, 0],
+  "uint 32 with no data": [0xce],
+  "uint 32 with too short data": [0xce, 0, 0],
+  "uint 64 with no data": [0xcf],
+  "uint 64 with too short data": [0xcf, 0, 0, 0, 0, 0],
+  "int 8 with no data": [0xd0],
+  "int 16 with no data": [0xd1],
+  "int 16 with too short data": [0xd1, 0],
+  "int 32 with no data": [0xd2],
+  "int 32 with too short data": [0xd2, 0, 0],
+  "int 64 with no data": [0xd3],
+  "int 64 with too short data": [0xd3, 0, 0, 0, 0, 0],
+  "str 8 with no length": [0xd9],
+  "str 8 with length 1, no data": [0xd9, 1],
+  "str 16 with no length": [0xda],
+  "str 16 with too short length": [0xda, 0],
+  "str 16 with length 1, no data": [0xda, 0, 1],
+  "str 32 with no length": [0xdb],
+  "str 32 with too short length": [0xdb, 0, 0, 0],
+  "str 32 with length 1, no data": [0xdb, 0, 0, 0, 1],
+  "array 16 with no length": [0xdc],
+  "array 16 with too short length": [0xdc, 0],
+  "array 16 with length 1, no data": [0xdc, 0, 1],
+  "array 32 with no length": [0xdd],
+  "array 32 with too short length": [0xdd, 0, 0, 0],
+  "array 32 with length 1, no data": [0xdd, 0, 0, 0, 1],
+  "map 16 with no length": [0xde],
+  "map 16 with too short length": [0xde, 0],
+  "map 16 with length 1, no data": [0xde, 0, 1],
+  "map 32 with no length": [0xdf],
+  "map 32 with too short length": [0xdf, 0, 0, 0],
+  "map 32 with length 1, no data": [0xdf, 0, 0, 0, 1],
+};
+
+Deno.test("decode() handles early end of data", async (t) => {
+  for (const name in EARLY_EOF_CASES) {
+    await t.step(name, () => {
+      assertThrows(() => decode(new Uint8Array(EARLY_EOF_CASES[name]!)));
+    });
+  }
+});


### PR DESCRIPTION
Previously data that was too short would not cause the `decode()` function to throw.

Now decoding a partial chunk will result in the `decode()` function throwing.
