### PR TITLE
refactor(streams): throw in `zipReadableStreams()` naturally

### DIFF
--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -80,23 +80,19 @@ export function zipReadableStreams<T>(
   const readers = new Set(streams.map((s) => s.getReader()));
   return new ReadableStream<T>({
     async start(controller) {
-      try {
-        let resolved = 0;
-        while (resolved !== streams.length) {
-          for (const reader of readers) {
-            const { value, done } = await reader.read();
-            if (!done) {
-              controller.enqueue(value!);
-            } else {
-              resolved++;
-              readers.delete(reader);
-            }
+      let resolved = 0;
+      while (resolved !== streams.length) {
+        for (const reader of readers) {
+          const { value, done } = await reader.read();
+          if (!done) {
+            controller.enqueue(value!);
+          } else {
+            resolved++;
+            readers.delete(reader);
           }
         }
-        controller.close();
-      } catch (e) {
-        controller.error(e);
       }
+      controller.close();
     },
   });
 }


### PR DESCRIPTION
This has the same effect as the previous code. Just a little tidier.