### PR TITLE
test(path): add test cases of `isAbsolute()`, `joinGlobs()`, and `common()`

### DIFF
--- a/path/common_test.ts
+++ b/path/common_test.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "@std/assert";
 import { common } from "./mod.ts";
+import * as posix from "./posix/mod.ts";
+import * as windows from "./windows/mod.ts";
 
 Deno.test({
   name: "common() returns shared path",
@@ -82,5 +84,35 @@ Deno.test({
       "/",
     );
     assertEquals(actual, "./deno/std/path/mod.ts");
+  },
+});
+
+Deno.test({
+  name: "windows.common() returns shared path",
+  fn() {
+    const actual = windows.common(
+      [
+        "file://deno/cli/js/deno.ts",
+        "file://deno/std/path/mod.ts",
+        "file://deno/cli/js/main.ts",
+      ],
+      "/",
+    );
+    assertEquals(actual, "file://deno/");
+  },
+});
+
+Deno.test({
+  name: "posix.common() returns shared path",
+  fn() {
+    const actual = posix.common(
+      [
+        "file://deno/cli/js/deno.ts",
+        "file://deno/std/path/mod.ts",
+        "file://deno/cli/js/main.ts",
+      ],
+      "/",
+    );
+    assertEquals(actual, "file://deno/");
   },
 });

--- a/path/is_absolute_test.ts
+++ b/path/is_absolute_test.ts
@@ -14,6 +14,7 @@ Deno.test("posix.isAbsolute()", function () {
 });
 
 Deno.test("windows.isAbsolute()", function () {
+  assertEquals(windows.isAbsolute(""), false);
   assertEquals(windows.isAbsolute("/"), true);
   assertEquals(windows.isAbsolute("//"), true);
   assertEquals(windows.isAbsolute("//server"), true);

--- a/path/join_globs_test.ts
+++ b/path/join_globs_test.ts
@@ -1,8 +1,34 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "@std/assert";
-import { joinGlobs } from "./join_globs.ts";
-import { SEPARATOR } from "./mod.ts";
+import * as windows from "./windows/mod.ts";
+import * as posix from "./posix/mod.ts";
 
-Deno.test("joinGlobs() checks options.globstar", function () {
-  assertEquals(joinGlobs(["**", ".."], { globstar: true }), `**${SEPARATOR}..`);
+Deno.test("windows.joinGlobs() joins the glob patterns", function () {
+  assertEquals(
+    windows.joinGlobs(["foo", "*", "bar"]),
+    `foo\\*\\bar`,
+  );
+  assertEquals(
+    windows.joinGlobs([""], { globstar: true }),
+    ".",
+  );
+  assertEquals(
+    windows.joinGlobs(["**", ".."], { globstar: true }),
+    `**\\..`,
+  );
+});
+
+Deno.test("windows.joinGlobs() joins the glob patterns", function () {
+  assertEquals(
+    posix.joinGlobs(["foo", "*", "bar"]),
+    `foo/*/bar`,
+  );
+  assertEquals(
+    posix.joinGlobs([""], { globstar: true }),
+    ".",
+  );
+  assertEquals(
+    posix.joinGlobs(["**", ".."], { globstar: true }),
+    `**/..`,
+  );
 });

--- a/path/posix/join_globs.ts
+++ b/path/posix/join_globs.ts
@@ -16,7 +16,6 @@ export function joinGlobs(
   if (!globstar || globs.length === 0) {
     return join(...globs);
   }
-  if (globs.length === 0) return ".";
   let joined: string | undefined;
   for (const glob of globs) {
     const path = glob;

--- a/path/windows/join_globs.ts
+++ b/path/windows/join_globs.ts
@@ -16,7 +16,6 @@ export function joinGlobs(
   if (!globstar || globs.length === 0) {
     return join(...globs);
   }
-  if (globs.length === 0) return ".";
   let joined: string | undefined;
   for (const glob of globs) {
     const path = glob;


### PR DESCRIPTION
part of #3713

This improves the test coverage of `isAboslute`, `joinGlobs`, and `common` in `path` package.