### PR TITLE
BREAKING(path): remove `GlobToRegExpOptions`

### DIFF
--- a/path/_common/glob_to_reg_exp.ts
+++ b/path/_common/glob_to_reg_exp.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-/** Options for {@linkcode globToRegExp}. */
+/**
+ * Options for {@linkcode globToRegExp}, {@linkcode joinGlobs},
+ * {@linkcode normalizeGlob} and {@linkcode expandGlob}.
+ */
 export interface GlobOptions {
   /** Extended glob syntax.
    * See https://www.linuxjournal.com/content/bash-extended-globbing.
@@ -23,9 +26,6 @@ export interface GlobOptions {
    */
   caseInsensitive?: boolean;
 }
-
-/** Options for {@linkcode globToRegExp}. */
-export type GlobToRegExpOptions = GlobOptions;
 
 const REG_EXP_ESCAPE_CHARS = [
   "!",
@@ -66,7 +66,7 @@ export function _globToRegExp(
     globstar: globstarOption = true,
     // os = osType,
     caseInsensitive = false,
-  }: GlobToRegExpOptions = {},
+  }: GlobOptions = {},
 ): RegExp {
   if (glob === "") {
     return /(?!)/;

--- a/path/glob_to_regexp.ts
+++ b/path/glob_to_regexp.ts
@@ -11,9 +11,6 @@ import {
 
 export type { GlobOptions };
 
-/** Options for {@linkcode globToRegExp}. */
-export type GlobToRegExpOptions = GlobOptions;
-
 /**
  * Converts a glob string to a regular expression.
  *
@@ -89,7 +86,7 @@ export type GlobToRegExpOptions = GlobOptions;
  */
 export function globToRegExp(
   glob: string,
-  options: GlobToRegExpOptions = {},
+  options: GlobOptions = {},
 ): RegExp {
   return isWindows
     ? windowsGlobToRegExp(glob, options)

--- a/path/posix/glob_to_regexp.ts
+++ b/path/posix/glob_to_regexp.ts
@@ -4,10 +4,10 @@
 import {
   _globToRegExp,
   type GlobConstants,
-  type GlobToRegExpOptions,
+  type GlobOptions,
 } from "../_common/glob_to_reg_exp.ts";
 
-export type { GlobToRegExpOptions };
+export type { GlobOptions };
 
 const constants: GlobConstants = {
   sep: "/+",
@@ -88,7 +88,7 @@ const constants: GlobConstants = {
  */
 export function globToRegExp(
   glob: string,
-  options: GlobToRegExpOptions = {},
+  options: GlobOptions = {},
 ): RegExp {
   return _globToRegExp(constants, glob, options);
 }

--- a/path/windows/glob_to_regexp.ts
+++ b/path/windows/glob_to_regexp.ts
@@ -4,7 +4,7 @@
 import {
   _globToRegExp,
   type GlobConstants,
-  type GlobToRegExpOptions,
+  type GlobOptions,
 } from "../_common/glob_to_reg_exp.ts";
 
 const constants: GlobConstants = {
@@ -86,7 +86,7 @@ const constants: GlobConstants = {
  */
 export function globToRegExp(
   glob: string,
-  options: GlobToRegExpOptions = {},
+  options: GlobOptions = {},
 ): RegExp {
   return _globToRegExp(constants, glob, options);
 }


### PR DESCRIPTION
### What's changed

The `GlobToRegExpOptions` interface has been replaced with `GlobOptions`, which is identical in behavior. This change only affects users who explicitly import `GlobToRegExpOptions`.

### Motiviation

This change was made because `GlobToRegExpOptions` is identical to `GlobOptions`, and `GlobOptions` is already used in `normalizeGlob()`, `joinGlobs()`, and `expandGlob()` in `@std/fs`. This removal means a decrease in the API surface of `@std/path` without impeding functionality.

### Migration guide

To migrate, use `GlobOptions` instead of `GlobToRegExpOptions`. This is only needed if you already explicitly import `GlobToRegExpOptions`.

```diff
- import type { GlobToRegExpOptions } from "@std/path/glob-to-regexp";
+ import type { GlobOptions } from "@std/path/glob-to-regexp";

- const options: GlobToRegExpOptions = {
+ const options: GlobOptions = {
    extended: false,
    globstar: false,
    caseInsensitive: true,
  };

  // ..
```

### Related
Towards https://github.com/denoland/deno_std/pull/5203#issuecomment-2208846773