### PR TITLE
refactor(yaml): remove repeat helper function

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -218,7 +218,7 @@ function encodeHex(character: number): string {
 
 // Indents every line in a string. Empty lines (\n only) are not indented.
 function indentString(string: string, spaces: number): string {
-  const ind = common.repeat(" ", spaces);
+  const ind = " ".repeat(spaces);
   const length = string.length;
   let position = 0;
   let next = -1;
@@ -244,7 +244,7 @@ function indentString(string: string, spaces: number): string {
 }
 
 function generateNextLine(state: DumperState, level: number): string {
-  return `\n${common.repeat(" ", state.indent * level)}`;
+  return `\n${" ".repeat(state.indent * level)}`;
 }
 
 function testImplicitResolving(state: DumperState, str: string): boolean {

--- a/yaml/_loader.ts
+++ b/yaml/_loader.ts
@@ -486,7 +486,7 @@ function writeFoldedLines(state: LoaderState, count: number) {
   if (count === 1) {
     state.result += " ";
   } else if (count > 1) {
-    state.result += common.repeat("\n", count - 1);
+    state.result += "\n".repeat(count - 1);
   }
 }
 
@@ -936,8 +936,7 @@ function readBlockScalar(state: LoaderState, nodeIndent: number): boolean {
     if (state.lineIndent < textIndent) {
       // Perform the chomping.
       if (chomping === CHOMPING_KEEP) {
-        state.result += common.repeat(
-          "\n",
+        state.result += "\n".repeat(
           didReadContent ? 1 + emptyLines : emptyLines,
         );
       } else if (chomping === CHOMPING_CLIP) {
@@ -957,15 +956,14 @@ function readBlockScalar(state: LoaderState, nodeIndent: number): boolean {
       if (isWhiteSpace(ch)) {
         atMoreIndented = true;
         // except for the first content line (cf. Example 8.1)
-        state.result += common.repeat(
-          "\n",
+        state.result += "\n".repeat(
           didReadContent ? 1 + emptyLines : emptyLines,
         );
 
         // End of more-indented block.
       } else if (atMoreIndented) {
         atMoreIndented = false;
-        state.result += common.repeat("\n", emptyLines + 1);
+        state.result += "\n".repeat(emptyLines + 1);
 
         // Just one line break - perceive as the same line.
       } else if (emptyLines === 0) {
@@ -976,16 +974,13 @@ function readBlockScalar(state: LoaderState, nodeIndent: number): boolean {
 
         // Several line breaks - perceive as different lines.
       } else {
-        state.result += common.repeat("\n", emptyLines);
+        state.result += "\n".repeat(emptyLines);
       }
 
       // Literal style: just add exact number of line breaks between content lines.
     } else {
       // Keep all line breaks except the header line break.
-      state.result += common.repeat(
-        "\n",
-        didReadContent ? 1 + emptyLines : emptyLines,
-      );
+      state.result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
     }
 
     didReadContent = true;

--- a/yaml/_mark.ts
+++ b/yaml/_mark.ts
@@ -3,8 +3,6 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { repeat } from "./_utils.ts";
-
 export class Mark {
   buffer: string;
   position: number;
@@ -56,11 +54,8 @@ export class Mark {
     }
 
     const snippet = this.buffer.slice(start, end);
-    return `${repeat(" ", indent)}${head}${snippet}${tail}\n${
-      repeat(
-        " ",
-        indent + this.position - start + head.length,
-      )
+    return `${" ".repeat(indent)}${head}${snippet}${tail}\n${
+      " ".repeat(indent + this.position - start + head.length)
     }^`;
   }
 

--- a/yaml/_utils.ts
+++ b/yaml/_utils.ts
@@ -14,16 +14,6 @@ export function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
-export function repeat(str: string, count: number): string {
-  let result = "";
-
-  for (let cycle = 0; cycle < count; cycle++) {
-    result += str;
-  }
-
-  return result;
-}
-
 export function isNegativeZero(i: number): boolean {
   return i === 0 && Number.NEGATIVE_INFINITY === 1 / i;
 }


### PR DESCRIPTION
- replaces repeat helper function with built in `String.prototype.repeat()`