### PR TITLE
fix(async): improve debounce node.js compatibility

### DIFF
--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -58,7 +58,7 @@ export function debounce<T extends Array<any>>(
       debounced.clear();
       fn.call(debounced, ...args);
     };
-    timeout = setTimeout(flush, wait);
+    timeout = Number(setTimeout(flush, wait));
   }) as DebouncedFunction<T>;
 
   debounced.clear = () => {


### PR DESCRIPTION
`debounce` does not work in node.js because setTimeout returning type difference.
This PR uses `Number()` to convert from Node.js `Timeout` to number by `toPrimitive()`.

## How to reproduce

```
npx jsr add @std/async
```

package.json
```json
{
  "dependencies": {
    "@std/async": "npm:@jsr/std__async@^1.0.0-rc.3"
  },
  "type": "module"
}
```

index.js
```js
import { debounce } from "@std/async/debounce";
const d = debounce(() => {
  console.log("test");
}, 200);
d();
d();
```

### Actual output

```
$ node index.js
test
test
```

### Expected output

```
$ node index.js
test
```
