### PR TITLE
chore: exclude 1st level items in `path` package from coverage report

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -65,7 +65,7 @@
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.17.1 --js-ext mjs --sync",
-    "cov": "deno coverage --ignore=\"**/*.generated.mjs\"",
+    "cov": "deno coverage --ignore=\"./path/*.ts,**/*.generated.mjs\"",
     "cov:gen": "deno task cov --lcov --output=cov.lcov",
     "cov:view": "deno task cov --html",
     "ok": "deno task lint && deno fmt --check && deno task test:browser && deno task test"


### PR DESCRIPTION
These files are all in the below form:

```ts
export function basename(path: string, suffix = ""): string {
  return isWindows
    ? windowsBasename(path, suffix)
    : posixBasename(path, suffix);
}
```

It's difficult to cover this function in testing because it depends on the platform. Also it's not important to track the coverage of these files because they don't have particular logic in it except branching by platform.

I think we should exclude these files from coverage report.