### PR TITLE
BREAKING(path): remove `path.posix` and `path.win32`

### DIFF
--- a/path/mod.ts
+++ b/path/mod.ts
@@ -33,26 +33,6 @@
  *
  * @module
  */
-
-import * as _windows from "./windows/mod.ts";
-import * as _posix from "./posix/mod.ts";
-
-/**
- * Module for working with Windows file paths.
- *
- * @deprecated This will be removed in 1.0.0. Import from
- * {@link https://jsr.io/@std/path/doc/windows/~ | @std/path/windows} instead.
- */
-export const win32: typeof _windows = _windows;
-
-/**
- * Module for working with POSIX file paths.
- *
- * @deprecated This will be removed in 1.0.0. Import from
- * {@link https://jsr.io/@std/path/doc/posix/~ | @std/path/posix} instead.
- */
-export const posix: typeof _posix = _posix;
-
 export * from "./basename.ts";
 export * from "./constants.ts";
 export * from "./dirname.ts";


### PR DESCRIPTION
### What's changed

This change removes the `posix` and `win32` exports from the `@std/path` root module.

### Why this change was made

This change was made to keep the root module of `@std/path` reserved for importing APIs that automatically detect and work on the OS of the current machine. OS-specific APIs can be imported instead from `@std/path/posix/*` or `@std/path/windows/*`. This helps keep dependencies lean.

### Migration guide

To migrate, import from `@std/path/posix/*` instead of `path.posix` for POSIX systems or `@std/path/windows/*` instead of `path.windows` for Windows systems.

For POSIX systems:

```diff
- import { posix } from "@std/path";
+ import { basename } from "@std/path/posix";

- posix.basename("/home/user/Documents/");
+ basename("/home/user/Documents/");
```

For Windows systems:

```diff
- import { windows } from "@std/path";
+ import { basename } from "@std/path/windows";

- windows.basename("C:\\user\\Documents\\");
+ basename("C:\\user\\Documents\\");
```