### PR TITLE
chore: exclude generated script from coverage report

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -65,8 +65,9 @@
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.17.1 --js-ext mjs --sync",
-    "cov:gen": "deno coverage coverage --lcov --output=cov.lcov",
-    "cov:view": "deno coverage --html coverage",
+    "cov": "deno coverage --ignore=\"**/*.generated.mjs\"",
+    "cov:gen": "deno task cov --lcov --output=cov.lcov",
+    "cov:view": "deno task cov --html",
     "ok": "deno task lint && deno fmt --check && deno task test:browser && deno task test"
   },
   "exclude": [


### PR DESCRIPTION
This PR excludes the generated script (by wasmbuild) from coverage report.

We don't develop these generated files. Measuring coverage of these files doesn't make much sense.

This improves the coverage of `std/crypto`.