### PR TITLE
test(expect): add test of `iterableEquality`

### DIFF
--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -267,3 +267,39 @@ Deno.test("expect().toEqual() matches when Error Objects are equal", () => {
   const expectErrObjectWithEmail = new Error("missing param: email");
   expect(getError()).not.toEqual(expectErrObjectWithEmail);
 });
+
+Deno.test("expect().toEqual() handles Sets", () => {
+  expect(new Set([1, 2, 3])).toEqual(new Set([1, 2, 3]));
+  expect(new Set([1, 2, 3])).not.toEqual(new Set([1, 2]));
+  expect(new Set([1, 2, 3])).not.toEqual(new Set([1, 2, 4]));
+  expect(new Set([1, 2, 3, 4])).not.toEqual(new Map([[1, 2], [3, 4]]));
+  expect(new Set([1, 2, new Set([0, 1])])).toEqual(
+    new Set([1, 2, new Set([0, 1])]),
+  );
+
+  // It handles circular reference structures
+  const a = new Set<unknown>([1, 2]);
+  a.add(a);
+  const b = new Set<unknown>([1, 2]);
+  b.add(b);
+  expect(a).toEqual(b);
+});
+
+Deno.test("expect().toEqual() handles Maps", () => {
+  expect(new Map([[1, 2], [3, 4]])).toEqual(new Map([[1, 2], [3, 4]]));
+  expect(new Map([[1, 2], [3, 4]])).not.toEqual(new Map([[1, 2], [3, 5]]));
+});
+
+// TODO(kt3k): Iterator global exists in the runtime but not in the typing
+// Remove the below lines when `Iterator` global is available in typing
+// deno-lint-ignore no-explicit-any
+const Iterator = (globalThis as any).Iterator;
+Deno.test("expect().toEqual() handles iterators", () => {
+  expect(Iterator.from([1, 2, 3])).toEqual(Iterator.from([1, 2, 3]));
+  expect(Iterator.from([1, 2, 3])).not.toEqual(Iterator.from([1, 2, 4]));
+  expect(Iterator.from([1, 2, 3])).not.toEqual(Iterator.from([1, 2, 3, 4]));
+  const iter0 = Iterator.from([1, 2, 3]);
+  const iter1 = Iterator.from([1, 2, 3]);
+  iter1.foo = 1;
+  expect(iter0).not.toEqual(iter1);
+});

--- a/expect/_to_equal_test.ts
+++ b/expect/_to_equal_test.ts
@@ -290,8 +290,8 @@ Deno.test("expect().toEqual() handles Maps", () => {
   expect(new Map([[1, 2], [3, 4]])).not.toEqual(new Map([[1, 2], [3, 5]]));
 });
 
-// TODO(kt3k): Iterator global exists in the runtime but not in the typing
-// Remove the below lines when `Iterator` global is available in typing
+// TODO(kt3k): Iterator global exists in the runtime but not in the TypeScript
+// Remove the below lines when `Iterator` global is available in TypeScript
 // deno-lint-ignore no-explicit-any
 const Iterator = (globalThis as any).Iterator;
 Deno.test("expect().toEqual() handles iterators", () => {


### PR DESCRIPTION
This PR adds tests of `expect` which exercise `iterableEquality` internal utility.

part of #3713 