### PR TITLE
docs(jsonc): remove docs for removed `options` parameter

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -19,7 +19,6 @@ export type { JsonValue } from "@std/json/types";
  *
  * @throws {SyntaxError} If the JSONC string is invalid.
  * @param text A valid JSONC string.
- * @param options Options for parsing.
  * @returns The parsed JsonValue from the JSONC string.
  */
 export function parse(text: string): JsonValue {


### PR DESCRIPTION
Options were removed in 255b7994ee20e8318016009693f0be00ab55416d