### PR TITLE
BREAKING(yaml): remove style aliases of `!!int` type

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -72,23 +72,16 @@ const DEPRECATED_BOOLEANS_SYNTAX = [
 ];
 
 function compileStyleMap(
-  schema: Schema,
   map?: ArrayObject<StyleVariant> | null,
 ): ArrayObject<StyleVariant> {
   if (typeof map === "undefined" || map === null) return {};
 
   const result: ArrayObject<StyleVariant> = {};
   for (let tag of Object.keys(map)) {
-    let style = String(map[tag]) as StyleVariant;
+    const style = String(map[tag]) as StyleVariant;
     if (tag.slice(0, 2) === "!!") {
       tag = `tag:yaml.org,2002:${tag.slice(2)}`;
     }
-    const type = schema.compiledTypeMap.fallback[tag];
-
-    if (type?.styleAliases && Object.hasOwn(type.styleAliases, style)) {
-      style = type.styleAliases[style];
-    }
-
     result[tag] = style;
   }
 
@@ -182,7 +175,7 @@ export class DumperState {
     this.arrayIndent = arrayIndent;
     this.skipInvalid = skipInvalid;
     this.flowLevel = flowLevel;
-    this.styleMap = compileStyleMap(this.schema, styles);
+    this.styleMap = compileStyleMap(styles);
     this.sortKeys = sortKeys;
     this.lineWidth = lineWidth;
     this.noRefs = noRefs;

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -15,17 +15,9 @@ export type StyleVariant =
   | "uppercase"
   | "camelcase"
   | "decimal"
-  | "dec"
-  | 10
   | "binary"
-  | "bin"
-  | 2
   | "octal"
-  | "oct"
-  | 8
-  | "hexadecimal"
-  | "hex"
-  | 16;
+  | "hexadecimal";
 export type RepresentFn = (data: Any, style?: StyleVariant) => Any;
 
 export interface Type {
@@ -35,7 +27,6 @@ export interface Type {
   predicate?: (data: Record<string, unknown>) => boolean;
   represent?: RepresentFn | ArrayObject<RepresentFn>;
   defaultStyle?: StyleVariant;
-  styleAliases?: ArrayObject;
   loadKind?: KindType;
   resolve: (data?: Any) => boolean;
   construct: (data?: Any) => Any;

--- a/yaml/_type/int.ts
+++ b/yaml/_type/int.ts
@@ -156,20 +156,6 @@ function isInteger(object: Any): boolean {
     !isNegativeZero(object);
 }
 
-function compileStyleAliases(map?: Record<string, unknown[] | null>) {
-  const result = {} as Record<string, string>;
-
-  if (map) {
-    Object.keys(map).forEach((style) => {
-      map[style]!.forEach((alias) => {
-        result[String(alias)] = style;
-      });
-    });
-  }
-
-  return result;
-}
-
 export const int: Type = {
   tag: "tag:yaml.org,2002:int",
   construct: constructYamlInteger,
@@ -195,10 +181,4 @@ export const int: Type = {
     },
   },
   resolve: resolveYamlInteger,
-  styleAliases: compileStyleAliases({
-    binary: [2, "bin"],
-    decimal: [10, "dec"],
-    hexadecimal: [16, "hex"],
-    octal: [8, "oct"],
-  }),
 };

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -88,35 +88,11 @@ Deno.test({
       "0b101010\n",
     );
     assertEquals(
-      stringify(42, { styles: { "!!int": "bin" } }),
-      "0b101010\n",
-    );
-    assertEquals(
-      stringify(42, { styles: { "!!int": 2 } }),
-      "0b101010\n",
-    );
-    assertEquals(
       stringify(42, { styles: { "!!int": "octal" } }),
       "052\n",
     );
     assertEquals(
-      stringify(42, { styles: { "!!int": "oct" } }),
-      "052\n",
-    );
-    assertEquals(
-      stringify(42, { styles: { "!!int": 8 } }),
-      "052\n",
-    );
-    assertEquals(
       stringify(42, { styles: { "!!int": "hexadecimal" } }),
-      "0x2A\n",
-    );
-    assertEquals(
-      stringify(42, { styles: { "!!int": "hex" } }),
-      "0x2A\n",
-    );
-    assertEquals(
-      stringify(42, { styles: { "!!int": 16 } }),
       "0x2A\n",
     );
   },


### PR DESCRIPTION
This PR removes the style aliases of `!!int` type in `stringify` API.

No users should be affected by this change.

closes #5272 