### PR TITLE
BREAKING(yaml): rename `StringifyOptions.noCompatMode` to `StringifyOptions.compatMode`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -131,11 +131,11 @@ export interface DumperStateOptions {
    */
   noRefs?: boolean;
   /**
-   * if true don't try to be compatible with older yaml versions.
+   * if false don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,
-   * as required for YAML 1.1 (default: false)
+   * as required for YAML 1.1 (default: true)
    */
-  noCompatMode?: boolean;
+  compatMode?: boolean;
   /**
    * if true flow sequences will be condensed, omitting the
    * space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
@@ -154,7 +154,7 @@ export class DumperState {
   sortKeys: boolean | ((a: Any, b: Any) => number);
   lineWidth: number;
   noRefs: boolean;
-  noCompatMode: boolean;
+  compatMode: boolean;
   condenseFlow: boolean;
   implicitTypes: Type[];
   explicitTypes: Type[];
@@ -175,7 +175,7 @@ export class DumperState {
     sortKeys = false,
     lineWidth = 80,
     noRefs = false,
-    noCompatMode = false,
+    compatMode = true,
     condenseFlow = false,
   }: DumperStateOptions) {
     this.schema = schema;
@@ -187,7 +187,7 @@ export class DumperState {
     this.sortKeys = sortKeys;
     this.lineWidth = lineWidth;
     this.noRefs = noRefs;
-    this.noCompatMode = noCompatMode;
+    this.compatMode = compatMode;
     this.condenseFlow = condenseFlow;
     this.implicitTypes = this.schema.compiledImplicit;
     this.explicitTypes = this.schema.compiledExplicit;
@@ -560,7 +560,7 @@ function writeScalar(
       return "''";
     }
     if (
-      !state.noCompatMode &&
+      state.compatMode &&
       DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1
     ) {
       return `'${string}'`;

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -48,11 +48,11 @@ export type StringifyOptions = {
    */
   noRefs?: boolean;
   /**
-   * If true don't try to be compatible with older yaml versions.
+   * If false don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,
-   * as required for YAML 1.1 (default: false)
+   * as required for YAML 1.1 (default: true)
    */
-  noCompatMode?: boolean;
+  compatMode?: boolean;
   /**
    * If true flow sequences will be condensed, omitting the
    * space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.


### PR DESCRIPTION
### What's changed

The `ParseOptions.noCompatMode` option has been renamed to `ParseOptions.compatMode`. As a result, the polarity of the option has been swapped. In other words, `true` behavior has been changed to `false` behavior, and visa-versa. This only affects users who currently use `ParseOptions.noCompatMode`.

### Motivation

This change makes the option far easier to understand by avoiding a negative-tensed name.

### Migration guide

Use `ParseOptions.compatMode` instead of `ParseOptions.noCompatMode` and swap the polarity of the option.

```diff
import { parse } from "@std/yaml/parse";

const yamlString = `fruits:
  - Apple
  - Banana
  - Cherry`;

- parse(yamlString, { noCompatMode: false });
+ parse(yamlString, { compatMode: true });
```

### Related

Towards #5124