### PR TITLE
BREAKING(streams): have `toJson()` and `toText()` accept `ReadableStream<Uint8Array>`

### DIFF
--- a/streams/mod.ts
+++ b/streams/mod.ts
@@ -9,7 +9,8 @@
  * import { toText } from "@std/streams";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * const stream = ReadableStream.from("Hello, world!");
+ * const stream = ReadableStream.from(["Hello, ", "world!"])
+ *   .pipeThrough(new TextEncoderStream());
  * const text = await toText(stream);
  *
  * assertEquals(text, "Hello, world!");

--- a/streams/to_blob.ts
+++ b/streams/to_blob.ts
@@ -3,7 +3,8 @@
 
 /**
  * Converts a {@linkcode ReadableStream} of {@linkcode Uint8Array}s to a
- * {@linkcode Blob}. Works the same as {@linkcode Response.blob}.
+ * {@linkcode Blob}. Works the same as {@linkcode Request.blob} and
+ * {@linkcode Response.blob}.
  *
  * @param stream A `ReadableStream` of `Uint8Array`s to convert into a `Blob`.
  * @returns A `Promise` that resolves to the `Blob`.

--- a/streams/to_json.ts
+++ b/streams/to_json.ts
@@ -4,7 +4,7 @@
 import { toText } from "./to_text.ts";
 
 /**
- * Converts a JSON-formatted {@linkcode ReadableSteam} of strings or
+ * Converts a JSON-formatted {@linkcode ReadableSteam} of
  * {@linkcode Uint8Array}s to an object. Works the same as
  * {@linkcode Response.json}.
  *
@@ -20,13 +20,13 @@ import { toText } from "./to_text.ts";
  *   "[1, true",
  *   ', [], {}, "hello',
  *   '", null]',
- * ]);
+ * ]).pipeThrough(new TextEncoderStream());
  * const json = await toJson(stream);
  * assertEquals(json, [1, true, [], {}, "hello", null]);
  * ```
  */
 export function toJson(
-  readableStream: ReadableStream,
+  readableStream: ReadableStream<Uint8Array>,
 ): Promise<unknown> {
   return toText(readableStream).then(JSON.parse);
 }

--- a/streams/to_json.ts
+++ b/streams/to_json.ts
@@ -6,7 +6,7 @@ import { toText } from "./to_text.ts";
 /**
  * Converts a JSON-formatted {@linkcode ReadableSteam} of
  * {@linkcode Uint8Array}s to an object. Works the same as
- * {@linkcode Response.json}.
+ * {@linkcode Request.json} and {@linkcode Response.json}.
  *
  * @param readableStream A `ReadableStream` whose chunks compose a JSON.
  * @returns A promise that resolves to the parsed JSON.

--- a/streams/to_json_test.ts
+++ b/streams/to_json_test.ts
@@ -6,18 +6,5 @@ import { toJson } from "./to_json.ts";
 Deno.test("toJson()", async () => {
   const byteStream = ReadableStream.from(["[", "1, 2, 3, 4", "]"])
     .pipeThrough(new TextEncoderStream());
-
   assertEquals(await toJson(byteStream), [1, 2, 3, 4]);
-
-  const stringStream = ReadableStream.from([
-    '{ "a": 2,',
-    ' "b": 3,',
-    ' "c": 4 }',
-  ]);
-
-  assertEquals(await toJson(stringStream), {
-    a: 2,
-    b: 3,
-    c: 4,
-  });
 });

--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -4,8 +4,8 @@
 const textDecoder = new TextDecoder();
 
 /**
- * Converts a {@linkcode ReadableSteam} of strings or {@linkcode Uint8Array}s
- * to a single string. Works the same as {@linkcode Response.text}.
+ * Converts a {@linkcode ReadableSteam} of {@linkcode Uint8Array}s to a single
+ * string. Works the same as {@linkcode Response.text}.
  *
  * @param readableStream A `ReadableStream` to convert into a `string`.
  * @returns A `Promise` that resolves to the `string`.
@@ -15,24 +15,23 @@ const textDecoder = new TextDecoder();
  * import { toText } from "@std/streams/to-text";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * const stream = ReadableStream.from(["Hello, ", "world!"]);
+ * const stream = ReadableStream.from(["Hello, ", "world!"])
+ *   .pipeThrough(new TextEncoderStream());
  * assertEquals(await toText(stream), "Hello, world!");
  * ```
  */
 export async function toText(
-  readableStream: ReadableStream,
+  readableStream: ReadableStream<Uint8Array>,
 ): Promise<string> {
   const reader = readableStream.getReader();
   let result = "";
 
   while (true) {
     const { done, value } = await reader.read();
-
     if (done) {
       break;
     }
-
-    result += typeof value === "string" ? value : textDecoder.decode(value);
+    result += textDecoder.decode(value);
   }
 
   return result;

--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -5,7 +5,8 @@ const textDecoder = new TextDecoder();
 
 /**
  * Converts a {@linkcode ReadableSteam} of {@linkcode Uint8Array}s to a single
- * string. Works the same as {@linkcode Response.text}.
+ * string. Works the same as {@linkcode Request.text} and
+ * {@linkcode Response.text}.
  *
  * @param readableStream A `ReadableStream` to convert into a `string`.
  * @returns A `Promise` that resolves to the `string`.

--- a/streams/to_text_test.ts
+++ b/streams/to_text_test.ts
@@ -4,12 +4,7 @@ import { assertEquals } from "@std/assert/assert-equals";
 import { toText } from "./to_text.ts";
 
 Deno.test("toText()", async () => {
-  const byteStream = ReadableStream.from(["hello", " js ", "fans"])
+  const stream = ReadableStream.from(["hello", " js ", "fans"])
     .pipeThrough(new TextEncoderStream());
-
-  assertEquals(await toText(byteStream), "hello js fans");
-
-  const stringStream = ReadableStream.from(["hello", " deno ", "world"]);
-
-  assertEquals(await toText(stringStream), "hello deno world");
+  assertEquals(await toText(stream), "hello js fans");
 });


### PR DESCRIPTION
### What's changed

Previously, [`toJson()`](https://jsr.io/@std/streams/doc/to-json/~/toJson) and [`toText()`](https://jsr.io/@std/streams/doc/to-text/~/toText) accepted `ReadableStream`, without the type of stream being defined. Now, these functions accept `ReadableStream<Uint8Array>`.

### Why this change was made

This change was made to align `toJson()` to [`Request.json()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/json) and [`Response.json()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/json), and `toText()` to [`Request.text()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/text) and [`Response.text()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/text), which seems to be the most common use case for these functions. The change also aligned these two functions with the similarly-oriented [`toBlob()`](https://jsr.io/@std/streams/doc/to-blob/~/toBlob), which did correctly accept `ReadableStream<Uint8Array>`.

### Migration guide

To migrate, ensure that a `ReadableStream` of `Uint8Array`s is being passed to these functions:
```diff
  import { toText } from "@std/streams/to-json";

- const stream = ReadableStream(["Hello, ", "world!"]);
+ const stream = ReadableStream(["Hello, ", "world!"]).pipeThrough(new TextEncoderStream());
  await toText(stream);
```

In most cases, adding `.pipeThrough(new TextEncoderStream())` for existing use cases that use `ReadableStream<string>` is all that's needed to migrate.

### Discussion

Alternatively, all 3 functions could be modified to accept `ReadbleStream<Uint8Array> | ReadableStream<string>`. However, this wasn't done in order to align with the `Request` and `Response` objects and slightly improve performance while still catering to the majority of use cases.