### PR TITLE
docs(data-structures): get all `@link` nodes working

### DIFF
--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -416,7 +416,8 @@ export class BinaryHeap<T> implements Iterable<T> {
    * from greatest to least. The binary heap is drained in the process.
    *
    * To avoid draining the binary heap, create a copy using
-   * {@link BinaryHeap.from} and then call {@link BinaryHeap#drain} on the copy.
+   * {@link BinaryHeap.from} and then call {@link BinaryHeap.prototype.drain}
+   * on the copy.
    *
    * @example Draining the binary heap
    * ```ts
@@ -440,8 +441,6 @@ export class BinaryHeap<T> implements Iterable<T> {
   /**
    * Create an iterator that retrieves values from the binary heap in order
    * from greatest to least. The binary heap is drained in the process.
-   *
-   * See {@link BinaryHeap#values}.
    *
    * @example Getting an iterator for the binary heap
    * ```ts

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -13,7 +13,7 @@ type Direction = "left" | "right";
  *
  * For performance, it's recommended that you use a self-balancing binary search
  * tree instead of this one unless you are extending this to create a
- * self-balancing tree. See RedBlackTree for an example of how BinarySearchTree
+ * self-balancing tree. See {@link RedBlackTree} for an example of how BinarySearchTree
  * can be extended to create a self-balancing binary search tree.
  *
  * | Method        | Average Case | Worst Case |
@@ -759,7 +759,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * assertEquals([...tree], [1, 2, 3, 4, 5]);
    * ```
    *
-   * See {@link BinarySearchTree#lnrValues}.
+   * See {@link BinarySearchTree.prototype.lnrValues}.
    *
    * @returns An iterator that traverses the tree in-order (LNR).
    */


### PR DESCRIPTION
This commit fixes the documentation in `data-structures` so all broken `@link` nodes are correctly linked.