### PR TITLE
chore: release `uuid@1.0.0`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -48,7 +48,7 @@
     "@std/toml": "jsr:@std/toml@^1.0.0-rc.2",
     "@std/ulid": "jsr:@std/ulid@^1.0.0-rc.2",
     "@std/url": "jsr:@std/url@^1.0.0-rc.1",
-    "@std/uuid": "jsr:@std/uuid@1.0.0-rc.1",
+    "@std/uuid": "jsr:@std/uuid@1.0.0",
     "@std/webgpu": "jsr:@std/webgpu@^0.224.4",
     "@std/yaml": "jsr:@std/yaml@^0.224.3"
   },

--- a/uuid/deno.json
+++ b/uuid/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/uuid",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "exports": {
     ".": "./mod.ts",
     "./common": "./common.ts",


### PR DESCRIPTION
closes #4748 