### PR TITLE
refactor(front-matter): replace regexp objects with maps

### DIFF
--- a/front_matter/_create_extractor.ts
+++ b/front_matter/_create_extractor.ts
@@ -30,11 +30,7 @@ function _extract<T>(
  * @param str String to recognize.
  * @param formats A list of formats to recognize. Defaults to all supported formats.
  */
-function recognize(str: string, formats?: Format[]): Format {
-  if (!formats) {
-    formats = [...RECOGNIZE_REGEXP_MAP.keys()] as Format[];
-  }
-
+function recognize(str: string, formats: Format[]): Format {
   const [firstLine] = str.split(/(\r?\n)/) as [string];
 
   for (const format of formats) {

--- a/front_matter/_create_extractor.ts
+++ b/front_matter/_create_extractor.ts
@@ -32,13 +32,13 @@ function _extract<T>(
  */
 function recognize(str: string, formats?: Format[]): Format {
   if (!formats) {
-    formats = Object.keys(RECOGNIZE_REGEXP_MAP) as Format[];
+    formats = [...RECOGNIZE_REGEXP_MAP.keys()] as Format[];
   }
 
   const [firstLine] = str.split(/(\r?\n)/) as [string];
 
   for (const format of formats) {
-    if (RECOGNIZE_REGEXP_MAP[format].test(firstLine)) {
+    if (RECOGNIZE_REGEXP_MAP.get(format)?.test(firstLine)) {
       return format;
     }
   }
@@ -71,7 +71,7 @@ export function createExtractor(
 
     const parser = formats[format];
     if (!parser) throw new TypeError(`Unsupported front matter format`);
-    const regexp = EXTRACT_REGEXP_MAP[format];
+    const regexp = EXTRACT_REGEXP_MAP.get(format);
     if (!regexp) throw new TypeError(`Unsupported front matter format`);
 
     return _extract(str, regexp, parser);

--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -48,14 +48,14 @@ const [RECOGNIZE_JSON_REGEXP, EXTRACT_JSON_REGEXP] = createRegExps(
   ],
 );
 
-export const RECOGNIZE_REGEXP_MAP = {
-  yaml: RECOGNIZE_YAML_REGEXP,
-  toml: RECOGNIZE_TOML_REGEXP,
-  json: RECOGNIZE_JSON_REGEXP,
-} as const;
+export const RECOGNIZE_REGEXP_MAP = new Map([
+  ["yaml", RECOGNIZE_YAML_REGEXP],
+  ["toml", RECOGNIZE_TOML_REGEXP],
+  ["json", RECOGNIZE_JSON_REGEXP],
+]);
 
-export const EXTRACT_REGEXP_MAP = {
-  yaml: EXTRACT_YAML_REGEXP,
-  toml: EXTRACT_TOML_REGEXP,
-  json: EXTRACT_JSON_REGEXP,
-} as const;
+export const EXTRACT_REGEXP_MAP = new Map([
+  ["yaml", EXTRACT_YAML_REGEXP],
+  ["toml", EXTRACT_TOML_REGEXP],
+  ["json", EXTRACT_JSON_REGEXP],
+]);

--- a/front_matter/test.ts
+++ b/front_matter/test.ts
@@ -67,10 +67,10 @@ export type { Format };
  * ```
  */
 export function test(str: string, formats?: Format[]): boolean {
-  if (!formats) formats = Object.keys(EXTRACT_REGEXP_MAP) as Format[];
+  if (!formats) formats = [...EXTRACT_REGEXP_MAP.keys()] as Format[];
 
   for (const format of formats) {
-    const regexp = EXTRACT_REGEXP_MAP[format];
+    const regexp = EXTRACT_REGEXP_MAP.get(format);
     if (!regexp) {
       throw new TypeError(`Unable to test for ${format} front matter format`);
     }


### PR DESCRIPTION
- replaces `RECOGNIZE_REGEXP_MAP` and `EXTRACT_REGEXP_MAP` objects with maps