### PR TITLE
refactor(yaml): move `getObjectTypeString()`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -29,7 +29,12 @@ import {
 import { YamlError } from "./_error.ts";
 import { DEFAULT_SCHEMA, type Schema } from "./_schema.ts";
 import type { StyleVariant, Type } from "./_type.ts";
-import { type Any, type ArrayObject, isObject } from "./_utils.ts";
+import {
+  type Any,
+  type ArrayObject,
+  getObjectTypeString,
+  isObject,
+} from "./_utils.ts";
 
 const ESCAPE_SEQUENCES = new Map<number, string>([
   [0x00, "\\0"],
@@ -875,7 +880,7 @@ function writeNode(
       if (state.skipInvalid) return false;
       throw new YamlError(
         `unacceptable kind of an object to dump ${
-          Object.prototype.toString.call(state.dump)
+          getObjectTypeString(state.dump)
         }`,
       );
     }

--- a/yaml/_loader.ts
+++ b/yaml/_loader.ts
@@ -39,7 +39,12 @@ import { YamlError } from "./_error.ts";
 import { Mark } from "./_mark.ts";
 import { DEFAULT_SCHEMA, type Schema, type TypeMap } from "./_schema.ts";
 import type { Type } from "./_type.ts";
-import { type Any, type ArrayObject, isObject } from "./_utils.ts";
+import {
+  type Any,
+  type ArrayObject,
+  getObjectTypeString,
+  isObject,
+} from "./_utils.ts";
 
 const CONTEXT_FLOW_IN = 1;
 const CONTEXT_FLOW_OUT = 2;
@@ -97,10 +102,6 @@ const SIMPLE_ESCAPE_SEQUENCES = new Map<number, string>([
   [0x4c, "\u2028"], // L
   [0x50, "\u2029"], // P
 ]);
-
-function getObjectTypeString(object: unknown) {
-  return Object.prototype.toString.call(object);
-}
 
 /**
  * Converts a hexadecimal character code to its decimal value.

--- a/yaml/_type/omap.ts
+++ b/yaml/_type/omap.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import type { Type } from "../_type.ts";
-import type { Any } from "../_utils.ts";
+import { type Any, getObjectTypeString } from "../_utils.ts";
 
 function resolveYamlOmap(data: Any): boolean {
   const objectKeys: string[] = [];
@@ -14,7 +14,7 @@ function resolveYamlOmap(data: Any): boolean {
   for (const pair of data) {
     pairHasKey = false;
 
-    if (Object.prototype.toString.call(pair) !== "[object Object]") {
+    if (getObjectTypeString(pair) !== "[object Object]") {
       return false;
     }
 

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import type { Type } from "../_type.ts";
-import type { Any } from "../_utils.ts";
+import { type Any, getObjectTypeString } from "../_utils.ts";
 
 function resolveYamlPairs(data: Any[][]): boolean {
   if (data === null) return true;
@@ -12,7 +12,7 @@ function resolveYamlPairs(data: Any[][]): boolean {
   const result = Array.from({ length: data.length });
 
   for (const [index, pair] of data.entries()) {
-    if (Object.prototype.toString.call(pair) !== "[object Object]") {
+    if (getObjectTypeString(pair) !== "[object Object]") {
       return false;
     }
 

--- a/yaml/_utils.ts
+++ b/yaml/_utils.ts
@@ -21,3 +21,7 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 export function isNegativeZero(i: number): boolean {
   return i === 0 && Number.NEGATIVE_INFINITY === 1 / i;
 }
+
+export function getObjectTypeString(object: unknown) {
+  return Object.prototype.toString.call(object);
+}


### PR DESCRIPTION
- moves `getObjectTypeString()` to `_utils.ts` as it can be shared.