### PR TITLE
test(path): improve `windows.parse()` test

### DIFF
--- a/path/parse_test.ts
+++ b/path/parse_test.ts
@@ -2,11 +2,9 @@
 
 import { assertEquals } from "@std/assert/assert-equals";
 import * as windows from "./windows/mod.ts";
-import * as posix from "./posix/mod.ts";
 
 Deno.test("windows.parse() parses UNC root only path", () => {
   const parsed = windows.parse("\\\\server\\share");
-  console.log(parsed);
   assertEquals<unknown>(parsed, {
     base: "\\",
     dir: "\\\\server\\share",

--- a/path/parse_test.ts
+++ b/path/parse_test.ts
@@ -1,0 +1,17 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "@std/assert/assert-equals";
+import * as windows from "./windows/mod.ts";
+import * as posix from "./posix/mod.ts";
+
+Deno.test("windows.parse() parses UNC root only path", () => {
+  const parsed = windows.parse("\\\\server\\share");
+  console.log(parsed);
+  assertEquals<unknown>(parsed, {
+    base: "\\",
+    dir: "\\\\server\\share",
+    ext: "",
+    name: "",
+    root: "\\\\server\\share",
+  });
+});


### PR DESCRIPTION
part of #3713 #4600

This improves the test coverage of `windows.parse()` function.