### PR TITLE
docs(async): avoid memory leak in example

### DIFF
--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -26,12 +26,15 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * ```ts no-eval
  * import { debounce } from "@std/async/debounce";
  *
- * await Array.fromAsync(
- *   Deno.watchFs('./'),
- *   debounce((event) => {
- *     console.log('[%s] %s', event.kind, event.paths[0]);
- *   }, 200),
+ * const log = debounce(
+ *   (event: Deno.FsEvent) =>
+ *     console.log("[%s] %s", event.kind, event.paths[0]),
+ *   200,
  * );
+ *
+ * for await (const event of Deno.watchFs("./")) {
+ *   log(event);
+ * }
  * // wait 200ms ...
  * // output: Function debounced after 200ms with baz
  * ```


### PR DESCRIPTION
This reverts https://github.com/denoland/deno_std/pull/4283

By using `Array.fromAsync`, the call result of the debounced function is stored in memory i.e. it's leaked unnecessarily. We can avoid it by not using `Array.fromAsync`.