### PR TITLE
refactor(csv): remove dead code

### DIFF
--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -175,20 +175,6 @@ export async function parseRecord(
             break parseField;
           }
           recordBuffer += "\n"; // preserve line feed (This is because TextProtoReader removes it.)
-        } else {
-          // Abrupt end of file (EOF on error).
-          if (!opt.lazyQuotes) {
-            const col = runeCount(fullLine);
-            quoteError = new ParseError(
-              startLine + 1,
-              lineIndex,
-              col,
-              ERR_QUOTE,
-            );
-            break parseField;
-          }
-          fieldIndexes.push(recordBuffer.length);
-          break parseField;
         }
       }
     }


### PR DESCRIPTION
Brings `@std/csv` coverage to 100%.

Towards #3713