### PR TITLE
chore: implement custom resolver for Super Linter

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -348,8 +348,15 @@ function assertConstructorDocs(
   assertHasExampleTag(constructor);
 }
 
+function resolve(specifier: string, referrer: string): string {
+  if (specifier.startsWith("@std/") && specifier.split("/").length > 2) {
+    specifier = specifier.replace("@std/", "../").replaceAll("-", "_") + ".ts";
+  }
+  return new URL(specifier, referrer).href;
+}
+
 async function checkDocs(specifier: string) {
-  const docs = await doc(specifier);
+  const docs = await doc(specifier, { resolve });
   for (const d of docs.filter(isExported)) {
     if (d.jsDoc === undefined) continue; // this is caught by other checks
     const document = d as DocNodeWithJsDoc<DocNode>;


### PR DESCRIPTION
Previously, inter-package module imports broke the Super Linter. This change fixes that.

Pre-requisite for #4790