### PR TITLE
BREAKING(yaml): remove `iterator` argument from `parseAll()`

### DIFF
--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -1765,27 +1765,11 @@ function loadDocuments(input: string, options?: LoaderStateOptions): unknown[] {
   return state.documents;
 }
 
-export type CbFunction = (doc: unknown) => void;
-function isCbFunction(fn: unknown): fn is CbFunction {
-  return typeof fn === "function";
-}
-
-export function loadAll<T extends CbFunction | LoaderStateOptions>(
+export function loadAll(
   input: string,
-  iteratorOrOption?: T,
   options?: LoaderStateOptions,
-): T extends CbFunction ? void : unknown[] {
-  if (!isCbFunction(iteratorOrOption)) {
-    return loadDocuments(input, iteratorOrOption as LoaderStateOptions) as Any;
-  }
-
-  const documents = loadDocuments(input, options);
-  const iterator = iteratorOrOption;
-  for (let index = 0; index < documents.length; index++) {
-    iterator(documents[index]);
-  }
-
-  return void 0 as Any;
+): unknown[] {
+  return loadDocuments(input, options);
 }
 
 export function load(input: string, options?: LoaderStateOptions): unknown {

--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -1729,7 +1729,10 @@ function readDocument(state: LoaderState) {
   }
 }
 
-function loadDocuments(input: string, options?: LoaderStateOptions): unknown[] {
+export function loadDocuments(
+  input: string,
+  options?: LoaderStateOptions,
+): unknown[] {
   input = String(input);
   options = options || {};
 
@@ -1763,13 +1766,6 @@ function loadDocuments(input: string, options?: LoaderStateOptions): unknown[] {
   }
 
   return state.documents;
-}
-
-export function loadAll(
-  input: string,
-  options?: LoaderStateOptions,
-): unknown[] {
-  return loadDocuments(input, options);
 }
 
 export function load(input: string, options?: LoaderStateOptions): unknown {

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { load, loadAll } from "./_loader/loader.ts";
+import { load, loadDocuments } from "./_loader/loader.ts";
 import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 
 /**
@@ -90,5 +90,5 @@ export function parse(content: string, options?: ParseOptions): unknown {
 export function parseAll(content: string, options?: ParseOptions): unknown {
   replaceSchemaNameWithSchemaClass(options);
   // deno-lint-ignore no-explicit-any
-  return loadAll(content, options as any);
+  return loadDocuments(content, options as any);
 }

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -69,41 +69,6 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * import { parseAll } from "@std/yaml/parse";
  * import { assertEquals } from "@std/assert/assert-equals";
  *
- * parseAll(`
- * ---
- * id: 1
- * name: Alice
- * ---
- * id: 2
- * name: Bob
- * ---
- * id: 3
- * name: Eve
- * `, (doc: any) => {
- *   assertEquals(typeof doc, "object");
- *   assertEquals(typeof doc.id, "number");
- *   assertEquals(typeof doc.name, "string");
- * });
- * ```
- *
- * @param content YAML string to parse.
- * @param iterator Function to call on each document.
- * @param options Parsing options.
- */
-export function parseAll(
-  content: string,
-  iterator: (doc: unknown) => void,
-  options?: ParseOptions,
-): void;
-/**
- * Same as `parse()`, but understands multi-document sources.
- * Applies iterator to each document if specified, or returns array of documents.
- *
- * @example Usage
- * ```ts
- * import { parseAll } from "@std/yaml/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
- *
  * const data = parseAll(`
  * ---
  * id: 1
@@ -122,16 +87,8 @@ export function parseAll(
  * @param options Parsing options.
  * @returns Array of parsed documents.
  */
-export function parseAll(content: string, options?: ParseOptions): unknown;
-export function parseAll(
-  content: string,
-  iteratorOrOption?: ((doc: unknown) => void) | ParseOptions,
-  options?: ParseOptions,
-): unknown {
-  if (typeof iteratorOrOption !== "function") {
-    replaceSchemaNameWithSchemaClass(iteratorOrOption);
-  }
+export function parseAll(content: string, options?: ParseOptions): unknown {
   replaceSchemaNameWithSchemaClass(options);
   // deno-lint-ignore no-explicit-any
-  return loadAll(content, iteratorOrOption as any, options as any);
+  return loadAll(content, options as any);
 }

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -149,28 +149,8 @@ regexp: !!js/regexp bar
         regexp: /bar/,
       },
     ];
-    const mockCallback = () => {
-      let count = 0;
-      const fn = () => {
-        count++;
-      };
-      const callback = {
-        calls() {
-          return count;
-        },
-        fn,
-      };
-      return callback;
-    };
 
     assertEquals(parseAll(yaml, { schema: EXTENDED_SCHEMA }), expected);
-
-    const callback = mockCallback();
-    assertEquals(
-      parseAll(yaml, callback.fn, { schema: EXTENDED_SCHEMA }),
-      undefined,
-    );
-    assertEquals(callback.calls(), 2);
   },
 });
 


### PR DESCRIPTION
Closes #5128