### PR TITLE
test(streams): improve `DelimiterStream` test cases

### DIFF
--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -93,7 +93,7 @@ export class DelimiterStream extends TransformStream<Uint8Array, Uint8Array> {
    */
   constructor(
     delimiter: Uint8Array,
-    options: DelimiterStreamOptions = { disposition: "discard" },
+    options: DelimiterStreamOptions = {},
   ) {
     super({
       transform: (chunk, controller) =>


### PR DESCRIPTION
This PR improves the test suite of `DelimiterStream`. Now the test cases cover the lines except 'unreachable' lines.

part of #3713 