### PR TITLE
refactor(cli): cleanup use of `@std/assert`

### DIFF
--- a/cli/_run_length.ts
+++ b/cli/_run_length.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "@std/assert/assert";
-
 export function runLengthEncode(arr: number[]) {
   const data: number[] = [];
   const runLengths: number[] = [];
@@ -18,7 +16,11 @@ export function runLengthEncode(arr: number[]) {
     }
   }
 
-  assert(runLengths.every((r) => r < 0x100));
+  for (const r of runLengths) {
+    if (r >= 0x100) {
+      throw new Error(`Run length too long: ${r}`);
+    }
+  }
 
   return {
     d: btoa(String.fromCharCode(...data)),

--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -14,7 +14,6 @@
  *
  * @module
  */
-import { assert } from "@std/assert/assert";
 
 /** Combines recursively all intersection types and returns a new single type.
  * @internal
@@ -510,7 +509,7 @@ export function parseArgs<
   if (alias) {
     for (const key in alias) {
       const val = (alias as Record<string, unknown>)[key];
-      assert(val !== undefined);
+      if (val === undefined) throw new TypeError("Alias value must be defined");
       const aliases = Array.isArray(val) ? val : [val];
       aliasMap.set(key, new Set(aliases));
       aliases.forEach((alias) =>


### PR DESCRIPTION
Towards #4865