### PR TITLE
refactor(yaml): remove first argument from `ParseOptions.onWarning`

### DIFF
--- a/yaml/_loader.ts
+++ b/yaml/_loader.ts
@@ -65,7 +65,7 @@ interface LoaderStateOptions {
   /** compatibility with JSON.parse behaviour. */
   json?: boolean;
   /** function to call on warning messages. */
-  onWarning?(this: null, e?: YamlError): void;
+  onWarning?(error?: YamlError): void;
 }
 
 // deno-lint-ignore no-explicit-any

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -16,7 +16,7 @@ export interface ParseOptions {
   /** compatibility with JSON.parse behaviour. */
   json?: boolean;
   /** function to call on warning messages. */
-  onWarning?(this: null, e?: Error): void;
+  onWarning?(error?: Error): void;
 }
 
 /**


### PR DESCRIPTION
This argument previously did nothing.

Towards #5195