### PR TITLE
BREAKING(semver): remove `SEMVER_SPEC_VERSION`

### DIFF
--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -301,6 +301,3 @@ export * from "./greater_or_equal.ts";
 export * from "./less_than.ts";
 export * from "./less_than_range.ts";
 export * from "./less_or_equal.ts";
-
-/** The SemVer spec version */
-export const SEMVER_SPEC_VERSION = "2.0.0";


### PR DESCRIPTION
### What's changed

The `SEMVER_SPEC_VERSION` constant has been removed from `@std/semver`.

### Motivation

This constant was removed as it provided no further value to the package. The single source of truth for this value can be found in the [documentation](https://jsr.io/@std/semver).

### Migration guide

If needed, see the [documentation](https://jsr.io/@std/semver) to get the currently supported SemVer spec version, and define the constant.

```diff
- import { SEMVER_SPEC_VERSION } from "@std/semver";

+ const SEMVER_SPEC_VERSION = "2.0.0";
  foo(SEMVER_SPEC_VERSION);
```