### PR TITLE
test(cli): improve test coverage

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -343,8 +343,7 @@ interface NestedMapping {
   [key: string]: NestedMapping | unknown;
 }
 
-function isNumber(x: unknown): boolean {
-  if (typeof x === "number") return true;
+function isNumber(x: string): boolean {
   if (/^0x[0-9a-f]+$/i.test(String(x))) return true;
   return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(String(x));
 }

--- a/cli/parse_args_test.ts
+++ b/cli/parse_args_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { type Args, parseArgs, type ParseOptions } from "./parse_args.ts";
 import { assertType, type IsExact } from "@std/testing/types";
 

--- a/cli/parse_args_test.ts
+++ b/cli/parse_args_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { type Args, parseArgs, type ParseOptions } from "./parse_args.ts";
 import { assertType, type IsExact } from "@std/testing/types";
 
@@ -267,6 +267,14 @@ Deno.test("parseArgs() handles latest flag boolean", function () {
     negatable: ["foo"],
   });
   assertEquals(parsed2.foo, true);
+});
+
+Deno.test("parseArgs() handles string negatable option", function () {
+  const parsed = parseArgs(["--no-foo"], {
+    boolean: ["foo"],
+    negatable: "foo",
+  });
+  assertEquals(parsed.foo, false);
 });
 
 Deno.test("parseArgs() handles hyphen", function () {
@@ -897,6 +905,22 @@ Deno.test("parseArgs() handles collect negateable args", function () {
   assertEquals(argv, {
     foo: false,
     f: false,
+    _: [],
+  });
+});
+
+Deno.test("parseArgs() handles string collect option", function () {
+  const argv = parseArgs([
+    "--foo",
+    "123",
+    "--foo",
+    "345",
+  ], {
+    collect: "foo",
+  });
+
+  assertEquals(argv, {
+    foo: [123, 345],
     _: [],
   });
 });
@@ -1925,4 +1949,18 @@ Deno.test("parseArgs() handles collect with alias", () => {
     },
   });
   assertEquals(parsed.header, ["abc", "def"]);
+});
+
+Deno.test("parseArgs() throws if the alias value is undefined", () => {
+  assertThrows(
+    () => {
+      parseArgs([], {
+        alias: {
+          h: undefined,
+        },
+      });
+    },
+    Error,
+    "Alias value must be defined",
+  );
 });


### PR DESCRIPTION
This PR adds test cases of `parseArgs`. This also removes a dead line.

The test coverage of `parse_args.ts` improves from `97.65%` to `98.99%`

part of #3713 