### PR TITLE
docs(assert): improve `assertObjectMatch` docs

### DIFF
--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -3,7 +3,7 @@
 import { assertEquals } from "./equals.ts";
 
 /**
- * Make an assertion that `actual` object is a superset of `expected` object,
+ * Make an assertion that `expected` object is a subset of `actual` object,
  * deeply. If not, then throw.
  *
  * @example Usage

--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -3,7 +3,7 @@
 import { assertEquals } from "./equals.ts";
 
 /**
- * Make an assertion that `actual` object is a subset of `expected` object,
+ * Make an assertion that `actual` object is a superset of `expected` object,
  * deeply. If not, then throw.
  *
  * @example Usage
@@ -12,6 +12,14 @@ import { assertEquals } from "./equals.ts";
  *
  * assertObjectMatch({ foo: "bar" }, { foo: "bar" }); // Doesn't throw
  * assertObjectMatch({ foo: "bar" }, { foo: "baz" }); // Throws
+ * ```
+ *
+ * @example Usage with nested objects
+ * ```ts
+ * import { assertObjectMatch } from "@std/assert";
+ *
+ * assertObjectMatch({ foo: { bar: 3, baz: 4 } }, { foo: { bar: 3 } }); // Doesn't throw
+ * assertObjectMatch({ foo: { bar: 3 } }, { foo: { bar: 3, baz: 4 } }); // Throws
  * ```
  *
  * @param actual The actual value to be matched.

--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -15,7 +15,7 @@ import { assertEquals } from "./equals.ts";
  * ```
  *
  * @example Usage with nested objects
- * ```ts
+ * ```ts no-eval
  * import { assertObjectMatch } from "@std/assert";
  *
  * assertObjectMatch({ foo: { bar: 3, baz: 4 } }, { foo: { bar: 3 } }); // Doesn't throw


### PR DESCRIPTION
This PR improves the docs of `assertObjectMatch`.