### PR TITLE
refactor(yaml): simplify and rename `dropEndingNewline()`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -431,9 +431,8 @@ function foldLine(line: string, width: number): string {
   return result.slice(1); // drop extra \n joiner
 }
 
-// (See the note for writeScalar.)
-function dropEndingNewline(string: string): string {
-  return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
+function trimTrailingNewline(string: string) {
+  return string.at(-1) ? string.slice(0, -1) : string;
 }
 
 // Note: a long line without a suitable break point will exceed the width limit.
@@ -578,13 +577,11 @@ function writeScalar(
         return `'${string.replace(/'/g, "''")}'`;
       case STYLE_LITERAL:
         return `|${blockHeader(string, state.indent)}${
-          dropEndingNewline(
-            indentString(string, indent),
-          )
+          trimTrailingNewline(indentString(string, indent))
         }`;
       case STYLE_FOLDED:
         return `>${blockHeader(string, state.indent)}${
-          dropEndingNewline(
+          trimTrailingNewline(
             indentString(foldString(string, lineWidth), indent),
           )
         }`;

--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -432,7 +432,7 @@ function foldLine(line: string, width: number): string {
 }
 
 export function trimTrailingNewline(string: string) {
-  return string.at(-1) ? string.slice(0, -1) : string;
+  return string.at(-1) === "\n" ? string.slice(0, -1) : string;
 }
 
 // Note: a long line without a suitable break point will exceed the width limit.

--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -431,7 +431,7 @@ function foldLine(line: string, width: number): string {
   return result.slice(1); // drop extra \n joiner
 }
 
-function trimTrailingNewline(string: string) {
+export function trimTrailingNewline(string: string) {
   return string.at(-1) ? string.slice(0, -1) : string;
 }
 

--- a/yaml/_dumper_test.ts
+++ b/yaml/_dumper_test.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { trimTrailingNewline } from "./_dumper.ts";
+
+Deno.test("trimTrailingNewline()", async (t) => {
+  await t.step("handles single line", () => {
+    assertEquals(trimTrailingNewline("hello\nworld"), "hello\nworld");
+  });
+  await t.step("handles trailing newline", () => {
+    assertEquals(trimTrailingNewline("hello\nworld\n"), "hello\nworld");
+  });
+});

--- a/yaml/_dumper_test.ts
+++ b/yaml/_dumper_test.ts
@@ -4,10 +4,10 @@ import { assertEquals } from "@std/assert";
 import { trimTrailingNewline } from "./_dumper.ts";
 
 Deno.test("trimTrailingNewline()", async (t) => {
-  await t.step("handles single line", () => {
+  await t.step("handles string without trailing newline", () => {
     assertEquals(trimTrailingNewline("hello\nworld"), "hello\nworld");
   });
-  await t.step("handles trailing newline", () => {
+  await t.step("handles string with trailing newline", () => {
     assertEquals(trimTrailingNewline("hello\nworld\n"), "hello\nworld");
   });
 });


### PR DESCRIPTION
- renames `dropEndingNewline()` to `trimTrailingNewline()`
- uses `.at(-1)`
- adds tests