### PR TITLE
test(yaml): test block scalar output of stringify

### DIFF
--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -266,3 +266,23 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "stringify() uses block scalar style for multiline strings",
+  fn() {
+    assertEquals(
+      stringify("foo\nbar"),
+      `|-
+  foo
+  bar
+`,
+    );
+    assertEquals(
+      stringify("foo  \nbar  "),
+      `|-
+  foo \x20
+  bar \x20
+`,
+    );
+  },
+});


### PR DESCRIPTION
This PR adds test cases which exercise block scalar output of `stringify`

part of #3713 