### PR TITLE
test(yaml): improve `parse()` testing

### DIFF
--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -294,3 +294,26 @@ Deno.test({
     );
   },
 });
+
+Deno.test("parse() handles escaped strings in double quotes", () => {
+  assertEquals(parse('"\\"bar\\""'), '"bar"');
+  assertEquals(parse('"\\x30\\x31"'), "01");
+  assertEquals(parse('"\\\na"'), "a");
+  assertEquals(parse('"\\x4a"'), "J");
+  assertEquals(parse('"\\u0041"'), "A");
+  assertEquals(parse('"\\U00000041"'), "A");
+  assertEquals(parse('"\\U0001F431"'), "🐱");
+
+  assertThrows(
+    // invalid hex character
+    () => parse('"\\xyz"'),
+    YamlError,
+    'expected hexadecimal character at line 1, column 4:\n    "\\xyz"\n       ^',
+  );
+  assertThrows(
+    // invalid escape sequence
+    () => parse('"\\X30"'),
+    YamlError,
+    'unknown escape sequence at line 1, column 3:\n    "\\X30"\n      ^',
+  );
+});

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -439,3 +439,12 @@ hello: world`),
     "ill-formed tag prefix (second argument) of the TAG directive at line 2, column 1:\n    ---\n    ^",
   );
 });
+
+Deno.test("parse() throws with invalid strings", () => {
+  assertThrows(() => parse(`"`), YamlError, "unexpected end of the stream");
+  assertThrows(
+    () => parse(`"\x08"`),
+    YamlError,
+    'expected valid JSON character at line 1, column 3:\n    "\b"\n      ^',
+  );
+});


### PR DESCRIPTION
This PR adds test cases of `parse` function.

This exercises the case of various escape sequences, invalid strings, yaml directives.

This improves line coverage of yaml package from 60.49% to 65.01%.

part of #3713 