### PR TITLE
chore(cli,http): fix typechecking errors

### DIFF
--- a/cli/_tools/compare_with_rust.ts
+++ b/cli/_tools/compare_with_rust.ts
@@ -49,7 +49,9 @@ Deno.test("fast-check equality with unicode_width Rust crate", async (t) => {
               // deno-lint-ignore no-explicit-any
               (str: any) =>
                 unicodeWidth(str) ===
-                  dylib.symbols.unicode_width(toCString(JSON.stringify(str))),
+                  Number(
+                    dylib.symbols.unicode_width(toCString(JSON.stringify(str))),
+                  ),
             ),
           );
         },

--- a/http/_mock_conn.ts
+++ b/http/_mock_conn.ts
@@ -13,7 +13,6 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       hostname: "",
       port: 0,
     },
-    rid: -1,
     closeWrite: () => {
       return Promise.resolve();
     },
@@ -24,7 +23,7 @@ export function mockConn(base: Partial<Deno.Conn> = {}): Deno.Conn {
       return Promise.resolve(-1);
     },
     close: () => {},
-    readable: new ReadableStream({
+    readable: new ReadableStream<Uint8Array<ArrayBuffer>>({
       type: "bytes",
       async pull(_controller) {
       },


### PR DESCRIPTION
resolves #6520

- `Deno.Conn.rid` was removed in https://github.com/denoland/deno/pull/25556
- `Deno.Conn.readable` changed type in https://github.com/denoland/deno/pull/27857
- Not sure when `unicode_width` started failing typecheck. The Rust `unicode_width` has been marked as a `usize` since `compare_with_rust.ts` was added, and `usize` has been marked as a `BigInt` since before that. But TS `unicode_width` has been marked as a `number` since it was added. The test failed before this change and succeeds after.