### PR TITLE
BREAKING(csv): throw `TypeError` in `stringify()` instead of `StringifyError`

### DIFF
--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -171,41 +171,6 @@ function normalizeColumn(column: Column): NormalizedColumn {
 }
 
 /**
- * Error thrown in {@linkcode stringify}.
- *
- * @example Usage
- * ```ts no-assert
- * import { stringify, StringifyError } from "@std/csv/stringify";
- *
- * try {
- *   stringify([{ a: 1 }, { a: 2 }], { separator: "\r\n" });
- * } catch (error) {
- *   if (error instanceof StringifyError) {
- *     console.error(error.message);
- *   }
- * }
- * ```
- */
-export class StringifyError extends Error {
-  /**
-   * Construct a new instance.
-   *
-   * @example Usage
-   * ```ts no-eval
-   * import { StringifyError } from "@std/csv/stringify";
-   *
-   * throw new StringifyError("An error occurred");
-   * ```
-   *
-   * @param message The error message.
-   */
-  constructor(message?: string) {
-    super(message);
-    this.name = "StringifyError";
-  }
-}
-
-/**
  * Returns an array of values from an object using the property accessors
  * (and optional transform function) in each column
  */
@@ -226,7 +191,7 @@ function getValuesFromItem(
         if (Array.isArray(value)) {
           if (typeof prop === "number") value = value[prop];
           else {
-            throw new StringifyError(
+            throw new TypeError(
               'Property accessor is not of type "number"',
             );
           }
@@ -240,7 +205,7 @@ function getValuesFromItem(
     if (Array.isArray(item)) {
       values.push(...item);
     } else if (typeof item === "object") {
-      throw new StringifyError(
+      throw new TypeError(
         "No property accessor function was provided for object",
       );
     } else {
@@ -313,7 +278,7 @@ export function stringify(
       '  - U+0022: Quotation mark (")',
       "  - U+000D U+000A: Carriage Return + Line Feed (\\r\\n)",
     ].join("\n");
-    throw new StringifyError(message);
+    throw new TypeError(message);
   }
 
   const normalizedColumns = columns.map(normalizeColumn);

--- a/csv/stringify_stream_test.ts
+++ b/csv/stringify_stream_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { CsvStringifyStream } from "./stringify_stream.ts";
-import { StringifyError } from "./stringify.ts";
 import { assertEquals, assertRejects } from "@std/assert";
 
 Deno.test({
@@ -29,7 +28,7 @@ Deno.test({
       ]).pipeThrough(new CsvStringifyStream({ columns: ["id", "name"] }));
       await assertRejects(
         async () => await Array.fromAsync(readable),
-        StringifyError,
+        TypeError,
       );
     });
 
@@ -53,7 +52,7 @@ Deno.test({
       ]).pipeThrough(new CsvStringifyStream({ separator: "\r\n" }));
       await assertRejects(
         async () => await Array.fromAsync(readable),
-        StringifyError,
+        TypeError,
       );
     });
 
@@ -64,7 +63,7 @@ Deno.test({
       ]).pipeThrough(new CsvStringifyStream({ columns: { length: 1 } as any }));
       await assertRejects(
         async () => await Array.fromAsync(readable),
-        StringifyError,
+        TypeError,
         "No property accessor function was provided for object",
       );
     });
@@ -93,7 +92,7 @@ Deno.test({
       ]).pipeThrough(new CsvStringifyStream());
       await assertRejects(
         async () => await Array.fromAsync(readable),
-        StringifyError,
+        TypeError,
       );
     });
   },

--- a/csv/stringify_test.ts
+++ b/csv/stringify_test.ts
@@ -10,7 +10,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
-import { stringify, StringifyError } from "./stringify.ts";
+import { stringify } from "./stringify.ts";
 
 const CRLF = "\r\n";
 const BYTE_ORDER_MARK = "\ufeff";
@@ -26,7 +26,7 @@ Deno.test({
         const errorMessage = 'Property accessor is not of type "number"';
         assertThrows(
           () => stringify(data, { columns }),
-          StringifyError,
+          TypeError,
           errorMessage,
         );
       },
@@ -46,7 +46,7 @@ Deno.test({
           const options = { separator: '"', columns };
           assertThrows(
             () => stringify(data, options),
-            StringifyError,
+            TypeError,
             errorMessage,
           );
         },
@@ -66,7 +66,7 @@ Deno.test({
           const options = { separator: "\r\n", columns };
           assertThrows(
             () => stringify(data, options),
-            StringifyError,
+            TypeError,
             errorMessage,
           );
         },
@@ -80,7 +80,7 @@ Deno.test({
           const data = [{ a: 1 }, { a: 2 }];
           assertThrows(
             () => stringify(data),
-            StringifyError,
+            TypeError,
             "No property accessor function was provided for object",
           );
         },
@@ -93,7 +93,7 @@ Deno.test({
           const data = [{ a: 1 }, { a: 2 }];
           assertThrows(
             () => stringify(data),
-            StringifyError,
+            TypeError,
             "No property accessor function was provided for object",
           );
         },


### PR DESCRIPTION
### What's changed

`StringifyError ` has been removed in favor of [`TypeError `](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) as the error thrown in [`stringify()`](https://jsr.io/@std/csv/doc/~/stringify).

### Motivation

This change aligns `stringify()` with [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) in its exceptions. The benefit of doing this is that a standard error class is used that fits the use case without having an extraneous custom error class.

### Migration guide

To migrate, compare against `TypeError` instead of `StringifyError`, when error-handling `stringify()`.

```diff
- import { stringify, TOMLParseError } from "@std/csv/stringify";
+ import { stringify } from "@std/csv/stringify";

try {
  stringify([["foo"], ["bar"]], { separator: '"' });
} catch (error) {
- if (error instanceof StringifyError) {
+ if (error instanceof TypeError) {
    // ...
  }
}
```

### Related

Towards https://github.com/denoland/deno_std/issues/5340#issuecomment-2212437577