### PR TITLE
fix(testing): Throw error eagerly when insufficient permissions are granted to write to snapshot file in update mode

### DIFF
--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -470,3 +470,26 @@ snapshot[`createAssertSnapshot() - options object - custom name 1`] = `This gree
 snapshot[`createAssertSnapshot() > message 1`] = `"This snapshot has failed as expected"`;
 
 snapshot[`createAssertSnapshot() - composite - custom Name 1`] = `This green text has had it's colours stripped`;
+
+snapshot[`assertSnapshot() - regression #5155 1`] = `
+"running 1 test from <tempDir>/test.ts
+Snapshot Test ... FAILED (--ms)
+
+ ERRORS 
+
+Snapshot Test => ../../../..<tempDir>/test.ts:4:12
+error: PermissionDenied: Missing write access to snapshot file (file://<path>). This is required because assertSnapshot was called in update mode. Please pass the --allow-write flag.
+        throw new Deno.errors.PermissionDenied(
+              ^
+    at AssertSnapshotContext.registerTeardown (file://<path>)
+    at async assertSnapshot (file://<path>)
+    at async file://<tempDir>/test.ts:5:9
+
+ FAILURES 
+
+Snapshot Test => ../../../..<tempDir>/test.ts:4:12
+
+FAILED | 0 passed | 1 failed (--ms)
+
+"
+`;

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -477,7 +477,6 @@ Snapshot Test ... FAILED (--ms)
 
  ERRORS 
 
-Snapshot Test => ../../../..<tempDir>/test.ts:4:12
 error: PermissionDenied: Missing write access to snapshot file (file://<path>). This is required because assertSnapshot was called in update mode. Please pass the --allow-write flag.
         throw new Deno.errors.PermissionDenied(
               ^
@@ -487,7 +486,6 @@ error: PermissionDenied: Missing write access to snapshot file (file://<path>). 
 
  FAILURES 
 
-Snapshot Test => ../../../..<tempDir>/test.ts:4:12
 
 FAILED | 0 passed | 1 failed (--ms)
 

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -476,16 +476,10 @@ snapshot[`assertSnapshot() - regression #5155 1`] = `
 Snapshot Test ... FAILED (--ms)
 
  ERRORS 
-
 error: PermissionDenied: Missing write access to snapshot file (file://<path>). This is required because assertSnapshot was called in update mode. Please pass the --allow-write flag.
         throw new Deno.errors.PermissionDenied(
               ^
-    at AssertSnapshotContext.registerTeardown (file://<path>)
-    at async assertSnapshot (file://<path>)
-    at async file://<tempDir>/test.ts:5:9
-
  FAILURES 
-
 
 FAILED | 0 passed | 1 failed (--ms)
 

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -863,10 +863,12 @@ Deno.test(
 
     await assertSnapshot(
       t,
-      formatTestOutput(errors).replaceAll(tempDir, "<tempDir>").replace(
-        /Snapshot Test => .+\n/g,
-        "",
-      ),
+      formatTestOutput(errors)
+        .replace(/\s+at .+\n/g, "")
+        .replace(
+          /\nSnapshot Test => .+\n/g,
+          "",
+        ),
     );
     assert(!output.success, "The test should fail");
   }),

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -9,6 +9,7 @@ import {
   fail,
 } from "@std/assert";
 import { assertSnapshot, createAssertSnapshot, serialize } from "./snapshot.ts";
+import { ensureDir } from "../fs/ensure_dir.ts";
 
 const SNAPSHOT_MODULE_URL = toFileUrl(join(
   dirname(fromFileUrl(import.meta.url)),
@@ -20,7 +21,7 @@ function formatTestOutput(string: string) {
   return stripAnsiCode(string).replace(/([0-9])+m?s/g, "--ms").replace(
     /(?<=running ([0-9])+ test(s)? from )(.*)(?=test.ts)/g,
     "<tempDir>/",
-  );
+  ).replace(/\(file:\/\/.+\)/g, "(file://<path>)");
 }
 
 function formatTestError(string: string) {
@@ -814,3 +815,56 @@ Deno.test("createAssertSnapshot()", async (t) => {
     );
   });
 });
+
+// Regression test for https://github.com/denoland/deno_std/issues/5155
+// Asserting snapshots in update mode without required write permissions
+Deno.test(
+  "assertSnapshot() - regression #5155",
+  testFnWithTempDir(async (t, tempDir) => {
+    const tempTestFileName = "test.ts";
+    const tempTestFilePath = join(tempDir, tempTestFileName);
+    const tempSnapshotFileName = `${tempTestFileName}.snap`;
+    const tempSnapshotDir = join(
+      tempDir,
+      "__snapshots__",
+    );
+    const tempSnapshotFilePath = join(tempSnapshotDir, tempSnapshotFileName);
+    await ensureDir(tempSnapshotDir);
+    await Deno.writeTextFile(
+      tempSnapshotFilePath,
+      [
+        "export const snapshot = {};",
+        "\nsnapshot[`Snapshot Test 1`] = \`42\`;",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(
+      tempTestFilePath,
+      `
+      import { assertSnapshot } from "${SNAPSHOT_MODULE_URL}";
+
+      Deno.test("Snapshot Test", async (t) => {
+        await assertSnapshot(t, 42);
+      });
+    `,
+    );
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "test",
+        "--no-lock",
+        "--allow-read",
+        tempTestFilePath,
+        "--",
+        "-u",
+      ],
+    });
+    const output = await command.output();
+    const errors = new TextDecoder().decode(output.stdout);
+
+    await assertSnapshot(
+      t,
+      formatTestOutput(errors).replaceAll(tempDir, "<tempDir>"),
+    );
+    assert(!output.success, "The test should fail");
+  }),
+);

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -863,7 +863,10 @@ Deno.test(
 
     await assertSnapshot(
       t,
-      formatTestOutput(errors).replaceAll(tempDir, "<tempDir>"),
+      formatTestOutput(errors).replaceAll(tempDir, "<tempDir>").replace(
+        /Snapshot Test => .+\n/g,
+        "",
+      ),
     );
     assert(!output.success, "The test should fail");
   }),


### PR DESCRIPTION
Fixes #5155