### PR TITLE
fix(expect): fix validation of nth param in `toHaveBeenNthCalledWith` matcher

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -605,7 +605,7 @@ export function toHaveBeenNthCalledWith(
   ...expected: unknown[]
 ): MatchResult {
   if (nth < 1) {
-    new Error(`nth must be greater than 0. ${nth} was given.`);
+    throw new Error(`nth must be greater than 0. ${nth} was given.`);
   }
 
   const calls = getMockCalls(context.value);

--- a/expect/_to_have_been_nth_called_with_test.ts
+++ b/expect/_to_have_been_nth_called_with_test.ts
@@ -42,3 +42,15 @@ Deno.test("expect().toHaveBeenNthCalledWith() should throw when mock call does n
     'Expected the n-th call (n=2) of mock function is with "hello", but the n-th call does not exist.',
   );
 });
+
+Deno.test("expect().toHaveBeenNthCalledWith() throw when n is not a positive integer", () => {
+  const mockFn = fn();
+
+  assertThrows(
+    () => {
+      expect(mockFn).toHaveBeenNthCalledWith(0, "hello");
+    },
+    Error,
+    "nth must be greater than 0. 0 was given.",
+  );
+});


### PR DESCRIPTION
This PR fixes the validation of `nth` argument of `toHaveBeenNthCalledWith` matcher.