### PR TITLE
test(jsonc): remove dead code and improve testing

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -203,6 +203,7 @@ class JSONCParser {
       }
     }
   }
+
   #parseJsonValue(value: Token): JsonValue {
     switch (value.type) {
       case "BeginObject":
@@ -217,6 +218,7 @@ class JSONCParser {
         throw new SyntaxError(buildErrorMessage(value));
     }
   }
+
   #parseObject(): { [key: string]: JsonValue | undefined } {
     const target: { [key: string]: JsonValue | undefined } = {};
     //   ┌─token1
@@ -276,6 +278,7 @@ class JSONCParser {
       }
     }
   }
+
   #parseArray(): JsonValue[] {
     const target: JsonValue[] = [];
     //   ┌─token1
@@ -311,6 +314,7 @@ class JSONCParser {
       }
     }
   }
+
   #parseString(value: {
     type: "String";
     sourceText: string;
@@ -328,6 +332,7 @@ class JSONCParser {
     }
     return parsed;
   }
+
   #parseNullOrTrueOrFalseOrNumber(value: {
     type: "NullOrTrueOrFalseOrNumber";
     sourceText: string;
@@ -384,8 +389,6 @@ function buildErrorMessage({ type, sourceText, position }: Token): string {
         ? `${sourceText.slice(0, 30)}...`
         : sourceText;
       break;
-    default:
-      throw new Error("unreachable");
   }
   return `Unexpected token ${token} in JSONC at position ${position}`;
 }

--- a/jsonc/parse_test.ts
+++ b/jsonc/parse_test.ts
@@ -8,6 +8,10 @@ import {
   assertThrows,
 } from "@std/assert";
 
+import "./testdata/JSONTestSuite/test.ts";
+import "./testdata/node-jsonc-parser/test.ts";
+import "./testdata/test262/test.ts";
+
 // The test code for the jsonc module can also be found in the testcode directory.
 
 function assertValidParse(
@@ -111,6 +115,21 @@ Deno.test({
       SyntaxError,
       "Unexpected token aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... in JSONC at position 1",
     );
+    assertInvalidParse(
+      `}`,
+      SyntaxError,
+      "Unexpected token } in JSONC at position 0",
+    );
+    assertInvalidParse(
+      `]`,
+      SyntaxError,
+      "Unexpected token ] in JSONC at position 0",
+    );
+    assertInvalidParse(
+      `,`,
+      SyntaxError,
+      "Unexpected token , in JSONC at position 0",
+    );
   },
 });
 
@@ -198,5 +217,17 @@ Deno.test({
     });
     const { success } = await command.output();
     assert(success);
+  },
+});
+
+Deno.test({
+  name: "new parse() throws error",
+  fn() {
+    assertThrows(
+      // deno-lint-ignore no-explicit-any
+      () => new (parse as any)(""),
+      TypeError,
+      "parse is not a constructor",
+    );
   },
 });


### PR DESCRIPTION
This improves the test coverage of `jsonc` from 85.26% to 97.42% (missed lines are reduced from  46 to 8)

part of #3713 