### PR TITLE
fix(fmt): fix the case when mantissa exceeds 10 by rounding and exponent is negative

### DIFF
--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -718,7 +718,7 @@ class Printf {
       if (10 <= mantissa) {
         mantissa = 1;
         const r = parseInt(esign + e) + 1;
-        e = r.toString();
+        e = Math.abs(r).toString();
         esign = r < 0 ? "-" : "+";
       }
     }

--- a/fmt/printf_test.ts
+++ b/fmt/printf_test.ts
@@ -108,6 +108,7 @@ Deno.test("sprintf() handles floats", function () {
   assertEquals(sprintf("%e", Number.MIN_SAFE_INTEGER), "-9.007199e+15");
   assertEquals(sprintf("%.3e", 1.9999), "2.000e+00");
   assertEquals(sprintf("%.3e", 29.99999), "3.000e+01");
+  assertEquals(sprintf("%.3e", 0.000099999), "1.000e-04");
 });
 Deno.test("sprintf() handles floatE", function () {
   assertEquals(sprintf("%E", 4), "4.000000E+00");


### PR DESCRIPTION
Currently `e` formatting with rounding has a bug in some edge cases. For example `sprintf("%.3e", 0.000099999)` becomes `1.000e--04` (which has double minus sign). This PR fixes it.