### PR TITLE
BREAKING(fmt): remove `stripColor`

### DIFF
--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -984,25 +984,6 @@ const ANSI_PATTERN = new RegExp(
  *
  * @example Usage
  * ```ts no-assert
- * import { stripColor, red } from "@std/fmt/colors";
- *
- * console.log(stripColor(red("Hello, world!")));
- * ```
- *
- * @param string The text to remove ANSI escape codes from
- * @returns The text without ANSI escape codes
- *
- * @deprecated This will be removed in 1.0.0. Use {@linkcode stripAnsiCode} instead.
- */
-export function stripColor(string: string): string {
-  return stripAnsiCode(string);
-}
-
-/**
- * Remove ANSI escape codes from the string.
- *
- * @example Usage
- * ```ts no-assert
  * import { stripAnsiCode, red } from "@std/fmt/colors";
  *
  * console.log(stripAnsiCode(red("Hello, world!")));


### PR DESCRIPTION
### What's changed

`stripColor` has been replaced by `stripAnsiColor` in `@std/fmt`. No changes in behavior have been made.

### Motivation

This change was made because `stripAnsiColor` more accurately describes the purpose of this function.

### Migration guide

To migrate, use `stripAnsiColor` instead of `stripColor`.

```diff
- import { stripColor, red } from "@std/fmt/colors";
+ import { stripAnsiCode, red } from "@std/fmt/colors";

- console.log(stripColor(red("Hello, world!")));
+ console.log(stripAnsiCode(red("Hello, world!")));
```