### PR TITLE
BREAKING(yaml): rename `StringifyOptions.noRefs` to `StringifyOptions.useAnchors`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -129,7 +129,7 @@ export interface DumperStateOptions {
    * if false, don't convert duplicate objects
    * into references (default: true)
    */
-  createRefs?: boolean;
+  useAnchors?: boolean;
   /**
    * if false don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,
@@ -153,7 +153,7 @@ export class DumperState {
   flowLevel: number;
   sortKeys: boolean | ((a: Any, b: Any) => number);
   lineWidth: number;
-  createRefs: boolean;
+  useAnchors: boolean;
   compatMode: boolean;
   condenseFlow: boolean;
   implicitTypes: Type[];
@@ -174,7 +174,7 @@ export class DumperState {
     styles = null,
     sortKeys = false,
     lineWidth = 80,
-    createRefs = true,
+    useAnchors = true,
     compatMode = true,
     condenseFlow = false,
   }: DumperStateOptions) {
@@ -186,7 +186,7 @@ export class DumperState {
     this.styleMap = compileStyleMap(this.schema, styles);
     this.sortKeys = sortKeys;
     this.lineWidth = lineWidth;
-    this.createRefs = createRefs;
+    this.useAnchors = useAnchors;
     this.compatMode = compatMode;
     this.condenseFlow = condenseFlow;
     this.implicitTypes = this.schema.compiledImplicit;
@@ -965,7 +965,7 @@ function getDuplicateReferences(
 export function dump(input: Any, options: DumperStateOptions = {}): string {
   const state = new DumperState(options);
 
-  if (state.createRefs) getDuplicateReferences(input, state);
+  if (state.useAnchors) getDuplicateReferences(input, state);
 
   if (writeNode(state, 0, input, true, true)) return `${state.dump}\n`;
 

--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -126,10 +126,10 @@ export interface DumperStateOptions {
   /** set max line width. (default: 80) */
   lineWidth?: number;
   /**
-   * if true, don't convert duplicate objects
-   * into references (default: false)
+   * if false, don't convert duplicate objects
+   * into references (default: true)
    */
-  noRefs?: boolean;
+  createRefs?: boolean;
   /**
    * if true don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,
@@ -153,7 +153,7 @@ export class DumperState {
   flowLevel: number;
   sortKeys: boolean | ((a: Any, b: Any) => number);
   lineWidth: number;
-  noRefs: boolean;
+  createRefs: boolean;
   noCompatMode: boolean;
   condenseFlow: boolean;
   implicitTypes: Type[];
@@ -174,7 +174,7 @@ export class DumperState {
     styles = null,
     sortKeys = false,
     lineWidth = 80,
-    noRefs = false,
+    createRefs = true,
     noCompatMode = false,
     condenseFlow = false,
   }: DumperStateOptions) {
@@ -186,7 +186,7 @@ export class DumperState {
     this.styleMap = compileStyleMap(this.schema, styles);
     this.sortKeys = sortKeys;
     this.lineWidth = lineWidth;
-    this.noRefs = noRefs;
+    this.createRefs = createRefs;
     this.noCompatMode = noCompatMode;
     this.condenseFlow = condenseFlow;
     this.implicitTypes = this.schema.compiledImplicit;
@@ -965,7 +965,7 @@ function getDuplicateReferences(
 export function dump(input: Any, options: DumperStateOptions = {}): string {
   const state = new DumperState(options);
 
-  if (!state.noRefs) getDuplicateReferences(input, state);
+  if (state.createRefs) getDuplicateReferences(input, state);
 
   if (writeNode(state, 0, input, true, true)) return `${state.dump}\n`;
 

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -43,10 +43,10 @@ export type StringifyOptions = {
   /** Set max line width. (default: 80) */
   lineWidth?: number;
   /**
-   * If true, don't convert duplicate objects
-   * into references (default: false)
+   * If false, don't convert duplicate objects
+   * into references (default: true)
    */
-  noRefs?: boolean;
+  createRefs?: boolean;
   /**
    * If true don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -46,7 +46,7 @@ export type StringifyOptions = {
    * If false, don't convert duplicate objects
    * into references (default: true)
    */
-  createRefs?: boolean;
+  useAnchors?: boolean;
   /**
    * If false don't try to be compatible with older yaml versions.
    * Currently: don't quote "yes", "no" and so on,

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -257,11 +257,11 @@ Deno.test({
   fn() {
     const obj = { foo: "bar" };
     assertEquals(
-      stringify([obj, obj], { useAnchors: true }),
+      stringify([obj, obj], { useAnchors: false }),
       `- foo: bar\n- foo: bar\n`,
     );
     assertEquals(
-      stringify([obj, obj], { useAnchors: false }),
+      stringify([obj, obj], { useAnchors: true }),
       `- &ref_0\n  foo: bar\n- *ref_0\n`,
     );
   },

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -253,15 +253,15 @@ Deno.test({
 });
 
 Deno.test({
-  name: "stringify() works with noRefs option",
+  name: "stringify() works with useAnchors option",
   fn() {
     const obj = { foo: "bar" };
     assertEquals(
-      stringify([obj, obj], { noRefs: true }),
+      stringify([obj, obj], { useAnchors: true }),
       `- foo: bar\n- foo: bar\n`,
     );
     assertEquals(
-      stringify([obj, obj], { noRefs: false }),
+      stringify([obj, obj], { useAnchors: false }),
       `- &ref_0\n  foo: bar\n- *ref_0\n`,
     );
   },


### PR DESCRIPTION
### What's changed

The `ParseOptions.noRefs` option has been renamed to `ParseOptions.useAnchors`. As a result, the polarity of the option has been swapped. In other words, `true` behavior has been changed to `false` behavior, and visa-versa. This only affects users who currently use `ParseOptions.noRefs`.

### Motivation

This change makes the option far easier to understand by avoiding a negative-tensed name.

### Migration guide

Use `ParseOptions.useAnchors` instead of `ParseOptions.noRefs` and swap the polarity of the option.

```diff
import { parse } from "@std/yaml/parse";

const yamlString = `fruits:
  - Apple
  - Banana
  - Cherry`;

- parse(yamlString, { noRefs: false });
+ parse(yamlString, { useAnchors: true });
```

### Related

Closes #5124