### PR TITLE
test(fs): check `ensureDir()` is not racy

### DIFF
--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -187,3 +187,22 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "ensureDir() isn't racy",
+  async fn() {
+    for (const _ of Array(100)) {
+      const dir = path.join(
+        await Deno.makeTempDir(),
+        "check",
+        "race",
+      );
+
+      // It doesn't throw with successive calls.
+      await Promise.all([
+        ensureDir(dir),
+        ensureDir(dir),
+      ]);
+    }
+  },
+});


### PR DESCRIPTION
This PR adds a check for #3233