### PR TITLE
refactor(yaml): remove dead code in `Schema` constructor

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -4,7 +4,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { YamlError } from "./_error.ts";
 import type { KindType, Type } from "./_type.ts";
 import type { ArrayObject } from "./_utils.ts";
 import {
@@ -88,15 +87,6 @@ export class Schema {
     this.explicit = definition.explicit || [];
     this.implicit = definition.implicit || [];
     this.include = definition.include || [];
-
-    for (const type of this.implicit) {
-      if (type.loadKind && type.loadKind !== "scalar") {
-        throw new YamlError(
-          "There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.",
-        );
-      }
-    }
-
     this.compiledImplicit = compileList(this, "implicit", []);
     this.compiledExplicit = compileList(this, "explicit", []);
     this.compiledTypeMap = compileMap(


### PR DESCRIPTION
This code checked that all `Type` objects passed to `Schema.implicit` had their `kind` properties set to `scalar`. I can confirm this is true for in all cases:
- Timestamp
- Merge
- Nil
- Bool
- Int
- Float

This code is not controlled by the user.