### PR TITLE
test(expect): improve `expect` test cases

### DIFF
--- a/expect/_extend_test.ts
+++ b/expect/_extend_test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "./expect.ts";
 import type { MatcherContext, Tester } from "./_types.ts";
+import { AssertionError, assertThrows } from "@std/assert";
 
 declare module "./_types.ts" {
   interface Expected {
@@ -97,4 +98,15 @@ Deno.test("expect.extend() api test case", () => {
   expect(book1a).not.toEqualBook(book2);
   expect(book1a).not.toEqualBook(1);
   expect(book1a).not.toEqualBook(null);
+
+  assertThrows(
+    () => expect(book1a).toEqualBook(book2),
+    AssertionError,
+    "Expected Book object: Book 2. Actual Book object: Book 1",
+  );
+  assertThrows(
+    () => expect(book1a).not.toEqualBook(book1b),
+    AssertionError,
+    "Expected Book object: Book 1. Actual Book object: Book 1",
+  );
 });

--- a/expect/test.ts
+++ b/expect/test.ts
@@ -1,12 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { expect } from "./expect.ts";
-import {
-  assert,
-  AssertionError,
-  assertRejects,
-  assertThrows,
-} from "@std/assert";
+import { AssertionError, assertRejects, assertThrows } from "@std/assert";
 
 Deno.test("expect().resolves.toEqual()", async () => {
   await expect(Promise.resolve(42)).resolves.toEqual(42);
@@ -20,7 +15,7 @@ Deno.test("expect().resolves.toEqual()", async () => {
   assertThrows(
     () => expect(null).resolves.toEqual(42),
     AssertionError,
-    "expected value must be PromiseLike",
+    "expected value must be Promiselike",
   );
 });
 

--- a/expect/test.ts
+++ b/expect/test.ts
@@ -1,0 +1,56 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { expect } from "./expect.ts";
+import {
+  assert,
+  AssertionError,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
+
+Deno.test("expect().resolves.toEqual()", async () => {
+  await expect(Promise.resolve(42)).resolves.toEqual(42);
+  await expect(Promise.resolve(42)).resolves.not.toEqual(0);
+
+  assertThrows(
+    () => expect(42).resolves.toEqual(42),
+    AssertionError,
+    "expected value must be Promiselike",
+  );
+  assertThrows(
+    () => expect(null).resolves.toEqual(42),
+    AssertionError,
+    "expected value must be PromiseLike",
+  );
+});
+
+Deno.test("expect().rejects.toEqual()", async () => {
+  await expect(Promise.reject(42)).rejects.toEqual(42);
+  await expect(Promise.reject(42)).rejects.not.toEqual(0);
+
+  assertThrows(
+    () => expect(42).rejects.toEqual(42),
+    AssertionError,
+    "expected value must be a PromiseLike",
+  );
+  await assertRejects(
+    () => expect(Promise.resolve(42)).rejects.toEqual(42),
+    AssertionError,
+    "Promise did not reject. resolved to 42",
+  );
+});
+
+Deno.test("expect()[nonExistentMatcher]()", () => {
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => (expect(() => {}) as any)["nonExistentMatcher"](),
+    TypeError,
+    "matcher not found: nonExistentMatcher",
+  );
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => (expect(() => {}) as any)[Symbol()](),
+    TypeError,
+    "matcher not found",
+  );
+});


### PR DESCRIPTION
This PR adds test cases of:
- `expect().resolves`
- `expect().rejects`
- Throwing cases of custom matchers.

This improves the code coverage of `expect` about 2%.

part of #3713 