### PR TITLE
BREAKING(path): remove `FormatInputPathObject`

### DIFF
--- a/path/_common/format.ts
+++ b/path/_common/format.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { FormatInputPathObject } from "../_interface.ts";
+import type { ParsedPath } from "../types.ts";
 
 export function _format(
   sep: string,
-  pathObject: FormatInputPathObject,
+  pathObject: Partial<ParsedPath>,
 ): string {
   const dir: string | undefined = pathObject.dir || pathObject.root;
   const base: string = pathObject.base ||
@@ -16,7 +16,7 @@ export function _format(
   return dir + sep + base;
 }
 
-export function assertArg(pathObject: FormatInputPathObject) {
+export function assertArg(pathObject: Partial<ParsedPath>) {
   if (pathObject === null || typeof pathObject !== "object") {
     throw new TypeError(
       `The "pathObject" argument must be of type Object. Received type ${typeof pathObject}`,

--- a/path/deno.json
+++ b/path/deno.json
@@ -42,6 +42,7 @@
     "./resolve": "./resolve.ts",
     "./to-file-url": "./to_file_url.ts",
     "./to-namespaced-path": "./to_namespaced_path.ts",
+    "./types": "./types.ts",
     "./windows": "./windows/mod.ts",
     "./windows/basename": "./windows/basename.ts",
     "./windows/common": "./windows/common.ts",

--- a/path/format.ts
+++ b/path/format.ts
@@ -4,10 +4,10 @@
 import { isWindows } from "./_os.ts";
 import { format as posixFormat } from "./posix/format.ts";
 import { format as windowsFormat } from "./windows/format.ts";
-import type { FormatInputPathObject } from "./_interface.ts";
+import type { ParsedPath } from "./types.ts";
 
 /**
- * Generate a path from a {@linkcode FormatInputPathObject} object. It does the
+ * Generate a path from a {@linkcode ParsedPath} object. It does the
  * opposite of {@linkcode https://jsr.io/@std/path/doc/~/parse | parse()}.
  *
  * @example Usage
@@ -25,6 +25,6 @@ import type { FormatInputPathObject } from "./_interface.ts";
  * @param pathObject Object with path components.
  * @returns The formatted path.
  */
-export function format(pathObject: FormatInputPathObject): string {
+export function format(pathObject: Partial<ParsedPath>): string {
   return isWindows ? windowsFormat(pathObject) : posixFormat(pathObject);
 }

--- a/path/mod.ts
+++ b/path/mod.ts
@@ -48,7 +48,7 @@ export * from "./resolve.ts";
 export * from "./to_file_url.ts";
 export * from "./to_namespaced_path.ts";
 export * from "./common.ts";
-export * from "./_interface.ts";
+export * from "./types.ts";
 export * from "./glob_to_regexp.ts";
 export * from "./is_glob.ts";
 export * from "./join_globs.ts";

--- a/path/parse.ts
+++ b/path/parse.ts
@@ -2,11 +2,11 @@
 // This module is browser compatible.
 
 import { isWindows } from "./_os.ts";
-import type { ParsedPath } from "./_interface.ts";
+import type { ParsedPath } from "./types.ts";
 import { parse as posixParse } from "./posix/parse.ts";
 import { parse as windowsParse } from "./windows/parse.ts";
 
-export type { ParsedPath } from "./_interface.ts";
+export type { ParsedPath } from "./types.ts";
 
 /**
  * Return an object containing the parsed components of the path.

--- a/path/parse_format_test.ts
+++ b/path/parse_format_test.ts
@@ -1,13 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // Copyright the Browserify authors. MIT License.
 // Ported from https://github.com/browserify/path-browserify/
-import type { FormatInputPathObject, ParsedPath } from "./mod.ts";
+import type { ParsedPath } from "./mod.ts";
 
 import { assertEquals } from "@std/assert";
 import * as posix from "./posix/mod.ts";
 import * as windows from "./windows/mod.ts";
 
-type FormatTestCase = [FormatInputPathObject, string];
+type FormatTestCase = [Partial<ParsedPath>, string];
 type ParseTestCase = [string, ParsedPath];
 
 const winPaths: Array<[string, string]> = [

--- a/path/posix/format.ts
+++ b/path/posix/format.ts
@@ -2,10 +2,10 @@
 // This module is browser compatible.
 
 import { _format, assertArg } from "../_common/format.ts";
-import type { FormatInputPathObject } from "../_interface.ts";
+import type { ParsedPath } from "../types.ts";
 
 /**
- * Generate a path from `FormatInputPathObject` object.
+ * Generate a path from `ParsedPath` object.
  *
  * @example Usage
  * ```ts
@@ -25,7 +25,7 @@ import type { FormatInputPathObject } from "../_interface.ts";
  * @param pathObject The path object to format.
  * @returns The formatted path.
  */
-export function format(pathObject: FormatInputPathObject): string {
+export function format(pathObject: Partial<ParsedPath>): string {
   assertArg(pathObject);
   return _format("/", pathObject);
 }

--- a/path/posix/mod.ts
+++ b/path/posix/mod.ts
@@ -34,7 +34,7 @@ export * from "./resolve.ts";
 export * from "./to_file_url.ts";
 export * from "./to_namespaced_path.ts";
 export * from "./common.ts";
-export * from "../_interface.ts";
+export * from "../types.ts";
 export * from "./glob_to_regexp.ts";
 export * from "./is_glob.ts";
 export * from "./join_globs.ts";

--- a/path/posix/parse.ts
+++ b/path/posix/parse.ts
@@ -2,12 +2,12 @@
 // This module is browser compatible.
 
 import { CHAR_DOT } from "../_common/constants.ts";
-import type { ParsedPath } from "../_interface.ts";
+import type { ParsedPath } from "../types.ts";
 import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
 import { assertPath } from "../_common/assert_path.ts";
 import { isPosixPathSeparator } from "./_util.ts";
 
-export type { ParsedPath } from "../_interface.ts";
+export type { ParsedPath } from "../types.ts";
 
 /**
  * Return a `ParsedPath` object of the `path`.

--- a/path/types.ts
+++ b/path/types.ts
@@ -38,8 +38,3 @@ export interface ParsedPath {
    */
   name: string;
 }
-
-/**
- * A parsed path object to be consumed by `path.format()`.
- */
-export type FormatInputPathObject = Partial<ParsedPath>;

--- a/path/windows/format.ts
+++ b/path/windows/format.ts
@@ -2,10 +2,10 @@
 // This module is browser compatible.
 
 import { _format, assertArg } from "../_common/format.ts";
-import type { FormatInputPathObject } from "../_interface.ts";
+import type { ParsedPath } from "../types.ts";
 
 /**
- * Generate a path from `FormatInputPathObject` object.
+ * Generate a path from `ParsedPath` object.
  *
  * @example Usage
  * ```ts
@@ -25,7 +25,7 @@ import type { FormatInputPathObject } from "../_interface.ts";
  * @param pathObject The path object to format.
  * @returns The formatted path.
  */
-export function format(pathObject: FormatInputPathObject): string {
+export function format(pathObject: Partial<ParsedPath>): string {
   assertArg(pathObject);
   return _format("\\", pathObject);
 }

--- a/path/windows/mod.ts
+++ b/path/windows/mod.ts
@@ -34,7 +34,7 @@ export * from "./resolve.ts";
 export * from "./to_file_url.ts";
 export * from "./to_namespaced_path.ts";
 export * from "./common.ts";
-export * from "../_interface.ts";
+export * from "../types.ts";
 export * from "./glob_to_regexp.ts";
 export * from "./is_glob.ts";
 export * from "./join_globs.ts";

--- a/path/windows/parse.ts
+++ b/path/windows/parse.ts
@@ -2,11 +2,11 @@
 // This module is browser compatible.
 
 import { CHAR_COLON, CHAR_DOT } from "../_common/constants.ts";
-import type { ParsedPath } from "../_interface.ts";
+import type { ParsedPath } from "../types.ts";
 import { assertPath } from "../_common/assert_path.ts";
 import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 
-export type { ParsedPath } from "../_interface.ts";
+export type { ParsedPath } from "../types.ts";
 
 /**
  * Return a `ParsedPath` object of the `path`.


### PR DESCRIPTION
### What's changed

`FormatInputPathObject` has been removed in favor of `Partial<ParsedPath>`, which is identical in behavior. This also introduces `@std/path/types`, where `ParsedPath` can be accessed.

### Motivation

This interface was removed because it's the same as `Partial<ParsedPath>`. By just using `Partial<ParsedPath>`, we can reduce the API surface area of `@std/path` without affecting behavior.

### Migration guide

To migrate, use `Partial<ParsedPath>` instead of `FormatInputPathObject`. This only affects users that explictly use `FormatInputPathObject`.

```diff
- import { FormatInputPathObject } from "@std/path";
+ import { ParsedPath } from "@std/path/types";

- const parsedPath: FormatInputPathObject = {
+ const parsedPath: Partial<ParsedPath> = {
    base: "file.txt",
    ext: ".txt",
    name: "file"
  }

  // ...
```

### Related

Towards https://github.com/denoland/deno_std/pull/5203#issuecomment-2208846773