### PR TITLE
feat(internal): `assertStrictThrows()` and `assertStrictRejects()`

### DIFF
--- a/internal/assert_strict.ts
+++ b/internal/assert_strict.ts
@@ -36,8 +36,8 @@ export class StrictAssertionError extends Error {
  * Asserts that the error is an instance of the given error class and that the
  * error message is a given string.
  *
- * @throws {import("@std/assert/assertion-error").AssertionError} If the error
- * is not an instance of the given error
+ * @throws {StrictAssertionError} If the error is not an instance of the given
+ * error.
  * @typeParam E The type of the error to assert.
  * @param error The error to assert.
  * @param ErrorClass The error class to assert.
@@ -83,9 +83,9 @@ function assertStrictIsError<E extends Error = Error>(
  * );
  * ```
  *
- * @throws {import("@std/assert/assertion-error").AssertionError} If the
- * function does not throw an error, or if the error is not an instance of the
- * given error class, or if the error message is not the given string.
+ * @throws {StrictAssertionError} If the function does not throw an error, or if
+ * the error is not an instance of the given error class, or if the error
+ * message is not the given string.
  * @typeParam E The type of the error to assert.
  * @param fn The function to assert throws an error.
  * @param errorClass The error class to assert.
@@ -123,9 +123,9 @@ export function assertStrictThrows<E extends Error = Error>(
  * );
  * ```
  *
- * @throws {import("@std/assert/assertion-error").AssertionError} If the
- * function does not reject with an error, or if the error is not an instance of
- * the given error class, or if the error message is not the given string.
+ * @throws {StrictAssertionError} If the function does not reject with an error,
+ * or if the error is not an instance of the given error class, or if the error
+ * message is not the given string.
  * @typeParam E The type of the error to assert.
  * @param fn The function to assert rejects with an error.
  * @param errorClass The error class to assert.

--- a/internal/assert_strict.ts
+++ b/internal/assert_strict.ts
@@ -1,0 +1,147 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+import { stripAnsiCode } from "@std/internal/styles";
+
+/**
+ * Error thrown when a strict assertion fails.
+ *
+ * @example Usage
+ * ```ts no-eval
+ * import { StrictAssertionError } from "@std/internal/assert-strict";
+ *
+ * throw new StrictAssertionError("Assertion failed");
+ * ```
+ */
+export class StrictAssertionError extends Error {
+  /**
+   * Constructs a new instance.
+   *
+   * @example Usage
+   * ```ts no-eval
+   * import { StrictAssertionError } from "@std/internal/assert-strict";
+   *
+   * throw new StrictAssertionError("Assertion failed");
+   * ```
+   *
+   * @param message The error message.
+   * @param options Error options.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = this.constructor.name;
+  }
+}
+
+/**
+ * Asserts that the error is an instance of the given error class and that the
+ * error message is a given string.
+ *
+ * @throws {import("@std/assert/assertion-error").AssertionError} If the error
+ * is not an instance of the given error
+ * @typeParam E The type of the error to assert.
+ * @param error The error to assert.
+ * @param ErrorClass The error class to assert.
+ * @param msgEquals The string to assert equals the error message.
+ */
+function assertStrictIsError<E extends Error = Error>(
+  error: unknown,
+  // deno-lint-ignore no-explicit-any
+  errorClass: new (...args: any[]) => E,
+  msgEquals: string,
+): asserts error is E {
+  if (!(error instanceof Error)) {
+    throw new StrictAssertionError(`Expected "error" to be an Error object`);
+  }
+  if (!(error instanceof errorClass)) {
+    throw new StrictAssertionError(
+      `Expected error to be instance of "${errorClass.name}", but was "${error?.constructor.name}"`,
+    );
+  }
+  if (stripAnsiCode(error.message) !== stripAnsiCode(msgEquals)) {
+    throw new StrictAssertionError(
+      `Expected error message to be ${JSON.stringify(msgEquals)}, but got ${
+        JSON.stringify(error?.message)
+      }`,
+    );
+  }
+}
+
+/**
+ * Asserts that the given function throws an error that is an instance of the
+ * given error class and that the error message is a given string.
+ *
+ * @example Usage
+ * ```ts no-assert
+ * import { assertStrictThrows } from "@std/internal/assert-strict";
+ *
+ * assertStrictThrows(
+ *   () => {
+ *     throw new RangeError("Out of range");
+ *   },
+ *   RangeError,
+ *   "Out of range"
+ * );
+ * ```
+ *
+ * @throws {import("@std/assert/assertion-error").AssertionError} If the
+ * function does not throw an error, or if the error is not an instance of the
+ * given error class, or if the error message is not the given string.
+ * @typeParam E The type of the error to assert.
+ * @param fn The function to assert throws an error.
+ * @param errorClass The error class to assert.
+ * @param msgEquals The string to assert equals the error message.
+ */
+export function assertStrictThrows<E extends Error = Error>(
+  fn: () => unknown,
+  // deno-lint-ignore no-explicit-any
+  errorClass: new (...args: any[]) => E,
+  msgEquals: string,
+) {
+  let thrownError;
+  try {
+    fn();
+  } catch (error) {
+    thrownError = error;
+  }
+  assertStrictIsError(thrownError, errorClass, msgEquals);
+}
+
+/**
+ * Asserts that the given function rejects with an error that is an instance of
+ * the given error class and that the error message is a given string.
+ *
+ * @example Usage
+ * ```ts no-assert
+ * import { assertStrictRejects } from "@std/internal/assert-strict";
+ *
+ * await assertStrictRejects(
+ *   async () => {
+ *     await Promise.reject(new RangeError("Out of range"));
+ *   },
+ *   RangeError,
+ *   "Out of range"
+ * );
+ * ```
+ *
+ * @throws {import("@std/assert/assertion-error").AssertionError} If the
+ * function does not reject with an error, or if the error is not an instance of
+ * the given error class, or if the error message is not the given string.
+ * @typeParam E The type of the error to assert.
+ * @param fn The function to assert rejects with an error.
+ * @param errorClass The error class to assert.
+ * @param msgEquals The string to assert equals the error message.
+ */
+export async function assertStrictRejects<E extends Error = Error>(
+  fn: () => PromiseLike<unknown>,
+  // deno-lint-ignore no-explicit-any
+  errorClass: new (...args: any[]) => E,
+  msgEquals: string,
+) {
+  let rejectedError;
+  try {
+    await fn();
+  } catch (error) {
+    rejectedError = error;
+  }
+  assertStrictIsError(rejectedError, errorClass, msgEquals);
+}

--- a/internal/assert_strict_test.ts
+++ b/internal/assert_strict_test.ts
@@ -1,0 +1,122 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import {
+  assertStrictRejects,
+  assertStrictThrows,
+  StrictAssertionError,
+} from "./assert_strict.ts";
+
+Deno.test("assertStrictThrows() passes with correct error class and message", () => {
+  assertStrictThrows(
+    () => {
+      throw new RangeError("Out of range");
+    },
+    RangeError,
+    "Out of range",
+  );
+});
+
+Deno.test("assertStrictThrows() throws with non-error object", () => {
+  assertStrictThrows(
+    () => {
+      assertStrictThrows(
+        () => {
+          throw "Not an error";
+        },
+        TypeError,
+        "Out of range",
+      );
+    },
+    StrictAssertionError,
+    `Expected "error" to be an Error object`,
+  );
+});
+
+Deno.test("assertStrictThrows() throws with incorrect error class", () => {
+  assertStrictThrows(
+    () => {
+      assertStrictThrows(
+        () => {
+          throw new RangeError("Out of range");
+        },
+        TypeError,
+        "Out of range",
+      );
+    },
+    StrictAssertionError,
+    `Expected error to be instance of "TypeError", but was "RangeError"`,
+  );
+});
+
+Deno.test("assertStrictThrows() throws with incorrect error message", () => {
+  assertStrictThrows(
+    () => {
+      assertStrictThrows(
+        () => {
+          throw new RangeError("Out of range");
+        },
+        RangeError,
+        "Within range",
+      );
+    },
+    StrictAssertionError,
+    `Expected error message to be "Within range", but got "Out of range"`,
+  );
+});
+
+Deno.test("assertStrictRejects() passes with correct error class and message", async () => {
+  await assertStrictRejects(
+    async () => {
+      await Promise.reject(new RangeError("Out of range"));
+    },
+    RangeError,
+    "Out of range",
+  );
+});
+
+Deno.test("assertStrictRejects() rejects with non-error object", async () => {
+  await assertStrictRejects(
+    async () => {
+      await assertStrictRejects(
+        async () => {
+          await Promise.reject("Not an error");
+        },
+        TypeError,
+        "Out of range",
+      );
+    },
+    StrictAssertionError,
+    `Expected "error" to be an Error object`,
+  );
+});
+
+Deno.test("assertStrictRejects() rejects with incorrect error class", async () => {
+  await assertStrictRejects(
+    async () => {
+      await assertStrictRejects(
+        async () => {
+          await Promise.reject(new RangeError("Out of range"));
+        },
+        TypeError,
+        "Out of range",
+      );
+    },
+    StrictAssertionError,
+    `Expected error to be instance of "TypeError", but was "RangeError"`,
+  );
+});
+
+Deno.test("assertStrictRejects() rejects with incorrect error message", async () => {
+  await assertStrictRejects(
+    async () => {
+      await assertStrictRejects(
+        async () => {
+          await Promise.reject(new RangeError("Out of range"));
+        },
+        RangeError,
+        "Within range",
+      );
+    },
+    StrictAssertionError,
+    `Expected error message to be "Within range", but got "Out of range"`,
+  );
+});

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "exports": {
     ".": "./mod.ts",
+    "./assert-strict": "./assert_strict.ts",
     "./build-message": "./build_message.ts",
     "./diff-str": "./diff_str.ts",
     "./diff": "./diff.ts",

--- a/internal/mod.ts
+++ b/internal/mod.ts
@@ -36,6 +36,7 @@
  *
  * @module
  */
+export * from "./assert_strict.ts";
 export * from "./build_message.ts";
 export * from "./diff.ts";
 export * from "./diff_str.ts";

--- a/uuid/common_test.ts
+++ b/uuid/common_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import { assertStrictThrows } from "@std/internal/assert-strict";
+
 import { isNil, NIL_UUID, validate, version } from "./mod.ts";
 
 Deno.test("isNil() checks if a UUID is the nil UUID", () => {
@@ -23,12 +25,19 @@ Deno.test("version() detects the RFC version of a UUID", () => {
   assertEquals(version("109156be-c4fb-41ea-b1b4-efe1671c5836"), 4);
   assertEquals(version("a981a0c2-68b1-35dc-bcfc-296e52ab01ec"), 3);
   assertEquals(version("90123e1c-7512-523e-bb28-76fab9f2f73d"), 5);
-  assertThrows(() => version(""));
-  assertThrows(() => version("not a UUID"));
-  assertThrows(() => version("00000000000000000000000000000000"));
-  assertThrows(() =>
-    version(
-      "=Y00a-f*v00b*-00c-00d#-p00f\b-00g-00h-####00i^^^-00j*1*2*3&-L00k-\n00l-/00m-----00n-fg000-00p-00r+",
-    )
+  assertStrictThrows(() => version(""), TypeError, "Invalid UUID");
+  assertStrictThrows(() => version("not a UUID"), TypeError, "Invalid UUID");
+  assertStrictThrows(
+    () => version("00000000000000000000000000000000"),
+    TypeError,
+    "Invalid UUID",
+  );
+  assertStrictThrows(
+    () =>
+      version(
+        "=Y00a-f*v00b*-00c-00d#-p00f\b-00g-00h-####00i^^^-00j*1*2*3&-L00k-\n00l-/00m-----00n-fg000-00p-00r+",
+      ),
+    TypeError,
+    "Invalid UUID",
   );
 });

--- a/uuid/v1_test.ts
+++ b/uuid/v1_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import { assertStrictThrows } from "@std/internal/assert-strict";
 import { generate, validate } from "./v1.ts";
 
 Deno.test("validate() checks if a string is a valid v1 UUID", () => {
@@ -44,7 +45,7 @@ Deno.test("generate() can generate a static v1 UUID", () => {
 });
 
 Deno.test("generate() throws when node is passed with less than 6 numbers", () => {
-  assertThrows(
+  assertStrictThrows(
     () => {
       generate({ node: [0x01, 0x23, 0x45, 0x67, 0x89] });
     },
@@ -54,7 +55,7 @@ Deno.test("generate() throws when node is passed with less than 6 numbers", () =
 });
 
 Deno.test("generate() throws when node is passed with more than 6 numbers", () => {
-  assertThrows(
+  assertStrictThrows(
     () => {
       generate({ node: [0x01, 0x23, 0x45, 0x67, 0x89, 0x89, 0x89] });
     },
@@ -64,7 +65,7 @@ Deno.test("generate() throws when node is passed with more than 6 numbers", () =
 });
 
 Deno.test("generate() throws when create more than 10M uuids/sec", () => {
-  assertThrows(
+  assertStrictThrows(
     () => {
       generate({ nsecs: 10001 });
     },


### PR DESCRIPTION
Once merged, we can track the updating of tests to use these new functions.

Closes #5072