### PR TITLE
fix(testing): cause type error for async function as describe body

### DIFF
--- a/testing/_test_suite.ts
+++ b/testing/_test_suite.ts
@@ -2,7 +2,7 @@
 /** The options for creating a test suite with the describe function. */
 export interface DescribeDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
   /** The body of the test suite */
-  fn?: () => void;
+  fn?: () => void | undefined;
   /**
    * The `describe` function returns a `TestSuite` representing the group of tests.
    * If `describe` is called within another `describe` calls `fn`, the suite will default to that parent `describe` calls returned `TestSuite`.

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -915,20 +915,20 @@ export type DescribeArgs<T> =
     name: string,
     options: Omit<DescribeDefinition<T>, "name">,
   ]
-  | [name: string, fn: () => void]
-  | [fn: () => void]
+  | [name: string, fn: () => void | undefined]
+  | [fn: () => void | undefined]
   | [
     name: string,
     options: Omit<DescribeDefinition<T>, "fn" | "name">,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     options: Omit<DescribeDefinition<T>, "fn">,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     options: Omit<DescribeDefinition<T>, "fn" | "name">,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     suite: TestSuite<T>,
@@ -942,27 +942,27 @@ export type DescribeArgs<T> =
   | [
     suite: TestSuite<T>,
     name: string,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     suite: TestSuite<T>,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     suite: TestSuite<T>,
     name: string,
     options: Omit<DescribeDefinition<T>, "fn" | "name" | "suite">,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<DescribeDefinition<T>, "fn" | "suite">,
-    fn: () => void,
+    fn: () => void | undefined,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<DescribeDefinition<T>, "fn" | "name" | "suite">,
-    fn: () => void,
+    fn: () => void | undefined,
   ];
 
 /** Generates a DescribeDefinition from DescribeArgs. */

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -2008,4 +2008,39 @@ Deno.test("describe()", async (t) => {
       }
     },
   );
+
+  await t.step(
+    "cause type error if async function is passed as describe definition",
+    () => {
+      // @ts-expect-error async function is not assignable to describe argument
+      describe({ name: "example", fn: async () => {} });
+      // @ts-expect-error async function is not assignable to describe argument
+      describe("example", { fn: async () => {} });
+      // @ts-expect-error async function is not assignable to describe argument
+      describe("example", async () => {});
+      // TODO(kt3k): This case should be type error but it's checked as
+      // DescribeDefinition<T> and passes the type check
+      // describe(async function example() {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe("example", {}, async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe({ name: "example" }, async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe({}, async function example() {});
+
+      const suite = describe("example");
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, "example", { fn: async () => {} });
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, "example", async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, "example", {}, async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, { name: "example" }, async () => {});
+      // @ts-expect-error async function is not assignable to describe argument
+      describe(suite, {}, async function example() {});
+    },
+  );
 });


### PR DESCRIPTION
Partially addresses #5034 

This changes uses `() => void | undefined` type for describe body type instead of `() => void`, which causes type error if the user assigned async functions to it.

This will prevents the confusion like https://github.com/denoland/deno/issues/22991