### PR TITLE
test(crypto): test node.js custom inspection of `KeyStack`

### DIFF
--- a/crypto/unstable_keystack_test.ts
+++ b/crypto/unstable_keystack_test.ts
@@ -248,9 +248,25 @@ Deno.test({
   async fn() {
     const { inspect } = await import("node:util");
 
+    const keyStack = new KeyStack(["abcdef"]);
+
+    // Needs to overwrite Deno.customInspect symbol to enable Node's inspect
+    // deno-lint-ignore no-explicit-any
+    (keyStack as any)[Symbol.for("Deno.customInspect")] = undefined;
+
     assertEquals(
-      inspect(new KeyStack(["abcdef"])),
+      inspect(keyStack),
       `KeyStack { length: 1 }`,
+    );
+    // Check the short form
+    assertEquals(
+      inspect({ stack: [[keyStack]] }),
+      `{ stack: [ [ [KeyStack] ] ] }`,
+    );
+    // Check the case when depth is null
+    assertEquals(
+      inspect({ stack: [[keyStack]] }, { depth: null }),
+      `{ stack: [ [ KeyStack { length: 1 } ] ] }`,
     );
   },
 });


### PR DESCRIPTION
This PR updates the test case of Node.js custom inspection.

Deno uses Deno's custom inspection if `Symbol.for("Deno.customInspect")` is defined. We need to overwrite it with undefined to invoke the custom Node.js inspection. ( https://github.com/denoland/deno/blob/4f9b23b3664578c2bf48415db246fb21e49abddb/ext/console/01_console.js#L451-L465 )

This improves the code coverage of `crypto` package.