### PR TITLE
refactor(testing): remove use of `public` keyword

### DIFF
--- a/testing/_test_utils.ts
+++ b/testing/_test_utils.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 export class Point {
-  constructor(public x: number, public y: number) {}
+  x: number;
+  y: number;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
   // deno-lint-ignore no-explicit-any
   action(...args: any[]): any {
     return args[0];

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -96,12 +96,14 @@
  *
  * class User {
  *   static users: Map<string, User> = new Map();
+ *   name: string;
  *   age?: number;
  *
- *   constructor(public name: string) {
+ *   constructor(name: string) {
  *     if (User.users.has(name)) {
  *       throw new Deno.errors.AlreadyExists(`User ${name} already exists`);
  *     }
+ *     this.name = name;
  *     User.users.set(name, this);
  *   }
  *
@@ -168,12 +170,14 @@
  *
  * class User {
  *   static users: Map<string, User> = new Map();
+ *   name: string;
  *   age?: number;
  *
- *   constructor(public name: string) {
+ *   constructor(name: string) {
  *     if (User.users.has(name)) {
  *       throw new Deno.errors.AlreadyExists(`User ${name} already exists`);
  *     }
+ *     this.name = name;
  *     User.users.set(name, this);
  *   }
  *
@@ -249,12 +253,14 @@
  *
  * class User {
  *   static users: Map<string, User> = new Map();
+ *   name: string;
  *   age?: number;
  *
- *   constructor(public name: string) {
+ *   constructor(name: string) {
  *     if (User.users.has(name)) {
  *       throw new Deno.errors.AlreadyExists(`User ${name} already exists`);
  *     }
+ *     this.name = name;
  *     User.users.set(name, this);
  *   }
  *
@@ -330,12 +336,14 @@
  *
  * class User {
  *   static users: Map<string, User> = new Map();
+ *   name: string;
  *   age?: number;
  *
- *   constructor(public name: string) {
+ *   constructor(name: string) {
  *     if (User.users.has(name)) {
  *       throw new Deno.errors.AlreadyExists(`User ${name} already exists`);
  *     }
+ *     this.name = name;
  *     User.users.set(name, this);
  *   }
  *

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -436,7 +436,7 @@ class AssertSnapshotContext {
    * This method can safely be called more than once and will only register the teardown
    * function once in a context.
    */
-  public registerTeardown() {
+  registerTeardown() {
     if (!this.#teardownRegistered) {
       globalThis.addEventListener("unload", this.#teardown);
       this.#teardownRegistered = true;
@@ -447,7 +447,7 @@ class AssertSnapshotContext {
    * Gets the number of snapshots which have been created with the same name and increments
    * the count by 1.
    */
-  public getCount(snapshotName: string) {
+  getCount(snapshotName: string) {
     let count = this.#snapshotCounts.get(snapshotName) || 0;
     this.#snapshotCounts.set(snapshotName, ++count);
     return count;
@@ -456,7 +456,7 @@ class AssertSnapshotContext {
   /**
    * Get an existing snapshot by name or returns `undefined` if the snapshot does not exist.
    */
-  public async getSnapshot(snapshotName: string, options: SnapshotOptions) {
+  async getSnapshot(snapshotName: string, options: SnapshotOptions) {
     const snapshots = await this.#readSnapshotFile(options);
     return snapshots.get(snapshotName);
   }
@@ -467,7 +467,7 @@ class AssertSnapshotContext {
    *
    * Should only be called when mode is `update`.
    */
-  public updateSnapshot(snapshotName: string, snapshot: string) {
+  updateSnapshot(snapshotName: string, snapshot: string) {
     if (!this.#snapshotsUpdated.includes(snapshotName)) {
       this.#snapshotsUpdated.push(snapshotName);
     }
@@ -481,7 +481,7 @@ class AssertSnapshotContext {
   /**
    * Get the number of updated snapshots.
    */
-  public getUpdatedCount() {
+  getUpdatedCount() {
     return this.#snapshotsUpdated.length;
   }
 
@@ -495,14 +495,14 @@ class AssertSnapshotContext {
    * `assertSnapshot` could cause updates to be written to the snapshot file if the
    * `update` mode is passed in the options.
    */
-  public pushSnapshotToUpdateQueue(snapshotName: string) {
+  pushSnapshotToUpdateQueue(snapshotName: string) {
     this.snapshotUpdateQueue.push(snapshotName);
   }
 
   /**
    * Check if exist snapshot
    */
-  public hasSnapshot(snapshotName: string): boolean {
+  hasSnapshot(snapshotName: string): boolean {
     return this.#currentSnapshots
       ? this.#currentSnapshots.has(snapshotName)
       : false;


### PR DESCRIPTION
As we don't use the access modifiers in the Standard Library.