### PR TITLE
feat(yaml): support schema name for 'schema' option

### DIFF
--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -5,9 +5,31 @@
 // This module is browser compatible.
 
 import { type CbFunction, load, loadAll } from "./_loader/loader.ts";
-import type { LoaderStateOptions } from "./_loader/loader_state.ts";
+import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
-export type ParseOptions = LoaderStateOptions;
+/**
+ * Options for parsing YAML.
+ */
+export interface ParseOptions {
+  /** Uses legacy mode */
+  legacy?: boolean;
+  /** The listener */
+  // deno-lint-ignore no-explicit-any
+  listener?: ((...args: any[]) => void) | null;
+  /** string to be used as a file path in error/warning messages. */
+  filename?: string;
+  /**
+   * Specifies a schema to use.
+   *
+   * Schema class or its name.
+   */
+  // deno-lint-ignore no-explicit-any
+  schema?: any;
+  /** compatibility with JSON.parse behaviour. */
+  json?: boolean;
+  /** function to call on warning messages. */
+  onWarning?(this: null, e?: Error): void;
+}
 
 /**
  * Parses `content` as single YAML document.
@@ -16,6 +38,7 @@ export type ParseOptions = LoaderStateOptions;
  * By default, does not support regexps, functions and undefined. This method is safe for untrusted data.
  */
 export function parse(content: string, options?: ParseOptions): unknown {
+  replaceSchemaNameWithSchemaClass(options);
   return load(content, options);
 }
 
