### PR TITLE
chore: don't require `@returns` tag when return type is type assertion

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -90,6 +90,11 @@ function isVoidOrPromiseVoid(returnType: TsTypeDef) {
       isVoid(returnType.typeRef.typeParams[0]!));
 }
 
+function isTypeAsserts(returnType: TsTypeDef) {
+  return returnType.kind === "typePredicate" &&
+    returnType.typePredicate.asserts === true;
+}
+
 function isVoid(returnType: TsTypeDef) {
   return returnType.kind === "keyword" && returnType.keyword === "void";
 }
@@ -249,7 +254,8 @@ function assertFunctionDocs(
   }
   if (
     document.functionDef.returnType !== undefined &&
-    !isVoidOrPromiseVoid(document.functionDef.returnType)
+    !isVoidOrPromiseVoid(document.functionDef.returnType) &&
+    !isTypeAsserts(document.functionDef.returnType)
   ) {
     assertHasReturnTag(document);
   }

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -92,7 +92,7 @@ function isVoidOrPromiseVoid(returnType: TsTypeDef) {
 
 function isTypeAsserts(returnType: TsTypeDef) {
   return returnType.kind === "typePredicate" &&
-    returnType.typePredicate.asserts === true;
+    returnType.typePredicate.asserts;
 }
 
 function isVoid(returnType: TsTypeDef) {


### PR DESCRIPTION
When the return type of a function is type assertion like `asserts expr`, the actual return value is undefined. We should skip requiring `@returns` doc in that case.

Example:
https://github.com/denoland/deno_std/blob/0b95598ec109a35f679b78cd92eb9573aa34ad27/assert/assert.ts#L16