### PR TITLE
BREAKING(yaml): remove `ParseOptions.legacy` option

### DIFF
--- a/yaml/_loader/loader.ts
+++ b/yaml/_loader/loader.ts
@@ -1593,7 +1593,7 @@ function readDocument(state: LoaderState) {
   let ch: number;
 
   state.version = null;
-  state.checkLineBreaks = state.legacy;
+  state.checkLineBreaks = false;
   state.tagMap = Object.create(null);
   state.anchorMap = Object.create(null);
 

--- a/yaml/_loader/loader_state.ts
+++ b/yaml/_loader/loader_state.ts
@@ -10,7 +10,6 @@ import type { Type } from "../_type.ts";
 import type { Any, ArrayObject } from "../_utils.ts";
 
 export interface LoaderStateOptions {
-  legacy?: boolean;
   /** specifies a schema to use. */
   schema?: SchemaDefinition;
   /** compatibility with JSON.parse behaviour. */
@@ -31,13 +30,12 @@ export class LoaderState extends State {
   position = 0;
   line = 0;
   onWarning?: (...args: Any[]) => void;
-  legacy: boolean;
   json: boolean;
   implicitTypes: Type[];
   typeMap: TypeMap;
 
   version?: string | null;
-  checkLineBreaks?: boolean;
+  checkLineBreaks = false;
   tagMap: ArrayObject = Object.create(null);
   anchorMap: ArrayObject = Object.create(null);
   tag?: string | null;
@@ -50,14 +48,12 @@ export class LoaderState extends State {
     {
       schema,
       onWarning,
-      legacy = false,
       json = false,
     }: LoaderStateOptions,
   ) {
     super(schema);
     this.input = input;
     this.onWarning = onWarning;
-    this.legacy = legacy;
     this.json = json;
 
     this.implicitTypes = (this.schema as Schema).compiledImplicit;

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -11,8 +11,6 @@ import { replaceSchemaNameWithSchemaClass } from "./_schema.ts";
  * Options for parsing YAML.
  */
 export interface ParseOptions {
-  /** Uses legacy mode */
-  legacy?: boolean;
   /** Name of the schema to use.*/
   schema?: "core" | "default" | "failsafe" | "json" | "extended";
   /** compatibility with JSON.parse behaviour. */


### PR DESCRIPTION
### What's changed

The `ParseOptions.legacy` option has been removed.

### Motivation

Setting this option to true allowed documents adhering to versions <1.2 of the YAML specification. v1.2 of the YAML spec was published in 2009 (15 years ago). It's fair to say that most, if not, all, YAML use these days adheres to >=v1.2 of the spec, making this option redundant.

### Migration guide

This option only affected those who have the option set to `true` and are adhering to YAML spec version <1.2. If you require this feature, use [`@std/yaml@0.224.3`](https://jsr.io/@std/yaml@0.224.3), as this is the last version containing this feature. Otherwise, we recommend updating your document to use the latest version of the YAML spec.