### PR TITLE
refactor(assert,async,bytes,cli,collections,crypto,csv,data-structures,datetime,dotenv,encoding,expect,fmt,front-matter,fs,html,http,ini,internal,io,json,jsonc,log,media-types,msgpack,net,path,semver,streams,testing,text,toml,ulid,url,uuid,webgpu,yaml): import from `@std/assert`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -420,8 +420,14 @@ function assertModuleDoc(document: DocNodeWithJsDoc<DocNodeModuleDoc>) {
 }
 
 function resolve(specifier: string, referrer: string): string {
-  if (specifier.startsWith("@std/") && specifier.split("/").length > 2) {
-    specifier = specifier.replace("@std/", "../").replaceAll("-", "_") + ".ts";
+  if (specifier.startsWith("@std/")) {
+    specifier = specifier.replace("@std/", "../").replaceAll("-", "_");
+    const parts = specifier.split("/");
+    if (parts.length === 2) {
+      specifier += "/mod.ts";
+    } else if (parts.length > 2) {
+      specifier += ".ts";
+    }
   }
   return new URL(specifier, referrer).href;
 }

--- a/assert/assert.ts
+++ b/assert/assert.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert("hello".includes("ello")); // Doesn't throw
  * assert("hello".includes("world")); // Throws

--- a/assert/assert_array_includes.ts
+++ b/assert/assert_array_includes.ts
@@ -16,7 +16,7 @@ export type ArrayLikeArg<T> = ArrayLike<T> & object;
  *
  * @example Usage
  * ```ts no-eval
- * import { assertArrayIncludes } from "@std/assert/assert-array-includes";
+ * import { assertArrayIncludes } from "@std/assert";
  *
  * assertArrayIncludes([1, 2], [2]); // Doesn't throw
  * assertArrayIncludes([1, 2], [3]); // Throws

--- a/assert/assert_equals.ts
+++ b/assert/assert_equals.ts
@@ -13,7 +13,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals("world", "world"); // Doesn't throw
  * assertEquals("hello", "world"); // Throws

--- a/assert/assert_exists.ts
+++ b/assert/assert_exists.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertExists } from "@std/assert/assert-exists";
+ * import { assertExists } from "@std/assert";
  *
  * assertExists("something"); // Doesn't throw
  * assertExists(undefined); // Throws

--- a/assert/assert_false.ts
+++ b/assert/assert_false.ts
@@ -10,7 +10,7 @@ export type Falsy = false | 0 | 0n | "" | null | undefined;
  *
  * @example Usage
  * ```ts no-eval
- * import { assertFalse } from "@std/assert/assert-false";
+ * import { assertFalse } from "@std/assert";
  *
  * assertFalse(false); // Doesn't throw
  * assertFalse(true); // Throws

--- a/assert/assert_greater.ts
+++ b/assert/assert_greater.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertGreater } from "@std/assert/assert-greater";
+ * import { assertGreater } from "@std/assert";
  *
  * assertGreater(2, 1); // Doesn't throw
  * assertGreater(1, 1); // Throws

--- a/assert/assert_greater_or_equal.ts
+++ b/assert/assert_greater_or_equal.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertGreaterOrEqual } from "@std/assert/assert-greater-or-equal";
+ * import { assertGreaterOrEqual } from "@std/assert";
  *
  * assertGreaterOrEqual(2, 1); // Doesn't throw
  * assertGreaterOrEqual(1, 1); // Doesn't throw

--- a/assert/assert_instance_of.ts
+++ b/assert/assert_instance_of.ts
@@ -16,7 +16,7 @@ new (...args: any) => infer C ? C
  *
  * @example Usage
  * ```ts no-eval
- * import { assertInstanceOf } from "@std/assert/assert-instance-of";
+ * import { assertInstanceOf } from "@std/assert";
  *
  * assertInstanceOf(new Date(), Date); // Doesn't throw
  * assertInstanceOf(new Date(), Number); // Throws

--- a/assert/assert_is_error.ts
+++ b/assert/assert_is_error.ts
@@ -11,7 +11,7 @@ import { stripAnsiCode } from "@std/internal/styles";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertIsError } from "@std/assert/assert-is-error";
+ * import { assertIsError } from "@std/assert";
  *
  * assertIsError(null); // Throws
  * assertIsError(new RangeError("Out of range")); // Doesn't throw

--- a/assert/assert_less.ts
+++ b/assert/assert_less.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertLess } from "@std/assert/assert-less";
+ * import { assertLess } from "@std/assert";
  *
  * assertLess(1, 2); // Doesn't throw
  * assertLess(2, 1); // Throws

--- a/assert/assert_less_or_equal.ts
+++ b/assert/assert_less_or_equal.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertLessOrEqual } from "@std/assert/assert-less-or-equal";
+ * import { assertLessOrEqual } from "@std/assert";
  *
  * assertLessOrEqual(1, 2); // Doesn't throw
  * assertLessOrEqual(1, 1); // Doesn't throw

--- a/assert/assert_match.ts
+++ b/assert/assert_match.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertMatch } from "@std/assert/assert-match";
+ * import { assertMatch } from "@std/assert";
  *
  * assertMatch("Raptor", RegExp(/Raptor/)); // Doesn't throw
  * assertMatch("Denosaurus", RegExp(/Raptor/)); // Throws

--- a/assert/assert_not_equals.ts
+++ b/assert/assert_not_equals.ts
@@ -12,7 +12,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertNotEquals } from "@std/assert/assert-not-equals";
+ * import { assertNotEquals } from "@std/assert";
  *
  * assertNotEquals(1, 2); // Doesn't throw
  * assertNotEquals(1, 1); // Throws

--- a/assert/assert_not_instance_of.ts
+++ b/assert/assert_not_instance_of.ts
@@ -8,7 +8,7 @@ import { assertFalse } from "./assert_false.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertNotInstanceOf } from "@std/assert/assert-not-instance-of";
+ * import { assertNotInstanceOf } from "@std/assert";
  *
  * assertNotInstanceOf(new Date(), Number); // Doesn't throw
  * assertNotInstanceOf(new Date(), Date); // Throws

--- a/assert/assert_not_match.ts
+++ b/assert/assert_not_match.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertNotMatch } from "@std/assert/assert-not-match";
+ * import { assertNotMatch } from "@std/assert";
  *
  * assertNotMatch("Denosaurus", RegExp(/Raptor/)); // Doesn't throw
  * assertNotMatch("Raptor", RegExp(/Raptor/)); // Throws

--- a/assert/assert_not_strict_equals.ts
+++ b/assert/assert_not_strict_equals.ts
@@ -10,7 +10,7 @@ import { format } from "@std/internal/format";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertNotStrictEquals } from "@std/assert/assert-not-strict-equals";
+ * import { assertNotStrictEquals } from "@std/assert";
  *
  * assertNotStrictEquals(1, 1); // Doesn't throw
  * assertNotStrictEquals(1, 2); // Throws

--- a/assert/assert_object_match.ts
+++ b/assert/assert_object_match.ts
@@ -8,7 +8,7 @@ import { assertEquals } from "./assert_equals.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertObjectMatch } from "@std/assert/assert-object-match";
+ * import { assertObjectMatch } from "@std/assert";
  *
  * assertObjectMatch({ foo: "bar" }, { foo: "bar" }); // Doesn't throw
  * assertObjectMatch({ foo: "bar" }, { foo: "baz" }); // Throws

--- a/assert/assert_rejects.ts
+++ b/assert/assert_rejects.ts
@@ -10,7 +10,7 @@ import { assertIsError } from "./assert_is_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertRejects } from "@std/assert/assert-rejects";
+ * import { assertRejects } from "@std/assert";
  *
  * await assertRejects(async () => Promise.reject(new Error())); // Doesn't throw
  * await assertRejects(async () => console.log("Hello world")); // Throws
@@ -33,7 +33,7 @@ export function assertRejects(
  *
  * @example Usage
  * ```ts no-eval
- * import { assertRejects } from "@std/assert/assert-rejects";
+ * import { assertRejects } from "@std/assert";
  *
  * await assertRejects(async () => Promise.reject(new Error()), Error); // Doesn't throw
  * await assertRejects(async () => Promise.reject(new Error()), SyntaxError); // Throws

--- a/assert/assert_strict_equals.ts
+++ b/assert/assert_strict_equals.ts
@@ -9,7 +9,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertStrictEquals } from "@std/assert/assert-strict-equals";
+ * import { assertStrictEquals } from "@std/assert";
  *
  * const a = {};
  * const b = a;

--- a/assert/assert_string_includes.ts
+++ b/assert/assert_string_includes.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertStringIncludes } from "@std/assert/assert-string-includes";
+ * import { assertStringIncludes } from "@std/assert";
  *
  * assertStringIncludes("Hello", "ello"); // Doesn't throw
  * assertStringIncludes("Hello", "world"); // Throws

--- a/assert/assert_throws.ts
+++ b/assert/assert_throws.ts
@@ -12,7 +12,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { assertThrows } from "@std/assert/assert-throws";
+ * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => { throw new TypeError("hello world!"); }); // Doesn't throw
  * assertThrows(() => console.log("hello world!")); // Throws
