### PR TITLE
fix(front-matter): improve `extract` types

### DIFF
--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -3,9 +3,15 @@
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse as parseYaml } from "@std/yaml/parse";
 import { parse as parseToml } from "@std/toml/parse";
-import type { Extractor } from "./types.ts";
+import type { Extract, Extractor } from "./types.ts";
 
-export type { Extractor };
+export type { Extract, Extractor };
+
+const _extractor = createExtractor({
+  yaml: parseYaml as Parser,
+  toml: parseToml as Parser,
+  json: JSON.parse as Parser,
+});
 
 /**
  * Extracts and parses {@link https://yaml.org | YAML}, {@link https://toml.io |
@@ -28,9 +34,11 @@ export type { Extractor };
  * result.body; // "Hello, world!"
  * result.attrs; // { title: "Three dashes marks the spot" }
  * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract front matter from.
+ * @returns The extracted front matter and body content.
  */
-export const extract: Extractor = createExtractor({
-  yaml: parseYaml as Parser,
-  toml: parseToml as Parser,
-  json: JSON.parse as Parser,
-});
+export function extract<T>(text: string): Extract<T> {
+  return _extractor(text);
+}

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -1,14 +1,40 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
-import type { Extractor } from "./types.ts";
+import type { Extract, Extractor } from "./types.ts";
 
-export type { Extractor };
+export type { Extract, Extractor };
+
+const _extractor = createExtractor({
+  ["json"]: JSON.parse as Parser,
+});
 
 /**
  * Extracts and parses {@link https://www.json.org/ | JSON } from the metadata
  * of front matter content.
+ *
+ * @example Extract JSON front matter
+ * ```ts
+ * import { extract } from "@std/front-matter/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const output = `---json
+ * { "title": "Three dashes marks the spot" }
+ * ---
+ * Hello, world!`;
+ * const result = extract(output);
+ *
+ * assertEquals(result, {
+ *   frontMatter: '{ "title": "Three dashes marks the spot" }',
+ *   body: "Hello, world!",
+ *   attrs: { title: "Three dashes marks the spot" },
+ * });
+ * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract JSON front matter from.
+ * @returns The extracted JSON front matter and body content.
  */
-export const extract: Extractor = createExtractor({
-  json: JSON.parse as Parser,
-});
+export function extract<T>(text: string): Extract<T> {
+  return _extractor(text);
+}

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -2,9 +2,13 @@
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse } from "@std/toml/parse";
-import type { Extractor } from "./types.ts";
+import type { Extract, Extractor } from "./types.ts";
 
-export type { Extractor };
+export type { Extract, Extractor };
+
+const _extractor = createExtractor({
+  ["toml"]: parse as Parser,
+});
 
 /**
  * Extracts and parses {@link https://toml.io | TOML} from the metadata of
@@ -27,7 +31,11 @@ export type { Extractor };
  *   attrs: { title: "Three dashes marks the spot" },
  * });
  * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract TOML front matter from.
+ * @returns The extracted TOML front matter and body content.
  */
-export const extract: Extractor = createExtractor({
-  ["toml"]: parse as Parser,
-});
+export function extract<T>(text: string): Extract<T> {
+  return _extractor(text);
+}

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -2,9 +2,13 @@
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse } from "@std/yaml/parse";
-import type { Extractor } from "./types.ts";
+import type { Extract, Extractor } from "./types.ts";
 
-export type { Extractor };
+export type { Extract, Extractor };
+
+const _extractor = createExtractor({
+  ["yaml"]: parse as Parser,
+});
 
 /**
  * Extracts and parses {@link https://yaml.org | YAML} from the metadata of
@@ -27,7 +31,11 @@ export type { Extractor };
  *   attrs: { title: "Three dashes marks the spot" },
  * });
  * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract YAML front matter from.
+ * @returns The extracted YAML front matter and body content.
  */
-export const extract: Extractor = createExtractor({
-  ["yaml"]: parse as Parser,
-});
+export function extract<T>(text: string): Extract<T> {
+  return _extractor(text);
+}


### PR DESCRIPTION
Currently in `std/front-matter` package `extract` functions are typed as `Extractor` variable, and therefore it doesn't show type information of `@params`, `@returns`, etc.

This PR changes them to functions and improves the docs.

BEFORE
<img width="935" alt="Screenshot 2024-07-05 at 13 42 35" src="https://github.com/denoland/deno_std/assets/613956/7a1b30b9-1219-4aef-97c2-8ad1e9a378ae">

AFTER
<img width="524" alt="Screenshot 2024-07-05 at 13 43 45" src="https://github.com/denoland/deno_std/assets/613956/e6d8ba70-cb07-43cd-836a-5a001e05ffc3">

This PR also exports `Extract` type (which is return type of `extract`) from each language file. This resolves #5323