### PR TITLE
refactor(http): change error thrown in `ServerSentEventStream` to `SyntaxError`

### DIFF
--- a/http/server_sent_event_stream.ts
+++ b/http/server_sent_event_stream.ts
@@ -24,7 +24,7 @@ export interface ServerSentEventMessage {
 
 function assertHasNoNewline(value: string, varName: string) {
   if (value.match(NEWLINE_REGEXP) !== null) {
-    throw new RangeError(`${varName} cannot contain a newline`);
+    throw new SyntaxError(`${varName} cannot contain a newline`);
   }
 }
 

--- a/http/server_sent_event_stream_test.ts
+++ b/http/server_sent_event_stream_test.ts
@@ -62,57 +62,57 @@ Deno.test("ServerSentEventStream throws if single-line fields contain a newline"
   // Comment
   await assertRejects(
     async () => await createStream([{ comment: "a\n" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.comment` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ comment: "a\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.comment` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ comment: "a\n\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.comment` cannot contain a newline",
   );
 
   // Event
   await assertRejects(
     async () => await createStream([{ event: "a\n" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.event` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ event: "a\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.event` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ event: "a\n\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.event` cannot contain a newline",
   );
 
   // ID
   await assertRejects(
     async () => await createStream([{ id: "a\n" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.id` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ id: "a\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.id` cannot contain a newline",
   );
 
   await assertRejects(
     async () => await createStream([{ id: "a\n\r" }]).getReader().read(),
-    RangeError,
+    SyntaxError,
     "`message.id` cannot contain a newline",
   );
 });


### PR DESCRIPTION
### What's changed

This PR changes the error thrown in [`ServerSentEventStream`](https://jsr.io/@std/http/doc/server-sent-event-stream/~/ServerSentEventStream) from [`RangeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError) to [`SyntaxError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) if the `comment`, `event` or `id` properties of the chunk contained a newline.

### Why this change was made

This change was made as `SyntaxError` is more appropriate for invalid characters, than `RangeError`.

### Migration guide

To migrate, when error-handling, compare against `SyntaxError` instead of `RangeError`.
```diff
import { ServerSentEventStream } from "@std/http/server-sent-event-stream";

const stream = ReadableStream
  .from<ServerSentEventMessage>([{ event: "a\nb" }])
  .pipeThrough(new ServerSentEventStream());

try {
  await Array.fromAsync(stream);
} catch (error) {
- if (error instanceof RangeError) {
+ if (error instanceof SyntaxError) {
    // ...
  }
}
```