### PR TITLE
fix(streams): prevent `earlyZipReadableStreams()` from possibly using excessive memory

### DIFF
--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -91,7 +91,9 @@ export function earlyZipReadableStreams<T>(
         const { done, value } = await readers[i]!.read();
         if (done) {
           await Promise.all(
-            readers.map((reader) => reader.cancel(`Stream ${i} ended`)),
+            readers.map((reader) =>
+              reader.cancel(`Stream at index ${i} ended`)
+            ),
           );
           controller.close();
           return;

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -93,7 +93,8 @@ export function earlyZipReadableStreams<T>(
           await Promise.all(
             readers.map((reader) => reader.cancel("early_zip_ended")), // A better cancel message should maybe be put here?
           );
-          return controller.close();
+          controller.close();
+          return;
         }
         controller.enqueue(value);
       }

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -91,7 +91,7 @@ export function earlyZipReadableStreams<T>(
         const { done, value } = await readers[i]!.read();
         if (done) {
           await Promise.all(
-            readers.map((reader) => reader.cancel(`Stream ended at ${i}`)),
+            readers.map((reader) => reader.cancel(`Stream ${i} ended`)),
           );
           controller.close();
           return;

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -87,11 +87,11 @@ export function earlyZipReadableStreams<T>(
   const readers = streams.map((stream) => stream.getReader());
   return new ReadableStream<T>({
     async pull(controller) {
-      for (const reader of readers) {
-        const { done, value } = await reader.read();
+      for (let i = 0; i < readers.length; ++i) {
+        const { done, value } = await readers[i]!.read();
         if (done) {
           await Promise.all(
-            readers.map((reader) => reader.cancel("early_zip_ended")), // A better cancel message should maybe be put here?
+            readers.map((reader) => reader.cancel(`Stream ended at ${i}`)),
           );
           controller.close();
           return;

--- a/streams/early_zip_readable_streams_test.ts
+++ b/streams/early_zip_readable_streams_test.ts
@@ -62,13 +62,16 @@ Deno.test("earlyZipReadableStreams() can zip three streams", async () => {
 });
 
 Deno.test("earlyZipReadableStreams() forwards cancel()", async () => {
-  const streams = new Array(10).fill(false).map(() =>
+  const num = 10;
+  let cancelled = 0;
+  const streams = new Array(num).fill(false).map(() =>
     new ReadableStream(
       {
         pull(controller) {
           controller.enqueue("chunk");
         },
         cancel(reason) {
+          cancelled++;
           assertEquals(reason, "I was cancelled!");
         },
       },
@@ -76,4 +79,5 @@ Deno.test("earlyZipReadableStreams() forwards cancel()", async () => {
   );
 
   await earlyZipReadableStreams(...streams).cancel("I was cancelled!");
+  assertEquals(cancelled, num);
 });

--- a/streams/early_zip_readable_streams_test.ts
+++ b/streams/early_zip_readable_streams_test.ts
@@ -1,62 +1,77 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { earlyZipReadableStreams } from "./early_zip_readable_streams.ts";
-import { assertEquals } from "@std/assert";
+import { earlyZipReadableStreams } from "./early_zip_readable_streams.ts"
+import { assertEquals } from "@std/assert"
 
 Deno.test("earlyZipReadableStreams() handles short first", async () => {
-  const textStream = ReadableStream.from(["1", "2", "3"]);
-  const textStream2 = ReadableStream.from(["a", "b", "c", "d", "e"]);
+	const textStream = ReadableStream.from(["1", "2", "3"])
+	const textStream2 = ReadableStream.from(["a", "b", "c", "d", "e"])
 
-  const buf = await Array.fromAsync(
-    earlyZipReadableStreams(textStream, textStream2),
-  );
+	const buf = await Array.fromAsync(
+		earlyZipReadableStreams(textStream, textStream2),
+	)
 
-  assertEquals(buf, [
-    "1",
-    "a",
-    "2",
-    "b",
-    "3",
-    "c",
-  ]);
-});
+	assertEquals(buf, [
+		"1",
+		"a",
+		"2",
+		"b",
+		"3",
+		"c",
+	])
+})
 
 Deno.test("earlyZipReadableStreams() handles long first", async () => {
-  const textStream = ReadableStream.from(["a", "b", "c", "d", "e"]);
-  const textStream2 = ReadableStream.from(["1", "2", "3"]);
+	const textStream = ReadableStream.from(["a", "b", "c", "d", "e"])
+	const textStream2 = ReadableStream.from(["1", "2", "3"])
 
-  const buf = await Array.fromAsync(
-    earlyZipReadableStreams(textStream, textStream2),
-  );
+	const buf = await Array.fromAsync(
+		earlyZipReadableStreams(textStream, textStream2),
+	)
 
-  assertEquals(buf, [
-    "a",
-    "1",
-    "b",
-    "2",
-    "c",
-    "3",
-    "d",
-  ]);
-});
+	assertEquals(buf, [
+		"a",
+		"1",
+		"b",
+		"2",
+		"c",
+		"3",
+		"d",
+	])
+})
 
 Deno.test("earlyZipReadableStreams() can zip three streams", async () => {
-  const textStream = ReadableStream.from(["a", "b", "c", "d", "e"]);
-  const textStream2 = ReadableStream.from(["1", "2", "3"]);
-  const textStream3 = ReadableStream.from(["x", "y"]);
+	const textStream = ReadableStream.from(["a", "b", "c", "d", "e"])
+	const textStream2 = ReadableStream.from(["1", "2", "3"])
+	const textStream3 = ReadableStream.from(["x", "y"])
 
-  const buf = await Array.fromAsync(
-    earlyZipReadableStreams(textStream, textStream2, textStream3),
-  );
+	const buf = await Array.fromAsync(
+		earlyZipReadableStreams(textStream, textStream2, textStream3),
+	)
 
-  assertEquals(buf, [
-    "a",
-    "1",
-    "x",
-    "b",
-    "2",
-    "y",
-    "c",
-    "3",
-  ]);
-});
+	assertEquals(buf, [
+		"a",
+		"1",
+		"x",
+		"b",
+		"2",
+		"y",
+		"c",
+		"3",
+	])
+})
+
+Deno.test("earlyZipReadableStreams() forwards cancel()", async () => {
+	const streams = new Array(10).fill(false).map(() => new ReadableStream(
+		{
+			pull(controller) {
+				controller.enqueue('chunk')
+			},
+			cancel(reason) {
+				assertEquals(reason, 'I was cancelled!')
+			}
+		}
+	))
+
+	await earlyZipReadableStreams(...streams).cancel('I was cancelled!')
+})

--- a/streams/early_zip_readable_streams_test.ts
+++ b/streams/early_zip_readable_streams_test.ts
@@ -1,77 +1,79 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { earlyZipReadableStreams } from "./early_zip_readable_streams.ts"
-import { assertEquals } from "@std/assert"
+import { earlyZipReadableStreams } from "./early_zip_readable_streams.ts";
+import { assertEquals } from "@std/assert";
 
 Deno.test("earlyZipReadableStreams() handles short first", async () => {
-	const textStream = ReadableStream.from(["1", "2", "3"])
-	const textStream2 = ReadableStream.from(["a", "b", "c", "d", "e"])
+  const textStream = ReadableStream.from(["1", "2", "3"]);
+  const textStream2 = ReadableStream.from(["a", "b", "c", "d", "e"]);
 
-	const buf = await Array.fromAsync(
-		earlyZipReadableStreams(textStream, textStream2),
-	)
+  const buf = await Array.fromAsync(
+    earlyZipReadableStreams(textStream, textStream2),
+  );
 
-	assertEquals(buf, [
-		"1",
-		"a",
-		"2",
-		"b",
-		"3",
-		"c",
-	])
-})
+  assertEquals(buf, [
+    "1",
+    "a",
+    "2",
+    "b",
+    "3",
+    "c",
+  ]);
+});
 
 Deno.test("earlyZipReadableStreams() handles long first", async () => {
-	const textStream = ReadableStream.from(["a", "b", "c", "d", "e"])
-	const textStream2 = ReadableStream.from(["1", "2", "3"])
+  const textStream = ReadableStream.from(["a", "b", "c", "d", "e"]);
+  const textStream2 = ReadableStream.from(["1", "2", "3"]);
 
-	const buf = await Array.fromAsync(
-		earlyZipReadableStreams(textStream, textStream2),
-	)
+  const buf = await Array.fromAsync(
+    earlyZipReadableStreams(textStream, textStream2),
+  );
 
-	assertEquals(buf, [
-		"a",
-		"1",
-		"b",
-		"2",
-		"c",
-		"3",
-		"d",
-	])
-})
+  assertEquals(buf, [
+    "a",
+    "1",
+    "b",
+    "2",
+    "c",
+    "3",
+    "d",
+  ]);
+});
 
 Deno.test("earlyZipReadableStreams() can zip three streams", async () => {
-	const textStream = ReadableStream.from(["a", "b", "c", "d", "e"])
-	const textStream2 = ReadableStream.from(["1", "2", "3"])
-	const textStream3 = ReadableStream.from(["x", "y"])
+  const textStream = ReadableStream.from(["a", "b", "c", "d", "e"]);
+  const textStream2 = ReadableStream.from(["1", "2", "3"]);
+  const textStream3 = ReadableStream.from(["x", "y"]);
 
-	const buf = await Array.fromAsync(
-		earlyZipReadableStreams(textStream, textStream2, textStream3),
-	)
+  const buf = await Array.fromAsync(
+    earlyZipReadableStreams(textStream, textStream2, textStream3),
+  );
 
-	assertEquals(buf, [
-		"a",
-		"1",
-		"x",
-		"b",
-		"2",
-		"y",
-		"c",
-		"3",
-	])
-})
+  assertEquals(buf, [
+    "a",
+    "1",
+    "x",
+    "b",
+    "2",
+    "y",
+    "c",
+    "3",
+  ]);
+});
 
 Deno.test("earlyZipReadableStreams() forwards cancel()", async () => {
-	const streams = new Array(10).fill(false).map(() => new ReadableStream(
-		{
-			pull(controller) {
-				controller.enqueue('chunk')
-			},
-			cancel(reason) {
-				assertEquals(reason, 'I was cancelled!')
-			}
-		}
-	))
+  const streams = new Array(10).fill(false).map(() =>
+    new ReadableStream(
+      {
+        pull(controller) {
+          controller.enqueue("chunk");
+        },
+        cancel(reason) {
+          assertEquals(reason, "I was cancelled!");
+        },
+      },
+    )
+  );
 
-	await earlyZipReadableStreams(...streams).cancel('I was cancelled!')
-})
+  await earlyZipReadableStreams(...streams).cancel("I was cancelled!");
+});


### PR DESCRIPTION
Jumping from: https://github.com/denoland/deno_std/pull/5078#discussion_r1645446809

This pull request changes the structure of the readable stream to use a pull method instead of the start method, stopping it from the possibility of using excessive memory, possibly overflowing it if not consumed fast enough, or at all. This alternative also offers a way to cancel the provided reason streams from the returned stream.

## Current Version - overloaded the memory
![Screenshot 2024-06-19 at 16 20 10](https://github.com/denoland/deno_std/assets/44320105/c0d6791d-28f6-419a-aad1-b808f841572b)

## Alterative Version
![Screenshot 2024-06-19 at 16 20 30](https://github.com/denoland/deno_std/assets/44320105/a0d3a28e-d258-4477-91f7-d2532bdb7b69)

## Benchmark
This refactor did turn out to be slightly slower than the existing one in a benchmark.
![Screenshot 2024-06-19 at 16 32 06](https://github.com/denoland/deno_std/assets/44320105/f708c43f-a2e0-4f6b-92b0-4cff0b1364d1)