### PR TITLE
BREAKING(assert): make `unreachable()` consistent with `@std/assert`

### DIFF
--- a/assert/unreachable.ts
+++ b/assert/unreachable.ts
@@ -15,6 +15,7 @@ import { AssertionError } from "./assertion_error.ts";
  * @param reason The reason why the code should be unreachable.
  * @returns Never returns, always throws.
  */
-export function unreachable(reason?: string): never {
-  throw new AssertionError(reason ?? "unreachable");
+export function unreachable(msg?: string): never {
+  const msgSuffix = msg ? `: ${msg}` : ".";
+  throw new AssertionError(`Unreachable${msgSuffix}`);
 }

--- a/assert/unreachable_test.ts
+++ b/assert/unreachable_test.ts
@@ -2,10 +2,10 @@
 import { AssertionError, assertThrows, unreachable } from "./mod.ts";
 
 Deno.test("unreachable()", () => {
-  assertThrows(() => unreachable(), AssertionError, "unreachable");
+  assertThrows(() => unreachable(), AssertionError, "Unreachable.");
   assertThrows(
     () => unreachable("custom message"),
     AssertionError,
-    "custom message",
+    "Unreachable: custom message",
   );
 });


### PR DESCRIPTION
### What's changed

This change changes the format of the error message thrown in `unreachable()` to consistent with the rest of `@std/assert`. It also capitalizes the first letter of the error message.

### Why this change was made

Previously, the format of the error message `unreachable()` threw didn't have the message suffix, given by the `msg` argument, at the end of the message string, which is what the rest of `@std/assert`. This change was made for consistency.

### Migration guide

To migrate, update the logic that handles the error message:

```diff
import { unreachable } from "@std/assert/unreachable";

try {
  unreachable("Hello");
} catch (error) {
- if (error.message === "Hello") {
+ if (error.message === "Unreachable: Hello") {
    foo();
  }
}
```