### PR TITLE
fix(testing): cast `globalThis` to any

### DIFF
--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -438,7 +438,8 @@ class AssertSnapshotContext {
    */
   public registerTeardown() {
     if (!this.#teardownRegistered) {
-      globalThis.addEventListener("unload", this.#teardown);
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).addEventListener("unload", this.#teardown);
       this.#teardownRegistered = true;
     }
   }


### PR DESCRIPTION
This casts `globalThis` to `any` for adding the event listener, following other examples, like this one: 

https://github.com/denoland/deno_std/blob/e48f7cf0611a79d132fa37230cd77bdf2f2d4938/path/_os.ts#L27

## Reason
I encountered:
```
src/deps/jsr.io/@std/testing/0.225.0/snapshot.ts:443:18 - error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.

443       globalThis.addEventListener("unload", this.#teardown);
                     ~~~~~~~~~~~~~~~~

error: Uncaught (in promise) Error: Had 1 diagnostics.
          throw new Error(`Had ${diagnostics.length} diagnostics.`);
                ^
    at getProgramAndMaybeTypeCheck (https://jsr.io/@deno/dnt/0.41.2/mod.ts:468:17)
    at build (https://jsr.io/@deno/dnt/0.41.2/mod.ts:354:17)
    at eventLoopTick (ext:core/01_core.js:168:7)
    at async file:///Users/joscha/dev/affinity-node/scripts/build_npm.ts:10:1
```
whilst using https://github.com/denoland/dnt/