### PR TITLE
BREAKING(yaml): rename `ParseOptions.noArrayIndent` to `ParseOptions.arrayIndent`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -99,8 +99,8 @@ function compileStyleMap(
 export interface DumperStateOptions {
   /** indentation width to use (in spaces). */
   indent?: number;
-  /** when true, will not add an indentation level to array elements */
-  noArrayIndent?: boolean;
+  /** when true, adds an indentation level to array elements */
+  arrayIndent?: boolean;
   /**
    * do not throw on invalid types (like function in the safe schema)
    * and skip pairs and single values with such types.
@@ -148,7 +148,7 @@ export interface DumperStateOptions {
 export class DumperState {
   schema: Schema;
   indent: number;
-  noArrayIndent: boolean;
+  arrayIndent: boolean;
   skipInvalid: boolean;
   flowLevel: number;
   sortKeys: boolean | ((a: Any, b: Any) => number);
@@ -168,7 +168,7 @@ export class DumperState {
   constructor({
     schema = DEFAULT_SCHEMA,
     indent = 2,
-    noArrayIndent = false,
+    arrayIndent = true,
     skipInvalid = false,
     flowLevel = -1,
     styles = null,
@@ -180,7 +180,7 @@ export class DumperState {
   }: DumperStateOptions) {
     this.schema = schema;
     this.indent = Math.max(1, indent);
-    this.noArrayIndent = noArrayIndent;
+    this.arrayIndent = arrayIndent;
     this.skipInvalid = skipInvalid;
     this.flowLevel = flowLevel;
     this.styleMap = compileStyleMap(this.schema, styles);
@@ -887,7 +887,7 @@ function writeNode(
         }
       }
     } else if (Array.isArray(state.dump)) {
-      const arrayLevel = state.noArrayIndent && level > 0 ? level - 1 : level;
+      const arrayLevel = !state.arrayIndent && level > 0 ? level - 1 : level;
       if (block && state.dump.length !== 0) {
         writeBlockSequence(state, arrayLevel, state.dump, compact);
         if (duplicate) {

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -16,8 +16,8 @@ export type { StyleVariant };
 export type StringifyOptions = {
   /** Indentation width to use (in spaces). */
   indent?: number;
-  /** When true, will not add an indentation level to array elements */
-  noArrayIndent?: boolean;
+  /** When true, adds an indentation level to array elements */
+  arrayIndent?: boolean;
   /**
    * Do not throw on invalid types (like function in the safe schema)
    * and skip pairs and single values with such types.


### PR DESCRIPTION
### What's changed

The `ParseOptions.noArrayIndent` option has been renamed to `ParseOptions.arrayIndent`. As a result, the polarity of the option has been swapped. In other words, `true` behavior has been changed to `false` behavior, and visa-versa. This only affects users who currently use `ParseOptions.noArrayIndent`.

### Motivation

This change makes the option far easier to understand by avoiding a negative-tensed name.

### Migration guide

Use `ParseOptions.arrayIndent` instead of `ParseOptions.noArrayIndent` and swap the polarity of the option.

```diff
import { parse } from "@std/yaml/parse";

const yamlString = `fruits:
  - Apple
  - Banana
  - Cherry`;

- parse(yamlString, { noArrayIndent: false });
+ parse(yamlString, { arrayIndent: true });
```

### Related

Towards #5124