### PR TITLE
fix(yaml): fix `StringifyOptions.noRefs`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -928,7 +928,7 @@ function inspectNode(
   if (object !== null && typeof object === "object") {
     const index = objects.indexOf(object);
     if (index !== -1) {
-      if (duplicatesIndexes.includes(index)) {
+      if (!duplicatesIndexes.includes(index)) {
         duplicatesIndexes.push(index);
       }
     } else {

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -275,3 +275,18 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "stringify() works with noRefs option",
+  fn() {
+    const obj = { foo: "bar" };
+    assertEquals(
+      stringify([obj, obj], { noRefs: true }),
+      `- foo: bar\n- foo: bar\n`,
+    );
+    assertEquals(
+      stringify([obj, obj], { noRefs: false }),
+      `- &ref_0\n  foo: bar\n- *ref_0\n`,
+    );
+  },
+});


### PR DESCRIPTION
`noRefs` option stopped working at 1.0.0-rc.1. This PR fixes it.


One of if-condition in `inspectNode` util was reversed here: https://github.com/denoland/deno_std/pull/5239/files#diff-d51202515e2d50a21e0e272ef2ce1cce07793bc5a2a01a7ea1f9e4b3ccb0c429R808