### PR TITLE
fix(fs): accept `exts` without leading period in `walk[Sync]()`

### DIFF
--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -136,7 +136,9 @@ export interface WalkOptions {
    * If specified, entries without the file extension specified by this option
    * are excluded.
    *
-   * @default {undefined}
+   * File extensions with or without a leading period are accepted.
+   *
+   * @default {[]}
    */
   exts?: string[];
   /**
@@ -433,8 +435,8 @@ export type { WalkEntry };
  *
  * @example Filter by file extensions
  *
- * Setting the `exts` option to `[".ts"]` will only include entries with the
- * `.ts` file extension.
+ * Setting the `exts` option to `[".ts"]` or `["ts"]` will only include entries
+ * with the `.ts` file extension.
  *
  * File structure:
  * ```
@@ -516,7 +518,7 @@ export async function* walk(
   root: string | URL,
   options: WalkOptions = {},
 ): AsyncIterableIterator<WalkEntry> {
-  const {
+  let {
     maxDepth = Infinity,
     includeFiles = true,
     includeDirs = true,
@@ -532,6 +534,9 @@ export async function* walk(
     return;
   }
   root = toPathString(root);
+  if (exts) {
+    exts = exts.map((ext) => ext.startsWith(".") ? ext : `.${ext}`);
+  }
   if (includeDirs && include(root, exts, match, skip)) {
     yield await createWalkEntry(root);
   }
@@ -856,8 +861,8 @@ export async function* walk(
  *
  * @example Filter by file extensions
  *
- * Setting the `exts` option to `[".ts"]` will only include entries with the
- * `.ts` file extension.
+ * Setting the `exts` option to `[".ts"]` or `["ts"]` will only include entries
+ * with the `.ts` file extension.
  *
  * File structure:
  * ```
@@ -950,6 +955,9 @@ export function* walkSync(
   }: WalkOptions = {},
 ): IterableIterator<WalkEntry> {
   root = toPathString(root);
+  if (exts) {
+    exts = exts.map((ext) => ext.startsWith(".") ? ext : `.${ext}`);
+  }
   if (maxDepth < 0) {
     return;
   }

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -89,7 +89,17 @@ Deno.test("walk() accepts ext option as strings", async () =>
     exts: [".rs", ".ts"],
   }));
 
+Deno.test("walk() accepts ext option as strings (excluding period prefix)", async () =>
+  await assertWalkPaths("ext", ["y.rs", "x.ts"], {
+    exts: ["rs", "ts"],
+  }));
+
 Deno.test("walkSync() accepts ext option as strings", () =>
+  assertWalkSyncPaths("ext", ["y.rs", "x.ts"], {
+    exts: [".rs", ".ts"],
+  }));
+
+Deno.test("walkSync() accepts ext option as strings (excluding period prefix)", () =>
   assertWalkSyncPaths("ext", ["y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));


### PR DESCRIPTION
Previously, `walk[Sync]()` would return files and folders ending with strings, as defined in the `exts` option. E.g. It'd return the `asserts` folder when setting `exts: ["ts"]`. This is unexpected behaviour, as one would not expect folders to be turned when setting file extensions.

This change adds the leading period, `.`, to any extensions defined in `exts`, if missing, as there doesn't appear to be any good reason to require the user to have this leading period.