### PR TITLE
BREAKING(async): stop exporting ERROR_WHILE_MAPPING_MESSAGE

### DIFF
--- a/async/pool.ts
+++ b/async/pool.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 /** Error message emitted from the thrown error while mapping. */
-export const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
+const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
 
 /**
  * pooledMap transforms values from an (async) iterable into another async

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { delay } from "./delay.ts";
-import { ERROR_WHILE_MAPPING_MESSAGE, pooledMap } from "./pool.ts";
+import { pooledMap } from "./pool.ts";
 import {
   assert,
   assertEquals,
@@ -38,7 +38,7 @@ Deno.test("pooledMap() handles errors", async () => {
       }
     },
     AggregateError,
-    ERROR_WHILE_MAPPING_MESSAGE,
+    "Threw while mapping.",
   );
   assertEquals(error.errors.length, 2);
   assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");


### PR DESCRIPTION
part of #5001

We usually don't export error message string as string constant value. Also exporting this doesn't look useful. I suggest we should remove this export.