### PR TITLE
docs(http): added `--allow-sys` to file server example

### DIFF
--- a/http/mod.ts
+++ b/http/mod.ts
@@ -8,7 +8,7 @@
  * A small program for serving local files over HTTP.
  *
  * ```sh
- * deno run --allow-net --allow-read jsr:@std/http/file-server
+ * deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server
  * > HTTP server listening on http://localhost:4507/
  * ```
  *


### PR DESCRIPTION
With this new [change](https://github.com/denoland/deno_std/pull/4604), running the following script asks the user to approve Deno.networkInterfaces.

`deno run --allow-net --allow-read jsr:@std/http/file-server`

![image](https://github.com/denoland/deno_std/assets/7959437/46468670-04b0-48a7-b8ac-1017e204cc97)

Certainly they are required so not having access ends the application:

![image](https://github.com/denoland/deno_std/assets/7959437/1d6f6491-bc6f-46db-b71d-d80412688da0)

Having --allow-sys fixes the prompt

![image](https://github.com/denoland/deno_std/assets/7959437/abee719f-eaea-470d-800c-64cce3d35b7f)
