### PR TITLE
test(assert): add "`assert()` throws if expr is falsy" test

### DIFF
--- a/assert/assert_test.ts
+++ b/assert/assert_test.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assert, AssertionError, assertThrows } from "./mod.ts";
+
+Deno.test("assert() throws if expr is falsy", () => {
+  const FALSY_VALUES = [false, 0, "", null, undefined, NaN];
+  for (const value of FALSY_VALUES) {
+    const msg = crypto.randomUUID();
+    assertThrows(() => assert(value, msg), AssertionError, msg);
+  }
+});


### PR DESCRIPTION
Mainly so `@std/assert` reaches 100% coverage.