### PR TITLE
test(yaml): test float handling

### DIFF
--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -240,3 +240,34 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name: "parse() handles float types",
+  fn() {
+    const yaml = `
+      - 3.14
+      - -3.14
+      - .inf
+      - -.inf
+      - .nan
+      - 12e03
+      - 1:15
+      - 1:15:20
+      - -1:15:20
+      - !!float 12000
+    `;
+
+    assertEquals(parse(yaml), [
+      3.14,
+      -3.14,
+      Infinity,
+      -Infinity,
+      NaN,
+      12000,
+      75,
+      4520,
+      -4520,
+      12000,
+    ]);
+  },
+});

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -171,3 +171,51 @@ Deno.test({
     assertEquals(stringify(object, { schema: SPACE_SCHEMA }), expected);
   },
 });
+
+Deno.test({
+  name: "stringify() handles float types",
+  fn() {
+    const floats = [
+      4.1,
+      -1.473,
+      6.82e-5,
+      6.82e-12,
+      5e-12,
+      0,
+      -0,
+    ];
+    assertEquals(
+      stringify(floats),
+      `- 4.1
+- -1.473
+- 0.0000682
+- 6.82e-12
+- 5.e-12
+- 0
+- -0.0
+`,
+    );
+    const infNaN = [Infinity, -Infinity, NaN];
+    assertEquals(
+      stringify(infNaN),
+      `- .inf
+- -.inf
+- .nan
+`,
+    );
+    assertEquals(
+      stringify(infNaN, { styles: { "tag:yaml.org,2002:float": "uppercase" } }),
+      `- .INF
+- -.INF
+- .NAN
+`,
+    );
+    assertEquals(
+      stringify(infNaN, { styles: { "tag:yaml.org,2002:float": "camelcase" } }),
+      `- .Inf
+- -.Inf
+- .NaN
+`,
+    );
+  },
+});


### PR DESCRIPTION
part of #3764 

This improves the test coverage of `std/yaml`. Added test cases which exercise the handling of floats.