### PR TITLE
fix(yaml): fix `!!int` style variation handling in `stringfiy`

### DIFF
--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -7,7 +7,14 @@
 import type { Any, ArrayObject } from "./_utils.ts";
 
 export type KindType = "sequence" | "scalar" | "mapping";
-export type StyleVariant = "lowercase" | "uppercase" | "camelcase" | "decimal";
+export type StyleVariant =
+  | "lowercase"
+  | "uppercase"
+  | "camelcase"
+  | "decimal"
+  | "binary"
+  | "octal"
+  | "hexadecimal";
 export type RepresentFn = (data: Any, style?: StyleVariant) => Any;
 
 interface TypeOptions {
@@ -19,6 +26,20 @@ interface TypeOptions {
   represent?: RepresentFn | ArrayObject<RepresentFn>;
   defaultStyle?: StyleVariant;
   styleAliases?: ArrayObject;
+}
+
+function compileStyleAliases(map?: Record<string, unknown[] | null>) {
+  const result = {} as Record<string, string>;
+
+  if (map) {
+    Object.keys(map).forEach((style) => {
+      map[style]!.forEach((alias) => {
+        result[String(alias)] = style;
+      });
+    });
+  }
+
+  return result;
 }
 
 function checkTagFormat(tag: string): string {
@@ -45,7 +66,7 @@ export class Type {
       this.predicate = options.predicate;
       this.represent = options.represent;
       this.defaultStyle = options.defaultStyle;
-      this.styleAliases = options.styleAliases;
+      this.styleAliases = compileStyleAliases(options.styleAliases);
     }
   }
   resolve: (data?: Any) => boolean = (): boolean => true;

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -7,14 +7,25 @@
 import type { Any, ArrayObject } from "./_utils.ts";
 
 export type KindType = "sequence" | "scalar" | "mapping";
+/**
+ * The style variation for `styles` option of {@linkcode stringify}
+ */
 export type StyleVariant =
   | "lowercase"
   | "uppercase"
   | "camelcase"
   | "decimal"
+  | "dec"
+  | 10
   | "binary"
+  | "bin"
+  | 2
   | "octal"
-  | "hexadecimal";
+  | "oct"
+  | 8
+  | "hexadecimal"
+  | "hex"
+  | 16;
 export type RepresentFn = (data: Any, style?: StyleVariant) => Any;
 
 interface TypeOptions {

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -26,7 +26,16 @@ export type StringifyOptions = {
    */
   flowLevel?: number;
   /** Each tag may have own set of styles.	- "tag" => "style" map. */
-  styles?: Record<string, "lowercase" | "uppercase" | "camelcase" | "decimal">;
+  styles?: Record<
+    string,
+    | "lowercase"
+    | "uppercase"
+    | "camelcase"
+    | "decimal"
+    | "binary"
+    | "octal"
+    | "hexadecimal"
+  >;
   /** Name of the schema to use. */
   schema?: "core" | "default" | "failsafe" | "json" | "extended";
   /**

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -6,6 +6,9 @@
 
 import { dump } from "./_dumper/dumper.ts";
 import { SCHEMA_MAP } from "./_schema.ts";
+import type { StyleVariant } from "./_type.ts";
+
+export type { StyleVariant };
 
 /**
  * The option for strinigfy.
@@ -26,16 +29,7 @@ export type StringifyOptions = {
    */
   flowLevel?: number;
   /** Each tag may have own set of styles.	- "tag" => "style" map. */
-  styles?: Record<
-    string,
-    | "lowercase"
-    | "uppercase"
-    | "camelcase"
-    | "decimal"
-    | "binary"
-    | "octal"
-    | "hexadecimal"
-  >;
+  styles?: Record<string, StyleVariant>;
   /** Name of the schema to use. */
   schema?: "core" | "default" | "failsafe" | "json" | "extended";
   /**

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -77,11 +77,33 @@ Deno.test({
 });
 
 Deno.test({
+  name: "stringify() serializes integers",
+  fn() {
+    assertEquals(stringify(42), "42\n");
+    assertEquals(stringify(-42), "-42\n");
+
+    // binary, octal, and hexadecimal can be specified in styles options
+    assertEquals(
+      stringify(42, { styles: { "!!int": "binary" } }),
+      "0b101010\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": "octal" } }),
+      "052\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": "hexadecimal" } }),
+      "0x2A\n",
+    );
+  },
+});
+
+Deno.test({
   name: "stringify() serializes boolean values",
   fn() {
     assertEquals(stringify([true, false]), "- true\n- false\n");
 
-    // casing can be controlled with style options
+    // casing can be controlled with styles options
     assertEquals(
       stringify([true, false], { styles: { "!!bool": "camelcase" } }),
       "- True\n- False\n",

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -88,11 +88,35 @@ Deno.test({
       "0b101010\n",
     );
     assertEquals(
+      stringify(42, { styles: { "!!int": "bin" } }),
+      "0b101010\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": 2 } }),
+      "0b101010\n",
+    );
+    assertEquals(
       stringify(42, { styles: { "!!int": "octal" } }),
       "052\n",
     );
     assertEquals(
+      stringify(42, { styles: { "!!int": "oct" } }),
+      "052\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": 8 } }),
+      "052\n",
+    );
+    assertEquals(
       stringify(42, { styles: { "!!int": "hexadecimal" } }),
+      "0x2A\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": "hex" } }),
+      "0x2A\n",
+    );
+    assertEquals(
+      stringify(42, { styles: { "!!int": 16 } }),
       "0x2A\n",
     );
   },


### PR DESCRIPTION
This PR fixes the handling of style variaions for `!!int` type.