### PR TITLE
docs(yaml): improve `yaml` document

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -71,6 +71,8 @@ const ENTRY_POINTS = [
   "../url/mod.ts",
   "../uuid/mod.ts",
   "../webgpu/mod.ts",
+  "../yaml/parse.ts",
+  "../yaml/stringify.ts",
 ] as const;
 
 const TS_SNIPPET = /```ts[\s\S]*?```/g;

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -31,10 +31,10 @@ export interface ParseOptions {
 }
 
 /**
- * Parses `content` as single YAML document.
+ * Parse `content` as single YAML document, and return it.
  *
- * Returns a JavaScript object or throws `YAMLError` on error.
- * By default, does not support regexps, functions and undefined. This method is safe for untrusted data.
+ * This function does not support regexps, functions, and undefined by default.
+ * This method is safe for parsing untrusted data.
  *
  * @example Usage
  * ```ts
@@ -49,6 +49,7 @@ export interface ParseOptions {
  * assertEquals(data, { id: 1, name: "Alice" });
  * ```
  *
+ * @throws {YAMLError} Throws error on invalid YAML.
  * @param content YAML string to parse.
  * @param options Parsing options.
  * @returns Parsed document.

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -22,6 +22,8 @@ export interface ParseOptions {
    * Specifies a schema to use.
    *
    * Schema class or its name.
+   *
+   * Passing Schema class is deprecated. Use schema name instead.
    */
   schema?: string | unknown;
   /** compatibility with JSON.parse behaviour. */

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -22,10 +22,8 @@ export interface ParseOptions {
    * Specifies a schema to use.
    *
    * Schema class or its name.
-   *
-   * Passing Schema class is deprecated. Use schema name instead.
    */
-  schema?: string | unknown;
+  schema?: "core" | "default" | "failsafe" | "json" | "extended" | unknown;
   /** compatibility with JSON.parse behaviour. */
   json?: boolean;
   /** function to call on warning messages. */
@@ -70,7 +68,7 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * import { parseAll } from "@std/yaml/parse";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * const data = parseAll(`
+ * parseAll(`
  * ---
  * id: 1
  * name: Alice
@@ -85,7 +83,6 @@ export function parse(content: string, options?: ParseOptions): unknown {
  *   assertEquals(typeof doc.id, "number");
  *   assertEquals(typeof doc.name, "string");
  * });
- * // => [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" } ]
  * ```
  *
  * @param content YAML string to parse.

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -80,7 +80,7 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * ---
  * id: 3
  * name: Eve
- * `, (doc) => {
+ * `, (doc: any) => {
  *   assertEquals(typeof doc, "object");
  *   assertEquals(typeof doc.id, "number");
  *   assertEquals(typeof doc.name, "string");

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -18,7 +18,9 @@ export {
 };
 
 export function replaceSchemaNameWithSchemaClass(
-  options?: { schema?: "core" | "default" | "failsafe" | "json" | "extended" | unknown },
+  options?: {
+    schema?: "core" | "default" | "failsafe" | "json" | "extended" | unknown;
+  },
 ) {
   switch (options?.schema) {
     case "core":

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -4,7 +4,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Schema } from "../schema.ts";
 import { CORE_SCHEMA } from "./core.ts";
 import { DEFAULT_SCHEMA } from "./default.ts";
 import { EXTENDED_SCHEMA } from "./extended.ts";
@@ -19,7 +18,7 @@ export {
 };
 
 export function replaceSchemaNameWithSchemaClass(
-  options?: { schema?: string | Schema },
+  options?: { schema?: string | unknown },
 ) {
   switch (options?.schema) {
     case "core":

--- a/yaml/schema/mod.ts
+++ b/yaml/schema/mod.ts
@@ -18,7 +18,7 @@ export {
 };
 
 export function replaceSchemaNameWithSchemaClass(
-  options?: { schema?: string | unknown },
+  options?: { schema?: "core" | "default" | "failsafe" | "json" | "extended" | unknown },
 ) {
   switch (options?.schema) {
     case "core":

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -4,7 +4,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { Schema } from "./schema.ts";
 import { dump } from "./_dumper/dumper.ts";
 import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
@@ -33,7 +32,7 @@ export type DumpOptions = {
    *
    * Schema class or its name.
    */
-  schema?: string | Schema;
+  schema?: string | unknown;
   /**
    * If true, sort keys when dumping YAML in ascending, ASCII character order.
    * If a function, use the function to sort the keys. (default: false)
@@ -68,6 +67,21 @@ export type DumpOptions = {
  * Serializes `data` as a YAML document.
  *
  * You can disable exceptions by setting the skipInvalid option to true.
+ *
+ * @example Usage
+ * ```ts
+ * import { stringify } from "@std/yaml/stringify";
+ * import { assertEquals } from "@std/assert/assert-equals";
+ *
+ * const data = { id: 1, name: "Alice" };
+ * const yaml = stringify(data);
+ *
+ * assertEquals(yaml, "id: 1\nname: Alice\n");
+ * ```
+ *
+ * @param data The data to serialize.
+ * @param options The options for serialization.
+ * @returns A YAML string.
  */
 export function stringify(
   data: unknown,

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -31,6 +31,8 @@ export type DumpOptions = {
    * Specifies a schema to use.
    *
    * Schema class or its name.
+   *
+   * Passing Schema class is deprecated. Use schema name instead.
    */
   schema?: string | unknown;
   /**

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -31,10 +31,8 @@ export type DumpOptions = {
    * Specifies a schema to use.
    *
    * Schema class or its name.
-   *
-   * Passing Schema class is deprecated. Use schema name instead.
    */
-  schema?: string | unknown;
+  schema?: "core" | "default" | "failsafe" | "json" | "extended" | unknown;
   /**
    * If true, sort keys when dumping YAML in ascending, ASCII character order.
    * If a function, use the function to sort the keys. (default: false)


### PR DESCRIPTION
part of #3764 

This PR documents `parse` and `stringify` of `yaml` package. I skipped documenting other items (such as `Schema`, `Type`, etc) as they are planned to be excluded from public APIs #5117 