### PR TITLE
BREAKING(yaml): rename `DumpOptions` to `StringifyOptions`

### DIFF
--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -10,7 +10,7 @@ import { replaceSchemaNameWithSchemaClass } from "./mod.ts";
 /**
  * The option for strinigfy.
  */
-export type DumpOptions = {
+export type StringifyOptions = {
   /** Indentation width to use (in spaces). */
   indent?: number;
   /** When true, will not add an indentation level to array elements */
@@ -85,7 +85,7 @@ export type DumpOptions = {
  */
 export function stringify(
   data: unknown,
-  options?: DumpOptions,
+  options?: StringifyOptions,
 ): string {
   replaceSchemaNameWithSchemaClass(options);
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
`DumpOptions` is the options for `stringify`. This should be named `StringifyOptions`

# What's changed

`DumpOptions` has been renamed to `StringifyOptions`

# Motivation

The current name isn't aligned to the naming convention of the option types because it's options for `stringify`. There's no public API called `dump`.

# Migration

```diff
-import type { DumpOptions } from "@std/yaml`;
+import type { StringifyOptions as DumpOptions } from "@std/yaml`;
```