### PR TITLE
docs(assert): update `assertMatch` example

### DIFF
--- a/assert/match.ts
+++ b/assert/match.ts
@@ -10,8 +10,8 @@ import { AssertionError } from "./assertion_error.ts";
  * ```ts no-eval
  * import { assertMatch } from "@std/assert";
  *
- * assertMatch("Raptor", RegExp(/Raptor/)); // Doesn't throw
- * assertMatch("Denosaurus", RegExp(/Raptor/)); // Throws
+ * assertMatch("Raptor", /Raptor/); // Doesn't throw
+ * assertMatch("Denosaurus", /Raptor/); // Throws
  * ```
  *
  * @param actual The actual value to be matched.

--- a/assert/not_match.ts
+++ b/assert/not_match.ts
@@ -10,8 +10,8 @@ import { AssertionError } from "./assertion_error.ts";
  * ```ts no-eval
  * import { assertNotMatch } from "@std/assert";
  *
- * assertNotMatch("Denosaurus", RegExp(/Raptor/)); // Doesn't throw
- * assertNotMatch("Raptor", RegExp(/Raptor/)); // Throws
+ * assertNotMatch("Denosaurus", /Raptor/); // Doesn't throw
+ * assertNotMatch("Raptor", /Raptor/); // Throws
  * ```
  *
  * @param actual The actual value to match.


### PR DESCRIPTION
This PR improves the example of `assertMatch` API. (`RegExp(/foo/)` works, but it looks confusing to me)