@@ -50,8 +73,12 @@ export function parseAll(
 export function parseAll(content: string, options?: ParseOptions): unknown;
 export function parseAll(
   content: string,
-  iterator?: CbFunction | ParseOptions,
+  iteratorOrOption?: CbFunction | ParseOptions,
   options?: ParseOptions,
 ): unknown {
-  return loadAll(content, iterator, options);
+  if (typeof iteratorOrOption !== "function") {
+    replaceSchemaNameWithSchemaClass(iteratorOrOption);
+  }
+  replaceSchemaNameWithSchemaClass(options);
+  return loadAll(content, iteratorOrOption, options);
 }

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -4,6 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+import type { Schema } from "./schema.ts";
 import { type CbFunction, load, loadAll } from "./_loader/loader.ts";
 import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
@@ -23,8 +24,7 @@ export interface ParseOptions {
    *
    * Schema class or its name.
    */
-  // deno-lint-ignore no-explicit-any
-  schema?: any;
+  schema?: string | Schema;
   /** compatibility with JSON.parse behaviour. */
   json?: boolean;
   /** function to call on warning messages. */
@@ -39,7 +39,8 @@ export interface ParseOptions {
  */
 export function parse(content: string, options?: ParseOptions): unknown {
   replaceSchemaNameWithSchemaClass(options);
-  return load(content, options);
+  // deno-lint-ignore no-explicit-any
+  return load(content, options as any);
 }
 
 /**
@@ -80,5 +81,6 @@ export function parseAll(
     replaceSchemaNameWithSchemaClass(iteratorOrOption);
   }
   replaceSchemaNameWithSchemaClass(options);
-  return loadAll(content, iteratorOrOption, options);
+  // deno-lint-ignore no-explicit-any
+  return loadAll(content, iteratorOrOption as any, options as any);
 }

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -86,6 +86,7 @@ Deno.test({
     };
 
     assertEquals(parse(yaml, { schema: EXTENDED_SCHEMA }), expected);
+    assertEquals(parse(yaml, { schema: "extended" }), expected);
   },
 });
 

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -4,8 +4,31 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+import { CORE_SCHEMA } from "./core.ts";
 export { CORE_SCHEMA } from "./core.ts";
+import { DEFAULT_SCHEMA } from "./default.ts";
 export { DEFAULT_SCHEMA } from "./default.ts";
+import { EXTENDED_SCHEMA } from "./extended.ts";
 export { EXTENDED_SCHEMA } from "./extended.ts";
+import { FAILSAFE_SCHEMA } from "./failsafe.ts";
 export { FAILSAFE_SCHEMA } from "./failsafe.ts";
+import { JSON_SCHEMA } from "./json.ts";
 export { JSON_SCHEMA } from "./json.ts";
+
+export function replaceSchemaNameWithSchemaClass(
+  options?: { schema?: any },
+) {
+  if (!options) return;
+  const name = options?.schema;
+  if (name === "core") {
+    options.schema = CORE_SCHEMA;
+  } else if (name === "default") {
+    options.schema = DEFAULT_SCHEMA;
+  } else if (name === "failsafe") {
+    options.schema = FAILSAFE_SCHEMA;
+  } else if (name === "json") {
+    options.schema = JSON_SCHEMA;
+  } else if (name === "extended") {
+    options.schema = EXTENDED_SCHEMA;
+  }
+}

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -4,32 +4,38 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+import type { Schema } from "../schema.ts";
 import { CORE_SCHEMA } from "./core.ts";
-export { CORE_SCHEMA } from "./core.ts";
 import { DEFAULT_SCHEMA } from "./default.ts";
-export { DEFAULT_SCHEMA } from "./default.ts";
 import { EXTENDED_SCHEMA } from "./extended.ts";
-export { EXTENDED_SCHEMA } from "./extended.ts";
 import { FAILSAFE_SCHEMA } from "./failsafe.ts";
-export { FAILSAFE_SCHEMA } from "./failsafe.ts";
 import { JSON_SCHEMA } from "./json.ts";
-export { JSON_SCHEMA } from "./json.ts";
+export {
+  CORE_SCHEMA,
+  DEFAULT_SCHEMA,
+  EXTENDED_SCHEMA,
+  FAILSAFE_SCHEMA,
+  JSON_SCHEMA,
+};
 
 export function replaceSchemaNameWithSchemaClass(
-  // deno-lint-ignore no-explicit-any
-  options?: { schema?: any },
+  options?: { schema?: string | Schema },
 ) {
-  if (!options) return;
-  const name = options?.schema;
-  if (name === "core") {
-    options.schema = CORE_SCHEMA;
-  } else if (name === "default") {
-    options.schema = DEFAULT_SCHEMA;
-  } else if (name === "failsafe") {
-    options.schema = FAILSAFE_SCHEMA;
-  } else if (name === "json") {
-    options.schema = JSON_SCHEMA;
-  } else if (name === "extended") {
-    options.schema = EXTENDED_SCHEMA;
+  switch (options?.schema) {
+    case "core":
+      options.schema = CORE_SCHEMA;
+      break;
+    case "default":
+      options.schema = DEFAULT_SCHEMA;
+      break;
+    case "failsafe":
+      options.schema = FAILSAFE_SCHEMA;
+      break;
+    case "json":
+      options.schema = JSON_SCHEMA;
+      break;
+    case "extended":
+      options.schema = EXTENDED_SCHEMA;
+      break;
   }
 }

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -16,6 +16,7 @@ import { JSON_SCHEMA } from "./json.ts";
 export { JSON_SCHEMA } from "./json.ts";
 
 export function replaceSchemaNameWithSchemaClass(
+  // deno-lint-ignore no-explicit-any
   options?: { schema?: any },
 ) {
   if (!options) return;

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -4,6 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+import type { Schema } from "./schema.ts";
 import { dump } from "./_dumper/dumper.ts";
 import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
@@ -32,8 +33,7 @@ export type DumpOptions = {
    *
    * Schema class or its name.
    */
-  // deno-lint-ignore no-explicit-any
-  schema?: any;
+  schema?: string | Schema;
   /**
    * If true, sort keys when dumping YAML in ascending, ASCII character order.
    * If a function, use the function to sort the keys. (default: false)
@@ -74,5 +74,6 @@ export function stringify(
   options?: DumpOptions,
 ): string {
   replaceSchemaNameWithSchemaClass(options);
-  return dump(data, options);
+  // deno-lint-ignore no-explicit-any
+  return dump(data, options as any);
 }

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -5,9 +5,64 @@
 // This module is browser compatible.
 
 import { dump } from "./_dumper/dumper.ts";
-import type { DumperStateOptions } from "./_dumper/dumper_state.ts";
+import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
-export type DumpOptions = DumperStateOptions;
+/**
+ * The option for strinigfy.
+ */
+export type DumpOptions = {
+  /** Indentation width to use (in spaces). */
+  indent?: number;
+  /** When true, will not add an indentation level to array elements */
+  noArrayIndent?: boolean;
+  /**
+   * Do not throw on invalid types (like function in the safe schema)
+   * and skip pairs and single values with such types.
+   */
+  skipInvalid?: boolean;
+  /**
+   * Specifies level of nesting, when to switch from
+   * block to flow style for collections. -1 means block style everywhere
+   */
+  flowLevel?: number;
+  /** Each tag may have own set of styles.	- "tag" => "style" map. */
+  styles?: Record<string, "lowercase" | "uppercase" | "camelcase" | "decimal">;
+  /**
+   * Specifies a schema to use.
+   *
+   * Schema class or its name.
+   */
+  // deno-lint-ignore no-explicit-any
+  schema?: any;
+  /**
+   * If true, sort keys when dumping YAML in ascending, ASCII character order.
+   * If a function, use the function to sort the keys. (default: false)
+   * If a function is specified, the function must return a negative value
+   * if first argument is less than second argument, zero if they're equal
+   * and a positive value otherwise.
+   */
+  sortKeys?: boolean | ((a: string, b: string) => number);
+  /** Set max line width. (default: 80) */
+  lineWidth?: number;
+  /**
+   * If true, don't convert duplicate objects
+   * into references (default: false)
+   */
+  noRefs?: boolean;
+  /**
+   * If true don't try to be compatible with older yaml versions.
+   * Currently: don't quote "yes", "no" and so on,
+   * as required for YAML 1.1 (default: false)
+   */
+  noCompatMode?: boolean;
+  /**
+   * If true flow sequences will be condensed, omitting the
+   * space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
+   * Can be useful when using yaml for pretty URL query params
+   * as spaces are %-encoded. (default: false).
+   */
+  condenseFlow?: boolean;
+};
 
 /**
  * Serializes `data` as a YAML document.
@@ -18,5 +73,6 @@ export function stringify(
   data: unknown,
   options?: DumpOptions,
 ): string {
+  replaceSchemaNameWithSchemaClass(options);
   return dump(data, options);
 }

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -119,6 +119,7 @@ undefined: !<tag:yaml.org,2002:js/undefined> ''
 `;
 
     assertEquals(stringify(object, { schema: EXTENDED_SCHEMA }), expected);
+    assertEquals(stringify(object, { schema: "extended" }), expected);
   },
 });
 
@@ -132,6 +133,9 @@ Deno.test({
 
     assertThrows(
       () => stringify({ function: func }, { schema: EXTENDED_SCHEMA }),
+    );
+    assertThrows(
+      () => stringify({ function: func }, { schema: "extended" }),
     );
   },
 });


### PR DESCRIPTION
This PR adds handling of string input for `schema` option for `parse` and `stringify`. This prepares for #5117

(Note: I plan to remove Schema class input for `schema` option at 1.0.0, which prevents exposing internal details of schema implementation as public APIs.)

This PR also removes the references to private types `DumperStateOptions` `LoaderStateOptions` from public types. This prepares for #3764 