### PR TITLE
test(yaml): test parsing of single quoted scalars

### DIFF
--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -586,6 +586,28 @@ Deno.test("parse() handles escaped strings in double quotes", () => {
   );
 });
 
+Deno.test("parse() handles single quoted scalar", () => {
+  assertEquals(parse("'bar'"), "bar");
+  // escaped single quote
+  assertEquals(parse("'''bar'''"), "'bar'");
+  // line break in single quoted scalar
+  assertEquals(parse("'foo\nbar'"), "foo bar");
+
+  assertThrows(
+    // document end in single quoted scalar
+    () => parse("'bar\n"),
+    YamlError,
+    "unexpected end of the stream within a single quoted scalar at line 2, column 1:\n    \n    ^",
+  );
+
+  assertThrows(
+    // document separator appears in single quoted scalar
+    () => parse("'bar\n..."),
+    YamlError,
+    "unexpected end of the document within a single quoted scalar at line 2, column 1:\n    ...\n    ^",
+  );
+});
+
 Deno.test("parse() handles %YAML directive", () => {
   assertEquals(
     parse(`%YAML 1.2


### PR DESCRIPTION
part of #3713 

This PR add test cases that exercises the parsing of single quoted strings.

This improves the coverage of `yaml/_loader.ts` from 82.51% to 84.76%.