### PR TITLE
BREAKING(yaml): rename `ParseOptions.json` to `ParseOptions.allowDuplicateKeys`

### DIFF
--- a/yaml/_loader.ts
+++ b/yaml/_loader.ts
@@ -63,7 +63,7 @@ interface LoaderStateOptions {
   /** specifies a schema to use. */
   schema?: Schema;
   /** compatibility with JSON.parse behaviour. */
-  json?: boolean;
+  allowDuplicateKeys?: boolean;
   /** function to call on warning messages. */
   onWarning?(this: null, e?: YamlError): void;
 }
@@ -80,7 +80,7 @@ class LoaderState {
   position = 0;
   line = 0;
   onWarning?: (...args: Any[]) => void;
-  json: boolean;
+  allowDuplicateKeys: boolean;
   implicitTypes: Type[];
   typeMap: TypeMap;
 
@@ -98,13 +98,13 @@ class LoaderState {
     {
       schema = DEFAULT_SCHEMA,
       onWarning,
-      json = false,
+      allowDuplicateKeys = false,
     }: LoaderStateOptions,
   ) {
     this.schema = schema;
     this.input = input;
     this.onWarning = onWarning;
-    this.json = json;
+    this.allowDuplicateKeys = allowDuplicateKeys;
     this.implicitTypes = this.schema.compiledImplicit;
     this.typeMap = this.schema.compiledTypeMap;
     this.length = input.length;
@@ -397,7 +397,7 @@ function storeMappingPair(
     }
   } else {
     if (
-      !state.json &&
+      !state.allowDuplicateKeys &&
       !Object.hasOwn(overridableKeys, keyNode) &&
       Object.hasOwn(result, keyNode)
     ) {

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -14,7 +14,7 @@ export interface ParseOptions {
   /** Name of the schema to use.*/
   schema?: "core" | "default" | "failsafe" | "json" | "extended";
   /** compatibility with JSON.parse behaviour. */
-  json?: boolean;
+  allowDuplicateKeys?: boolean;
   /** function to call on warning messages. */
   onWarning?(this: null, e?: Error): void;
 }

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -976,13 +976,13 @@ name: Jane Doe`,
   );
 });
 
-Deno.test("parse() allows duplicate keys when `json` option is set to `true`", () => {
+Deno.test("parse() allows duplicate keys when `allowDuplicateKeys` option is set to `true`", () => {
   assertEquals(
     parse(
       `name: John Doe
 age: 30
 name: Jane Doe`,
-      { json: true },
+      { allowDuplicateKeys: true },
     ),
     { name: "Jane Doe", age: 30 },
   );


### PR DESCRIPTION
### What's changed

[`ParseOptions.json`](https://jsr.io/@std/yaml@0.224.3/doc/parse/~/ParseOptions.json) has been renamed `ParseOptions.allowDuplicateKeys`. This change only affects those that previously set `ParseOptions.json` to `true`. No changes in behavior have been made.

### Motivation

This name more clearly describes how the option affects the behavior of [`parse()`](https://jsr.io/@std/yaml/doc/~/parse).

### Migration guide

To migrate, use the `allowDuplicateKeys` option instead of the `json` option for `parse()`.

```diff
import { parse } from "@std/yaml/parse";

const yamlString = `name: John Doe
age: 30
name: Jane Doe`;

- parse(yamlString, { json: true });
+ parse(yamlString, { allowDuplicateKeys: true });
```

### Related

Towards #5195