### PR TITLE
chore(async): mark `Tuple` and `TupleOf` as `@internal`

### DIFF
--- a/async/tee.ts
+++ b/async/tee.ts
@@ -1,12 +1,20 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/** Utility for representing n-tuple. Used in {@linkcode tee}. */
+/**
+ * Utility for representing n-tuple. Used in {@linkcode tee}.
+ *
+ * @internal
+ */
 export type Tuple<T, N extends number> = N extends N
   ? number extends N ? T[] : TupleOf<T, N, []>
   : never;
 
-/** Utility for representing n-tuple of. Used in {@linkcode Tuple}. */
+/**
+ * Utility for representing n-tuple of. Used in {@linkcode Tuple}.
+ *
+ * @internal
+ */
 export type TupleOf<T, N extends number, R extends unknown[]> =
   R["length"] extends N ? R
     : TupleOf<T, N, [T, ...R]>;


### PR DESCRIPTION
towards #5001 

This PR marks `Tuple` and `TupleOf` types as @internal (We would remove them if TypeScript natively support something similar).

These 2 types are too general to be exported as part of `@std/async`. We shouldn't consider these as public APIs.