### PR TITLE
chore: use `--no-lock` in doc snippet eval

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -150,6 +150,7 @@ async function assertSnippetEvals(
       "eval",
       "--ext=ts",
       "--unstable-webgpu",
+      "--no-lock",
       snippet,
     ],
     stderr: "piped",


### PR DESCRIPTION
The conflicts while writing to lockfile seem causing flaky CI failures. This PR prevents it.

See https://github.com/denoland/deno_std/actions/runs/9312185249/job/25632575577?pr=4912