### PR TITLE
BREAKING(expect): remove special handling of Immutable.js objects

### DIFF
--- a/expect/_utils.ts
+++ b/expect/_utils.ts
@@ -22,63 +22,6 @@ export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   }
 }
 
-// Check of these sentinel values are supported in jest (expect-utils)
-// See https://github.com/jestjs/jest/blob/442c7f692e3a92f14a2fb56c1737b26fc663a0ef/packages/expect-utils/src/immutableUtils.ts#L29
-// SENTINEL constants are from https://github.com/facebook/immutable-js
-const IS_KEYED_SENTINEL = "@@__IMMUTABLE_KEYED__@@";
-const IS_SET_SENTINEL = "@@__IMMUTABLE_SET__@@";
-const IS_LIST_SENTINEL = "@@__IMMUTABLE_LIST__@@";
-const IS_ORDERED_SENTINEL = "@@__IMMUTABLE_ORDERED__@@";
-const IS_RECORD_SYMBOL = "@@__IMMUTABLE_RECORD__@@";
-
-function isObjectLiteral(source: unknown): source is Record<string, unknown> {
-  return source != null && typeof source === "object" && !Array.isArray(source);
-}
-
-export function isImmutableUnorderedKeyed(source: unknown): boolean {
-  return Boolean(
-    source &&
-      isObjectLiteral(source) &&
-      source[IS_KEYED_SENTINEL] &&
-      !source[IS_ORDERED_SENTINEL],
-  );
-}
-
-export function isImmutableUnorderedSet(source: unknown): boolean {
-  return Boolean(
-    source &&
-      isObjectLiteral(source) &&
-      source[IS_SET_SENTINEL] &&
-      !source[IS_ORDERED_SENTINEL],
-  );
-}
-
-export function isImmutableList(source: unknown): boolean {
-  return Boolean(source && isObjectLiteral(source) && source[IS_LIST_SENTINEL]);
-}
-
-export function isImmutableOrderedKeyed(source: unknown): boolean {
-  return Boolean(
-    source &&
-      isObjectLiteral(source) &&
-      source[IS_KEYED_SENTINEL] &&
-      source[IS_ORDERED_SENTINEL],
-  );
-}
-
-export function isImmutableOrderedSet(source: unknown): boolean {
-  return Boolean(
-    source &&
-      isObjectLiteral(source) &&
-      source[IS_SET_SENTINEL] &&
-      source[IS_ORDERED_SENTINEL],
-  );
-}
-
-export function isImmutableRecord(source: unknown): boolean {
-  return Boolean(source && isObjectLiteral(source) && source[IS_RECORD_SYMBOL]);
-}
-
 // deno-lint-ignore no-explicit-any
 export function hasIterator(object: any) {
   return !!(object != null && object[Symbol.iterator]);
@@ -159,7 +102,7 @@ export function iterableEquality(
   if (a.size !== undefined) {
     if (a.size !== b.size) {
       return false;
-    } else if (isA<Set<unknown>>("Set", a) || isImmutableUnorderedSet(a)) {
+    } else if (isA<Set<unknown>>("Set", a)) {
       let allFound = true;
       for (const aValue of a) {
         if (!b.has(aValue)) {
@@ -183,10 +126,7 @@ export function iterableEquality(
       aStack.pop();
       bStack.pop();
       return allFound;
-    } else if (
-      isA<Map<unknown, unknown>>("Map", a) ||
-      isImmutableUnorderedKeyed(a)
-    ) {
+    } else if (isA<Map<unknown, unknown>>("Map", a)) {
       let allFound = true;
       for (const aEntry of a) {
         if (
@@ -244,17 +184,10 @@ export function iterableEquality(
     return false;
   }
 
-  if (
-    !isImmutableList(a) &&
-    !isImmutableOrderedKeyed(a) &&
-    !isImmutableOrderedSet(a) &&
-    !isImmutableRecord(a)
-  ) {
-    const aEntries = entries(a);
-    const bEntries = entries(b);
-    if (!equal(aEntries, bEntries)) {
-      return false;
-    }
+  const aEntries = entries(a);
+  const bEntries = entries(b);
+  if (!equal(aEntries, bEntries)) {
+    return false;
   }
 
   // Remove the first value from the stack of traversed values.


### PR DESCRIPTION
This PR removes the special handlings of [immutable-js](https://www.npmjs.com/package/immutable) objects in iterable equality check in `std/expect`. None of std packages has special handling for specific 3rd party library support except this one. This kind of special logic doesn't seem aligned to the concept of the standard library. So I suggest we should remove these handlings before the stabilization.

towards #5014 

