### PR TITLE
fix(testing): throw error when async func is passed to describe

### DIFF
--- a/testing/_test_suite.ts
+++ b/testing/_test_suite.ts
@@ -97,7 +97,13 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
       const temp = TestSuiteInternal.current;
       TestSuiteInternal.current = this;
       try {
-        fn();
+        // deno-lint-ignore no-explicit-any
+        const value = fn() as any;
+        if (value instanceof Promise) {
+          throw new Error(
+            'Returning a Promise from "describe" is not supported. Tests must be defined synchronously.',
+          );
+        }
       } finally {
         TestSuiteInternal.current = temp;
       }

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -2012,35 +2012,51 @@ Deno.test("describe()", async (t) => {
   await t.step(
     "cause type error if async function is passed as describe definition",
     () => {
-      // @ts-expect-error async function is not assignable to describe argument
-      describe({ name: "example", fn: async () => {} });
-      // @ts-expect-error async function is not assignable to describe argument
-      describe("example", { fn: async () => {} });
-      // @ts-expect-error async function is not assignable to describe argument
-      describe("example", async () => {});
-      // TODO(kt3k): This case should be type error but it's checked as
-      // DescribeDefinition<T> and passes the type check
-      // describe(async function example() {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe("example", {}, async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe({ name: "example" }, async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe({}, async function example() {});
+      try {
+        // @ts-expect-error async function is not assignable to describe argument
+        describe({ name: "example", fn: async () => {} });
+        // @ts-expect-error async function is not assignable to describe argument
+        describe("example", { fn: async () => {} });
+        // @ts-expect-error async function is not assignable to describe argument
+        describe("example", async () => {});
+        // TODO(kt3k): This case should be type error but it's checked as
+        // DescribeDefinition<T> and passes the type check
+        // describe(async function example() {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe("example", {}, async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe({ name: "example" }, async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe({}, async function example() {});
 
-      const suite = describe("example");
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, "example", { fn: async () => {} });
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, "example", async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, "example", {}, async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, { name: "example" }, async () => {});
-      // @ts-expect-error async function is not assignable to describe argument
-      describe(suite, {}, async function example() {});
+        const suite = describe("example");
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, "example", { fn: async () => {} });
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, "example", async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, "example", {}, async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, { name: "example" }, async () => {});
+        // @ts-expect-error async function is not assignable to describe argument
+        describe(suite, {}, async function example() {});
+      } catch {
+        // Ignores runtime errors as this case is for static type checking
+      }
+    },
+  );
+
+  await t.step(
+    "throws runtime error if async function is passed as describe fn",
+    () => {
+      assertThrows(
+        // deno-lint-ignore no-explicit-any
+        () => describe("async describe", (async () => {}) as any),
+        Error,
+        'Returning a Promise from "describe" is not supported. Tests must be defined synchronously.',
+      );
     },
   );
 });


### PR DESCRIPTION
closes #5034

This PR updates the behavior of `describe` in `testing/bdd`. Now `describe` throws if an async function is passed to it.

