### PR TITLE
fix(http): allow deleting cookie with `secure`, `httpOnly` and `partitioned` attributes

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -299,7 +299,10 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 export function deleteCookie(
   headers: Headers,
   name: string,
-  attributes?: Omit<Cookie, "name" | "value" | "sameSite">,
+  attributes?: Pick<
+    Cookie,
+    "path" | "domain" | "secure" | "httpOnly" | "partitioned"
+  >,
 ) {
   setCookie(headers, {
     name: name,

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -273,7 +273,8 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 /**
  * Set the cookie header with empty value in the headers to delete it.
  *
- * The attributes (path, domain, secure, httpOnly, partitioned) need to match the values when the cookie was set.
+ * The attributes (`path`, `domain`, `secure`, `httpOnly`, `partitioned`) need
+ * to match the values when the cookie was set.
  *
  * > Note: Deleting a `Cookie` will set its expiration date before now. Forcing
  * > the browser to delete it.
@@ -298,13 +299,7 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 export function deleteCookie(
   headers: Headers,
   name: string,
-  attributes?: {
-    path?: string;
-    domain?: string;
-    secure?: boolean;
-    httpOnly?: boolean;
-    partitioned?: boolean;
-  },
+  attributes?: Omit<Cookie, "name" | "value">,
 ) {
   setCookie(headers, {
     name: name,

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -299,7 +299,7 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 export function deleteCookie(
   headers: Headers,
   name: string,
-  attributes?: Omit<Cookie, "name" | "value">,
+  attributes?: Omit<Cookie, "name" | "value" | "sameSite">,
 ) {
   setCookie(headers, {
     name: name,

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -271,7 +271,9 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 }
 
 /**
- * Set the cookie header with empty value in the headers to delete it
+ * Set the cookie header with empty value in the headers to delete it.
+ *
+ * The attributes (path, domain, secure, httpOnly, partitioned) need to match the values when the cookie was set.
  *
  * > Note: Deleting a `Cookie` will set its expiration date before now. Forcing
  * > the browser to delete it.
@@ -296,7 +298,13 @@ export function setCookie(headers: Headers, cookie: Cookie) {
 export function deleteCookie(
   headers: Headers,
   name: string,
-  attributes?: { path?: string; domain?: string },
+  attributes?: {
+    path?: string;
+    domain?: string;
+    secure?: boolean;
+    httpOnly?: boolean;
+    partitioned?: boolean;
+  },
 ) {
   setCookie(headers, {
     name: name,

--- a/http/cookie_test.ts
+++ b/http/cookie_test.ts
@@ -182,6 +182,18 @@ Deno.test({
       headers.get("Set-Cookie"),
       "Space=Cat; Domain=deno.land; Path=/, Space=; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
     );
+    headers = new Headers();
+    deleteCookie(headers, "Space", {
+      domain: "deno.land",
+      path: "/",
+      secure: true,
+      httpOnly: true,
+      partitioned: true,
+    });
+    assertEquals(
+      headers.get("Set-Cookie"),
+      "Space=; Secure; HttpOnly; Partitioned; Domain=deno.land; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    );
   },
 });
 


### PR DESCRIPTION
closes #5049 