### PR TITLE
fix(http): handle the case fileInfo.mode=0 correctly

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -76,10 +76,7 @@ function modeToString(isDir: boolean, maybeMode: number | null): string {
   if (maybeMode === null) {
     return "(unknown mode)";
   }
-  const mode = maybeMode.toString(8);
-  if (mode.length < 3) {
-    return "(unknown mode)";
-  }
+  const mode = maybeMode.toString(8).padStart(3, "0");
   let output = "";
   mode
     .split("")

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -223,6 +223,21 @@ Deno.test("serveDir() serves directory index with file containing space in the f
   await Deno.remove(filePath);
 });
 
+Deno.test("serveDir() serves directory index with file's mode is 0", async () => {
+  const stat = Deno.stat;
+  using _stub = stub(
+    Deno,
+    "stat",
+    async (path: string | URL): Promise<Deno.FileInfo> => ({
+      ...(await stat(path)),
+      mode: 0,
+    }),
+  );
+  const res = await serveDir(new Request("http://localhost/"), serveDirOptions);
+  const page = await res.text();
+  assertMatch(page, /<td class="mode">(\s)*- --- --- ---(\s)*<\/td>/);
+});
+
 Deno.test("serveDir() returns a response even if fileinfo is inaccessible", async () => {
   // Note: Deno.stat for windows system files may be rejected with os error 32.
   // Mock Deno.stat to test that the dirlisting page can be generated


### PR DESCRIPTION
In file_server, currently when the fileInfo.mode is 0, it shows `(unknown mode)` for its mode, but it should be `--- --- ---` (no permission). This PR fixes it.