### PR TITLE
test(yaml): test `stringify()` case when string encoded into hex sequences

### DIFF
--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -181,3 +181,13 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "stringify() encode string with special characters",
+  fn() {
+    assertEquals(stringify("\x03"), `"\\x03"\n`);
+    assertEquals(stringify("\x08"), `"\\b"\n`);
+    assertEquals(stringify("\uffff"), `"\\uFFFF"\n`);
+    assertEquals(stringify("🐱"), `"\\U0001F431"\n`);
+  },
+});


### PR DESCRIPTION
part of #3713 

This PR adds the test cases of `stringify` when the output is hex encoded strings.