### PR TITLE
chore(io): undeprecate `BufReader` and `BufWriter`

### DIFF
--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -11,7 +11,7 @@ const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 
 /**
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * BufferFullError is thrown when the buffer is full.
  */
 export class BufferFullError extends Error {
   override name = "BufferFullError";
@@ -21,7 +21,7 @@ export class BufferFullError extends Error {
 }
 
 /**
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * PartialReadError is thrown when the data is partially read.
  */
 export class PartialReadError extends Error {
   override name = "PartialReadError";
@@ -33,8 +33,6 @@ export class PartialReadError extends Error {
 
 /**
  * Result type returned by of BufReader.readLine().
- *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export interface ReadLineResult {
   line: Uint8Array;
@@ -42,7 +40,7 @@ export interface ReadLineResult {
 }
 
 /**
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * {@code BufReader} implements buffering for {@linkcode Reader}.
  */
 export class BufReader implements Reader {
   #buf!: Uint8Array;

--- a/io/buf_writer.ts
+++ b/io/buf_writer.ts
@@ -33,14 +33,13 @@ abstract class AbstractBufBase {
   }
 }
 
-/** BufWriter implements buffering for an deno.Writer object.
+/**
+ * {@code BufWriter} implements buffering for an {@linkcode Writer} object.
  * If an error occurs writing to a Writer, no more data will be
  * accepted and all subsequent writes, and flush(), will return the error.
  * After all data has been written, the client should call the
  * flush() method to guarantee all data has been forwarded to
  * the underlying deno.Writer.
- *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export class BufWriter extends AbstractBufBase implements Writer {
   #writer: Writer;


### PR DESCRIPTION
It seems that some active users exist for `BufReader`. So I suggest we should cancel the deprecation of these 2 classes

- The usage in dax https://github.com/dsherret/dax/blob/0c1cc7ba3e22e02fd7a2b6b83e3fe1a2774cd729/src/common.ts#L1
- The usage in cliffy https://github.com/c4spar/deno-cliffy/blob/7a932da08076ff7914c1a87e8f433a5ade046636/examples/prompt/custom_prompts.ts#L3