@@ -36,7 +36,7 @@ export function assertThrows(
  *
  * @example Usage
  * ```ts no-eval
- * import { assertThrows } from "@std/assert/assert-throws";
+ * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => { throw new TypeError("hello world!"); }, TypeError); // Doesn't throw
  * assertThrows(() => { throw new TypeError("hello world!"); }, RangeError); // Throws

--- a/assert/assertion_error.ts
+++ b/assert/assertion_error.ts
@@ -6,7 +6,7 @@
  *
  * @example Usage
  * ```ts no-eval
- * import { AssertionError } from "@std/assert/assertion-error";
+ * import { AssertionError } from "@std/assert";
  *
  * throw new AssertionError("Assertion failed");
  * ```
@@ -16,7 +16,7 @@ export class AssertionError extends Error {
    *
    * @example Usage
    * ```ts no-eval
-   * import { AssertionError } from "@std/assert/assertion-error";
+   * import { AssertionError } from "@std/assert";
    *
    * throw new AssertionError("Assertion failed");
    * ```

--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -19,7 +19,7 @@ function constructorsEqual(a: object, b: object) {
  *
  * @example Usage
  * ```ts
- * import { equal } from "@std/assert/equal";
+ * import { equal } from "@std/assert";
  *
  * equal({ foo: "bar" }, { foo: "bar" }); // Returns `true`
  * equal({ foo: "bar" }, { foo: "baz" }); // Returns `false

--- a/assert/fail.ts
+++ b/assert/fail.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { fail } from "@std/assert/fail";
+ * import { fail } from "@std/assert";
  *
  * fail("Deliberately failed!"); // Throws
  * ```

--- a/assert/mod.ts
+++ b/assert/mod.ts
@@ -9,7 +9,7 @@
  * values for AssertionError messages in browsers.
  *
  * ```ts no-eval
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert("I am truthy"); // Doesn't throw
  * assert(false); // Throws `AssertionError`

--- a/assert/unimplemented.ts
+++ b/assert/unimplemented.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { unimplemented } from "@std/assert/unimplemented";
+ * import { unimplemented } from "@std/assert";
  *
  * unimplemented(); // Throws
  * ```

--- a/assert/unreachable.ts
+++ b/assert/unreachable.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Usage
  * ```ts no-eval
- * import { unreachable } from "@std/assert/unreachable";
+ * import { unreachable } from "@std/assert";
  *
  * unreachable(); // Throws
  * ```

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -15,7 +15,7 @@ interface TaggedYieldedValue<T> {
  * @example Usage
  * ```ts
  * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * async function* gen123(): AsyncIterableIterator<number> {
  *   yield 1;
@@ -55,7 +55,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    * @example Usage
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * async function* gen123(): AsyncIterableIterator<number> {
    *   yield 1;
@@ -99,7 +99,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    * @example Usage
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * async function* gen123(): AsyncIterableIterator<number> {
    *   yield 1;
@@ -144,7 +144,7 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    * @example Usage
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * async function* gen123(): AsyncIterableIterator<number> {
    *   yield 1;

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -17,7 +17,7 @@ const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
  * @example Usage
  * ```ts
  * import { pooledMap } from "@std/async/pool";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const results = pooledMap(
  *   2,

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -62,7 +62,7 @@ class Queue<T> {
  * @example Usage
  * ```ts
  * import { tee } from "@std/async/tee";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const gen = async function* gen() {
  *   yield 1;

--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -10,7 +10,7 @@
  * @example Basic usage
  * ```ts
  * import { concat } from "@std/bytes/concat";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);

--- a/bytes/copy.ts
+++ b/bytes/copy.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { copy } from "@std/bytes/copy";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const src = new Uint8Array([9, 8, 7]);
  * const dst = new Uint8Array([0, 1, 2, 3, 4, 5]);
@@ -29,7 +29,7 @@
  * @example Copy with offset
  * ```ts
  * import { copy } from "@std/bytes/copy";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const src = new Uint8Array([1, 1, 1, 1]);
  * const dst = new Uint8Array([0, 0, 0, 0]);

--- a/bytes/ends_with.ts
+++ b/bytes/ends_with.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { endsWith } from "@std/bytes/ends-with";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const suffix = new Uint8Array([1, 2, 3]);

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -69,7 +69,7 @@ const THRESHOLD_32_BIT = 160;
  * @example Basic usage
  * ```ts
  * import { equals } from "@std/bytes/equals";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = new Uint8Array([1, 2, 3]);
  * const b = new Uint8Array([1, 2, 3]);

--- a/bytes/includes_needle.ts
+++ b/bytes/includes_needle.ts
@@ -18,7 +18,7 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * @example Basic usage
  * ```ts
  * import { includesNeedle } from "@std/bytes/includes-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
@@ -29,7 +29,7 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * @example Start index
  * ```ts
  * import { includesNeedle } from "@std/bytes/includes-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -20,7 +20,7 @@
  * @example Basic usage
  * ```ts
  * import { indexOfNeedle } from "@std/bytes/index-of-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
@@ -33,7 +33,7 @@
  * @example Start index
  * ```ts
  * import { indexOfNeedle } from "@std/bytes/index-of-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { lastIndexOfNeedle } from "@std/bytes/last-index-of-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);
@@ -30,7 +30,7 @@
  * @example Start index
  * ```ts
  * import { lastIndexOfNeedle } from "@std/bytes/last-index-of-needle";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const needle = new Uint8Array([1, 2]);

--- a/bytes/mod.ts
+++ b/bytes/mod.ts
@@ -8,7 +8,7 @@
  *
  * ```ts
  * import { concat, indexOfNeedle, endsWith } from "@std/bytes";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = new Uint8Array([0, 1, 2]);
  * const b = new Uint8Array([3, 4, 5]);

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -14,7 +14,7 @@ import { copy } from "./copy.ts";
  * @example Basic usage
  * ```ts
  * import { repeat } from "@std/bytes/repeat";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2]);
  *
@@ -24,7 +24,7 @@ import { copy } from "./copy.ts";
  * @example Zero count
  * ```ts
  * import { repeat } from "@std/bytes/repeat";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2]);
  *

--- a/bytes/starts_with.ts
+++ b/bytes/starts_with.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { startsWith } from "@std/bytes/starts-with";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
  * const prefix = new Uint8Array([0, 1, 2]);

--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -5,7 +5,7 @@
  *
  * ```ts
  * import { parseArgs } from "@std/cli/parse-args";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * // Same as running `deno run example.ts --foo --bar=baz ./quux.txt`
  * const args = parseArgs(["--foo", "--bar=baz", "./quux.txt"]);

--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -447,7 +447,7 @@ const FLAG_REGEXP =
  * @example Usage
  * ```ts
  * import { parseArgs } from "@std/cli/parse-args";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * // For proper use, one should use `parseArgs(Deno.args)`
  * assertEquals(parseArgs(["--foo", "--bar=baz", "./quux.txt"]), {

--- a/cli/unicode_width.ts
+++ b/cli/unicode_width.ts
@@ -51,7 +51,7 @@ function charWidth(char: string) {
  * @example Calculating the unicode width of a string
  * ```ts
  * import { unicodeWidth } from "@std/cli/unicode-width";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unicodeWidth("hello world"), 11);
  * assertEquals(unicodeWidth("天地玄黃宇宙洪荒"), 16);
@@ -62,7 +62,7 @@ function charWidth(char: string) {
  * ```ts
  * import { unicodeWidth } from "@std/cli/unicode-width";
  * import { stripAnsiCode } from "@std/fmt/colors";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unicodeWidth(stripAnsiCode("\x1b[36mголубой\x1b[39m")), 7);
  * assertEquals(unicodeWidth(stripAnsiCode("\x1b[31m紅色\x1b[39m")), 4);

--- a/collections/aggregate_groups.ts
+++ b/collections/aggregate_groups.ts
@@ -20,7 +20,7 @@ import { mapEntries } from "./map_entries.ts";
  * @example Basic usage
  * ```ts
  * import { aggregateGroups } from "@std/collections/aggregate-groups";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const foodProperties = {
  *   Curry: ["spicy", "vegan"],

--- a/collections/associate_by.ts
+++ b/collections/associate_by.ts
@@ -19,7 +19,7 @@
  * @example Basic usage
  * ```ts
  * import { associateBy } from "@std/collections/associate-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const users = [
  *   { id: "a2e", userName: "Anna" },

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -19,7 +19,7 @@
  * @example Basic usage
  * ```ts
  * import { associateWith } from "@std/collections/associate-with";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const names = ["Kim", "Lara", "Jonathan"];
  *

--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -14,7 +14,7 @@
  * @example Basic usage
  * ```ts
  * import { chunk } from "@std/collections/chunk";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const words = [
  *   "lorem",

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -21,7 +21,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Merge objects
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: true };
  * const b = { foo: { bar: true } };
@@ -36,7 +36,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Merge arrays
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: [1, 2] };
  * const b = { foo: [3, 4] };
@@ -51,7 +51,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Merge maps
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: new Map([["a", 1]]) };
  * const b = { foo: new Map([["b", 2]]) };
@@ -66,7 +66,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Merge sets
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: new Set([1]) };
  * const b = { foo: new Set([2]) };
@@ -81,7 +81,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Merge with custom options
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: [1, 2] };
  * const b = { foo: [3, 4] };
@@ -120,7 +120,7 @@ export function deepMerge<
  * @example Merge objects
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: true };
  * const b = { foo: { bar: true } };
@@ -135,7 +135,7 @@ export function deepMerge<
  * @example Merge arrays
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: [1, 2] };
  * const b = { foo: [3, 4] };
@@ -150,7 +150,7 @@ export function deepMerge<
  * @example Merge maps
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: new Map([["a", 1]]) };
  * const b = { foo: new Map([["b", 2]]) };
@@ -165,7 +165,7 @@ export function deepMerge<
  * @example Merge sets
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: new Set([1]) };
  * const b = { foo: new Set([2]) };
@@ -180,7 +180,7 @@ export function deepMerge<
  * @example Merge with custom options
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = { foo: [1, 2] };
  * const b = { foo: [3, 4] };

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -14,7 +14,7 @@
  * @example Basic usage
  * ```ts
  * import { distinct } from "@std/collections/distinct";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [3, 2, 5, 2, 5];
  * const distinctNumbers = distinct(numbers);

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { distinctBy } from "@std/collections/distinct-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const names = ["Anna", "Kim", "Arnold", "Kate"];
  * const exampleNamesByFirstLetter = distinctBy(names, (name) => name.charAt(0));

--- a/collections/drop_last_while.ts
+++ b/collections/drop_last_while.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { dropLastWhile } from "@std/collections/drop-last-while";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [11, 42, 55, 20, 33, 44];
  *

--- a/collections/drop_while.ts
+++ b/collections/drop_while.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { dropWhile } from "@std/collections/drop-while";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [3, 2, 5, 2, 5];
  * const dropWhileNumbers = dropWhile(numbers, (number) => number !== 2);

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { filterEntries } from "@std/collections/filter-entries";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const menu = {
  *   Salad: 11,

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { filterKeys } from "@std/collections/filter-keys";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const menu = {
  *   Salad: 11,

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { filterValues } from "@std/collections/filter-values";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = {
  *   Arnold: 37,

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { findSingle } from "@std/collections/find-single";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const bookings = [
  *   { month: "January", active: false },

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { firstNotNullishOf } from "@std/collections/first-not-nullish-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const tables = [
  *   { number: 11, order: null },

--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { includesValue } from "@std/collections/includes-value";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const input = {
  *   first: 33,

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -17,7 +17,7 @@ import { filterInPlace } from "./_utils.ts";
  * @example Basic usage
  * ```ts
  * import { intersect } from "@std/collections/intersect";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const lisaInterests = ["Cooking", "Music", "Hiking"];
  * const kimInterests = ["Music", "Tennis", "Cooking"];

--- a/collections/invert.ts
+++ b/collections/invert.ts
@@ -22,7 +22,7 @@ export type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {
  * @example Basic usage
  * ```ts
  * import { invert } from "@std/collections/invert";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const record = { a: "x", b: "y", c: "z" };
  *

--- a/collections/invert_by.ts
+++ b/collections/invert_by.ts
@@ -27,7 +27,7 @@ export type InvertByResult<
  * @example Basic usage
  * ```ts
  * import { invertBy } from "@std/collections/invert-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const record = { a: "x", b: "y", c: "z" };
  *

--- a/collections/invert_by_test.ts
+++ b/collections/invert_by_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { invertBy } from "./invert_by.ts";
 
 function invertByTest<R extends Record<PropertyKey, PropertyKey>>(

--- a/collections/join_to_string.ts
+++ b/collections/join_to_string.ts
@@ -56,7 +56,7 @@ export type JoinToStringOptions = {
  * @example Usage with options
  * ```ts
  * import { joinToString } from "@std/collections/join-to-string";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const users = [
  *   { name: "Kim" },

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { mapEntries } from "@std/collections/map-entries";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const usersById = {
  *   "a2e": { name: "Kim", age: 22 },

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { mapKeys } from "@std/collections/map-keys";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const counts = { a: 5, b: 3, c: 8 };
  *

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { mapNotNullish } from "@std/collections/map-not-nullish";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { middleName: null },

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { mapValues } from "@std/collections/map-values";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const usersById = {
  *   a5ec: { name: "Mischa" },
@@ -56,7 +56,7 @@ export function mapValues<T, O, K extends string>(
  * @example Basic usage
  * ```ts
  * import { mapValues } from "@std/collections/map-values";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const usersById = {
  *   "a5ec": { name: "Mischa" },

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34 },
@@ -48,7 +48,7 @@ export function maxBy<T>(
  * @example Basic usage
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna" },
@@ -80,7 +80,7 @@ export function maxBy<T>(
  * @example Basic usage
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34n },
@@ -112,7 +112,7 @@ export function maxBy<T>(
  * @example Basic usage
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", startedAt: new Date("2020-01-01") },

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { maxOf } from "@std/collections/max-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inventory = [
  *   { name: "mustard", count: 2 },
@@ -50,7 +50,7 @@ export function maxOf<T>(
  * @example Basic usage
  * ```ts
  * import { maxOf } from "@std/collections/max-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inventory = [
  *   { name: "mustard", count: 2n },

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -20,7 +20,7 @@
  * @example Basic usage
  * ```ts
  * import { maxWith } from "@std/collections/max-with";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = ["Kim", "Anna", "John", "Arthur"];
  * const largestName = maxWith(people, (a, b) => a.length - b.length);

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { minBy } from "@std/collections/min-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34 },
@@ -48,7 +48,7 @@ export function minBy<T>(
  * @example Basic usage
  * ```ts
  * import { minBy } from "@std/collections/min-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna" },
@@ -80,7 +80,7 @@ export function minBy<T>(
  * @example Basic usage
  * ```ts
  * import { minBy } from "@std/collections/min-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34n },
@@ -112,7 +112,7 @@ export function minBy<T>(
  * @example Basic usage
  * ```ts
  * import { minBy } from "@std/collections/min-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", startedAt: new Date("2020-01-01") },

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { minOf } from "@std/collections/min-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inventory = [
  *   { name: "mustard", count: 2 },
@@ -50,7 +50,7 @@ export function minOf<T>(
  * @example Basic usage
  * ```ts
  * import { minOf } from "@std/collections/min-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inventory = [
  *   { name: "mustard", count: 2n },

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { minWith } from "@std/collections/min-with";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = ["Kim", "Anna", "John"];
  * const smallestName = minWith(people, (a, b) => a.length - b.length);

--- a/collections/omit.ts
+++ b/collections/omit.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { omit } from "@std/collections/omit";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = { a: 5, b: 6, c: 7, d: 8 };
  * const omitted = omit(obj, ["a", "c"]);

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { partition } from "@std/collections/partition";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [5, 6, 7, 8, 9];
  * const [even, odd] = partition(numbers, (it) => it % 2 === 0);
@@ -53,7 +53,7 @@ export function partition<T>(
  * @example Basic usage
  * ```ts
  * import { partition } from "@std/collections/partition";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [5, 6, 7, 8, 9];
  * const [even, odd] = partition(numbers, (it) => it % 2 === 0);

--- a/collections/partition_entries.ts
+++ b/collections/partition_entries.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { partitionEntries } from "@std/collections/partition-entries";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const menu = {
  *   Salad: 11,

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { permutations } from "@std/collections/permutations";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [ 1, 2 ];
  * const windows = permutations(numbers);

--- a/collections/pick.ts
+++ b/collections/pick.ts
@@ -16,7 +16,7 @@
  * @example Basic usage
  * ```ts
  * import { pick } from "@std/collections/pick";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = { a: 5, b: 6, c: 7, d: 8 };
  * const picked = pick(obj, ["a", "c"]);

--- a/collections/reduce_groups.ts
+++ b/collections/reduce_groups.ts
@@ -21,7 +21,7 @@ import { mapValues } from "./map_values.ts";
  * @example Basic usage
  * ```ts
  * import { reduceGroups } from "@std/collections/reduce-groups";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const votes = {
  *   Woody: [2, 3, 1, 4],

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -18,7 +18,7 @@
  * @example Basic usage
  * ```ts
  * import { runningReduce } from "@std/collections/running-reduce";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4, 5];
  * const sumSteps = runningReduce(numbers, (sum, current) => sum + current, 0);

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -17,7 +17,7 @@ import { randomInteger } from "./_utils.ts";
  * @example Basic usage
  * ```ts
  * import { sample } from "@std/collections/sample";
- * import { assertArrayIncludes } from "@std/assert/assert-array-includes";
+ * import { assertArrayIncludes } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4];
  * const random = sample(numbers);

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -40,7 +40,7 @@ export interface SlidingWindowsOptions {
  * @example Usage
  * ```ts
  * import { slidingWindows } from "@std/collections/sliding-windows";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * const numbers = [1, 2, 3, 4, 5];
  *
  * const windows = slidingWindows(numbers, 3);

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -31,7 +31,7 @@ export type SortByOptions = {
  * @example Usage
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34 },
@@ -77,7 +77,7 @@ export function sortBy<T>(
  * @example Usage
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna" },
@@ -115,7 +115,7 @@ export function sortBy<T>(
  * @example Usage
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34n },
@@ -155,7 +155,7 @@ export function sortBy<T>(
  * @example Usage
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", startedAt: new Date("2020-01-01") },

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { sumOf } from "@std/collections/sum-of";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const people = [
  *   { name: "Anna", age: 34 },

--- a/collections/take_last_while.ts
+++ b/collections/take_last_while.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { takeLastWhile } from "@std/collections/take-last-while";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/take_while.ts
+++ b/collections/take_while.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { takeWhile } from "@std/collections/take-while";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4, 5, 6];
  *

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -13,7 +13,7 @@
  * @example Basic usage
  * ```ts
  * import { union } from "@std/collections/union";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const soupIngredients = ["Pepper", "Carrots", "Leek"];
  * const saladIngredients = ["Carrots", "Radicchio", "Pepper"];

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -17,7 +17,7 @@
  * @example Basic usage
  * ```ts
  * import { unzip } from "@std/collections/unzip";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const parents = [
  *   ["Maria", "Jeff"],

--- a/collections/without_all.ts
+++ b/collections/without_all.ts
@@ -15,7 +15,7 @@
  * @example Basic usage
  * ```ts
  * import { withoutAll } from "@std/collections/without-all";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const withoutList = withoutAll([2, 1, 2, 3], [1, 2]);
  *

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -16,7 +16,7 @@ import { minOf } from "./min_of.ts";
  * @example Basic usage
  * ```ts
  * import { zip } from "@std/collections/zip";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4];
  * const letters = ["a", "b", "c", "d"];

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -26,7 +26,7 @@ function toDataView(
  * @example Usage
  * ```ts
  * import { timingSafeEqual } from "@std/crypto/timing-safe-equal";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const a = await crypto.subtle.digest(
  *   "SHA-384",

--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -218,7 +218,7 @@ function runeCount(s: string): number {
  * @example Usage
  * ```ts
  * import { parse, ParseError } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * try {
  *   parse(`a "word","b"`);
@@ -236,7 +236,7 @@ export class ParseError extends SyntaxError {
    * @example Usage
    * ```ts
    * import { parse, ParseError } from "@std/csv/parse";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * try {
    *   parse(`a "word","b"`);
@@ -254,7 +254,7 @@ export class ParseError extends SyntaxError {
    * @example Usage
    * ```ts
    * import { parse, ParseError } from "@std/csv/parse";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * try {
    *   parse(`a "word","b"`);
@@ -272,7 +272,7 @@ export class ParseError extends SyntaxError {
    * @example Usage
    * ```ts
    * import { parse, ParseError } from "@std/csv/parse";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * try {
    *   parse(`a "word","b"`);
@@ -291,7 +291,7 @@ export class ParseError extends SyntaxError {
    * @example Usage
    * ```ts
    * import { parse, ParseError } from "@std/csv/parse";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * try {
    *   parse(`a "word","b"`);

--- a/csv/mod.ts
+++ b/csv/mod.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const string = "a,b,c\nd,e,f";
  *

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -336,7 +336,7 @@ export interface ParseOptions {
  * @example Usage
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const string = "a,b,c\nd,e,f";
  *
@@ -354,7 +354,7 @@ export function parse(input: string): string[][];
  * @example Usage
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const string = "a,b,c\nd,e,f";
  *

--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -258,7 +258,7 @@ function getValuesFromItem(
  *   Column,
  *   stringify,
  * } from "@std/csv/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * type Character = {
  *   age: number;

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -33,7 +33,7 @@ function getParentIndex(index: number) {
  *   BinaryHeap,
  *   descend,
  * } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const maxHeap = new BinaryHeap<number>();
  * maxHeap.push(4, 1, 3, 5, 2);
@@ -97,7 +97,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Getting the underlying array
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *
@@ -234,7 +234,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Getting the length of the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *
@@ -256,7 +256,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Getting the greatest value from the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *
@@ -266,7 +266,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Getting the greatest value from an empty binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = new BinaryHeap<number>();
    *
@@ -286,7 +286,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Removing the greatest value from the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *
@@ -300,7 +300,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Removing the greatest value from an empty binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = new BinaryHeap<number>();
    *
@@ -342,7 +342,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Adding values to the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 2]);
    * heap.push(5);
@@ -376,7 +376,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Clearing the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    * heap.clear();
@@ -394,7 +394,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Checking if the binary heap is empty
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = new BinaryHeap<number>();
    *
@@ -421,7 +421,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Draining the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *
@@ -446,7 +446,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * @example Getting an iterator for the binary heap
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    *

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -31,7 +31,7 @@ type Direction = "left" | "right";
  *   ascend,
  *   descend,
  * } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const values = [3, 10, 13, 4, 6, 7, 1, 14];
  * const tree = new BinarySearchTree<number>();
@@ -319,7 +319,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Getting the size of the tree
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42, 43, 41]);
    *
@@ -436,7 +436,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Inserting values into the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = new BinarySearchTree<number>();
    *
@@ -460,7 +460,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Removing values from the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42]);
    *
@@ -486,7 +486,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Finding values in the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42]);
    *
@@ -511,7 +511,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Finding the minimum value in the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42, 43, 41]);
    *
@@ -534,7 +534,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Finding the maximum value in the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42, 43, 41]);
    *
@@ -555,7 +555,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Clearing the tree
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from<number>([42, 43, 41]);
    * tree.clear();
@@ -577,7 +577,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Checking if the tree is empty
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = new BinarySearchTree<number>();
    *
@@ -601,7 +601,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the in-order LNR iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    *
@@ -632,7 +632,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the reverse in-order RNL iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    * [...tree.rnlValues()] // 5, 4, 3, 2, 1
@@ -662,7 +662,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the pre-order NLR iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    *
@@ -689,7 +689,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the post-order LRN iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    *
@@ -725,7 +725,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the level-order BFS iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    *
@@ -752,7 +752,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * @example Using the in-order iterator
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = BinarySearchTree.from([4, 1, 2, 5, 3]);
    *

--- a/data_structures/comparators.ts
+++ b/data_structures/comparators.ts
@@ -8,7 +8,7 @@
  * @example Comparing numbers
  * ```ts
  * import { ascend } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(ascend(1, 2), -1);
  * assertEquals(ascend(2, 1), 1);
@@ -31,7 +31,7 @@ export function ascend<T>(a: T, b: T): -1 | 0 | 1 {
  * @example Comparing numbers
  * ```ts
  * import { descend } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(descend(1, 2), 1);
  * assertEquals(descend(2, 1), -1);

--- a/data_structures/mod.ts
+++ b/data_structures/mod.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { BinarySearchTree } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const values = [3, 10, 13, 4, 6, 7, 1, 14];
  * const tree = new BinarySearchTree<number>();

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -41,7 +41,7 @@ const {
  *   descend,
  *   RedBlackTree,
  * } from "@std/data-structures";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const values = [3, 10, 13, 4, 6, 7, 1, 14];
  * const tree = new RedBlackTree<number>();
@@ -331,7 +331,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * @example Inserting a value into the tree
    * ```ts
    * import { RedBlackTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = new RedBlackTree<number>();
    *
@@ -388,7 +388,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * @example Removing values from the tree
    * ```ts
    * import { RedBlackTree } from "@std/data-structures";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const tree = RedBlackTree.from<number>([42]);
    *

--- a/datetime/day_of_year.ts
+++ b/datetime/day_of_year.ts
@@ -12,7 +12,7 @@ import { DAY } from "./constants.ts";
  * @example Basic usage
  * ```ts
  * import { dayOfYear } from "@std/datetime/day-of-year";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(dayOfYear(new Date("2019-03-11T03:24:00")), 70);
  * ```
@@ -39,7 +39,7 @@ export function dayOfYear(date: Date): number {
  * @example Usage
  * ```ts
  * import { dayOfYearUtc } from "@std/datetime/day-of-year";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(dayOfYearUtc(new Date("2019-03-11T03:24:00.000Z")), 70);
  * ```

--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -50,7 +50,7 @@ function calculateMonthsDifference(from: Date, to: Date): number {
  * @example Basic usage
  * ```ts
  * import { difference } from "@std/datetime/difference";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const date0 = new Date("2018-05-14");
  * const date1 = new Date("2020-05-13");
@@ -74,7 +74,7 @@ function calculateMonthsDifference(from: Date, to: Date): number {
  *
  * ```ts
  * import { difference } from "@std/datetime/difference";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const date0 = new Date("2018-05-14");
  * const date1 = new Date("2020-05-13");

--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -44,7 +44,7 @@ export interface FormatOptions {
  * @example Basic usage
  * ```ts no-eval
  * import { format } from "@std/datetime/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const date = new Date(2019, 0, 20, 16, 34, 23, 123);
  *
@@ -61,7 +61,7 @@ export interface FormatOptions {
  *
  * ```ts no-eval
  * import { format } from "@std/datetime/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const date = new Date(2019, 0, 20, 16, 34, 23, 123);
  *

--- a/datetime/is_leap.ts
+++ b/datetime/is_leap.ts
@@ -22,7 +22,7 @@ function isYearNumberALeapYear(yearNumber: number): boolean {
  * @example Basic usage
  * ```ts
  * import { isLeap } from "@std/datetime/is-leap";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(isLeap(new Date("1970-01-02")), false);
  *
@@ -63,7 +63,7 @@ export function isLeap(year: Date | number): boolean {
  * @example Basic usage
  * ```ts
  * import { isUtcLeap } from "@std/datetime/is-leap";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(isUtcLeap(new Date("2000-01-01")), true);
  *

--- a/datetime/mod.ts
+++ b/datetime/mod.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { dayOfYear, isLeap, difference } from "@std/datetime";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(dayOfYear(new Date("2019-03-11T03:24:00")), 70);
  * assertEquals(isLeap(1970), false);

--- a/datetime/parse.ts
+++ b/datetime/parse.ts
@@ -37,7 +37,7 @@ import { DateTimeFormatter } from "./_date_time_formatter.ts";
  * @example Basic usage
  * ```ts
  * import { parse } from "@std/datetime/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(parse("01-03-2019 16:30", "MM-dd-yyyy HH:mm"), new Date(2019, 0, 3, 16, 30));
  *

--- a/datetime/week_of_year.ts
+++ b/datetime/week_of_year.ts
@@ -24,7 +24,7 @@ const Day = {
  * @example Basic usage
  * ```ts
  * import { weekOfYear } from "@std/datetime/week-of-year";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(weekOfYear(new Date("2020-12-28T03:24:00")), 53);
  *

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -11,7 +11,7 @@
  *
  * ```ts
  * import { parse, stringify } from "@std/dotenv";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(parse("GREETING=hello world"), { GREETING: "hello world" });
  * assertEquals(stringify({ GREETING: "hello world" }), "GREETING='hello world'");

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -60,7 +60,7 @@ function expand(str: string, variablesMap: { [key: string]: string }): string {
  * @example Usage
  * ```ts
  * import { parse } from "@std/dotenv/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const env = parse("GREETING=hello world");
  * assertEquals(env, { GREETING: "hello world" });

--- a/dotenv/stringify.ts
+++ b/dotenv/stringify.ts
@@ -7,7 +7,7 @@
  * @example Usage
  * ```ts
  * import { stringify } from "@std/dotenv/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const object = { GREETING: "hello world" };
  * assertEquals(stringify(object), "GREETING='hello world'");

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -61,7 +61,7 @@ const Z85 =
  * @example Usage
  * ```ts
  * import { encodeAscii85 } from "@std/encoding/ascii85";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeAscii85("Hello world!"), "87cURD]j7BEbo80");
  * ```
@@ -145,7 +145,7 @@ export type DecodeAscii85Options = Omit<EncodeAscii85Options, "delimiter">;
  * @example Usage
  * ```ts
  * import { decodeAscii85 } from "@std/encoding/ascii85";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeAscii85("87cURD]j7BEbo80"),

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -11,7 +11,7 @@
  *
  * ```ts
  * import { encodeBase32, decodeBase32 } from "@std/encoding/base32";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeBase32("foobar"), "MZXW6YTBOI======");
  *
@@ -70,7 +70,7 @@ function getByteLength(validLen: number, placeHoldersLen: number): number {
  * @example Usage
  * ```ts
  * import { decodeBase32 } from "@std/encoding/base32";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeBase32("GZRTMMDDGA======"),
@@ -179,7 +179,7 @@ function encodeChunk(uint8: Uint8Array, start: number, end: number): string {
  * @example Usage
  * ```ts
  * import { encodeBase32 } from "@std/encoding/base32";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeBase32("6c60c0"), "GZRTMMDDGA======");
  * ```

--- a/encoding/base32_test.ts
+++ b/encoding/base32_test.ts
@@ -1,7 +1,7 @@
 // Test cases copied from https://github.com/LinusU/base32-encode/blob/master/test.js
 // Copyright (c) 2016-2017 Linus Unnebäck. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertThrows } from "@std/assert/assert-throws";
+import { assertThrows } from "@std/assert";
 import { assertEquals, assertExists } from "@std/assert";
 import { decodeBase32, encodeBase32 } from "./base32.ts";
 import { decodeHex, encodeHex } from "./mod.ts";

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -8,7 +8,7 @@
  *
  * ```ts
  * import { encodeBase58, decodeBase58 } from "@std/encoding/base58";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const hello = new TextEncoder().encode("Hello World!");
  *
@@ -46,7 +46,7 @@ const base58alphabet =
  * @example Usage
  * ```ts
  * import { encodeBase58 } from "@std/encoding/base58";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeBase58("Hello World!"), "2NEpo7TZRRrLZSi2U");
  * ```
@@ -112,7 +112,7 @@ export function encodeBase58(data: ArrayBuffer | Uint8Array | string): string {
  * @example Usage
  * ```ts
  * import { decodeBase58 } from "@std/encoding/base58";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeBase58("2NEpo7TZRRrLZSi2U"),

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -11,7 +11,7 @@
  *   encodeBase64,
  *   decodeBase64,
  * } from "@std/encoding/base64";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const foobar = new TextEncoder().encode("foobar");
  *
@@ -102,7 +102,7 @@ const base64abc = [
  * @example Usage
  * ```ts
  * import { encodeBase64 } from "@std/encoding/base64";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeBase64("foobar"), "Zm9vYmFy");
  * ```
@@ -155,7 +155,7 @@ export function encodeBase64(data: ArrayBuffer | Uint8Array | string): string {
  * @example Usage
  * ```ts
  * import { decodeBase64 } from "@std/encoding/base64";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeBase64("Zm9vYmFy"),

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -53,7 +53,7 @@ function convertBase64ToBase64url(b64: string) {
  * @example Usage
  * ```ts
  * import { encodeBase64Url } from "@std/encoding/base64url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeBase64Url("foobar"), "Zm9vYmFy");
  * ```
@@ -75,7 +75,7 @@ export function encodeBase64Url(
  * @example Usage
  * ```ts
  * import { decodeBase64Url } from "@std/encoding/base64url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeBase64Url("Zm9vYmFy"),

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -13,7 +13,7 @@
  *   decodeHex,
  *   encodeHex,
  * } from "@std/encoding/hex";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeHex("abc"), "616263");
  *
@@ -62,7 +62,7 @@ function fromHexChar(byte: number): number {
  * @example Usage
  * ```ts
  * import { encodeHex } from "@std/encoding/hex";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(encodeHex("abc"), "616263");
  * ```
@@ -90,7 +90,7 @@ export function encodeHex(src: string | Uint8Array | ArrayBuffer): string {
  * @example Usage
  * ```ts
  * import { decodeHex } from "@std/encoding/hex";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   decodeHex("616263"),

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -5,7 +5,7 @@
  *
  * ```ts
  * import { encodeBase64, decodeBase64 } from "@std/encoding";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const foobar = new TextEncoder().encode("foobar");
  * assertEquals(encodeBase64(foobar), "Zm9vYmFy");

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -8,7 +8,7 @@
  *
  * ```ts
  * import { encodeVarint, decodeVarint } from "@std/encoding/varint";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const buf = new Uint8Array(10);
  * assertEquals(
@@ -74,7 +74,7 @@ const U64_VIEW = new BigUint64Array(AB);
  * @example Usage
  * ```ts
  * import { decodeVarint } from "@std/encoding/varint";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const buf = new Uint8Array([0x8E, 0x02]);
  * assertEquals(decodeVarint(buf), [270n, 2]);
@@ -160,7 +160,7 @@ export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
  * @example Usage
  * ```ts
  * import { decodeVarint32 } from "@std/encoding/varint";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const buf = new Uint8Array([0x8E, 0x02]);
  * assertEquals(decodeVarint32(buf), [270, 2]);
@@ -202,7 +202,7 @@ export function decodeVarint32(buf: Uint8Array, offset = 0): [number, number] {
  * @example Usage
  * ```ts
  * import { encodeVarint } from "@std/encoding/varint";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const buf = new Uint8Array(10);
  * assertEquals(encodeVarint(42n, buf), [new Uint8Array([42]), 1]);

--- a/expect/_assert_equals.ts
+++ b/expect/_assert_equals.ts
@@ -2,7 +2,7 @@
 
 // This file is copied from `std/assert`.
 
-import { AssertionError } from "@std/assert/assertion-error";
+import { AssertionError } from "@std/assert";
 import { buildEqualErrorMessage } from "./_build_message.ts";
 import { equal } from "./_equal.ts";
 import type { EqualOptions } from "./_types.ts";
@@ -16,7 +16,7 @@ import type { EqualOptions } from "./_types.ts";
  *
  * @example
  * ```ts
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals("world", "world"); // Doesn't throw
  * assertEquals("hello", "world"); // Throws

--- a/expect/_assert_not_equals.ts
+++ b/expect/_assert_not_equals.ts
@@ -2,7 +2,7 @@
 
 // This file is copied from `std/assert`.
 
-import { AssertionError } from "@std/assert/assertion-error";
+import { AssertionError } from "@std/assert";
 import { buildNotEqualErrorMessage } from "./_build_message.ts";
 import { equal } from "./_equal.ts";
 import type { EqualOptions } from "./_types.ts";
@@ -15,7 +15,7 @@ import type { EqualOptions } from "./_types.ts";
  *
  * @example
  * ```ts
- * import { assertNotEquals } from "@std/assert/assert-not-equals";
+ * import { assertNotEquals } from "@std/assert";
  *
  * assertNotEquals(1, 2); // Doesn't throw
  * assertNotEquals(1, 1); // Throws

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -1,14 +1,14 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertNotStrictEquals } from "@std/assert/assert-not-strict-equals";
-import { assertStrictEquals } from "@std/assert/assert-strict-equals";
-import { assertInstanceOf } from "@std/assert/assert-instance-of";
-import { assertIsError } from "@std/assert/assert-is-error";
-import { assertNotInstanceOf } from "@std/assert/assert-not-instance-of";
-import { assertMatch } from "@std/assert/assert-match";
-import { assertObjectMatch } from "@std/assert/assert-object-match";
-import { assertNotMatch } from "@std/assert/assert-not-match";
-import { AssertionError } from "@std/assert/assertion-error";
+import { assertNotStrictEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
+import { assertInstanceOf } from "@std/assert";
+import { assertIsError } from "@std/assert";
+import { assertNotInstanceOf } from "@std/assert";
+import { assertMatch } from "@std/assert";
+import { assertObjectMatch } from "@std/assert";
+import { assertNotMatch } from "@std/assert";
+import { AssertionError } from "@std/assert";
 
 import { assertEquals } from "./_assert_equals.ts";
 import { assertNotEquals } from "./_assert_not_equals.ts";

--- a/expect/_to_have_returned_with.ts
+++ b/expect/_to_have_returned_with.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import type { MatcherContext, MatchResult } from "./_types.ts";
-import { AssertionError } from "@std/assert/assertion-error";
-import { equal } from "@std/assert/equal";
+import { AssertionError } from "@std/assert";
+import { equal } from "@std/assert";
 import { getMockCalls } from "./_mock_util.ts";
 import { inspectArg } from "./_inspect_args.ts";
 

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -13,7 +13,7 @@ import type {
   MatcherKey,
   Matchers,
 } from "./_types.ts";
-import { AssertionError } from "@std/assert/assertion-error";
+import { AssertionError } from "@std/assert";
 import {
   addCustomEqualityTesters,
   getCustomEqualityTesters,

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -64,7 +64,7 @@ export interface FormatOptions {
  * @example Basic usage
  * ```ts
  * import { format } from "@std/fmt/bytes";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(1337), "1.34 kB");
  * assertEquals(format(100), "100 B");
@@ -74,7 +74,7 @@ export interface FormatOptions {
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(1337, { bits: true }), "1.34 kbit");
  * ```
@@ -83,7 +83,7 @@ export interface FormatOptions {
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(42, { signed: true }), "+42 B");
  * assertEquals(format(-42, { signed: true }), "-42 B");
@@ -93,7 +93,7 @@ export interface FormatOptions {
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(1337, { locale: "de" }), "1,34 kB");
  * ```

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { format } from "@std/fmt/duration";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(99674, { style: "digital" }), "00:00:01:39:674:000:000");
  *
@@ -95,7 +95,7 @@ export interface PrettyDurationOptions {
  * @example Usage
  * ```ts
  * import { format } from "@std/fmt/duration";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format(99674, { style: "digital" }), "00:00:01:39:674:000:000");
  *

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { sprintf } from "@std/fmt/printf";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(sprintf("%d", 9), "9");
  * assertEquals(sprintf("%o", 9), "11");

--- a/front_matter/create_extractor.ts
+++ b/front_matter/create_extractor.ts
@@ -79,7 +79,7 @@ function recognize(str: string, formats?: Format[]): Format {
  * @example Extract YAML front matter
  * ```ts
  * import { createExtractor, Parser } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { parse as parseYaml } from "@std/yaml/parse";
  *
  * const extractYaml = createExtractor({ yaml: parseYaml as Parser });
@@ -96,7 +96,7 @@ function recognize(str: string, formats?: Format[]): Format {
  * @example Extract TOML front matter
  * ```ts
  * import { createExtractor, Parser } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { parse as parseToml } from "@std/toml/parse";
  *
  * const extractToml = createExtractor({ toml: parseToml as Parser });
@@ -113,7 +113,7 @@ function recognize(str: string, formats?: Format[]): Format {
  * @example Extract JSON front matter
  * ```ts
  * import { createExtractor, Parser } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const extractJson = createExtractor({ json: JSON.parse as Parser });
  * const { attrs, body, frontMatter } = extractJson<{ title: string }>(
@@ -129,7 +129,7 @@ function recognize(str: string, formats?: Format[]): Format {
  * @example Extract YAML or JSON front matter
  * ```ts
  * import { createExtractor, Parser } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { parse as parseYaml } from "@std/yaml/parse";
  *
  * const extractYamlOrJson = createExtractor({

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -13,7 +13,7 @@ import {
  * @example Extract JSON front matter
  * ```ts
  * import { extract } from "@std/front-matter/json";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = `---json
  * {

--- a/front_matter/mod.ts
+++ b/front_matter/mod.ts
@@ -13,7 +13,7 @@
  *
  * ```ts
  * import { test, extractJson } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const str = "---json\n{\"and\": \"this\"}\n---\ndeno is awesome";
  *
@@ -46,7 +46,7 @@
  *
  * ```ts
  * import { test, extractToml } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const str = "---toml\nmodule = 'front_matter'\n---\ndeno is awesome";
  *
@@ -85,7 +85,7 @@
  *
  * ```ts
  * import { test, extractYaml } from "@std/front-matter";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const str = "---yaml\nmodule: front_matter\n---\ndeno is awesome";
  *

--- a/front_matter/test.ts
+++ b/front_matter/test.ts
@@ -17,7 +17,7 @@ export type { Format };
  * @example Test for valid YAML front matter
  * ```ts
  * import { test } from "@std/front-matter/test";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const result = test(
  * `---
@@ -30,7 +30,7 @@ export type { Format };
  * @example Test for valid TOML front matter
  * ```ts
  * import { test } from "@std/front-matter/test";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const result = test(
  * `---toml
@@ -43,7 +43,7 @@ export type { Format };
  * @example Test for valid JSON front matter
  * ```ts
  * import { test } from "@std/front-matter/test";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const result = test(
  * `---json
@@ -56,7 +56,7 @@ export type { Format };
  * @example JSON front matter is not valid as YAML
  * ```ts
  * import { test } from "@std/front-matter/test";
- * import { assertFalse } from "@std/assert/assert-false";
+ * import { assertFalse } from "@std/assert";
  *
  * const result = test(
  * `---json

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -14,7 +14,7 @@ import { parse } from "@std/toml/parse";
  * @example Extract TOML front matter
  * ```ts
  * import { extract } from "@std/front-matter/toml";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = `---toml
  * title = "Three dashes marks the spot"

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -14,7 +14,7 @@ import { parse } from "@std/yaml/parse";
  * @example Extract YAML front matter
  * ```ts
  * import { extract } from "@std/front-matter/yaml";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = `---yaml
  * title: Three dashes marks the spot

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -36,7 +36,7 @@ export class WalkError extends Error {
    * @example Usage
    * ```ts
    * import { WalkError } from "@std/fs/walk";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const error = new WalkError("error message", "./foo");
    *

--- a/html/entities.ts
+++ b/html/entities.ts
@@ -28,7 +28,7 @@ const rawRe = new RegExp(`[${[...rawToEntity.keys()].join("")}]`, "g");
  * @example Usage
  * ```ts
  * import { escape } from "@std/html/entities";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(escape("<>'&AA"), "&lt;&gt;&#39;&amp;AA");
  *
@@ -66,7 +66,7 @@ const entityListRegexCache = new WeakMap<EntityList, RegExp>();
  * @example Basic usage
  * ```ts
  * import { unescape } from "@std/html/entities";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unescape("&lt;&gt;&#39;&amp;AA"), "<>'&AA");
  * assertEquals(unescape("&thorn;&eth;"), "&thorn;&eth;");
@@ -79,7 +79,7 @@ const entityListRegexCache = new WeakMap<EntityList, RegExp>();
  * ```ts
  * import { unescape } from "@std/html/entities";
  * import entityList from "@std/html/named-entity-list.json" with { type: "json" };
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unescape("&lt;&gt;&#39;&amp;AA", { entityList }), "<>'&AA");
  * ```

--- a/html/mod.ts
+++ b/html/mod.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { unescape } from "@std/html/entities";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unescape("&lt;&gt;&#39;&amp;AA"), "<>'&AA");
  * assertEquals(unescape("&thorn;&eth;"), "&thorn;&eth;");

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -211,7 +211,7 @@ function validateDomain(domain: string) {
  * @example Usage
  * ```ts
  * import { getCookies } from "@std/http/cookie";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const headers = new Headers();
  * headers.set("Cookie", "full=of; tasty=chocolate");
@@ -247,7 +247,7 @@ export function getCookies(headers: Headers): Record<string, string> {
  * @example Usage
  * ```ts
  * import { Cookie, setCookie } from "@std/http/cookie";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const headers = new Headers();
  * const cookie: Cookie = { name: "Space", value: "Cat" };
@@ -279,7 +279,7 @@ export function setCookie(headers: Headers, cookie: Cookie) {
  * @example Usage
  * ```ts
  * import { deleteCookie } from "@std/http/cookie";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const headers = new Headers();
  * deleteCookie(headers, "deno");
@@ -397,7 +397,7 @@ function parseSetCookie(value: string): Cookie | null {
  * @example Usage
  * ```ts
  * import { getSetCookies } from "@std/http/cookie";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const headers = new Headers([
  *   ["Set-Cookie", "lulu=meow; Secure; Max-Age=3600"],

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -98,7 +98,7 @@ async function calcFileInfo(
  * @example Usage
  * ```ts
  * import { calculate } from "@std/http/etag";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const body = "hello deno!";
  *
@@ -138,7 +138,7 @@ export async function calculate(
  *   calculate,
  *   ifMatch,
  * } from "@std/http/etag";
- * import { assert } from "@std/assert/assert"
+ * import { assert } from "@std/assert";
  *
  * const body = "hello deno!";
  *
@@ -186,7 +186,7 @@ export function ifMatch(
  *   calculate,
  *   ifNoneMatch,
  * } from "@std/http/etag";
- * import { assert } from "@std/assert/assert"
+ * import { assert } from "@std/assert";
  *
  * const body = "hello deno!";
  *

--- a/http/negotiation.ts
+++ b/http/negotiation.ts
@@ -20,7 +20,7 @@ import { preferredMediaTypes } from "./_negotiation/media_type.ts";
  * @example Usage
  * ```ts
  * import { accepts } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: {
@@ -49,7 +49,7 @@ export function accepts(request: Request): string[];
  *  @example Usage
  * ```ts
  * import { accepts } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: {
@@ -89,7 +89,7 @@ export function accepts(
  * @example Usage
  * ```ts
  * import { acceptsEncodings } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: { "accept-encoding": "deflate, gzip;q=1.0, *;q=0.5" },
@@ -114,7 +114,7 @@ export function acceptsEncodings(request: Request): string[];
  * @example Usage
  * ```ts
  * import { acceptsEncodings } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: { "accept-encoding": "deflate, gzip;q=1.0, *;q=0.5" },
@@ -153,7 +153,7 @@ export function acceptsEncodings(
  * @example Usage
  * ```ts
  * import { acceptsLanguages } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: {
@@ -175,7 +175,7 @@ export function acceptsLanguages(request: Request): string[];
  * @example Usage
  * ```ts
  * import { acceptsLanguages } from "@std/http/negotiation";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const request = new Request("https://example.com/", {
  *   headers: {

--- a/http/signed_cookie_test.ts
+++ b/http/signed_cookie_test.ts
@@ -4,7 +4,7 @@ import {
   signCookie,
   verifySignedCookie,
 } from "./signed_cookie.ts";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 Deno.test("signCookie() and verifySignedCookie() work circularly", async () => {
   const key = await crypto.subtle.generateKey(

--- a/http/status.ts
+++ b/http/status.ts
@@ -319,7 +319,7 @@ export type ErrorStatus = ClientErrorStatus | ServerErrorStatus;
  * @example Usage
  * ```ts
  * import { isStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isStatus(404));
  * ```
@@ -337,7 +337,7 @@ export function isStatus(status: number): status is StatusCode {
  * @example Usage
  * ```ts
  * import { isInformationalStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isInformationalStatus(100));
  * ```
@@ -357,7 +357,7 @@ export function isInformationalStatus(
  * @example Usage
  * ```ts
  * import { isSuccessfulStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isSuccessfulStatus(200));
  * ```
@@ -377,7 +377,7 @@ export function isSuccessfulStatus(
  * @example Usage
  * ```ts
  * import { isRedirectStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isRedirectStatus(302));
  * ```
@@ -395,7 +395,7 @@ export function isRedirectStatus(status: number): status is RedirectStatus {
  * @example Usage
  * ```ts
  * import { isClientErrorStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isClientErrorStatus(404));
  * ```
@@ -415,7 +415,7 @@ export function isClientErrorStatus(
  * @example Usage
  * ```ts
  * import { isServerErrorStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isServerErrorStatus(502));
  * ```
@@ -435,7 +435,7 @@ export function isServerErrorStatus(
  * @example Usage
  * ```ts
  * import { isErrorStatus } from "@std/http/status";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(isErrorStatus(502));
  * ```

--- a/http/user_agent_test.ts
+++ b/http/user_agent_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { UserAgent } from "./user_agent.ts";
 
 Deno.test({

--- a/ini/ini_map.ts
+++ b/ini/ini_map.ts
@@ -44,7 +44,7 @@ export type ReviverFunction = (
  * @example Usage
  * ```ts
  * import { IniMap } from "@std/ini";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const ini = new IniMap();
  * ini.set("section1", "keyA", 100)
@@ -185,7 +185,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const ini = new IniMap();
    * ini.set("section1", "keyA", 100)
@@ -213,7 +213,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -246,7 +246,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -266,7 +266,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * // Hey
@@ -295,7 +295,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -348,7 +348,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -381,7 +381,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -435,7 +435,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -459,7 +459,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -545,7 +545,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -582,7 +582,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -656,7 +656,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -819,7 +819,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -881,7 +881,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -915,7 +915,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * // Hey
@@ -981,7 +981,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = new IniMap();
    *
@@ -1116,7 +1116,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from(`
    * key0 = value0
@@ -1152,7 +1152,7 @@ export class IniMap {
    * @example Usage
    * ```ts
    * import { IniMap } from "@std/ini/ini-map";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const iniMap = IniMap.from({
    *   key0: "value0",

--- a/ini/mod.ts
+++ b/ini/mod.ts
@@ -13,7 +13,7 @@
  *
  * ```ts
  * import * as ini from "@std/ini";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const iniFile = `# Example configuration file
  * Global Key=Some data here
@@ -60,7 +60,7 @@
  *
  * ```ts
  * import { IniMap } from "@std/ini/ini-map";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const ini = new IniMap();
  * ini.set("section1", "keyA", 100);
@@ -81,7 +81,7 @@
  *
  * ```ts
  * import { IniMap } from "@std/ini/ini-map";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const iniFile = `# Example of key/value arrays
  * [section1]

--- a/ini/parse.ts
+++ b/ini/parse.ts
@@ -8,7 +8,7 @@ import { IniMap, type ParseOptions } from "./ini_map.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/ini/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const parsed = parse(`
  * key = value
@@ -24,7 +24,7 @@ import { IniMap, type ParseOptions } from "./ini_map.ts";
  * @example Using custom reviver
  * ```ts
  * import { parse } from "@std/ini/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const parsed = parse(`
  * [section Foo]

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -19,7 +19,7 @@ export interface StringifyOptions extends FormattingOptions {
  * @example Usage
  * ```ts
  * import { stringify } from "@std/ini/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const str = stringify({
  *   key1: "value1",
@@ -43,7 +43,7 @@ export interface StringifyOptions extends FormattingOptions {
  * @example Using replacer option
  * ```ts
  * import { stringify } from "@std/ini/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const str = stringify({
  *   "section X": {

--- a/internal/build_message.ts
+++ b/internal/build_message.ts
@@ -15,7 +15,7 @@ import type { DiffResult, DiffType } from "./types.ts";
  * @example Usage
  * ```ts
  * import { createColor } from "@std/internal";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { bold, green, red, white } from "@std/fmt/colors";
  *
  * assertEquals(createColor("added")("foo"), green(bold("foo")));
@@ -51,7 +51,7 @@ export function createColor(
  * @example Usage
  * ```ts
  * import { createSign } from "@std/internal";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(createSign("added"), "+   ");
  * assertEquals(createSign("removed"), "-   ");

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -28,7 +28,7 @@ const ADDED = 3;
  * @example Usage
  * ```ts
  * import { createCommon } from "@std/internal/diff";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = [1, 2, 3];
  * const b = [1, 2, 4];
@@ -62,7 +62,7 @@ export function createCommon<T>(A: T[], B: T[]): T[] {
  * @example Usage
  * ```ts
  * import { assertFp } from "@std/internal/diff";
- * import { assertThrows } from "@std/assert/assert-throws";
+ * import { assertThrows } from "@std/assert";
  *
  * assertFp({ y: 0, id: 0 });
  * assertThrows(() => assertFp({ id: 0 }));
@@ -98,7 +98,7 @@ export function assertFp(value: unknown): asserts value is FarthestPoint {
  * @example Usage
  * ```ts
  * import { backTrace } from "@std/internal/diff";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   backTrace([], [], { y: 0, id: 0 }, false, new Uint32Array(0), 0),
@@ -166,7 +166,7 @@ export function backTrace<T>(
  * @example Usage
  * ```ts
  * import { createFp } from "@std/internal/diff";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
  *   createFp(
@@ -227,7 +227,7 @@ export function createFp(
  * @example Usage
  * ```ts
  * import { diff } from "@std/internal/diff";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = [1, 2, 3];
  * const b = [1, 2, 4];

--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -14,7 +14,7 @@ import { diff } from "./diff.ts";
  * @example Usage
  * ```ts
  * import { unescape } from "@std/internal/diff-str";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(unescape("Hello\nWorld"), "Hello\\n\nWorld");
  * ```
@@ -45,7 +45,7 @@ const WHITESPACE_SYMBOLS = /([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/;
  * @example Usage
  * ```ts
  * import { tokenize } from "@std/internal/diff-str";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(tokenize("Hello\nWorld"), ["Hello\n", "World"]);
  * ```
@@ -81,7 +81,7 @@ export function tokenize(string: string, wordDiff = false): string[] {
  * @example Usage
  * ```ts
  * import { createDetails } from "@std/internal/diff-str";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const tokens = [
  *   { type: "added", value: "a" },
@@ -126,7 +126,7 @@ export function createDetails(
  * @example Usage
  * ```ts
  * import { diffStr } from "@std/internal/diff-str";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(diffStr("Hello!", "Hello"), [
  *   {

--- a/internal/diff_str_test.ts
+++ b/internal/diff_str_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { createDetails, diffStr, tokenize, unescape } from "./diff_str.ts";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 Deno.test({
   name: 'diff() "a" vs "b" (diffstr)',

--- a/internal/format.ts
+++ b/internal/format.ts
@@ -12,7 +12,7 @@
  * @example Usage
  * ```ts
  * import { format } from "@std/internal/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(format({ a: 1, b: 2 }), "{\n  a: 1,\n  b: 2,\n}");
  * assertEquals(format(new Set([1, 2])), "Set(2) {\n  1,\n  2,\n}");

--- a/internal/mod.ts
+++ b/internal/mod.ts
@@ -7,7 +7,7 @@
  *
  * ```ts
  * import { diff, diffStr, buildMessage } from "@std/internal";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const a = [1, 2, 3];
  * const b = [1, 2, 4];

--- a/io/copy_test.ts
+++ b/io/copy_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { copy } from "./copy.ts";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 const SRC_PATH = "./io/testdata/copy-src.txt";
 const DST_PATH = "./io/testdata/copy-dst.txt";

--- a/io/iterate_reader_test.ts
+++ b/io/iterate_reader_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { iterateReader, iterateReaderSync } from "./iterate_reader.ts";

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -22,7 +22,7 @@ export interface ByteRange {
  * range.
  *
  * ```ts
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { readRange } from "@std/io/read-range";
  *
  * // Read the first 10 bytes of a file
@@ -68,7 +68,7 @@ export async function readRange(
  * within that range.
  *
  * ```ts
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  * import { readRangeSync } from "@std/io/read-range";
  *
  * // Read the first 10 bytes of a file

--- a/json/concatenated_json_parse_stream.ts
+++ b/json/concatenated_json_parse_stream.ts
@@ -19,7 +19,7 @@ const primitives = new Map(
  *
  * ```ts
  * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   `{"foo":"bar"}`,
@@ -40,7 +40,7 @@ export class ConcatenatedJsonParseStream
    * @example Usage
    * ```ts
    * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *   `{"foo":"bar"}`,
@@ -60,7 +60,7 @@ export class ConcatenatedJsonParseStream
    * @example Usage
    * ```ts
    * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *   `{"foo":"bar"}`,
@@ -81,7 +81,7 @@ export class ConcatenatedJsonParseStream
    * @example Usage
    *  ```ts
    * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *   `{"foo":"bar"}`,

--- a/json/json_parse_stream.ts
+++ b/json/json_parse_stream.ts
@@ -21,7 +21,7 @@ function isBrankString(str: string) {
  *
  * ```ts
  * import { JsonParseStream } from "@std/json/json-parse-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   `{"foo":"bar"}\n`,
@@ -38,7 +38,7 @@ function isBrankString(str: string) {
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { JsonParseStream } from "@std/json/json-parse-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const file = await Deno.open("json/testdata/test.jsonl");
  *
@@ -62,7 +62,7 @@ export class JsonParseStream extends TransformStream<string, JsonValue> {
    *
    * ```ts
    * import { JsonParseStream } from "@std/json/json-parse-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *   `{"foo":"bar"}`,
@@ -79,7 +79,7 @@ export class JsonParseStream extends TransformStream<string, JsonValue> {
    * ```ts
    * import { TextLineStream } from "@std/streams/text-line-stream";
    * import { JsonParseStream } from "@std/json/json-parse-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const file = await Deno.open("json/testdata/test.jsonl");
    *

--- a/json/json_stringify_stream.ts
+++ b/json/json_stringify_stream.ts
@@ -31,7 +31,7 @@ export interface StringifyStreamOptions {
  *
  * ```ts
  * import { JsonStringifyStream } from "@std/json/json-stringify-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([{ foo: "bar" }, { baz: 100 }])
  *   .pipeThrough(new JsonStringifyStream());
@@ -49,7 +49,7 @@ export interface StringifyStreamOptions {
  *
  * ```ts
  * import { JsonStringifyStream } from "@std/json/json-stringify-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([{ foo: "bar" }, { baz: 100 }])
  *   .pipeThrough(new JsonStringifyStream({ prefix: "\x1E", suffix: "\n" }));
@@ -95,7 +95,7 @@ export class JsonStringifyStream extends TransformStream<unknown, string> {
    * @example Usage
    * ```ts
    * import { JsonStringifyStream } from "@std/json/json-stringify-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([{ foo: "bar" }, { baz: 100 }])
    *   .pipeThrough(new JsonStringifyStream());

--- a/json/mod.ts
+++ b/json/mod.ts
@@ -5,7 +5,7 @@
  *
  * ```ts
  * import { JsonStringifyStream } from "@std/json";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([{ foo: "bar" }, { baz: 100 }])
  *   .pipeThrough(new JsonStringifyStream());

--- a/jsonc/mod.ts
+++ b/jsonc/mod.ts
@@ -11,7 +11,7 @@
  *
  * ```ts
  * import { parse } from "@std/jsonc";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(parse('{"foo": "bar", } // comment'), { foo: "bar" });
  * assertEquals(parse('{"foo": "bar", } /* comment *\/'), { foo: "bar" });

--- a/log/base_handler_test.ts
+++ b/log/base_handler_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import * as log from "./mod.ts";
 import { TestHandler } from "./_test_handler.ts";
 

--- a/log/critical_test.ts
+++ b/log/critical_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { critical } from "./critical.ts";
 
 Deno.test("critical()", () => {

--- a/log/debug_test.ts
+++ b/log/debug_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import "./setup.ts";
 import { debug } from "./debug.ts";
 

--- a/log/error_test.ts
+++ b/log/error_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { error } from "./error.ts";
 
 Deno.test("error()", () => {

--- a/log/info_test.ts
+++ b/log/info_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { info } from "./info.ts";
 
 Deno.test("info()", () => {

--- a/log/setup_test.ts
+++ b/log/setup_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import * as log from "./mod.ts";
 import { TestHandler } from "./_test_handler.ts";
 

--- a/log/warn_test.ts
+++ b/log/warn_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { warn } from "./warn.ts";
 
 Deno.test("warn()", () => {

--- a/media_types/all_extensions.ts
+++ b/media_types/all_extensions.ts
@@ -18,7 +18,7 @@ import { extensions } from "./_db.ts";
  * @example Usage
  * ```ts
  * import { allExtensions } from "@std/media-types/all-extensions";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(allExtensions("application/json"), ["json", "map"]);
  * assertEquals(allExtensions("text/html; charset=UTF-8"), ["html", "htm", "shtml"]);

--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -45,7 +45,7 @@ export type KnownExtensionOrType =
  * @example Usage
  * ```ts
  * import { contentType } from "@std/media-types/content-type";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(contentType(".json"), "application/json; charset=UTF-8");
  * assertEquals(contentType("text/html"), "text/html; charset=UTF-8");

--- a/media_types/extension.ts
+++ b/media_types/extension.ts
@@ -17,7 +17,7 @@ import { allExtensions } from "./all_extensions.ts";
  * @example Usage
  * ```ts
  * import { extension } from "@std/media-types/extension";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(extension("text/plain"), "txt");
  * assertEquals(extension("application/json"), "json");

--- a/media_types/format_media_type.ts
+++ b/media_types/format_media_type.ts
@@ -21,7 +21,7 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
  * @example Basic usage
  * ```ts
  * import { formatMediaType } from "@std/media-types/format-media-type";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(formatMediaType("text/plain"), "text/plain");
  * ```
@@ -29,7 +29,7 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
  * @example With parameters
  * ```ts
  * import { formatMediaType } from "@std/media-types/format-media-type";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(formatMediaType("text/plain", { charset: "UTF-8" }), "text/plain; charset=UTF-8");
  * ```

--- a/media_types/get_charset.ts
+++ b/media_types/get_charset.ts
@@ -17,7 +17,7 @@ import { db, type KeyOfDb } from "./_db.ts";
  * @example Usage
  * ```ts
  * import { getCharset } from "@std/media-types/get-charset";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(getCharset("text/plain"), "UTF-8");
  * assertEquals(getCharset("application/foo"), undefined);

--- a/media_types/mod.ts
+++ b/media_types/mod.ts
@@ -15,7 +15,7 @@
  *
  * ```ts
  * import { contentType, allExtensions, getCharset } from "@std/media-types";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(allExtensions("application/json"), ["json", "map"]);
  *

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -26,7 +26,7 @@ import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { parseMediaType } from "@std/media-types/parse-media-type";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(parseMediaType("application/JSON"), ["application/json", undefined]);
  * assertEquals(parseMediaType("text/html; charset=UTF-8"), ["text/html", { charset: "UTF-8" }]);

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -18,7 +18,7 @@ import { types } from "./_db.ts";
  * @example Usage
  * ```ts
  * import { typeByExtension } from "@std/media-types/type-by-extension";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(typeByExtension("js"), "application/javascript");
  * assertEquals(typeByExtension(".HTML"), "text/html");

--- a/msgpack/decode.ts
+++ b/msgpack/decode.ts
@@ -11,7 +11,7 @@ import type { ValueType } from "./encode.ts";
  * @example Usage
  * ```ts
  * import { decode } from "@std/msgpack/decode";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const encoded = new Uint8Array([163, 72, 105, 33]);
  *

--- a/msgpack/encode.ts
+++ b/msgpack/encode.ts
@@ -43,7 +43,7 @@ const encoder = new TextEncoder();
  * @example Usage
  * ```ts
  * import { encode } from "@std/msgpack/encode";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = {
  *   str: "deno",

--- a/msgpack/mod.ts
+++ b/msgpack/mod.ts
@@ -10,7 +10,7 @@
  *
  * ```ts
  * import { decode, encode } from "@std/msgpack";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = {
  *   str: "deno",

--- a/net/get_network_address_test.ts
+++ b/net/get_network_address_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { getNetworkAddress } from "./get_network_address.ts";
 import { stub } from "@std/testing/mock";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 const INTERFACES: Deno.NetworkInterfaceInfo[] = [
   // Network inaccessible

--- a/path/basename.ts
+++ b/path/basename.ts
@@ -14,7 +14,7 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  * @example Usage
  * ```ts
  * import { basename } from "@std/path/basename";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");

--- a/path/common.ts
+++ b/path/common.ts
@@ -13,7 +13,7 @@ import { SEPARATOR } from "./constants.ts";
  * @example Usage
  * ```ts
  * import { common } from "@std/path/common";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   const path = common([

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -11,7 +11,7 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
  * @example Usage
  * ```ts
  * import { dirname } from "@std/path/dirname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(dirname("C:\\home\\user\\Documents\\image.png"), "C:\\home\\user\\Documents");

--- a/path/extname.ts
+++ b/path/extname.ts
@@ -10,7 +10,7 @@ import { extname as windowsExtname } from "./windows/extname.ts";
  * @example Usage
  * ```ts
  * import { extname } from "@std/path/extname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(extname("C:\\home\\user\\Documents\\image.png"), ".png");

--- a/path/format.ts
+++ b/path/format.ts
@@ -13,7 +13,7 @@ import type { FormatInputPathObject } from "./_interface.ts";
  * @example Usage
  * ```ts
  * import { format } from "@std/path/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(format({ dir: "C:\\path\\to", base: "script.ts" }), "C:\\path\\to\\script.ts");

--- a/path/from_file_url.ts
+++ b/path/from_file_url.ts
@@ -11,7 +11,7 @@ import { fromFileUrl as windowsFromFileUrl } from "./windows/from_file_url.ts";
  * @example Usage
  * ```ts
  * import { fromFileUrl } from "@std/path/from-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(fromFileUrl("file:///home/foo"), "\\home\\foo");

--- a/path/glob_to_regexp.ts
+++ b/path/glob_to_regexp.ts
@@ -74,7 +74,7 @@ export type GlobToRegExpOptions = GlobOptions;
  * @example Usage
  * ```ts
  * import { globToRegExp } from "@std/path/glob-to-regexp";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(globToRegExp("*.js"), /^[^\\/]*\.js(?:\\|\/)*$/);

--- a/path/is_glob.ts
+++ b/path/is_glob.ts
@@ -7,7 +7,7 @@
  * @example Usage
  * ```ts
  * import { isGlob } from "@std/path/is-glob";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * assert(!isGlob("foo/bar/../baz"));
  * assert(isGlob("foo/*ar/../baz"));

--- a/path/join.ts
+++ b/path/join.ts
@@ -11,7 +11,7 @@ import { join as windowsJoin } from "./windows/join.ts";
  * @example Usage
  * ```ts
  * import { join } from "@std/path/join";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(join("C:\\foo", "bar", "baz\\quux", "garply", ".."), "C:\\foo\\bar\\baz\\quux");

--- a/path/join_globs.ts
+++ b/path/join_globs.ts
@@ -17,7 +17,7 @@ export type { GlobOptions };
  * @example Usage
  * ```ts
  * import { joinGlobs } from "@std/path/join-globs";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(joinGlobs(["foo", "bar", "..", "baz"]), "foo\\baz");

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -17,7 +17,7 @@
  *
  * ```ts
  * import { fromFileUrl } from "@std/path/posix/from-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "/home/foo");
  * ```
@@ -26,7 +26,7 @@
  *
  * ```ts
  * import { fromFileUrl } from "@std/path/windows/from-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "\\home\\foo");
  * ```

--- a/path/normalize.ts
+++ b/path/normalize.ts
@@ -14,7 +14,7 @@ import { normalize as windowsNormalize } from "./windows/normalize.ts";
  * @example Usage
  * ```ts
  * import { normalize } from "@std/path/normalize";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(normalize("C:\\foo\\bar\\..\\baz\\quux"), "C:\\foo\\baz\\quux");

--- a/path/normalize_glob.ts
+++ b/path/normalize_glob.ts
@@ -20,7 +20,7 @@ export type { GlobOptions };
  * @example Usage
  * ```ts
  * import { normalizeGlob } from "@std/path/normalize-glob";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(normalizeGlob("foo\\bar\\..\\baz"), "foo\\baz");

--- a/path/parse.ts
+++ b/path/parse.ts
@@ -17,7 +17,7 @@ export type { ParsedPath } from "./_interface.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/path/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   const parsedPathObj = parse("C:\\path\\to\\script.ts");

--- a/path/parse_test.ts
+++ b/path/parse_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import * as windows from "./windows/mod.ts";
 
 Deno.test("windows.parse() parses UNC root only path", () => {

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -16,7 +16,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { basename } from "@std/path/posix/basename";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(basename("/home/user/Documents/"), "Documents");
  * assertEquals(basename("/home/user/Documents/image.png"), "image.png");

--- a/path/posix/common.ts
+++ b/path/posix/common.ts
@@ -9,7 +9,7 @@ import { SEPARATOR } from "./constants.ts";
  * @example Usage
  * ```ts
  * import { common } from "@std/path/posix/common";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = common([
  *   "./deno/std/path/mod.ts",

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -11,7 +11,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { dirname } from "@std/path/posix/dirname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(dirname("/home/user/Documents/"), "/home/user");
  * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");

--- a/path/posix/extname.ts
+++ b/path/posix/extname.ts
@@ -11,7 +11,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { extname } from "@std/path/posix/extname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(extname("/home/user/Documents/file.ts"), ".ts");
  * assertEquals(extname("/home/user/Documents/"), "");

--- a/path/posix/format.ts
+++ b/path/posix/format.ts
@@ -10,7 +10,7 @@ import type { FormatInputPathObject } from "../_interface.ts";
  * @example Usage
  * ```ts
  * import { format } from "@std/path/posix/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = format({
  *   root: "/",

--- a/path/posix/from_file_url.ts
+++ b/path/posix/from_file_url.ts
@@ -9,7 +9,7 @@ import { assertArg } from "../_common/from_file_url.ts";
  * @example Usage
  * ```ts
  * import { fromFileUrl } from "@std/path/posix/from-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl(new URL("file:///home/foo")), "/home/foo");
  * ```

--- a/path/posix/glob_to_regexp.ts
+++ b/path/posix/glob_to_regexp.ts
@@ -77,7 +77,7 @@ const constants: GlobConstants = {
  * @example Usage
  * ```ts
  * import { globToRegExp } from "@std/path/posix/glob-to-regexp";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(globToRegExp("*.js"), /^[^/]*\.js\/*$/);
  * ```

--- a/path/posix/join.ts
+++ b/path/posix/join.ts
@@ -10,7 +10,7 @@ import { normalize } from "./normalize.ts";
  * @example Usage
  * ```ts
  * import { join } from "@std/path/posix/join";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = join("/foo", "bar", "baz/asdf", "quux", "..");
  * assertEquals(path, "/foo/bar/baz/asdf");

--- a/path/posix/join_globs.ts
+++ b/path/posix/join_globs.ts
@@ -14,7 +14,7 @@ export type { GlobOptions };
  * @example Usage
  * ```ts
  * import { joinGlobs } from "@std/path/posix/join-globs";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = joinGlobs(["foo", "bar", "**"], { globstar: true });
  * assertEquals(path, "foo/bar/**");

--- a/path/posix/mod.ts
+++ b/path/posix/mod.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * import { fromFileUrl } from "@std/path/posix";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "/home/foo");
  * ```

--- a/path/posix/normalize.ts
+++ b/path/posix/normalize.ts
@@ -13,7 +13,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { normalize } from "@std/path/posix/normalize";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = normalize("/foo/bar//baz/asdf/quux/..");
  * assertEquals(path, "/foo/bar/baz/asdf");

--- a/path/posix/normalize_glob.ts
+++ b/path/posix/normalize_glob.ts
@@ -13,7 +13,7 @@ export type { GlobOptions };
  * @example Usage
  * ```ts
  * import { normalizeGlob } from "@std/path/posix/normalize-glob";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = normalizeGlob("foo/bar/../*", { globstar: true });
  * assertEquals(path, "foo/*");

--- a/path/posix/parse.ts
+++ b/path/posix/parse.ts
@@ -15,7 +15,7 @@ export type { ParsedPath } from "../_interface.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/path/posix/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = parse("/home/user/file.txt");
  * assertEquals(path, {

--- a/path/posix/relative.ts
+++ b/path/posix/relative.ts
@@ -13,7 +13,7 @@ import { assertArgs } from "../_common/relative.ts";
  * @example Usage
  * ```ts
  * import { relative } from "@std/path/posix/relative";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = relative("/data/orandea/test/aaa", "/data/orandea/impl/bbb");
  * assertEquals(path, "../../impl/bbb");

--- a/path/posix/resolve.ts
+++ b/path/posix/resolve.ts
@@ -11,7 +11,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { resolve } from "@std/path/posix/resolve";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = resolve("/foo", "bar", "baz/asdf", "quux", "..");
  * assertEquals(path, "/foo/bar/baz/asdf");

--- a/path/posix/to_file_url.ts
+++ b/path/posix/to_file_url.ts
@@ -10,7 +10,7 @@ import { isAbsolute } from "./is_absolute.ts";
  * @example Usage
  * ```ts
  * import { toFileUrl } from "@std/path/posix/to-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toFileUrl("/home/foo"), new URL("file:///home/foo"));
  * assertEquals(toFileUrl("/home/foo bar"), new URL("file:///home/foo%20bar"));

--- a/path/posix/to_namespaced_path.ts
+++ b/path/posix/to_namespaced_path.ts
@@ -7,7 +7,7 @@
  * @example Usage
  * ```ts
  * import { toNamespacedPath } from "@std/path/posix/to-namespaced-path";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toNamespacedPath("/home/foo"), "/home/foo");
  * ```

--- a/path/relative.ts
+++ b/path/relative.ts
@@ -12,7 +12,7 @@ import { relative as windowsRelative } from "./windows/relative.ts";
  * @example Usage
  * ```ts
  * import { relative } from "@std/path/relative";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   const path = relative("C:\\foobar\\test\\aaa", "C:\\foobar\\impl\\bbb");

--- a/path/resolve.ts
+++ b/path/resolve.ts
@@ -11,7 +11,7 @@ import { resolve as windowsResolve } from "./windows/resolve.ts";
  * @example Usage
  * ```ts
  * import { resolve } from "@std/path/resolve";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(resolve("C:\\foo", "bar", "baz"), "C:\\foo\\bar\\baz");

--- a/path/to_file_url.ts
+++ b/path/to_file_url.ts
@@ -11,7 +11,7 @@ import { toFileUrl as windowsToFileUrl } from "./windows/to_file_url.ts";
  * @example Usage
  * ```ts
  * import { toFileUrl } from "@std/path/to-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(toFileUrl("\\home\\foo"), new URL("file:///home/foo"));

--- a/path/to_namespaced_path.ts
+++ b/path/to_namespaced_path.ts
@@ -12,7 +12,7 @@ import { toNamespacedPath as windowsToNamespacedPath } from "./windows/to_namesp
  * @example Usage
  * ```ts
  * import { toNamespacedPath } from "@std/path/to-namespaced-path";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(toNamespacedPath("C:\\foo\\bar"), "\\\\?\\C:\\foo\\bar");

--- a/path/to_namespaced_path_test.ts
+++ b/path/to_namespaced_path_test.ts
@@ -2,7 +2,7 @@
 
 import * as posix from "./posix/mod.ts";
 import * as windows from "./windows/mod.ts";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 Deno.test("windows.toNamespacedPath() returns the namespaced path", () => {
   {

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -17,7 +17,7 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { basename } from "@std/path/windows/basename";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(basename("C:\\user\\Documents\\"), "Documents");
  * assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");

--- a/path/windows/common.ts
+++ b/path/windows/common.ts
@@ -10,7 +10,7 @@ import { SEPARATOR } from "./constants.ts";
  * @example Usage
  * ```ts
  * import { common } from "@std/path/windows/common";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = common([
  *   "C:\\foo\\bar",

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -16,7 +16,7 @@ import {
  * @example Usage
  * ```ts
  * import { dirname } from "@std/path/windows/dirname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const dir = dirname("C:\\foo\\bar\\baz.ext");
  * assertEquals(dir, "C:\\foo\\bar");

--- a/path/windows/extname.ts
+++ b/path/windows/extname.ts
@@ -11,7 +11,7 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { extname } from "@std/path/windows/extname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const ext = extname("file.ts");
  * assertEquals(ext, ".ts");

--- a/path/windows/format.ts
+++ b/path/windows/format.ts
@@ -10,7 +10,7 @@ import type { FormatInputPathObject } from "../_interface.ts";
  * @example Usage
  * ```ts
  * import { format } from "@std/path/windows/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const path = format({
  *   root: "C:\\",

--- a/path/windows/from_file_url.ts
+++ b/path/windows/from_file_url.ts
@@ -9,7 +9,7 @@ import { assertArg } from "../_common/from_file_url.ts";
  * @example Usage
  * ```ts
  * import { fromFileUrl } from "@std/path/windows/from-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "\\home\\foo");
  * assertEquals(fromFileUrl("file:///C:/Users/foo"), "C:\\Users\\foo");

--- a/path/windows/glob_to_regexp.ts
+++ b/path/windows/glob_to_regexp.ts
@@ -75,7 +75,7 @@ const constants: GlobConstants = {
  * @example Usage
  * ```ts
  * import { globToRegExp } from "@std/path/windows/glob-to-regexp";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(globToRegExp("*.js"), /^[^\\/]*\.js(?:\\|\/)*$/);
  * ```

--- a/path/windows/join.ts
+++ b/path/windows/join.ts
@@ -11,7 +11,7 @@ import { normalize } from "./normalize.ts";
  * @example Usage
  * ```ts
  * import { join } from "@std/path/windows/join";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const joined = join("C:\\foo", "bar", "baz\\..");
  * assertEquals(joined, "C:\\foo\\bar");

--- a/path/windows/join_globs.ts
+++ b/path/windows/join_globs.ts
@@ -15,7 +15,7 @@ export type { GlobOptions };
  *
  * ```ts
  * import { joinGlobs } from "@std/path/windows/join-globs";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const joined = joinGlobs(["foo", "**", "bar"], { globstar: true });
  * assertEquals(joined, "foo\\**\\bar");

--- a/path/windows/mod.ts
+++ b/path/windows/mod.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * import { fromFileUrl } from "@std/path/windows";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "\\home\\foo");
  * ```

--- a/path/windows/normalize.ts
+++ b/path/windows/normalize.ts
@@ -14,7 +14,7 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { normalize } from "@std/path/windows/normalize";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const normalized = normalize("C:\\foo\\..\\bar");
  * assertEquals(normalized, "C:\\bar");

--- a/path/windows/normalize_glob.ts
+++ b/path/windows/normalize_glob.ts
@@ -13,7 +13,7 @@ export type { GlobOptions };
  * @example Usage
  * ```ts
  * import { normalizeGlob } from "@std/path/windows/normalize-glob";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const normalized = normalizeGlob("**\\foo\\..\\bar", { globstar: true });
  * assertEquals(normalized, "**\\bar");

--- a/path/windows/parse.ts
+++ b/path/windows/parse.ts
@@ -14,7 +14,7 @@ export type { ParsedPath } from "../_interface.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/path/windows/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const parsed = parse("C:\\foo\\bar\\baz.ext");
  * assertEquals(parsed, {

--- a/path/windows/relative.ts
+++ b/path/windows/relative.ts
@@ -16,7 +16,7 @@ import { assertArgs } from "../_common/relative.ts";
  * @example Usage
  * ```ts
  * import { relative } from "@std/path/windows/relative";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const relativePath = relative("C:\\foobar\\test\\aaa", "C:\\foobar\\impl\\bbb");
  * assertEquals(relativePath, "..\\..\\impl\\bbb");

--- a/path/windows/resolve.ts
+++ b/path/windows/resolve.ts
@@ -12,7 +12,7 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { resolve } from "@std/path/windows/resolve";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const resolved = resolve("C:\\foo\\bar", "..\\baz");
  * assertEquals(resolved, "C:\\foo\\baz");

--- a/path/windows/to_file_url.ts
+++ b/path/windows/to_file_url.ts
@@ -10,7 +10,7 @@ import { isAbsolute } from "./is_absolute.ts";
  * @example Usage
  * ```ts
  * import { toFileUrl } from "@std/path/windows/to-file-url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toFileUrl("\\home\\foo"), new URL("file:///home/foo"));
  * assertEquals(toFileUrl("C:\\Users\\foo"), new URL("file:///C:/Users/foo"));

--- a/path/windows/to_namespaced_path.ts
+++ b/path/windows/to_namespaced_path.ts
@@ -16,7 +16,7 @@ import { resolve } from "./resolve.ts";
  * @example Usage
  * ```ts
  * import { toNamespacedPath } from "@std/path/windows/to-namespaced-path";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const namespaced = toNamespacedPath("C:\\foo\\bar");
  * assertEquals(namespaced, "\\\\?\\C:\\foo\\bar");

--- a/semver/compare.ts
+++ b/semver/compare.ts
@@ -18,7 +18,7 @@ import {
  * @example Usage
  * ```ts
  * import { parse, compare } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/difference.ts
+++ b/semver/difference.ts
@@ -10,7 +10,7 @@ import { compareIdentifier } from "./_shared.ts";
  * @example Usage
  * ```ts
  * import { parse, difference } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -23,7 +23,7 @@ function formatNumber(value: number) {
  * @example Usage
  * ```ts
  * import { format } from "@std/semver/format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const semver = {
  *   major: 1,

--- a/semver/greater_or_equal.ts
+++ b/semver/greater_or_equal.ts
@@ -11,7 +11,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, greaterOrEqual } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/greater_than.ts
+++ b/semver/greater_than.ts
@@ -12,7 +12,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, greaterThan } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/greater_than_range.ts
+++ b/semver/greater_than_range.ts
@@ -12,7 +12,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, parseRange, greaterThanRange } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const v0 = parse("1.2.3");
  * const v1 = parse("1.2.4");

--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -59,7 +59,7 @@ function bumpPrerelease(
  * @example Usage
  * ```ts
  * import { increment, parse } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const version = parse("1.2.3");
  * assertEquals(increment(version, "major"), parse("2.0.0"));

--- a/semver/is_range.ts
+++ b/semver/is_range.ts
@@ -30,7 +30,7 @@ function isComparator(value: unknown): value is Comparator {
  * @example Usage
  * ```ts
  * import { isRange } from "@std/semver/is-range";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const range = [[{ major: 1, minor: 2, patch: 3 }]];
  * assert(isRange(range));

--- a/semver/is_semver.ts
+++ b/semver/is_semver.ts
@@ -20,7 +20,7 @@ import { isValidNumber, isValidString } from "./_shared.ts";
  * @example Usage
  * ```ts
  * import { isSemVer } from "@std/semver/is-semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const value = {
  *   major: 1,

--- a/semver/less_or_equal.ts
+++ b/semver/less_or_equal.ts
@@ -11,7 +11,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, lessOrEqual } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/less_than.ts
+++ b/semver/less_than.ts
@@ -11,7 +11,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, lessThan } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/less_than_range.ts
+++ b/semver/less_than_range.ts
@@ -12,7 +12,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, parseRange, lessThanRange } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const v0 = parse("1.2.3");
  * const v1 = parse("1.0.0");

--- a/semver/max_satisfying.ts
+++ b/semver/max_satisfying.ts
@@ -11,7 +11,7 @@ import { greaterThan } from "./greater_than.ts";
  * @example Usage
  * ```ts
  * import { parse, parseRange, maxSatisfying } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const versions = ["1.2.3", "1.2.4", "1.3.0", "2.0.0", "2.1.0"].map(parse);
  * const range = parseRange(">=1.0.0 <2.0.0");

--- a/semver/min_satisfying.ts
+++ b/semver/min_satisfying.ts
@@ -11,7 +11,7 @@ import { lessThan } from "./less_than.ts";
  * @example Usage
  * ```ts
  * import { parse, parseRange, minSatisfying } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const versions = ["0.2.0", "1.2.3", "1.3.0", "2.0.0", "2.1.0"].map(parse);
  * const range = parseRange(">=1.0.0 <2.0.0");

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -15,7 +15,7 @@
  *   lessThan,
  *   format
  * } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const semver = parse("1.2.3");
  * assertEquals(semver, {
@@ -128,7 +128,7 @@
  *
  * ```ts
  * import { increment, parse } from "@std/semver";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(increment(parse("1.2.3"), "prerelease", "alpha"), parse("1.2.4-alpha.0"));
  * ```

--- a/semver/not_equals.ts
+++ b/semver/not_equals.ts
@@ -11,7 +11,7 @@ import { compare } from "./compare.ts";
  * @example Usage
  * ```ts
  * import { parse, notEquals } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const s0 = parse("1.2.3");
  * const s1 = parse("1.2.4");

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -10,7 +10,7 @@ import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/semver/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const version = parse("1.2.3");
  * assertEquals(version, {

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -385,7 +385,7 @@ function parseOperatorRanges(string: string): Comparator[] {
  * @example Usage
  * ```ts
  * import { parseRange } from "@std/semver/parse-range";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const range = parseRange(">=1.0.0 <2.0.0 || >=3.0.0");
  * assertEquals(range, [

--- a/semver/range_intersects.ts
+++ b/semver/range_intersects.ts
@@ -72,7 +72,7 @@ function comparatorsSatisfiable(comparators: Comparator[]): boolean {
  * @example Usage
  * ```ts
  * import { parseRange, rangeIntersects } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const r0 = parseRange(">=1.0.0 <2.0.0");
  * const r1 = parseRange(">=1.0.0 <1.2.3");

--- a/semver/satisfies.ts
+++ b/semver/satisfies.ts
@@ -9,7 +9,7 @@ import { testComparatorSet } from "./_test_comparator_set.ts";
  * @example Usage
  * ```ts
  * import { parse, parseRange, satisfies } from "@std/semver";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const version = parse("1.2.3");
  * const range0 = parseRange(">=1.0.0 <2.0.0");

--- a/semver/try_parse.ts
+++ b/semver/try_parse.ts
@@ -9,7 +9,7 @@ import { parse } from "./parse.ts";
  * @example Usage
  * ```ts
  * import { tryParse } from "@std/semver/try-parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(tryParse("1.2.3"), { major: 1, minor: 2, patch: 3, prerelease: [], build: [] });
  * assertEquals(tryParse("1.2.3-alpha"), { major: 1, minor: 2, patch: 3, prerelease: ["alpha"], build: [] });

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -39,8 +39,8 @@ export interface BufferBytesOptions {
  * ```ts
  * import { Buffer } from "@std/streams/buffer";
  * import { toText } from "@std/streams/to-text";
- * import { assert } from "@std/assert/assert";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assert } from "@std/assert";
+ * import { assertEquals } from "@std/assert";
  *
  * // Create a new buffer
  * const buf = new Buffer();
@@ -176,8 +176,8 @@ export class Buffer {
    *
    * @example Copy the buffer
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
-   * import { assertNotEquals } from "@std/assert/assert-not-equals";
+   * import { assertEquals } from "@std/assert";
+   * import { assertNotEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([0, 1, 2]);
@@ -195,7 +195,7 @@ export class Buffer {
    *
    * @example Get a slice to the buffer
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([0, 1, 2]);
@@ -223,7 +223,7 @@ export class Buffer {
    *
    * @example Empty buffer
    * ```ts
-   * import { assert } from "@std/assert/assert";
+   * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const buf = new Buffer();
@@ -232,7 +232,7 @@ export class Buffer {
    *
    * @example Non-empty buffer
    * ```ts
-   * import { assert } from "@std/assert/assert";
+   * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([42]);
@@ -242,7 +242,7 @@ export class Buffer {
    *
    * @example Non-empty, but the content was already read
    * ```ts
-   * import { assert } from "@std/assert/assert";
+   * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([42]);
@@ -265,7 +265,7 @@ export class Buffer {
    *
    * @example Basic usage
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([0, 1, 2]);
@@ -275,7 +275,7 @@ export class Buffer {
    *
    * @example Length becomes 0 after the content is read
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([42]);
@@ -299,7 +299,7 @@ export class Buffer {
    *
    * @example Basic usage
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const arrayBuffer = new ArrayBuffer(256);
@@ -320,7 +320,7 @@ export class Buffer {
    *
    * @example Basic usage
    * ```ts
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([0, 1, 2]);
@@ -348,7 +348,7 @@ export class Buffer {
    *
    * @example Basic usage
    * ```ts
-   * import { assert } from "@std/assert/assert";
+   * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const array = new Uint8Array([0, 1, 2]);
@@ -423,8 +423,8 @@ export class Buffer {
    *
    * @example Basic usage
    * ```ts
-   * import { assert } from "@std/assert/assert";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assert } from "@std/assert";
+   * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
    * const buf = new Buffer();

--- a/streams/byte_slice_stream.ts
+++ b/streams/byte_slice_stream.ts
@@ -8,7 +8,7 @@
  * @example Basic usage
  * ```ts
  * import { ByteSliceStream } from "@std/streams/byte-slice-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   new Uint8Array([0, 1]),
@@ -25,7 +25,7 @@
  * @example Get a range of bytes from a fetch response body
  * ```ts
  * import { ByteSliceStream } from "@std/streams/byte-slice-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const response = await fetch("https://example.com");
  * const rangedStream = response.body!

--- a/streams/concat_readable_streams.ts
+++ b/streams/concat_readable_streams.ts
@@ -13,7 +13,7 @@
  * @example Usage
  * ```ts
  * import { concatReadableStreams } from "@std/streams/concat-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from([1, 2, 3]);
  * const stream2 = ReadableStream.from([4, 5, 6]);

--- a/streams/delimiter_stream.ts
+++ b/streams/delimiter_stream.ts
@@ -33,7 +33,7 @@ export interface DelimiterStreamOptions {
  * Divide a CSV stream by commas, discarding the commas:
  * ```ts
  * import { DelimiterStream } from "@std/streams/delimiter-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inputStream = ReadableStream.from(["foo,bar", ",baz"]);
  *
@@ -48,7 +48,7 @@ export interface DelimiterStreamOptions {
  * Divide a stream after semi-colons, keeping the semicolons in the output:
  * ```ts
  * import { DelimiterStream } from "@std/streams/delimiter-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const inputStream = ReadableStream.from(["foo;", "bar;baz", ";"]);
  *

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -17,7 +17,7 @@
  * @example Zip 2 streams with the same length
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2", "3"]);
  * const stream2 = ReadableStream.from(["a", "b", "c"]);
@@ -32,7 +32,7 @@
  * @example Zip 2 streams with different length (first one is shorter)
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2"]);
  * const stream2 = ReadableStream.from(["a", "b", "c", "d"]);
@@ -50,7 +50,7 @@
  * @example Zip 2 streams with different length (first one is longer)
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2", "3", "4"]);
  * const stream2 = ReadableStream.from(["a", "b"]);
@@ -68,7 +68,7 @@
  * @example Zip 3 streams
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1"]);
  * const stream2 = ReadableStream.from(["a", "b"]);

--- a/streams/limited_bytes_transform_stream.ts
+++ b/streams/limited_bytes_transform_stream.ts
@@ -22,7 +22,7 @@ export interface LimitedBytesTransformStreamOptions {
  * @example `size` is equal to the total byte length of the chunks
  * ```ts
  * import { LimitedBytesTransformStream } from "@std/streams/limited-bytes-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(new TextEncoderStream()).pipeThrough(
@@ -39,7 +39,7 @@ export interface LimitedBytesTransformStreamOptions {
  * boundary of the chunks
  * ```ts
  * import { LimitedBytesTransformStream } from "@std/streams/limited-bytes-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(new TextEncoderStream()).pipeThrough(
@@ -58,7 +58,7 @@ export interface LimitedBytesTransformStreamOptions {
  * the boundary of the chunks
  * ```ts
  * import { LimitedBytesTransformStream } from "@std/streams/limited-bytes-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(new TextEncoderStream()).pipeThrough(
@@ -76,7 +76,7 @@ export interface LimitedBytesTransformStreamOptions {
  * @example error: true
  * ```ts
  * import { LimitedBytesTransformStream } from "@std/streams/limited-bytes-transform-stream";
- * import { assertRejects } from "@std/assert/assert-rejects";
+ * import { assertRejects } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(new TextEncoderStream()).pipeThrough(

--- a/streams/limited_transform_stream.ts
+++ b/streams/limited_transform_stream.ts
@@ -25,7 +25,7 @@ export interface LimitedTransformStreamOptions {
  * @example `size` is equal to the total number of chunks
  * ```ts
  * import { LimitedTransformStream } from "@std/streams/limited-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(
@@ -42,7 +42,7 @@ export interface LimitedTransformStreamOptions {
  * @example `size` is less than the total number of chunks
  * ```ts
  * import { LimitedTransformStream } from "@std/streams/limited-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(
@@ -59,7 +59,7 @@ export interface LimitedTransformStreamOptions {
  * @example error: true
  * ```ts
  * import { LimitedTransformStream } from "@std/streams/limited-transform-stream";
- * import { assertRejects } from "@std/assert/assert-rejects";
+ * import { assertRejects } from "@std/assert";
  *
  * const stream = ReadableStream.from(["1234", "5678"]);
  * const transformed = stream.pipeThrough(

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -12,7 +12,7 @@
  * @example Merge 2 streams
  * ```ts
  * import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from([1, 2]);
  * const stream2 = ReadableStream.from([3, 4, 5]);
@@ -25,7 +25,7 @@
  * @example Merge 3 streams
  * ```ts
  * import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from([1, 2]);
  * const stream2 = ReadableStream.from([3, 4, 5]);

--- a/streams/mod.ts
+++ b/streams/mod.ts
@@ -7,7 +7,7 @@
  *
  * ```ts
  * import { toText } from "@std/streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from("Hello, world!");
  * const text = await toText(stream);

--- a/streams/text_delimiter_stream.ts
+++ b/streams/text_delimiter_stream.ts
@@ -19,7 +19,7 @@ import type {
  * @example Comma-separated values
  * ```ts
  * import { TextDelimiterStream } from "@std/streams/text-delimiter-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   "alice,20,",
@@ -37,7 +37,7 @@ import type {
  * @example Semicolon-separated values with suffix disposition
  * ```ts
  * import { TextDelimiterStream } from "@std/streams/text-delimiter-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   "const a = 42;;let b =",

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -21,7 +21,7 @@ export interface TextLineStreamOptions {
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { toTransformStream } from "@std/streams/to-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   '{"name": "Alice", "age": ',
@@ -52,7 +52,7 @@ export interface TextLineStreamOptions {
  *
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *  "CR\rLF",
@@ -75,7 +75,7 @@ export class TextLineStream extends TransformStream<string, string> {
    * @example No parameters
    * ```ts
    * import { TextLineStream } from "@std/streams/text-line-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *  "Hello,\n",
@@ -91,7 +91,7 @@ export class TextLineStream extends TransformStream<string, string> {
    *
    * ```ts
    * import { TextLineStream } from "@std/streams/text-line-stream";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const stream = ReadableStream.from([
    *  "CR\rLF",

--- a/streams/to_array_buffer.ts
+++ b/streams/to_array_buffer.ts
@@ -13,7 +13,7 @@ import { concat } from "@std/bytes/concat";
  * @example Basic usage
  * ```ts
  * import { toArrayBuffer } from "@std/streams/to-array-buffer";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   new Uint8Array([1, 2]),

--- a/streams/to_array_buffer_test.ts
+++ b/streams/to_array_buffer_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { toArrayBuffer } from "./to_array_buffer.ts";
 
 Deno.test("toArrayBuffer()", async () => {

--- a/streams/to_blob.ts
+++ b/streams/to_blob.ts
@@ -11,7 +11,7 @@
  * @example Basic usage
  * ```ts
  * import { toBlob } from "@std/streams/to-blob";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   new Uint8Array([1, 2]),

--- a/streams/to_blob_test.ts
+++ b/streams/to_blob_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "@std/assert/assert";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assert } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { toBlob } from "./to_blob.ts";
 
 Deno.test("toBlob()", async () => {

--- a/streams/to_json.ts
+++ b/streams/to_json.ts
@@ -14,7 +14,7 @@ import { toText } from "./to_text.ts";
  * @example Basic usage
  * ```ts
  * import { toJson } from "@std/streams/to-json";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   "[1, true",

--- a/streams/to_json_test.ts
+++ b/streams/to_json_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { toJson } from "./to_json.ts";
 
 Deno.test("toJson()", async () => {

--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -13,7 +13,7 @@ const textDecoder = new TextDecoder();
  * @example Basic usage
  * ```ts
  * import { toText } from "@std/streams/to-text";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from(["Hello, ", "world!"]);
  * assertEquals(await toText(stream), "Hello, world!");

--- a/streams/to_text_test.ts
+++ b/streams/to_text_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { toText } from "./to_text.ts";
 
 Deno.test("toText()", async () => {

--- a/streams/to_transform_stream.ts
+++ b/streams/to_transform_stream.ts
@@ -14,7 +14,7 @@
  * @example Build a transform stream that multiplies each value by 100
  * ```ts
  * import { toTransformStream } from "@std/streams/to-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([0, 1, 2])
  *   .pipeThrough(toTransformStream(async function* (src) {
@@ -33,7 +33,7 @@
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { toTransformStream } from "@std/streams/to-transform-stream";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = ReadableStream.from([
  *   '{"name": "Alice", "age": ',

--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -16,7 +16,7 @@
  * @example Zip 2 streams with the same length
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2", "3"]);
  * const stream2 = ReadableStream.from(["a", "b", "c"]);
@@ -31,7 +31,7 @@
  * @example Zip 2 streams with different length (first one is shorter)
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2"]);
  * const stream2 = ReadableStream.from(["a", "b", "c", "d"]);
@@ -46,7 +46,7 @@
  * @example Zip 2 streams with different length (first one is longer)
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1", "2", "3", "4"]);
  * const stream2 = ReadableStream.from(["a", "b"]);
@@ -61,7 +61,7 @@
  * @example Zip 3 streams
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream1 = ReadableStream.from(["1"]);
  * const stream2 = ReadableStream.from(["a", "b"]);

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -546,7 +546,7 @@ export interface it {
  * @example Usage
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -611,7 +611,7 @@ export function it<T>(...args: ItArgs<T>) {
  * @example Usage
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -640,7 +640,7 @@ it.only = function itOnly<T>(...args: ItArgs<T>): void {
  * @example Usage
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -668,7 +668,7 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>): void {
  * @example Usage
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -695,7 +695,7 @@ it.skip = function itSkip<T>(...args: ItArgs<T>): void {
  * @example Usage
  * ```ts
  * import { test } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * test("a test case", () => {
  *   // test case
@@ -735,7 +735,7 @@ function addHook<T>(
  * @example Usage
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * beforeAll(() => {
  *  console.log("beforeAll");
@@ -766,7 +766,7 @@ export function beforeAll<T>(
  * @example Usage
  * ```ts
  * import { describe, it, before } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * before(() => {
  *  console.log("before");
@@ -795,7 +795,7 @@ export function before<T>(
  * @example Usage
  * ```ts
  * import { describe, it, afterAll } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * afterAll(() => {
  *  console.log("afterAll");
@@ -826,7 +826,7 @@ export function afterAll<T>(
  * @example Usage
  * ```ts
  * import { describe, it, after } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * after(() => {
  *  console.log("after");
@@ -855,7 +855,7 @@ export function after<T>(
  * @example Usage
  * ```ts
  * import { describe, it, beforeEach } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * beforeEach(() => {
  *  console.log("beforeEach");
@@ -884,7 +884,7 @@ export function beforeEach<T>(
  * @example Usage
  * ```ts
  * import { describe, it, afterEach } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * afterEach(() => {
  *  console.log("afterEach");
@@ -1051,7 +1051,7 @@ export interface describe {
  * @example Usage
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -1085,7 +1085,7 @@ export function describe<T>(
  * @example Usage
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -1119,7 +1119,7 @@ describe.only = function describeOnly<T>(
  * @example Usage
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {
@@ -1152,7 +1152,7 @@ describe.ignore = function describeIgnore<T>(
  * @example Usage
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * describe("example", () => {
  *   it("should pass", () => {

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -26,7 +26,7 @@
  *   assertSpyCalls,
  *   spy,
  * } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * function multiply(a: number, b: number): number {
  *   return a * b;
@@ -72,7 +72,7 @@
  *   assertSpyCalls,
  *   spy,
  * } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * function multiply(a: number, b: number): number {
  *   return a * b;
@@ -125,7 +125,7 @@
  *   assertSpyCalls,
  *   spy,
  * } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * function multiply(a: number, b: number): number {
  *   return a * b;
@@ -187,7 +187,7 @@
  *   returnsNext,
  *   stub,
  * } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * function randomInt(lowerBound: number, upperBound: number): number {
  *   return lowerBound + Math.floor(Math.random() * (upperBound - lowerBound));
@@ -238,7 +238,7 @@
  *   returnsNext,
  *   stub,
  * } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * function randomInt(lowerBound: number, upperBound: number): number {
  *   return lowerBound + Math.floor(Math.random() * (upperBound - lowerBound));
@@ -319,10 +319,10 @@
  * @module
  */
 
-import { assertEquals } from "@std/assert/assert-equals";
-import { assertIsError } from "@std/assert/assert-is-error";
-import { assertRejects } from "@std/assert/assert-rejects";
-import { AssertionError } from "@std/assert/assertion-error";
+import { assertEquals } from "@std/assert";
+import { assertIsError } from "@std/assert";
+import { assertRejects } from "@std/assert";
+import { AssertionError } from "@std/assert";
 
 /**
  * An error related to spying on a function or instance method.
@@ -330,7 +330,7 @@ import { AssertionError } from "@std/assert/assertion-error";
  * @example Usage
  * ```ts
  * import { MockError, spy } from "@std/testing/mock";
- * import { assertThrows } from "@std/assert/assert-throws";
+ * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => {
  *   spy({} as any, "no-such-method");
@@ -344,7 +344,7 @@ export class MockError extends Error {
    * @example Usage
    * ```ts
    * import { MockError, spy } from "@std/testing/mock";
-   * import { assertThrows } from "@std/assert/assert-throws";
+   * import { assertThrows } from "@std/assert";
    *
    * assertThrows(() => {
    *   spy({} as any, "no-such-method");
@@ -1051,7 +1051,7 @@ export function stub<
  * @example Usage
  * ```ts
  * import { stub } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = {
  *   method(): number {
@@ -1650,7 +1650,7 @@ export function assertSpyCallArgs<
  * @example Usage
  * ```ts
  * import { returnsThis } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const func = returnsThis();
  * const obj = { func };
@@ -1678,7 +1678,7 @@ export function returnsThis<
  * @example Usage
  * ```ts
  * import { returnsArg } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const func = returnsArg(1);
  * assertEquals(func(1, 2, 3), 2);
@@ -1707,7 +1707,7 @@ export function returnsArg<
  * @example Usage
  * ```ts
  * import { returnsArgs } from "@std/testing/mock";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const func = returnsArgs();
  * assertEquals(func(1, 2, 3), [1, 2, 3]);

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -141,9 +141,9 @@ import { parse } from "@std/path/parse";
 import { resolve } from "@std/path/resolve";
 import { toFileUrl } from "@std/path/to-file-url";
 import { ensureFile, ensureFileSync } from "@std/fs/ensure-file";
-import { assert } from "@std/assert/assert";
-import { AssertionError } from "@std/assert/assertion-error";
-import { equal } from "@std/assert/equal";
+import { assert } from "@std/assert";
+import { AssertionError } from "@std/assert";
+import { equal } from "@std/assert";
 import { diff } from "@std/internal/diff";
 import { diffStr } from "@std/internal/diff-str";
 import { buildMessage } from "@std/internal/build-message";
@@ -204,7 +204,7 @@ function getErrorMessage(message: string, options: SnapshotOptions) {
  * @example Usage
  * ```ts
  * import { serialize } from "@std/testing/snapshot";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(serialize({ foo: 42 }), "{\n  foo: 42,\n}")
  * ```

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -47,7 +47,7 @@ import { _internals } from "./_time.ts";
  * @example Usage
  * ```ts
  * import { FakeTime, TimeError } from "@std/testing/time";
- * import { assertThrows } from "@std/assert/assert-throws";
+ * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => {
  *   new FakeTime(NaN);
@@ -60,7 +60,7 @@ export class TimeError extends Error {
    * @example Usage
    * ```ts
    * import { FakeTime, TimeError } from "@std/testing/time";
-   * import { assertThrows } from "@std/assert/assert-throws";
+   * import { assertThrows } from "@std/assert";
    *
    * assertThrows(() => {
    *   new FakeTime(NaN);
@@ -454,7 +454,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -477,7 +477,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -524,7 +524,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -543,7 +543,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -588,7 +588,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assert } from "@std/assert/assert";
+   * import { assert } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -742,7 +742,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *
@@ -773,7 +773,7 @@ export class FakeTime {
    * @example Usage
    * ```ts
    * import { FakeTime } from "@std/testing/time";
-   * import { assertEquals } from "@std/assert/assert-equals";
+   * import { assertEquals } from "@std/assert";
    *
    * const fakeTime = new FakeTime(15_000);
    *

--- a/text/_util_test.ts
+++ b/text/_util_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { splitToWords } from "./_util.ts";
 
 Deno.test({

--- a/text/case.ts
+++ b/text/case.ts
@@ -9,7 +9,7 @@ import { capitalizeWord, splitToWords } from "./_util.ts";
  * @example Usage
  * ```ts
  * import { toCamelCase } from "@std/text/case";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toCamelCase("deno is awesome"),"denoIsAwesome");
  * ```
@@ -29,7 +29,7 @@ export function toCamelCase(input: string): string {
  * @example Usage
  * ```ts
  * import { toKebabCase } from "@std/text/case";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toKebabCase("deno is awesome"), "deno-is-awesome");
  * ```
@@ -48,7 +48,7 @@ export function toKebabCase(input: string): string {
  * @example Usage
  * ```ts
  * import { toPascalCase } from "@std/text/case";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toPascalCase("deno is awesome"), "DenoIsAwesome");
  * ```
@@ -67,7 +67,7 @@ export function toPascalCase(input: string): string {
  * @example Usage
  * ```ts
  * import { toSnakeCase } from "@std/text/case";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toSnakeCase("deno is awesome"), "deno_is_awesome");
  * ```

--- a/text/case_test.ts
+++ b/text/case_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 import { toCamelCase, toKebabCase, toPascalCase, toSnakeCase } from "./case.ts";
 
 Deno.test("toCamelCase() handles an empty string", () => {

--- a/text/closest_string.ts
+++ b/text/closest_string.ts
@@ -11,7 +11,7 @@ const getWordDistance = levenshteinDistance;
  * @example Usage
  * ```ts
  * import { closestString } from "@std/text/closest-string";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const possibleWords = ["length", "size", "blah", "help"];
  * const suggestion = closestString("hep", possibleWords);

--- a/text/compare_similarity.ts
+++ b/text/compare_similarity.ts
@@ -30,7 +30,7 @@ export interface CompareSimilarityOptions {
  *
  * ```ts
  * import { compareSimilarity } from "@std/text/compare-similarity";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const words = ["hi", "hello", "help"];
  * const sortedWords = words.sort(compareSimilarity("hep"));

--- a/text/levenshtein_distance.ts
+++ b/text/levenshtein_distance.ts
@@ -9,7 +9,7 @@
  * @example Usage
  * ```ts
  * import { levenshteinDistance } from "@std/text/levenshtein-distance";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(levenshteinDistance("aa", "bb"), 2);
  * ```

--- a/text/mod.ts
+++ b/text/mod.ts
@@ -6,7 +6,7 @@
  *
  * ```ts
  * import { toCamelCase, compareSimilarity } from "@std/text";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(toCamelCase("snake_case"), "snakeCase");
  *

--- a/text/word_similarity_sort.ts
+++ b/text/word_similarity_sort.ts
@@ -15,7 +15,7 @@ export interface WordSimilaritySortOptions extends CompareSimilarityOptions {}
  *
  * ```ts
  * import { wordSimilaritySort } from "@std/text/word-similarity-sort";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const possibleWords = ["length", "size", "blah", "help"];
  * const suggestions = wordSimilaritySort("hep", possibleWords);
@@ -27,7 +27,7 @@ export interface WordSimilaritySortOptions extends CompareSimilarityOptions {}
  *
  * ```ts
  * import { wordSimilaritySort } from "@std/text/word-similarity-sort";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const possibleWords = ["length", "Size", "blah", "HELP"];
  * const suggestions = wordSimilaritySort("hep", possibleWords, { caseSensitive: true });

--- a/toml/mod.ts
+++ b/toml/mod.ts
@@ -76,7 +76,7 @@
  *
  * ```ts
  * import { parse, stringify } from "@std/toml";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = {
  *   bin: [

--- a/toml/parse.ts
+++ b/toml/parse.ts
@@ -9,7 +9,7 @@ import { ParserFactory, Toml } from "./_parser.ts";
  * @example Usage
  * ```ts
  * import { parse } from "@std/toml/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const tomlString = `title = "TOML Example"
  * [owner]

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -268,7 +268,7 @@ class Dumper {
  * @example Usage
  * ```ts
  * import { stringify } from "@std/toml/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const obj = {
  *   title: "TOML Example",

--- a/ulid/mod.ts
+++ b/ulid/mod.ts
@@ -33,7 +33,7 @@
  *
  * ```ts
  * import { decodeTime, ulid } from "@std/ulid";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const timestamp = 150_000;
  * const ulidString = ulid(timestamp);
@@ -62,7 +62,7 @@ import {
  * @example Decode the time from a ULID
  * ```ts
  * import { decodeTime, ulid } from "@std/ulid";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const timestamp = 150_000;
  * const ulidString = ulid(timestamp);

--- a/url/basename.ts
+++ b/url/basename.ts
@@ -18,7 +18,7 @@ import { strip } from "./_strip.ts";
  * @example Basic usage
  * ```ts
  * import { basename } from "@std/url/basename";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(basename("https://deno.land/std/assert/mod.ts"), "mod.ts");
  * assertEquals(basename(new URL("https://deno.land/std/assert/mod.ts")), "mod.ts");
@@ -33,7 +33,7 @@ import { strip } from "./_strip.ts";
  *
  * ```ts
  * import { basename } from "@std/url/basename";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(basename("https://deno.land/std/assert/mod.ts", ".ts"), "mod");
  * assertEquals(basename(new URL("https://deno.land/std/assert/mod.ts"), ".ts"), "mod");

--- a/url/dirname.ts
+++ b/url/dirname.ts
@@ -16,7 +16,7 @@ import { strip } from "./_strip.ts";
  * @example Usage
  * ```ts
  * import { dirname } from "@std/url/dirname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(dirname("https://deno.land/std/path/mod.ts"), new URL("https://deno.land/std/path"));
  * assertEquals(dirname(new URL("https://deno.land/std/path/mod.ts")), new URL("https://deno.land/std/path"));

--- a/url/extname.ts
+++ b/url/extname.ts
@@ -16,7 +16,7 @@ import { strip } from "./_strip.ts";
  * @example Usage
  * ```ts
  * import { extname } from "@std/url/extname";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(extname("https://deno.land/std/path/mod.ts"), ".ts");
  * assertEquals(extname("https://deno.land/std/path/mod"), "");

--- a/url/join.ts
+++ b/url/join.ts
@@ -15,7 +15,7 @@ import { join as posixJoin } from "@std/path/posix/join";
  *
  * ```ts
  * import { join } from "@std/url/join";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(join("https://deno.land/", "std", "path", "mod.ts").href, "https://deno.land/std/path/mod.ts");
  * assertEquals(join("https://deno.land", "//std", "path/", "/mod.ts").href, "https://deno.land/std/path/mod.ts");

--- a/url/mod.ts
+++ b/url/mod.ts
@@ -7,7 +7,7 @@
  *
  * ```ts
  * import { basename, join, normalize } from "@std/url";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const url = new URL("https:///deno.land///std//assert//.//mod.ts");
  * const normalizedUrl = normalize(url);

--- a/url/normalize.ts
+++ b/url/normalize.ts
@@ -14,7 +14,7 @@ import { normalize as posixNormalize } from "@std/path/posix/normalize";
  *
  * ```ts
  * import { normalize } from "@std/url/normalize";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(normalize("https:///deno.land///std//assert//.//mod.ts").href, "https://deno.land/std/assert/mod.ts");
  * assertEquals(normalize("https://deno.land/std/assert/../async/retry.ts").href, "https://deno.land/std/async/retry.ts");

--- a/uuid/common.ts
+++ b/uuid/common.ts
@@ -57,7 +57,7 @@ export function validate(uuid: string): boolean {
  * @example Usage
  * ```ts
  * import { version } from "@std/uuid";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(version("d9428888-122b-11e1-b85c-61cd3cbb3210"), 1);
  * assertEquals(version("6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b"), 4);

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -41,7 +41,7 @@ import { generate as generateV5, validate as validateV5 } from "./v5.ts";
  * @example Usage
  * ```ts
  * import { v1 } from "@std/uuid";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const uuid = v1.generate();
  * assert(v1.validate(uuid as string));
@@ -59,7 +59,7 @@ export const v1 = {
  * @example Usage
  * ```ts
  * import { v3, NAMESPACE_DNS } from "@std/uuid";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const data = new TextEncoder().encode("deno.land");
  * const uuid = await v3.generate(NAMESPACE_DNS, data);
@@ -78,7 +78,7 @@ export const v3 = {
  * @example Usage
  * ```ts
  * import { v4 } from "@std/uuid";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const uuid = crypto.randomUUID();
  * assert(v4.validate(uuid));
@@ -95,7 +95,7 @@ export const v4 = {
  * @example Usage
  * ```ts
  * import { v5, NAMESPACE_DNS } from "@std/uuid";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const data = new TextEncoder().encode("deno.land");
  * const uuid = await v5.generate(NAMESPACE_DNS, data);

--- a/uuid/v1.ts
+++ b/uuid/v1.ts
@@ -83,7 +83,7 @@ export interface GenerateOptions {
  * @example Usage
  * ```ts
  * import { generate, validate } from "@std/uuid/v1";
- * import { assert } from "@std/assert/assert";
+ * import { assert } from "@std/assert";
  *
  * const options = {
  *   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],

--- a/webgpu/describe_texture_format.ts
+++ b/webgpu/describe_texture_format.ts
@@ -33,7 +33,7 @@ const allFlags = GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST |
  * @example Basic usage
  * ```ts
  * import { describeTextureFormat } from "@std/webgpu/describe-texture-format";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(describeTextureFormat("rgba8unorm"), {
  *   requiredFeature: undefined,

--- a/webgpu/row_padding.ts
+++ b/webgpu/row_padding.ts
@@ -24,7 +24,7 @@ export const BYTES_PER_PIXEL = 4;
  * @example Usage
  * ```ts
  * import { getRowPadding } from "@std/webgpu/row-padding";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * assertEquals(getRowPadding(1), { unpadded: 4, padded: 256 });
  * ```
@@ -57,7 +57,7 @@ export function getRowPadding(width: number): Padding {
  * @example Usage
  * ```ts
  * import { resliceBufferWithPadding } from "@std/webgpu/row-padding";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const input = new Uint8Array([0, 255, 0, 255, 120, 120, 120]);
  * const result = resliceBufferWithPadding(input, 1, 1);

--- a/webgpu/row_padding_test.ts
+++ b/webgpu/row_padding_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getRowPadding, resliceBufferWithPadding } from "./row_padding.ts";
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert";
 
 Deno.test("getRowPadding()", () => {
   const { unpadded, padded } = getRowPadding(64);

--- a/webgpu/texture_with_data_test.ts
+++ b/webgpu/texture_with_data_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "@std/assert/assert";
+import { assert } from "@std/assert";
 import { createTextureWithData } from "./texture_with_data.ts";
 import { ignore } from "./_test_utils.ts";
 

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -35,7 +35,7 @@ export interface ParseOptions {
  * @example Usage
  * ```ts
  * import { parse } from "@std/yaml/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const data = parse(`
  * id: 1
@@ -63,7 +63,7 @@ export function parse(content: string, options?: ParseOptions): unknown {
  * @example Usage
  * ```ts
  * import { parseAll } from "@std/yaml/parse";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const data = parseAll(`
  * ---

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -67,7 +67,7 @@ export type StringifyOptions = {
  * @example Usage
  * ```ts
  * import { stringify } from "@std/yaml/stringify";
- * import { assertEquals } from "@std/assert/assert-equals";
+ * import { assertEquals } from "@std/assert";
  *
  * const data = { id: 1, name: "Alice" };
  * const yaml = stringify(data);


### PR DESCRIPTION
Unblocks #5176 (will result in a cleaner diff). All these imports will be updated after #5176 is merged.