### PR TITLE
fix(encoding): throw `TypeError` on invalid input

### DIFF
--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -145,7 +145,9 @@ export function decodeBase58(b58: string): Uint8Array {
     let i = 0;
 
     if (carry === undefined) {
-      throw new Error(`Invalid base58 char at index ${idx} with value ${char}`);
+      throw new TypeError(
+        `Invalid base58 char at index ${idx} with value ${char}`,
+      );
     }
 
     for (

--- a/encoding/base58_test.ts
+++ b/encoding/base58_test.ts
@@ -67,7 +67,7 @@ Deno.test("decodeBase58() decodes binary", () => {
 Deno.test("decodeBase58() throws on invalid input", () => {
   assertThrows(
     () => decodeBase58("+2NEpo7TZRRrLZSi2U"),
-    Error,
+    TypeError,
     `Invalid base58 char at index 0 with value +`,
   );
 });


### PR DESCRIPTION
This error class is typically used for invalid input.