### PR TITLE
test(testing): fix flakiness of snapshot test

### DIFF
--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -418,14 +418,14 @@ Snapshot Test - First ... ok (--ms)
 Snapshot Test - Second ... ok (--ms)
 ------- post-test output -------
 
- > 1 snapshot updated.
+ > some snapshots updated.
 ----- post-test output end -----
 running 2 tests from <tempDir>/test.ts
 Snapshot Test - First ... ok (--ms)
 Snapshot Test - Second ... ok (--ms)
 ------- post-test output -------
 
- > 2 snapshots updated.
+ > some snapshots updated.
 ----- post-test output end -----
 
 ok | 4 passed | 0 failed (--ms)

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -6,6 +6,7 @@ import {
   assertInstanceOf,
   AssertionError,
   assertRejects,
+  assertStringIncludes,
   fail,
 } from "@std/assert";
 import { assertSnapshot, createAssertSnapshot, serialize } from "./snapshot.ts";
@@ -644,6 +645,10 @@ Deno.test(
       }
     }
 
+    function maskSnapshotCount(output: string) {
+      return output.replace(/(1|2) snapshots?/g, "some snapshots");
+    }
+
     /**
      * New snapshot
      */
@@ -721,10 +726,17 @@ Deno.test(
       });`,
     );
     assertNoError(result2.error);
-    await assertSnapshot(t, formatTestOutput(result2.output), {
-      name:
-        "assertSnapshot() - different directory - Existing snapshot - update",
-    });
+    const output = formatTestOutput(result2.output);
+    await assertSnapshot(
+      t,
+      maskSnapshotCount(output),
+      {
+        name:
+          "assertSnapshot() - different directory - Existing snapshot - update",
+      },
+    );
+    assertStringIncludes(output, "> 1 snapshot updated");
+    assertStringIncludes(output, "> 2 snapshots updated");
   }),
 );
 


### PR DESCRIPTION
This PR fixes the flakiness of `assertSnapshot() - different directory` test case.

In the test case, 2 snapshot updates happen, but the order of them seems racy now.

This change masks the count of these 2 updates, instead checks them independently.