### PR TITLE
chore: fix workspace dependency specifiers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,7 @@
     "graphviz": "npm:node-graphviz@^0.1.1",
 
     "@std/archive": "jsr:@std/archive@^0.224.3",
-    "@std/assert": "jsr:@std/assert@1.0.0",
+    "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/async": "jsr:@std/async@^1.0.0-rc.3",
     "@std/bytes": "jsr:@std/bytes@^1.0.1-rc.3",
     "@std/cli": "jsr:@std/cli@^1.0.0-rc.3",
@@ -48,7 +48,7 @@
     "@std/toml": "jsr:@std/toml@^1.0.0-rc.3",
     "@std/ulid": "jsr:@std/ulid@^1.0.0-rc.3",
     "@std/url": "jsr:@std/url@^1.0.0-rc.2",
-    "@std/uuid": "jsr:@std/uuid@1.0.0",
+    "@std/uuid": "jsr:@std/uuid@^1.0.0",
     "@std/webgpu": "jsr:@std/webgpu@^0.224.5",
     "@std/yaml": "jsr:@std/yaml@^1.0.0-rc.1"
   },


### PR DESCRIPTION
These are necessary to make deduplication happen in depending packages/apps.

`assert@1.0.0` is not published yet.
`uuid` is not depended from other std packages.

So I think these 2 non-range specifiers didn't actually have effect of preventing deduplication.