### PR TITLE
refactor(collections): inline `randomInteger` utility function

### DIFF
--- a/collections/_utils.ts
+++ b/collections/_utils.ts
@@ -24,10 +24,3 @@ export function filterInPlace<T>(
 
   return array;
 }
-
-/**
- * Produces a random number between the inclusive `lower` and `upper` bounds.
- */
-export function randomInteger(lower: number, upper: number): number {
-  return lower + Math.floor(Math.random() * (upper - lower + 1));
-}

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -1,7 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { randomInteger } from "./_utils.ts";
+/**
+ * Produces a random number between the inclusive `lower` and `upper` bounds.
+ */
+function randomInteger(lower: number, upper: number): number {
+  return lower + Math.floor(Math.random() * (upper - lower + 1));
+}
 
 /**
  * Returns a random element from the given array.


### PR DESCRIPTION
- inlines `randomInteger()` as it is not used elsewhere.