### PR TITLE
docs(fs): add not supported docs for `CopyOptions.preserveTimestamps`

### DIFF
--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -23,6 +23,8 @@ export interface CopyOptions {
    * the original source files. When `false`, timestamp behavior is
    * OS-dependent.
    *
+   * Note: This options is currently unsupported for symbolic links.
+   *
    * @default {false}
    */
   preserveTimestamps?: boolean;


### PR DESCRIPTION
Temporarily addresses #5083