### PR TITLE
BREAKING(encoding): rename `MaxUInt64` to `MaxUint64`

### DIFF
--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -24,4 +24,3 @@ export * from "./base64.ts";
 export * from "./base64url.ts";
 export * from "./hex.ts";
 export * from "./varint.ts";
-

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -28,7 +28,7 @@ export {
   decodeVarint,
   decodeVarint32,
   encodeVarint,
-  MaxUInt64,
+  MaxUint64,
   MaxVarIntLen32,
   MaxVarIntLen64,
 } from "./varint.ts";

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -32,7 +32,7 @@
  * The maximum value of an unsigned 64-bit integer.
  * Equivalent to `2n**64n - 1n`
  */
-export const MaxUInt64 = 18446744073709551615n;
+export const MaxUint64 = 18446744073709551615n;
 
 /**
  * The maximum length, in bytes, of a VarInt encoded 64-bit integer.

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -7,7 +7,7 @@ import {
   decode,
   decode32,
   encode,
-  MaxUInt64,
+  MaxUint64,
   MaxVarIntLen64,
 } from "./varint.ts";
 
@@ -139,7 +139,7 @@ Deno.test("encodeDecode() handles BigInt", () => {
   ) {
     encodeDecode(i);
   }
-  for (let i = 0x7n; i < MaxUInt64; i <<= 1n) {
+  for (let i = 0x7n; i < MaxUint64; i <<= 1n) {
     encodeDecode(i);
   }
 });


### PR DESCRIPTION
closes #4895