### PR TITLE
refactor(http): remove dead code and improve `UserAgent` testing

### DIFF
--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -146,7 +146,7 @@ const windowsVersionMap = new Map<string, string | string[]>([
 ]);
 
 function has(str1: string, str2: string): boolean {
-  return lowerize(str2).indexOf(lowerize(str1)) !== -1;
+  return lowerize(str2).includes(lowerize(str1));
 }
 
 function mapWinVer(str: string) {

--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -53,12 +53,11 @@ const ZEBRA = "Zebra";
 type ProcessingFn = (value: string) => string | undefined;
 
 type MatchingTuple = [matchers: [RegExp, ...RegExp[]], processors: (
-  string | [string, string] | [string, ProcessingFn] | [
-    string,
-    RegExp,
-    string,
-    ProcessingFn?,
-  ]
+  | string
+  | [string, string]
+  | [string, ProcessingFn]
+  | [string, RegExp, string]
+  | [string, RegExp, string, ProcessingFn]
 )[]];
 
 interface Matchers {
@@ -146,15 +145,7 @@ const windowsVersionMap = new Map<string, string | string[]>([
   ["RT", "ARM"],
 ]);
 
-function has(str1: string | string[], str2: string): boolean {
-  if (Array.isArray(str1)) {
-    for (const el of str1) {
-      if (lowerize(el) === lowerize(str2)) {
-        return true;
-      }
-    }
-    return false;
-  }
+function has(str1: string, str2: string): boolean {
   return lowerize(str2).indexOf(lowerize(str1)) !== -1;
 }
 
@@ -184,21 +175,18 @@ function mapper(
     let j = 0;
     let k = 0;
     while (j < matchers.length && !matches) {
-      if (!matchers[j]) {
-        break;
-      }
       matches = matchers[j++]!.exec(ua);
 
       if (matches) {
         for (const processor of processors) {
-          const match = matches[++k]!;
+          const match = matches[++k];
           if (Array.isArray(processor)) {
             if (processor.length === 2) {
               const [prop, value] = processor;
               if (typeof value === "function") {
                 target[prop] = value.call(
                   target,
-                  match,
+                  match!,
                 );
               } else {
                 target[prop] = value;
@@ -208,9 +196,6 @@ function mapper(
               target[prop] = match ? match.replace(re, value) : undefined;
             } else {
               const [prop, re, value, fn] = processor;
-              if (!fn) {
-                throw new TypeError("Function must be defined in processor");
-              }
               target[prop] = match
                 ? fn.call(prop, match.replace(re, value))
                 : undefined;

--- a/http/user_agent_test.ts
+++ b/http/user_agent_test.ts
@@ -106,3 +106,97 @@ Deno.test({
     }
   },
 });
+
+Deno.test("UserAgent.constructor() accepts null", () => {
+  const ua = new UserAgent(null);
+  assertEquals(ua.ua, "");
+  assertEquals(ua.browser, {
+    name: undefined,
+    version: undefined,
+    major: undefined,
+  });
+  assertEquals(ua.cpu, { architecture: undefined });
+  assertEquals(ua.device, {
+    model: undefined,
+    type: undefined,
+    vendor: undefined,
+  });
+  assertEquals(ua.engine, { name: undefined, version: undefined });
+  assertEquals(ua.os, { name: undefined, version: undefined });
+});
+
+Deno.test("UserAgent.toString() returns ua itself", () => {
+  const ua = new UserAgent(
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+  );
+  assertEquals(ua.toString(), ua.ua);
+});
+
+Deno.test("UserAgent.toJSON() returns the object { browser, cpu, device, engine, os, ua }", () => {
+  const ua = new UserAgent(
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+  );
+  assertEquals(ua.toJSON(), {
+    browser: { name: "Chrome", version: "64.0.3282.140", major: "64" },
+    cpu: { architecture: "amd64" },
+    device: { model: undefined, type: undefined, vendor: undefined },
+    engine: { name: "Blink", version: "64.0.3282.140" },
+    os: { name: "Linux", version: "x86_64" },
+    ua:
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+  });
+});
+
+Deno.test("UserAgent supports custom inspect in Deno", () => {
+  const ua = new UserAgent(
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+  );
+  assertEquals(
+    Deno.inspect(ua),
+    `UserAgent {
+  browser: { name: "Chrome", version: "64.0.3282.140", major: "64" },
+  cpu: { architecture: "amd64" },
+  device: { model: undefined, type: undefined, vendor: undefined },
+  engine: { name: "Blink", version: "64.0.3282.140" },
+  os: { name: "Linux", version: "x86_64" },
+  ua: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36"
+}`,
+  );
+});
+
+Deno.test("UserAgent supports custom inspect in Node.js", async () => {
+  const { inspect } = await import("node:util");
+
+  const ua = new UserAgent(
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+  );
+  // Needs to delete Deno.customInspect to enable Node's inspect
+  // deno-lint-ignore no-explicit-any
+  (ua as any)[Symbol.for("Deno.customInspect")] = undefined;
+  assertEquals(
+    inspect(ua),
+    `UserAgent {
+  browser: { name: 'Chrome', version: '64.0.3282.140', major: '64' },
+  cpu: { architecture: 'amd64' },
+  device: { model: undefined, type: undefined, vendor: undefined },
+  engine: { name: 'Blink', version: '64.0.3282.140' },
+  os: { name: 'Linux', version: 'x86_64' },
+  ua: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36'
+}`,
+  );
+  assertEquals(
+    inspect(ua, { depth: null }),
+    `UserAgent {
+  browser: { name: 'Chrome', version: '64.0.3282.140', major: '64' },
+  cpu: { architecture: 'amd64' },
+  device: { model: undefined, type: undefined, vendor: undefined },
+  engine: { name: 'Blink', version: '64.0.3282.140' },
+  os: { name: 'Linux', version: 'x86_64' },
+  ua: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36'
+}`,
+  );
+  assertEquals(
+    inspect([[ua]], { depth: 1 }),
+    `[ [ [UserAgent] ] ]`,
+  );
+});


### PR DESCRIPTION
This PR removes some dead code and improves typings in `http/user_agent.ts`, and also adds test cases which exercise uncovered lines.

towards #3713 