### PR TITLE
fix(testing): do not throw when calling `FakeTime.restore()` more than once

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -400,7 +400,7 @@ export class FakeTime {
    * ```
    */
   static restore() {
-    if (!time) throw new TimeError("time already restored");
+    if (!time) return;
     time.restore();
   }
 

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -818,7 +818,7 @@ export class FakeTime {
    * ```
    */
   restore() {
-    if (!time) throw new TimeError("time already restored");
+    if (!time) return;
     time = undefined;
     restoreGlobals();
     if (advanceIntervalId) clearInterval(advanceIntervalId);

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -632,3 +632,8 @@ Deno.test("Date from FakeTime is structured cloneable", () => {
   assert(date instanceof Date);
   assert(cloned instanceof Date_);
 });
+
+Deno.test("FakeTime does not throw when restored more than once", () => {
+  using _time1 = new FakeTime();
+  using _time2 = new FakeTime();
+});

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -633,7 +633,12 @@ Deno.test("Date from FakeTime is structured cloneable", () => {
   assert(cloned instanceof Date_);
 });
 
-Deno.test("FakeTime does not throw when restored more than once", () => {
+Deno.test("time.restore() does not throw when called more than once", () => {
   using _time1 = new FakeTime();
   using _time2 = new FakeTime();
+});
+
+Deno.test("FakeTime.restore() does not throw when called more than once", () => {
+  FakeTime.restore();
+  FakeTime.restore();
 });


### PR DESCRIPTION
Reviewing #5123, I thought this behavior was unreasonable.