### PR TITLE
BREAKING(json): remove `writableStrategy` and `readableStrategy` options

### DIFF
--- a/json/_test_common.ts
+++ b/json/_test_common.ts
@@ -2,16 +2,14 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import type { ConcatenatedJsonParseStream } from "./concatenated_json_parse_stream.ts";
 import type { JsonParseStream } from "./json_parse_stream.ts";
-import type { ParseStreamOptions } from "./common.ts";
 
 export async function assertValidParse(
   transform: typeof ConcatenatedJsonParseStream | typeof JsonParseStream,
   chunks: string[],
   expect: unknown[],
-  options?: ParseStreamOptions,
 ) {
   const r = ReadableStream.from(chunks)
-    .pipeThrough(new transform(options));
+    .pipeThrough(new transform());
   const res = await Array.fromAsync(r);
   assertEquals(res, expect);
 }
@@ -19,13 +17,12 @@ export async function assertValidParse(
 export async function assertInvalidParse(
   transform: typeof ConcatenatedJsonParseStream | typeof JsonParseStream,
   chunks: string[],
-  options: ParseStreamOptions,
   // deno-lint-ignore no-explicit-any
   ErrorClass: new (...args: any[]) => Error,
   msgIncludes: string | undefined,
 ) {
   const r = ReadableStream.from(chunks)
-    .pipeThrough(new transform(options));
+    .pipeThrough(new transform());
   await assertRejects(
     async () => await Array.fromAsync(r),
     ErrorClass,

--- a/json/common.ts
+++ b/json/common.ts
@@ -9,22 +9,3 @@ export type JsonValue =
   | number
   | boolean
   | null;
-
-/**
- * Options for {@linkcode JsonParseStream} and
- * {@linkcode ConcatenatedJsonParseStream}.
- */
-export interface ParseStreamOptions {
-  /**
-   * Controls the buffer of the {@linkcode TransformStream} used internally.
-   *
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream#writablestrategy}
-   */
-  readonly writableStrategy?: QueuingStrategy<string>;
-  /**
-   * Controls the buffer of the {@linkcode TransformStream} used internally.
-   *
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream#readablestrategy}
-   */
-  readonly readableStrategy?: QueuingStrategy<JsonValue>;
-}

--- a/json/concatenated_json_parse_stream.ts
+++ b/json/concatenated_json_parse_stream.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { toTransformStream } from "@std/streams/to-transform-stream";
-import type { JsonValue, ParseStreamOptions } from "./common.ts";
+import type { JsonValue } from "./common.ts";
 import { parse } from "./_common.ts";
 
 function isBlankChar(char: string | undefined) {
@@ -94,11 +94,9 @@ export class ConcatenatedJsonParseStream
    * ]);
    * ```
    */
-  constructor({ writableStrategy, readableStrategy }: ParseStreamOptions = {}) {
+  constructor() {
     const { writable, readable } = toTransformStream(
       this.#concatenatedJSONIterator,
-      writableStrategy,
-      readableStrategy,
     );
     this.writable = writable;
     this.readable = readable;

--- a/json/concatenated_json_parse_stream_test.ts
+++ b/json/concatenated_json_parse_stream_test.ts
@@ -272,7 +272,6 @@ Deno.test({
     await assertInvalidParse(
       ConcatenatedJsonParseStream,
       ["truu"],
-      {},
       SyntaxError,
       `Unexpected token 'u', \"truu\" is not valid JSON (parsing: 'truu')`,
     );
@@ -318,7 +317,6 @@ Deno.test({
     await assertInvalidParse(
       ConcatenatedJsonParseStream,
       ['{"foo": "bar"} {"foo": '],
-      {},
       SyntaxError,
       `Unexpected end of JSON input (parsing: ' {"foo": ')`,
     );
@@ -331,7 +329,6 @@ Deno.test({
     await assertInvalidParse(
       ConcatenatedJsonParseStream,
       [`{${"foo".repeat(100)}}`],
-      {},
       SyntaxError,
       `Expected property name or '}' in JSON at position 1 (line 1 column 2) (parsing: '{foofoofoofoofoofoofoofoofoofo...')`,
     );

--- a/json/json_parse_stream.ts
+++ b/json/json_parse_stream.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { JsonValue, ParseStreamOptions } from "./common.ts";
+import type { JsonValue } from "./common.ts";
 import { parse } from "./_common.ts";
 
 const branks = /^[ \t\r\n]*$/;
@@ -95,7 +95,7 @@ export class JsonParseStream extends TransformStream<string, JsonValue> {
    * ]);
    * ```
    */
-  constructor({ writableStrategy, readableStrategy }: ParseStreamOptions = {}) {
+  constructor() {
     super(
       {
         transform(chunk, controller) {
@@ -104,8 +104,6 @@ export class JsonParseStream extends TransformStream<string, JsonValue> {
           }
         },
       },
-      writableStrategy,
-      readableStrategy,
     );
   }
 }

--- a/json/json_parse_stream_test.ts
+++ b/json/json_parse_stream_test.ts
@@ -45,7 +45,6 @@ Deno.test({
     await assertInvalidParse(
       JsonParseStream,
       ['{"foo": "bar"}', '{"foo": '],
-      {},
       SyntaxError,
       `Unexpected end of JSON input (parsing: '{"foo": ')`,
     );

--- a/json/json_stringify_stream.ts
+++ b/json/json_stringify_stream.ts
@@ -15,18 +15,6 @@ export interface StringifyStreamOptions {
    * @default {"\n"}
    */
   readonly suffix?: string;
-  /**
-   * Controls the buffer of the {@linkcode TransformStream} used internally.
-   *
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream#writablestrategy}
-   */
-  readonly writableStrategy?: QueuingStrategy<unknown>;
-  /**
-   * Controls the buffer of the {@linkcode TransformStream} used internally.
-   *
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/TransformStream/TransformStream#readablestrategy}
-   */
-  readonly readableStrategy?: QueuingStrategy<string>;
 }
 
 /**
@@ -121,8 +109,6 @@ export class JsonStringifyStream extends TransformStream<unknown, string> {
   constructor({
     prefix = "",
     suffix = "\n",
-    writableStrategy,
-    readableStrategy,
   }: StringifyStreamOptions = {}) {
     super(
       {
@@ -130,8 +116,6 @@ export class JsonStringifyStream extends TransformStream<unknown, string> {
           controller.enqueue(`${prefix}${JSON.stringify(chunk)}${suffix}`);
         },
       },
-      writableStrategy,
-      readableStrategy,
     );
   }
 }


### PR DESCRIPTION
### What's changed

The `writableStrategy` and `readableStrategy` options have been removed from the constructors from `ConcatenatedJsonParseStream`, `JsonParseStream` and `JsonStringifyStream`.

### Why this change was made

These options were removed because they aren't used in most use cases. For this reason, none of the other `TransformStream` implementations in the Standard Library have these options.

### Who this affects

Only those who use these options.

### Migration guide

If you require the use of these options, please implement a custom class that uses them.

```
class CustomJsonStringifyStream extends TransformStream<unknown, string> {
  constructor(
    writableStrategy: QueuingStrategy<unknown>,
    readableStrategy: QueuingStrategy<string>,
  ) {
    super(
      {
        transform(chunk, controller) {
          controller.enqueue(JSON.stringify(chunk));
        },
      },
      writableStrategy,
      readableStrategy,
    );
  }
}
```

### Related

Closes #4113