### PR TITLE
BREAKING(testing): disable multiple `FakeTime` creations

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -313,7 +313,7 @@ export class FakeTime {
     start?: number | string | Date | null,
     options?: FakeTimeOptions,
   ) {
-    if (time) time.restore();
+    if (time) throw new TimeError("The time is already faked");
     initializedAt = _internals.Date.now();
     startedAt = start instanceof Date
       ? start.valueOf()

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -7,6 +7,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertStrictEquals,
+  assertThrows,
 } from "@std/assert";
 import { FakeTime, TimeError } from "./time.ts";
 import { _internals } from "./_time.ts";
@@ -637,4 +638,9 @@ Deno.test("Date from FakeTime is structured cloneable", () => {
   assertEquals(cloned.getTime(), date.getTime());
   assert(date instanceof Date);
   assert(cloned instanceof Date_);
+});
+
+Deno.test("new FakeTime() throws if the time is already faked", () => {
+  using _time: FakeTime = new FakeTime();
+  assertThrows(() => new FakeTime());
 });

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -641,6 +641,6 @@ Deno.test("Date from FakeTime is structured cloneable", () => {
 });
 
 Deno.test("new FakeTime() throws if the time is already faked", () => {
-  using _time: FakeTime = new FakeTime();
+  using _time = new FakeTime();
   assertThrows(() => new FakeTime());
 });


### PR DESCRIPTION
Alternative to #5125. This PR disables multiple FakeTime creations.

context: https://github.com/denoland/deno_std/pull/5125#issuecomment-2187684400