### PR TITLE
test(yaml): test handling of omap

### DIFF
--- a/yaml/_type/omap.ts
+++ b/yaml/_type/omap.ts
@@ -36,7 +36,7 @@ function resolveYamlOmap(data: Any): boolean {
 }
 
 function constructYamlOmap(data: Any): Any {
-  return data !== null ? data : [];
+  return data;
 }
 
 export const omap = new Type("tag:yaml.org,2002:omap", {

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -240,3 +240,31 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name: "parse() handles omap type",
+  fn() {
+    const yaml = `--- !!omap
+- Mark McGwire: 65
+- Sammy Sosa: 63
+- Ken Griffey: 58
+`;
+    assertEquals(parse(yaml), [
+      { "Mark McGwire": 65 },
+      { "Sammy Sosa": 63 },
+      { "Ken Griffey": 58 },
+    ]);
+
+    // Invalid omap
+    // map entry is not an object
+    assertThrows(() => parse("--- !!omap\n"));
+    // map entry is not an object
+    assertThrows(() => parse("--- !!omap\n- 1"));
+    // map entry is empty object
+    assertThrows(() => parse("--- !!omap\n- {}"));
+    // map entry is an object with multiple keys
+    assertThrows(() => parse("--- !!omap\n- foo: 1\n  bar: 2"));
+    // 2 map entries have the same key
+    assertThrows(() => parse("--- !!omap\n- foo: 1\n- foo: 2"));
+  },
+});


### PR DESCRIPTION
This PR adds test cases of `yaml`, which exercises the handling `omap` type in yaml string.

related: #3713 