### PR TITLE
fix(uuid): validate namespace UUIDs in `v3.generate()` and `v5.generate()`

### DIFF
--- a/uuid/_common.ts
+++ b/uuid/_common.ts
@@ -2,8 +2,11 @@
 // This module is browser compatible.
 
 /**
- * Converts the byte array to a UUID string
- * @param bytes Used to convert Byte to Hex
+ * Converts a hex byte array to a UUID string.
+ *
+ * @param bytes Byte array of the UUID.
+ *
+ * @returns UUID string.
  */
 export function bytesToUuid(bytes: number[] | Uint8Array): string {
   const bits = [...bytes].map((bit) => {
@@ -24,16 +27,15 @@ export function bytesToUuid(bytes: number[] | Uint8Array): string {
 }
 
 /**
- * Converts a string to a byte array by converting the hex value to a number.
+ * Converts a UUID string to a hex byte array.
+ *
  * @param uuid Value that gets converted.
+ *
+ * @returns Byte array of the UUID.
  */
 export function uuidToBytes(uuid: string): number[] {
-  const bytes: number[] = [];
-
-  uuid.replace(/[a-fA-F0-9]{2}/g, (hex: string): string => {
-    bytes.push(parseInt(hex, 16));
-    return "";
-  });
-
-  return bytes;
+  return uuid
+    .replace("-", "")
+    .match(/[a-fA-F0-9]{2}/g)!
+    .map((byte) => parseInt(byte, 16));
 }

--- a/uuid/_common.ts
+++ b/uuid/_common.ts
@@ -2,11 +2,8 @@
 // This module is browser compatible.
 
 /**
- * Converts a hex byte array to a UUID string.
- *
- * @param bytes Byte array of the UUID.
- *
- * @returns UUID string.
+ * Converts the byte array to a UUID string
+ * @param bytes Used to convert Byte to Hex
  */
 export function bytesToUuid(bytes: number[] | Uint8Array): string {
   const bits = [...bytes].map((bit) => {
@@ -27,15 +24,16 @@ export function bytesToUuid(bytes: number[] | Uint8Array): string {
 }
 
 /**
- * Converts a UUID string to a hex byte array.
- *
+ * Converts a string to a byte array by converting the hex value to a number.
  * @param uuid Value that gets converted.
- *
- * @returns Byte array of the UUID.
  */
 export function uuidToBytes(uuid: string): number[] {
-  return uuid
-    .replace("-", "")
-    .match(/[a-fA-F0-9]{2}/g)!
-    .map((byte) => parseInt(byte, 16));
+  const bytes: number[] = [];
+
+  uuid.replace(/[a-fA-F0-9]{2}/g, (hex: string): string => {
+    bytes.push(parseInt(hex, 16));
+    return "";
+  });
+
+  return bytes;
 }

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -3,8 +3,8 @@
 
 import { bytesToUuid, uuidToBytes } from "./_common.ts";
 import { concat } from "@std/bytes/concat";
-import { assert } from "@std/assert/assert";
 import { crypto } from "@std/crypto/crypto";
+import { validate as validateCommon } from "./common.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[3][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -55,12 +55,11 @@ export async function generate(
   namespace: string,
   data: Uint8Array,
 ): Promise<string> {
-  // TODO(lino-levan): validate that `namespace` is a valid UUID.
-
-  const space = uuidToBytes(namespace);
-  assert(space.length === 16, "namespace must be a valid UUID");
-
-  const toHash = concat([new Uint8Array(space), data]);
+  if (!validateCommon(namespace)) {
+    throw new TypeError("Invalid namespace UUID");
+  }
+  const namespaceBytes = uuidToBytes(namespace);
+  const toHash = concat([new Uint8Array(namespaceBytes), data]);
   const buffer = await crypto.subtle.digest("MD5", toHash);
   const bytes = new Uint8Array(buffer);
 

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -39,6 +39,8 @@ export function validate(id: string): boolean {
  *
  * @returns A UUIDv3 string.
  *
+ * @throws {TypeError} If the namespace is not a valid UUID.
+ *
  * @example Usage
  * ```ts
  * import { NAMESPACE_URL } from "@std/uuid/constants";

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -58,8 +58,8 @@ export async function generate(
   if (!validateCommon(namespace)) {
     throw new TypeError("Invalid namespace UUID");
   }
-  const namespaceBytes = uuidToBytes(namespace);
-  const toHash = concat([new Uint8Array(namespaceBytes), data]);
+  const space = uuidToBytes(namespace);
+  const toHash = concat([new Uint8Array(space), data]);
   const buffer = await crypto.subtle.digest("MD5", toHash);
   const bytes = new Uint8Array(buffer);
 

--- a/uuid/v3_test.ts
+++ b/uuid/v3_test.ts
@@ -1,10 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import {
-  assert,
-  assertEquals,
-  AssertionError,
-  assertRejects,
-} from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { generate, validate } from "./v3.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
@@ -46,7 +41,13 @@ Deno.test("validate() checks if a string is a valid v3 UUID", async () => {
 Deno.test("generate() throws on invalid namespace", async () => {
   await assertRejects(
     async () => await generate("invalid-uuid", new Uint8Array()),
-    AssertionError,
-    "namespace must be a valid UUID",
+    TypeError,
+    "Invalid namespace UUID",
+  );
+  await assertRejects(
+    async () =>
+      await generate("1b671a64-40d5-491e-99b0-da01ff1f334Z", new Uint8Array()),
+    TypeError,
+    "Invalid namespace UUID",
   );
 });

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -58,8 +58,8 @@ export async function generate(
     throw new TypeError("Invalid namespace UUID");
   }
 
-  const namespaceBytes = uuidToBytes(namespace);
-  const toHash = concat([new Uint8Array(namespaceBytes), data]);
+  const space = uuidToBytes(namespace);
+  const toHash = concat([new Uint8Array(space), data]);
   const buffer = await crypto.subtle.digest("sha-1", toHash);
   const bytes = new Uint8Array(buffer);
 

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -38,6 +38,8 @@ export function validate(id: string): boolean {
  *
  * @returns A UUIDv5 string.
  *
+ * @throws {TypeError} If the namespace is not a valid UUID.
+ *
  * @example Usage
  * ```ts
  * import { NAMESPACE_URL } from "@std/uuid/constants";

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -3,7 +3,7 @@
 
 import { bytesToUuid, uuidToBytes } from "./_common.ts";
 import { concat } from "@std/bytes/concat";
-import { assert } from "@std/assert/assert";
+import { validate as validateCommon } from "./common.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -54,12 +54,12 @@ export async function generate(
   namespace: string,
   data: Uint8Array,
 ): Promise<string> {
-  // TODO(lucacasonato): validate that `namespace` is a valid UUID.
+  if (!validateCommon(namespace)) {
+    throw new TypeError("Invalid namespace UUID");
+  }
 
-  const space = uuidToBytes(namespace);
-  assert(space.length === 16, "namespace must be a valid UUID");
-
-  const toHash = concat([new Uint8Array(space), data]);
+  const namespaceBytes = uuidToBytes(namespace);
+  const toHash = concat([new Uint8Array(namespaceBytes), data]);
   const buffer = await crypto.subtle.digest("sha-1", toHash);
   const bytes = new Uint8Array(buffer);
 

--- a/uuid/v5_test.ts
+++ b/uuid/v5_test.ts
@@ -1,10 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import {
-  assert,
-  assertEquals,
-  AssertionError,
-  assertRejects,
-} from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { generate, validate } from "./v5.ts";
 
 const NAMESPACE = "1b671a64-40d5-491e-99b0-da01ff1f3341";
@@ -46,7 +41,13 @@ Deno.test("validate() checks if a string is a valid v5 UUID", async () => {
 Deno.test("generate() throws on invalid namespace", async () => {
   await assertRejects(
     async () => await generate("invalid-uuid", new Uint8Array()),
-    AssertionError,
-    "namespace must be a valid UUID",
+    TypeError,
+    "Invalid namespace UUID",
+  );
+  await assertRejects(
+    async () =>
+      await generate("1b671a64-40d5-491e-99b0-da01ff1f334Z", new Uint8Array()),
+    TypeError,
+    "Invalid namespace UUID",
   );
 });


### PR DESCRIPTION
Previously, these `generate()` functions only checked if the namespace UUIDs were the correct length and nothing more. In other words, providing a string with the proper length but incorrect UUID format would go uncaught. It also threw an `AssertionError`, meaning that handling that error, if using these functions, would require importing `AssertionError` from `@std/assert.`

These functions now check that the namespace UUID is a valid UUID and throw a `TypeError` if it is not, making error handling a little easier, as it's a native JS error.

This is a breaking fix, as the class and message of the thrown error have changed.

Related #4865