### PR TITLE
chore(streams): remove unused test util

### DIFF
--- a/streams/_test_common.ts
+++ b/streams/_test_common.ts
@@ -2,17 +2,6 @@
 
 import { assert, assertEquals } from "@std/assert";
 
-// N controls how many iterations of certain checks are performed.
-const N = 100;
-
-export function init(): Uint8Array {
-  const testBytes = new Uint8Array(N);
-  for (let i = 0; i < N; i++) {
-    testBytes[i] = "a".charCodeAt(0) + (i % 26);
-  }
-  return testBytes;
-}
-
 /**
  * Verify that a transform stream produces the expected output data
  * @param transform The transform stream to test


### PR DESCRIPTION
This PR removes a test util in `@std/streams` which is not used from anywhere.