### PR TITLE
BREAKING(path): remove separator argument from `common()`

### DIFF
--- a/path/_common/common.ts
+++ b/path/_common/common.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-export function _common(paths: string[], sep: string): string {
+export function common(paths: string[], sep: string): string {
   const [first = "", ...remaining] = paths;
   const parts = first.split(sep);
 

--- a/path/common.ts
+++ b/path/common.ts
@@ -1,15 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { _common } from "./_common/common.ts";
+import { common as _common } from "./_common/common.ts";
 import { SEPARATOR } from "./constants.ts";
 
 /**
- * Determines the common path from a set of paths, using an optional separator,
- * which defaults to the OS default separator.
+ * Determines the common path from a set of paths for the given OS.
  *
  * @param paths Paths to search for common path.
- * @param sep Path separator to use.
  * @returns The common path.
  *
  * @example Usage
@@ -32,9 +30,6 @@ import { SEPARATOR } from "./constants.ts";
  * }
  * ```
  */
-export function common(
-  paths: string[],
-  sep: string = SEPARATOR,
-): string {
-  return _common(paths, sep);
+export function common(paths: string[]): string {
+  return _common(paths, SEPARATOR);
 }

--- a/path/common_test.ts
+++ b/path/common_test.ts
@@ -7,13 +7,12 @@ import * as windows from "./windows/mod.ts";
 Deno.test({
   name: "common() returns shared path",
   fn() {
-    const actual = common(
+    const actual = posix.common(
       [
         "file://deno/cli/js/deno.ts",
         "file://deno/std/path/mod.ts",
         "file://deno/cli/js/main.ts",
       ],
-      "/",
     );
     assertEquals(actual, "file://deno/");
   },
@@ -22,9 +21,8 @@ Deno.test({
 Deno.test({
   name: "common() returns empty string if no shared path is present",
   fn() {
-    const actual = common(
+    const actual = posix.common(
       ["file://deno/cli/js/deno.ts", "https://deno.land/std/path/mod.ts"],
-      "/",
     );
     assertEquals(actual, "");
   },
@@ -33,13 +31,12 @@ Deno.test({
 Deno.test({
   name: "common() checks windows separator",
   fn() {
-    const actual = common(
+    const actual = windows.common(
       [
         "c:\\deno\\cli\\js\\deno.ts",
         "c:\\deno\\std\\path\\mod.ts",
         "c:\\deno\\cli\\js\\main.ts",
       ],
-      "\\",
     );
     assertEquals(actual, "c:\\deno\\");
   },
@@ -48,7 +45,7 @@ Deno.test({
 Deno.test({
   name: "common(['', '/'], '/') returns ''",
   fn() {
-    const actual = common(["", "/"], "/");
+    const actual = posix.common(["", "/"]);
     assertEquals(actual, "");
   },
 });
@@ -56,10 +53,10 @@ Deno.test({
 Deno.test({
   name: "common(['/', ''], '/') returns ''",
   fn() {
-    const actual = common([
+    const actual = posix.common([
       "/",
       "",
-    ], "/");
+    ]);
     assertEquals(actual, "");
   },
 });
@@ -67,7 +64,7 @@ Deno.test({
 Deno.test({
   name: "common() returns the first path unmodified when it's the only path",
   fn() {
-    const actual = common(["./deno/std/path/mod.ts"], "/");
+    const actual = posix.common(["./deno/std/path/mod.ts"]);
     assertEquals(actual, "./deno/std/path/mod.ts");
   },
 });
@@ -81,24 +78,8 @@ Deno.test({
         "./deno/std/path/mod.ts",
         "./deno/std/path/mod.ts",
       ],
-      "/",
     );
     assertEquals(actual, "./deno/std/path/mod.ts");
-  },
-});
-
-Deno.test({
-  name: "windows.common() returns shared path",
-  fn() {
-    const actual = windows.common(
-      [
-        "file://deno/cli/js/deno.ts",
-        "file://deno/std/path/mod.ts",
-        "file://deno/cli/js/main.ts",
-      ],
-      "/",
-    );
-    assertEquals(actual, "file://deno/");
   },
 });
 
@@ -111,7 +92,6 @@ Deno.test({
         "file://deno/std/path/mod.ts",
         "file://deno/cli/js/main.ts",
       ],
-      "/",
     );
     assertEquals(actual, "file://deno/");
   },

--- a/path/posix/common.ts
+++ b/path/posix/common.ts
@@ -1,11 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { _common } from "../_common/common.ts";
+import { common as _common } from "../_common/common.ts";
 import { SEPARATOR } from "./constants.ts";
 
-/** Determines the common path from a set of paths, using an optional separator,
- * which defaults to the OS default separator.
+/** Determines the common path from a set of paths for POSIX systems.
  *
  * @example Usage
  * ```ts
@@ -20,12 +19,8 @@ import { SEPARATOR } from "./constants.ts";
  * ```
  *
  * @param paths The paths to compare.
- * @param sep The separator to use. Defaults to `/`.
  * @returns The common path.
  */
-export function common(
-  paths: string[],
-  sep: string = SEPARATOR,
-): string {
-  return _common(paths, sep);
+export function common(paths: string[]): string {
+  return _common(paths, SEPARATOR);
 }

--- a/path/windows/common.ts
+++ b/path/windows/common.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { _common } from "../_common/common.ts";
+import { common as _common } from "../_common/common.ts";
 import { SEPARATOR } from "./constants.ts";
 
-/** Determines the common path from a set of paths, using an optional separator,
- * which defaults to the OS default separator.
+/**
+ * Determines the common path from a set of paths for Windows systems.
  *
  * @example Usage
  * ```ts
@@ -20,12 +20,8 @@ import { SEPARATOR } from "./constants.ts";
  * ```
  *
  * @param paths The paths to compare.
- * @param sep The separator to use. Defaults to `\\`.
  * @returns The common path.
  */
-export function common(
-  paths: string[],
-  sep: string = SEPARATOR,
-): string {
-  return _common(paths, sep);
+export function common(paths: string[]): string {
+  return _common(paths, SEPARATOR);
 }


### PR DESCRIPTION
### What's changed

This change removes the separator argument, `sep`, from `posix.common()`, `windows.common()` and `common()`.

### Why this change was made

This change was made so these functions are made to be consistent with other APIs within `@std/path`, which don't have the ability to set the path separator via an argument. Instead, the user should use the OS-specific variant of `common()` if OS-specific behavior is required and the OS-agnostic `common()` so behavior is oriented for the current machine's OS.

### Migration guide

To migrate, either use the OS-specific or OS-agnostic variant of `common()`, for your use case:

For the current machine's OS (automatically detected):
```ts
import { common } from "@std/path/common";

// No need to define a second argument
common(["C:\\foo\\bar", "C:\\foo\\baz"]);
```

For Windows systems:
```diff
- import { common } from "@std/path/common";
+ import { common } from "@std/path/windows/common";

- common(["C:\\foo\\bar", "C:\\foo\\baz"], "\\");
+ common(["C:\\foo\\bar", "C:\\foo\\baz"]);
```

For POSIX systems:
```diff
- import { common } from "@std/path/common";
+ import { common } from "@std/path/posix/common";

- common(["C:\\foo\\bar", "C:\\foo\\baz"], "/");
+ common(["./deno/std/path/mod.ts", "./deno/std/fs/mod.ts"]);
```