### PR TITLE
fix(streams): toText() incorrect with multibyte strings in different chunks

### DIFF
--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -1,8 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-const textDecoder = new TextDecoder();
-
 /**
  * Converts a {@linkcode ReadableSteam} of strings or {@linkcode Uint8Array}s
  * to a single string. Works the same as {@linkcode Response.text}.
@@ -22,6 +20,7 @@ const textDecoder = new TextDecoder();
 export async function toText(
   readableStream: ReadableStream,
 ): Promise<string> {
+  const textDecoder = new TextDecoder();
   const reader = readableStream.getReader();
   let result = "";
 
@@ -32,8 +31,10 @@ export async function toText(
       break;
     }
 
-    result += typeof value === "string" ? value : textDecoder.decode(value);
+    result += typeof value === "string"
+      ? value
+      : textDecoder.decode(value, { stream: true });
   }
-
+  result += textDecoder.decode();
   return result;
 }

--- a/streams/to_text_test.ts
+++ b/streams/to_text_test.ts
@@ -12,4 +12,14 @@ Deno.test("toText()", async () => {
   const stringStream = ReadableStream.from(["hello", " deno ", "world"]);
 
   assertEquals(await toText(stringStream), "hello deno world");
+
+  const utf8ByteStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([228, 184, 173, 230, 150]));
+      controller.enqueue(new Uint8Array([135]));
+      controller.close();
+    },
+  });
+
+  assertEquals(await toText(utf8ByteStream), "中文");
 });


### PR DESCRIPTION
toText() should return complete UTF-8 string.