### PR TITLE
fix(bytes,cli,collections,expect): add missing non-null assertions

### DIFF
--- a/bytes/equals_test.ts
+++ b/bytes/equals_test.ts
@@ -21,10 +21,10 @@ Deno.test("equals() handles randomized testing", () => {
     const arr3 = arr1.slice(0);
     // the chance of arr1 equaling arr2 is basically 0
     // but introduce an inequality at the end just in case
-    arr2[arr2.length - 1] = arr1.at(-1)! ^ 1;
+    arr2[arr2.length - 1]! = arr1.at(-1)! ^ 1;
     // arr3 is arr1 but with an inequality in the very last element
     // this is to test the equality check when length isn't a multiple of 4
-    arr3[arr3.length - 1] ^= 1;
+    arr3[arr3.length - 1]! ^= 1;
     // arrays with same underlying ArrayBuffer should be equal
     assert(equals(arr1, arr1));
     // equal arrays with different underlying ArrayBuffers should be equal

--- a/cli/_run_length.ts
+++ b/cli/_run_length.ts
@@ -8,7 +8,7 @@ export function runLengthEncode(arr: number[]) {
 
   for (const x of arr) {
     if (x === prev) {
-      ++runLengths[runLengths.length - 1];
+      ++runLengths[runLengths.length - 1]!;
     } else {
       prev = x;
       data.push(x);

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -54,7 +54,7 @@ export function permutations<T>(inputArray: Iterable<T>): T[][] {
 
       result.push([...array]);
 
-      c[i] += 1;
+      c[i]! += 1;
       i = 1;
     } else {
       c[i] = 0;

--- a/expect/_utils.ts
+++ b/expect/_utils.ts
@@ -36,14 +36,13 @@ function isObject(a: unknown) {
 }
 
 // deno-lint-ignore no-explicit-any
-export function entries(obj: any) {
+function entries(obj: any) {
   if (!isObject(obj)) return [];
 
-  const symbolProperties = Object.getOwnPropertySymbols(obj)
+  return Object.getOwnPropertySymbols(obj)
     .filter((key) => key !== Symbol.iterator)
-    .map((key) => [key, obj[key]]);
-
-  return [...symbolProperties, ...Object.entries(obj)];
+    .map((key) => [key, obj[key as keyof typeof obj]])
+    .concat(Object.entries(obj));
 }
 
 // Ported from https://github.com/jestjs/jest/blob/442c7f692e3a92f14a2fb56c1737b26fc663a0ef/packages/expect-utils/src/utils.ts#L173


### PR DESCRIPTION
Fixes errors on `main` (see [here](https://github.com/denoland/deno_std/actions/runs/9785146367/job/27017549354)).