### PR TITLE
fix (text): keep cyrilic, latin and greek letters in casing functions

### DIFF
--- a/text/_util.ts
+++ b/text/_util.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 export function splitToWords(input: string) {
-  input = input.replaceAll(/[^a-zA-Z0-9\s-_]/g, "");
+  input = input.replaceAll(/[^A-Za-zΑ-Ωα-ωА-Яа-яЁё0-9\s-_]/g, "");
   if (/[\s-_]+/.test(input)) return input.split(/[\s-_]+/);
   return input.split(/(?=[A-Z])+/);
 }

--- a/text/case_test.ts
+++ b/text/case_test.ts
@@ -69,6 +69,12 @@ Deno.test("toPascalCase() converts a single word", () => {
   assertEquals(toPascalCase(input), expected);
 });
 
+Deno.test("toPascalCase() converts a single word with Cyrillic letters", () => {
+  const input = "шруберри";
+  const expected = "Шруберри";
+  assertEquals(toPascalCase(input), expected);
+});
+
 Deno.test("toPascalCase() converts a sentence", () => {
   const input = "she turned me into a newt";
   const expected = "SheTurnedMeIntoANewt";


### PR DESCRIPTION
I suggest not deleting letters from non-latin alphabets that support casing 