### PR TITLE
chore: check import map in lint task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -63,7 +63,7 @@
     "lint:tools-types": "deno check _tools/*.ts",
     "lint:docs": "deno run -A _tools/check_docs.ts",
     "lint:import-map": "deno run -A _tools/check_import_map.ts",
-    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:circular && deno task lint:deprecations && deno task lint:tools-types && deno task lint:mod-exports && deno task lint:docs && deno task lint:docs",
+    "lint": "deno lint && deno task fmt:licence-headers --check && deno task lint:circular && deno task lint:deprecations && deno task lint:tools-types && deno task lint:mod-exports && deno task lint:import-map && deno task lint:docs",
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.17.1 --js-ext mjs --sync",


### PR DESCRIPTION
There was a mistake in `lint` task definition in #5380 (`lint:docs` is executed twice). This PR fixes it.