### PR TITLE
fix(testing): function call of `Date` constructor is not correctly faked

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -85,10 +85,8 @@ const FakeDate = new Proxy(Date, {
     // @ts-expect-error this is a passthrough
     return new _internals.Date(...args);
   },
-  apply(_target, _thisArg, args) {
-    if (args.length === 0) args.push(FakeDate.now());
-    // @ts-expect-error this is a passthrough
-    return _internals.Date(...args);
+  apply(_target, _thisArg, _args) {
+    return new _internals.Date(FakeTimeNow()).toString();
   },
   get(target, prop, receiver) {
     if (prop === "now") {

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -3,6 +3,7 @@ import {
   assert,
   assertEquals,
   assertInstanceOf,
+  assertMatch,
   assertNotEquals,
   assertRejects,
   assertStrictEquals,
@@ -96,6 +97,11 @@ Deno.test("FakeTime causes Date instance methods passthrough to real Date instan
   } finally {
     func2.restore();
   }
+});
+
+Deno.test("FakeTime causes Date function to return the string representation of the current faked time", () => {
+  using _time = new FakeTime(24 * 60 * 60 * 1000);
+  assertMatch(Date(), /(Fri|Thu) Jan 0(1|2) 1970/);
 });
 
 Deno.test("FakeTime timeout functions unchanged if FakeTime is uninitialized", () => {


### PR DESCRIPTION
`Date()` (call without `new`) isn't faked correctly with the current implementation. This PR fixes it.