### PR TITLE
BREAKING(front-matter): make `Extractor` helper type private

### DIFF
--- a/front_matter/_create_extractor.ts
+++ b/front_matter/_create_extractor.ts
@@ -2,7 +2,8 @@
 
 import { EXTRACT_REGEXP_MAP, RECOGNIZE_REGEXP_MAP } from "./_formats.ts";
 import type { Format } from "./_types.ts";
-import type { Extract, Extractor } from "./types.ts";
+import type { Extract } from "./types.ts";
+import type { Extractor } from "./_types.ts";
 
 /** Parser function type used alongside {@linkcode createExtractor}. */
 export type Parser = <T = Record<string, unknown>>(str: string) => T;

--- a/front_matter/_create_extractor.ts
+++ b/front_matter/_create_extractor.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { EXTRACT_REGEXP_MAP, RECOGNIZE_REGEXP_MAP } from "./_formats.ts";
-import type { Format } from "./_types.ts";
+import type { Extractor, Format } from "./_types.ts";
 import type { Extract } from "./types.ts";
-import type { Extractor } from "./_types.ts";
 
 /** Parser function type used alongside {@linkcode createExtractor}. */
 export type Parser = <T = Record<string, unknown>>(str: string) => T;

--- a/front_matter/_types.ts
+++ b/front_matter/_types.ts
@@ -1,7 +1,17 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+import type { Extract } from "./types.ts";
+
 /**
  * Supported format for front matter. `"unknown"` is used when auto format
  * detection logic fails.
  */
 export type Format = "yaml" | "toml" | "json" | "unknown";
+
+/**
+ * Type for function that accepts an input string and returns
+ * {@linkcode Extract}.
+ */
+export type Extractor = <T = Record<string, unknown>>(
+  str: string,
+) => Extract<T>;

--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -3,9 +3,9 @@
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse as parseYaml } from "@std/yaml/parse";
 import { parse as parseToml } from "@std/toml/parse";
-import type { Extract, Extractor } from "./types.ts";
+import type { Extract } from "./types.ts";
 
-export type { Extract, Extractor };
+export type { Extract };
 
 const _extractor = createExtractor({
   yaml: parseYaml as Parser,

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
-import type { Extract, Extractor } from "./types.ts";
+import type { Extract } from "./types.ts";
 
-export type { Extract, Extractor };
+export type { Extract };
 
 const _extractor = createExtractor({
   ["json"]: JSON.parse as Parser,

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -2,9 +2,9 @@
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse } from "@std/toml/parse";
-import type { Extract, Extractor } from "./types.ts";
+import type { Extract } from "./types.ts";
 
-export type { Extract, Extractor };
+export type { Extract };
 
 const _extractor = createExtractor({
   ["toml"]: parse as Parser,

--- a/front_matter/types.ts
+++ b/front_matter/types.ts
@@ -6,11 +6,3 @@ export type Extract<T> = {
   body: string;
   attrs: T;
 };
-
-/**
- * Type for function that accepts an input string and returns
- * {@linkcode Extract}.
- */
-export type Extractor = <T = Record<string, unknown>>(
-  str: string,
-) => Extract<T>;

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -2,9 +2,9 @@
 
 import { createExtractor, type Parser } from "./_create_extractor.ts";
 import { parse } from "@std/yaml/parse";
-import type { Extract, Extractor } from "./types.ts";
+import type { Extract } from "./types.ts";
 
-export type { Extract, Extractor };
+export type { Extract };
 
 const _extractor = createExtractor({
   ["yaml"]: parse as Parser,


### PR DESCRIPTION
We updated `extract` function types in #5325, and `Extractor` type became unused from any public APIs.

This PR makes `Extractor` type private.