### PR TITLE
fix(yaml): fix merge (<<) type handling in `parse()`

### DIFF
--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -300,7 +300,7 @@ function mergeMappings(
     );
   }
 
-  for (const key in Object.keys(source)) {
+  for (const key of Object.keys(source)) {
     if (!hasOwn(destination, key)) {
       Object.defineProperty(destination, key, {
         value: source[key],

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -448,3 +448,20 @@ Deno.test("parse() throws with invalid strings", () => {
     'expected valid JSON character at line 1, column 3:\n    "\b"\n      ^',
   );
 });
+
+Deno.test("parse() handles merge (<<) types", () => {
+  assertEquals(
+    parse(`<<: { a: 1, b: 2 }
+c: 3`),
+    { a: 1, b: 2, c: 3 },
+  );
+
+  assertThrows(
+    () =>
+      // number can't be used as merge value
+      parse(`<<: 1
+c: 3`),
+    YamlError,
+    "cannot merge mappings; the provided source object is unacceptable at line 1, column 6:\n    <<: 1\n         ^",
+  );
+});


### PR DESCRIPTION
[merge type](https://yaml.org/type/merge) (`<<`) handling seems broken (ref #4457). This PR fixes it and add test cases to check it.