### PR TITLE
docs(assert): improve `assertNotStrictEquals` example

### DIFF
--- a/assert/not_strict_equals.ts
+++ b/assert/not_strict_equals.ts
@@ -12,8 +12,11 @@ import { format } from "@std/internal/format";
  * ```ts no-eval
  * import { assertNotStrictEquals } from "@std/assert";
  *
- * assertNotStrictEquals(1, 1); // Doesn't throw
- * assertNotStrictEquals(1, 2); // Throws
+ * assertNotStrictEquals(1, 1); // Throws
+ * assertNotStrictEquals(1, 2); // Doesn't throw
+ *
+ * assertNotStrictEquals(0, 0); // Throws
+ * assertNotStrictEquals(0, -0); // Doesn't throw
  * ```
  *
  * @typeParam T The type of the values to compare.


### PR DESCRIPTION
This PR improves the example of `assertNotStrictEquals` doc.