### PR TITLE
fix(net): check `scopeid === 0` in `getNetworkAddress()`

### DIFF
--- a/net/get_network_address.ts
+++ b/net/get_network_address.ts
@@ -42,7 +42,7 @@ export function getNetworkAddress(
         // Cannot lie within 127.0.0.0/8
         ? !i.address.startsWith("127")
         // Cannot be loopback or link-local addresses
-        : !(i.address === "::1" || i.address === "fe80::1"))
+        : !(i.address === "::1" || i.address === "fe80::1") && i.scopeid === 0)
     )
     ?.address;
 }

--- a/net/get_network_address_test.ts
+++ b/net/get_network_address_test.ts
@@ -72,6 +72,14 @@ Deno.test("getNetworkAddress() works with IPv4", () => {
   assertEquals(hostname, INTERFACES[4]!.address);
 });
 
+Deno.test("getNetworkAddress() returns listenable IPv4 address", () => {
+  const hostname = getNetworkAddress();
+  // Only do this test if the network is accessible
+  if (hostname !== undefined) {
+    using _listener = Deno.listen({ hostname, port: 0 });
+  }
+});
+
 Deno.test("getNetworkAddress() works with IPv6", () => {
   using _networkInterfaces = stub(
     Deno,
@@ -80,4 +88,12 @@ Deno.test("getNetworkAddress() works with IPv6", () => {
   );
   const hostname = getNetworkAddress("IPv6");
   assertEquals(hostname, INTERFACES[5]!.address);
+});
+
+Deno.test("getNetworkAddress() returns listenable IPv6 address", () => {
+  const hostname = getNetworkAddress("IPv6");
+  // Only do this test if the network is accessible
+  if (hostname !== undefined) {
+    using _listener = Deno.listen({ hostname, port: 0 });
+  }
 });

--- a/net/get_network_address_test.ts
+++ b/net/get_network_address_test.ts
@@ -74,7 +74,7 @@ Deno.test("getNetworkAddress() works with IPv4", () => {
 
 Deno.test("getNetworkAddress() returns listenable IPv4 address", () => {
   const hostname = getNetworkAddress();
-  // Only do this test if the network is accessible
+  // Only do this test if listenable network interfaces exist
   if (hostname !== undefined) {
     using _listener = Deno.listen({ hostname, port: 0 });
   }
@@ -92,7 +92,7 @@ Deno.test("getNetworkAddress() works with IPv6", () => {
 
 Deno.test("getNetworkAddress() returns listenable IPv6 address", () => {
   const hostname = getNetworkAddress("IPv6");
-  // Only do this test if the network is accessible
+  // Only do this test if listenable network interfaces exist
   if (hostname !== undefined) {
     using _listener = Deno.listen({ hostname, port: 0 });
   }

--- a/net/get_network_address_test.ts
+++ b/net/get_network_address_test.ts
@@ -32,6 +32,15 @@ const INTERFACES: Deno.NetworkInterfaceInfo[] = [
     cidr: "fe80::1/64",
     mac: "00:00:00:00:00:00",
   },
+  {
+    family: "IPv6",
+    name: "utun2",
+    address: "fe80::7c00:d02e:f1ae:3980",
+    netmask: "ffff:ffff:ffff:ffff::",
+    scopeid: 17,
+    cidr: "fe80::7c00:d02e:f1ae:3980/64",
+    mac: "00:00:00:00:00:00"
+  },
   // Network accessible
   {
     family: "IPv4",
@@ -60,7 +69,7 @@ Deno.test("getNetworkAddress() works with IPv4", () => {
     () => INTERFACES,
   );
   const hostname = getNetworkAddress();
-  assertEquals(hostname, INTERFACES[3]!.address);
+  assertEquals(hostname, INTERFACES[4]!.address);
 });
 
 Deno.test("getNetworkAddress() works with IPv6", () => {
@@ -70,5 +79,5 @@ Deno.test("getNetworkAddress() works with IPv6", () => {
     () => INTERFACES,
   );
   const hostname = getNetworkAddress("IPv6");
-  assertEquals(hostname, INTERFACES[4]!.address);
+  assertEquals(hostname, INTERFACES[5]!.address);
 });


### PR DESCRIPTION
According to https://github.com/mafintosh/network-address/pull/3 the scopeid needs to be 0 for the address to be reachable if the family is `IPv6`.

(This is a PR targeting the feature branch, not main)