### PR TITLE
BREAKING(http): rename `verifyCookie()` to `verifySignedCookie()`

### DIFF
--- a/http/signed_cookie.ts
+++ b/http/signed_cookie.ts
@@ -63,7 +63,7 @@ export async function signCookie(
  *
  * @example Usage
  * ```ts no-eval no-assert
- * import { verifyCookie } from "@std/http/signed-cookie";
+ * import { verifySignedCookie } from "@std/http/signed-cookie";
  * import { getCookies } from "@std/http/cookie";
  *
  * const key = await crypto.subtle.generateKey(
@@ -77,14 +77,14 @@ export async function signCookie(
  * });
  * const signedCookie = getCookies(headers)["location"];
  * if (signedCookie === undefined) throw new Error("Cookie not found");
- * await verifyCookie(signedCookie, key);
+ * await verifySignedCookie(signedCookie, key);
  * ```
  *
  * @param signedCookie The signed cookie to verify.
  * @param key The cryptographic key to verify the cookie with.
  * @returns Whether or not the cookie is valid.
  */
-export async function verifyCookie(
+export async function verifySignedCookie(
   signedCookie: string,
   key: CryptoKey,
 ): Promise<boolean> {
@@ -102,13 +102,13 @@ export async function verifyCookie(
  *
  * Parses a signed cookie to get its value.
  *
- * Important: always verify the cookie using {@linkcode verifyCookie} first.
+ * Important: always verify the cookie using {@linkcode verifySignedCookie} first.
  *
  * @experimental
  *
  * @example Usage
  * ```ts no-eval no-assert
- * import { verifyCookie, parseSignedCookie } from "@std/http/signed-cookie";
+ * import { verifySignedCookie, parseSignedCookie } from "@std/http/signed-cookie";
  * import { getCookies } from "@std/http/cookie";
  *
  * const key = await crypto.subtle.generateKey(
@@ -122,7 +122,7 @@ export async function verifyCookie(
  * });
  * const signedCookie = getCookies(headers)["location"];
  * if (signedCookie === undefined) throw new Error("Cookie not found");
- * await verifyCookie(signedCookie, key);
+ * await verifySignedCookie(signedCookie, key);
  * const cookie = parseSignedCookie(signedCookie);
  * ```
  *

--- a/http/signed_cookie_test.ts
+++ b/http/signed_cookie_test.ts
@@ -2,11 +2,11 @@
 import {
   parseSignedCookie,
   signCookie,
-  verifyCookie,
+  verifySignedCookie,
 } from "./signed_cookie.ts";
 import { assertEquals } from "@std/assert/assert-equals";
 
-Deno.test("signCookie() and verifyCookie() work circularly", async () => {
+Deno.test("signCookie() and verifySignedCookie() work circularly", async () => {
   const key = await crypto.subtle.generateKey(
     { name: "HMAC", hash: "SHA-256" },
     true,
@@ -15,13 +15,13 @@ Deno.test("signCookie() and verifyCookie() work circularly", async () => {
   const value = "boris";
 
   const signedCookie = await signCookie(value, key);
-  assertEquals(await verifyCookie(signedCookie, key), true);
+  assertEquals(await verifySignedCookie(signedCookie, key), true);
 
   const tamperedCookie = signedCookie.replace(value, "xenia");
-  assertEquals(await verifyCookie(tamperedCookie, key), false);
+  assertEquals(await verifySignedCookie(tamperedCookie, key), false);
 });
 
-Deno.test("signCookie() and verifyCookie() work circularly when the cookie value contains a period", async () => {
+Deno.test("signCookie() and verifySignedCookie() work circularly when the cookie value contains a period", async () => {
   const key = await crypto.subtle.generateKey(
     { name: "HMAC", hash: "SHA-256" },
     true,
@@ -30,22 +30,22 @@ Deno.test("signCookie() and verifyCookie() work circularly when the cookie value
   const value = "boris.xenia";
 
   const signedCookie = await signCookie(value, key);
-  assertEquals(await verifyCookie(signedCookie, key), true);
+  assertEquals(await verifySignedCookie(signedCookie, key), true);
 
   const tamperedCookie = signedCookie.replace(value, "xenia");
-  assertEquals(await verifyCookie(tamperedCookie, key), false);
+  assertEquals(await verifySignedCookie(tamperedCookie, key), false);
 });
 
-Deno.test("verifyCookie() returns false on poorly formed value", async () => {
+Deno.test("verifySignedCookie() returns false on poorly formed value", async () => {
   const key = await crypto.subtle.generateKey(
     { name: "HMAC", hash: "SHA-256" },
     true,
     ["sign", "verify"],
   );
 
-  assertEquals(await verifyCookie(".", key), false);
-  assertEquals(await verifyCookie("hello.", key), false);
-  assertEquals(await verifyCookie(".world", key), false);
+  assertEquals(await verifySignedCookie(".", key), false);
+  assertEquals(await verifySignedCookie("hello.", key), false);
+  assertEquals(await verifySignedCookie(".world", key), false);
 });
 
 Deno.test("parseSignedCookie() returns parsed cookie value", () => {


### PR DESCRIPTION
### What's changed

`verifyCookie()` has been renamed to `verifySignedCookie()`.

### Why this change was made

This change was made to make it clear to users that this function only deals with signed cookies.

### Migration guide

Use `verifySignedCookie()` instead of `verifyCookie()`.

```diff
- import { verifyCookie } from "@std/http/signed-cookie";
+ import { verifySignedCookie } from "@std/http/signed-cookie";

// ...
- await verifyCookie(signedCookie, key);
+ await verifySignedCookie(signedCookie, key);
// ...
```

### Related

Closes #5134