### PR TITLE
chore: remove `RUST_BACKTRACE=1` from `test` task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -53,7 +53,7 @@
     "@std/yaml": "jsr:@std/yaml@^0.224.1"
   },
   "tasks": {
-    "test": "RUST_BACKTRACE=1 deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
+    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | xargs deno check --config browser-compat.tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env ./_tools/check_deprecation.ts",


### PR DESCRIPTION
I realise this actually makes troubleshooting harder because diagnostics are difficult to understand. We can instead temporarily enable this environment variable when needed.