### PR TITLE
BREAKING(async): make `abortablePromise()` and `abortableAsyncIterable()` private

### DIFF
--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -73,30 +73,7 @@ export function abortable<T>(
   }
 }
 
-/**
- * Make a {@linkcode Promise} abortable with the given signal.
- *
- * @typeParam T The type of the provided and returned promise.
- * @param p The promise to make abortable.
- * @param signal The signal to abort the promise with.
- * @returns A promise that can be aborted.
- *
- * @example Usage
- * ```ts no-eval
- * import { abortablePromise } from "@std/async/abortable";
- *
- * const request = fetch("https://example.com");
- *
- * const c = new AbortController();
- * setTimeout(() => c.abort(), 100);
- *
- * const p = abortablePromise(request, c.signal);
- *
- * // The below throws if the request didn't resolve in 100ms
- * await p;
- * ```
- */
-export function abortablePromise<T>(
+function abortablePromise<T>(
   p: Promise<T>,
   signal: AbortSignal,
 ): Promise<T> {
@@ -111,38 +88,7 @@ export function abortablePromise<T>(
   });
 }
 
-/**
- * Make an {@linkcode AsyncIterable} abortable with the given signal.
- *
- * @typeParam T The type of the provided and returned async iterable.
- * @param p The async iterable to make abortable.
- * @param signal The signal to abort the promise with.
- * @returns An async iterable that can be aborted.
- *
- * @example Usage
- * ```ts no-eval
- * import {
- *   abortableAsyncIterable,
- *   delay,
- * } from "@std/async";
- *
- * const p = async function* () {
- *   yield "Hello";
- *   await delay(1000);
- *   yield "World";
- * };
- * const c = new AbortController();
- * setTimeout(() => c.abort(), 100);
- *
- * // Below throws `DOMException` after 100 ms
- * // and items become `["Hello"]`
- * const items: string[] = [];
- * for await (const item of abortableAsyncIterable(p(), c.signal)) {
- *   items.push(item);
- * }
- * ```
- */
-export async function* abortableAsyncIterable<T>(
+async function* abortableAsyncIterable<T>(
   p: AsyncIterable<T>,
   signal: AbortSignal,
 ): AsyncGenerator<T> {


### PR DESCRIPTION
### What's changed

`abortablePromise()` and `abortableAsyncIterable()` have been made private functions (no longer exported) in favor of [`abortable()`](https://jsr.io/@std/async/doc/~/abortable).

### Why this change was made

Under the hood, `abortable()` uses `abortablePromise()` if the first argument, `p`, is a promise, or `abortableAsyncIterable()` if `p` is an async iterable. This change was made to avoid confusion for users regarding which function to use; now, use `abortable()`.

### Migration guide

To migrate, use `abortable()` instead of `abortablePromise()` or `abortableAsyncIterable()` in the same way.

For promises:
```diff
- import { abortablePromise } from "@std/async/abortable";
+ import { abortable } from "@std/async/abortable";

  const request = fetch("https://example.com");

  const c = new AbortController();
  setTimeout(() => c.abort(), 100);

- const p = abortablePromise(request, c.signal);
+ const p = abortable(request, c.signal);

  // The below throws if the request didn't resolve in 100ms
  await p;
```

For async iterables:
```diff
- import { abortableAsyncIterable, delay } from "@std/async";
+ import { abortable, delay } from "@std/async";

  const p = async function* () {
    yield "Hello";
    await delay(1000);
    yield "World";
  };
  const c = new AbortController();
  setTimeout(() => c.abort(), 100);

  // Below throws `DOMException` after 100 ms
  // and items become `["Hello"]`
  const items: string[] = [];
- for await (const item of abortableAsyncIterable(p(), c.signal)) {
+ for await (const item of abortable(p(), c.signal)) {
    items.push(item);
  }
```