### PR TITLE
BREAKING(http): improve thrown errors in `cookie` module

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -137,7 +137,7 @@ function toString(cookie: Cookie): string {
  */
 function validateName(name: string | undefined | null) {
   if (name && !FIELD_CONTENT_REGEXP.test(name)) {
-    throw new TypeError(`Invalid cookie name: "${name}".`);
+    throw new SyntaxError(`Invalid cookie name: "${name}".`);
   }
 }
 
@@ -156,7 +156,7 @@ function validatePath(path: string | null) {
       c < String.fromCharCode(0x20) || c > String.fromCharCode(0x7E) ||
       c === ";"
     ) {
-      throw new Error(
+      throw new SyntaxError(
         path + ": Invalid cookie path char '" + c + "'",
       );
     }
@@ -177,12 +177,12 @@ function validateValue(name: string, value: string | null) {
       c === String.fromCharCode(0x2c) || c === String.fromCharCode(0x3b) ||
       c === String.fromCharCode(0x5c) || c === String.fromCharCode(0x7f)
     ) {
-      throw new Error(
+      throw new SyntaxError(
         "RFC2616 cookie '" + name + "' cannot contain character '" + c + "'",
       );
     }
     if (c > String.fromCharCode(0x80)) {
-      throw new Error(
+      throw new SyntaxError(
         "RFC2616 cookie '" + name + "' can only have US-ASCII chars as value" +
           c.charCodeAt(0).toString(16),
       );
@@ -199,7 +199,7 @@ function validateDomain(domain: string) {
   const char1 = domain.charAt(0);
   const charN = domain.charAt(domain.length - 1);
   if (char1 === "-" || charN === "." || charN === "-") {
-    throw new Error(
+    throw new SyntaxError(
       "Invalid first/last char in cookie domain: " + domain,
     );
   }
@@ -231,7 +231,7 @@ export function getCookies(headers: Headers): Record<string, string> {
     for (const kv of c) {
       const [cookieKey, ...cookieVal] = kv.split("=");
       if (cookieKey === undefined) {
-        throw new TypeError("Cookie cannot start with '='");
+        throw new SyntaxError("Cookie cannot start with '='");
       }
       const key = cookieKey.trim();
       out[key] = cookieVal.join("=");

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -60,7 +60,7 @@ Deno.test({
             maxAge: 3,
           });
         },
-        Error,
+        SyntaxError,
         'Invalid cookie name: "' + name + '".',
       );
     });
@@ -97,7 +97,7 @@ Deno.test({
             },
           );
         },
-        Error,
+        SyntaxError,
         "RFC2616 cookie 'Space'",
       );
     });
@@ -109,7 +109,7 @@ Deno.test({
           value: "United Kingdom",
         });
       },
-      Error,
+      SyntaxError,
       "RFC2616 cookie 'location' cannot contain character ' '",
     );
   },
@@ -131,7 +131,7 @@ Deno.test({
           maxAge: 3,
         });
       },
-      Error,
+      SyntaxError,
       path + ": Invalid cookie path char ';'",
     );
   },
@@ -154,7 +154,7 @@ Deno.test({
             maxAge: 3,
           });
         },
-        Error,
+        SyntaxError,
         "Invalid first/last char in cookie domain: " + domain,
       );
     });


### PR DESCRIPTION
### What's changed

[`getCookies()`](https://jsr.io/@std/http/doc/cookie/~/getCookies) or [`setCookie()`](https://jsr.io/@std/http/doc/cookie/~/setCookie) now throw [`SyntaxError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError)s if they encounter invalid characters for their respective implementations. Previously, they threw a mix of [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)s and [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)s.

### Why this change was made

This change was made because `SyntaxError` is typically used in JavaScript to represent the encountering of invalid characters.

### Migration guide

When error-handling either of these functions, compare against `SyntaxError`, rather than `Error` or `TypeError`.

```diff
import { setCookie } from "@std/http/cookie";

const headers = new Headers();

try {
  setCookie(headers, {
    name: "location",
    value: "United Kingdom",
  });
} catch (error) {
- if (error instanceof Error) {
+ if (error instanceof SyntaxError) {
    // ...
  }
}
```