### PR TITLE
BREAKING(media-types): rename `extensionsByType` to `allExtensions`

### DIFF
--- a/media_types/all_extensions.ts
+++ b/media_types/all_extensions.ts
@@ -5,7 +5,7 @@ import { parseMediaType } from "./parse_media_type.ts";
 import { extensions } from "./_db.ts";
 
 /**
- * Returns the extensions known to be associated with the media type `type`, or
+ * Returns all the extensions known to be associated with the media type `type`, or
  * `undefined` if no extensions are found.
  *
  * Extensions are returned without a leading `.`.
@@ -17,15 +17,15 @@ import { extensions } from "./_db.ts";
  *
  * @example Usage
  * ```ts
- * import { extensionsByType } from "@std/media-types/extensions-by-type";
+ * import { allExtensions } from "@std/media-types/all-extensions";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * assertEquals(extensionsByType("application/json"), ["json", "map"]);
- * assertEquals(extensionsByType("text/html; charset=UTF-8"), ["html", "htm", "shtml"]);
- * assertEquals(extensionsByType("application/foo"), undefined);
+ * assertEquals(allExtensions("application/json"), ["json", "map"]);
+ * assertEquals(allExtensions("text/html; charset=UTF-8"), ["html", "htm", "shtml"]);
+ * assertEquals(allExtensions("application/foo"), undefined);
  * ```
  */
-export function extensionsByType(type: string): string[] | undefined {
+export function allExtensions(type: string): string[] | undefined {
   try {
     const [mediaType] = parseMediaType(type);
     return extensions.get(mediaType);

--- a/media_types/all_extensions_test.ts
+++ b/media_types/all_extensions_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals } from "@std/assert";
-import { extensionsByType } from "./extensions_by_type.ts";
+import { allExtensions } from "./all_extensions.ts";
 
 Deno.test({
   name: "extensionsByType()",
@@ -14,7 +14,7 @@ Deno.test({
       ["application/foo", undefined],
     ];
     for (const [fixture, expected] of fixtures) {
-      assertEquals(extensionsByType(fixture), expected);
+      assertEquals(allExtensions(fixture), expected);
     }
   },
 });

--- a/media_types/deno.json
+++ b/media_types/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts",
     "./content-type": "./content_type.ts",
     "./extension": "./extension.ts",
-    "./extensions-by-type": "./extensions_by_type.ts",
+    "./all-extensions": "./all_extensions.ts",
     "./format-media-type": "./format_media_type.ts",
     "./get-charset": "./get_charset.ts",
     "./parse-media-type": "./parse_media_type.ts",

--- a/media_types/extension.ts
+++ b/media_types/extension.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { extensionsByType } from "./extensions_by_type.ts";
+import { allExtensions } from "./all_extensions.ts";
 
 /**
  * Returns the most relevant extension for the given media type, or `undefined`
@@ -26,5 +26,5 @@ import { extensionsByType } from "./extensions_by_type.ts";
  * ```
  */
 export function extension(type: string): string | undefined {
-  return extensionsByType(type)?.[0];
+  return allExtensions(type)?.[0];
 }

--- a/media_types/mod.ts
+++ b/media_types/mod.ts
@@ -14,10 +14,10 @@
  * along with its license.
  *
  * ```ts
- * import { contentType, extensionsByType, getCharset } from "@std/media-types";
+ * import { contentType, allExtensions, getCharset } from "@std/media-types";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * assertEquals(extensionsByType("application/json"), ["json", "map"]);
+ * assertEquals(allExtensions("application/json"), ["json", "map"]);
  *
  * assertEquals(contentType(".json"), "application/json; charset=UTF-8");
  *
@@ -29,7 +29,7 @@
 
 export * from "./content_type.ts";
 export * from "./extension.ts";
-export * from "./extensions_by_type.ts";
+export * from "./all_extensions.ts";
 export * from "./format_media_type.ts";
 export * from "./get_charset.ts";
 export * from "./parse_media_type.ts";


### PR DESCRIPTION
This PR renames `extensionsByType` to `allExtensions` to align the naming convention to `extension` which takes the same arguments.

# What's changed

`extensionsByType` has been renamed to `allExtensions`

# Motivation

`extension` and `extensionsByType` take the same arguments (the content type), but named in an inconsistent way. This change align the naming of the latter to the former.

# Migration

```diff
-import { extensionsByType } from "@std/media-types";
+import { allExtensions } from "@std/media-types";
```