### PR TITLE
fix(testing): correctly throw in constructor with `spy()`

### DIFF
--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -759,10 +759,11 @@ function constructorSpy<
   const calls: SpyCall<Self, Args, Self>[] = [];
   // @ts-ignore TS2509: Can't know the type of `original` statically.
   const spy = class extends original {
+    // deno-lint-ignore constructor-super
     constructor(...args: Args) {
-      super(...args);
       const call: SpyCall<Self, Args, Self> = { args };
       try {
+        super(...args);
         call.returned = this as unknown as Self;
       } catch (error) {
         call.error = error as Error;

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -518,6 +518,11 @@ Deno.test("spy() works on constructor that throws an error", () => {
   }
   const FooSpy = spy(Foo);
   assertThrows(() => new FooSpy(), Error, "foo");
+  assertSpyCall(FooSpy, 0, {
+    self: undefined,
+    args: [],
+    error: { Class: Error, msgIncludes: "foo" },
+  });
 });
 
 Deno.test("spy() works with throwing method", () => {

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -510,6 +510,16 @@ Deno.test("spy() works on constructor of child class", () => {
   assertSpyCalls(PointSpy, 1);
 });
 
+Deno.test("spy() works on constructor that throws an error", () => {
+  class Foo {
+    constructor() {
+      throw new Error("foo");
+    }
+  }
+  const FooSpy = spy(Foo);
+  assertThrows(() => new FooSpy(), Error, "foo");
+});
+
 Deno.test("stub()", () => {
   const point = new Point(2, 3);
   const func = stub(point, "action");

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -563,7 +563,6 @@ Deno.test("spy() throws when the property is not configurable", () => {
     MockError,
     "cannot spy on non configurable instance method",
   );
->>>>>>> main
 });
 
 Deno.test("stub()", () => {


### PR DESCRIPTION
Currently thrown error from constructor is not captured by `spy`. This PR enables spying thrown errors from constructor.