### PR TITLE
fix(testing): align types for fake timeout/interval signatures

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -127,16 +127,26 @@ interface DueNode {
 
 let time: FakeTime | undefined = undefined;
 
-function fakeSetTimeout(
-  // deno-lint-ignore no-explicit-any
-  callback: (...args: any[]) => void,
+function assertIsCallbackFunction(
+  callback: unknown,
+  fnName: "setTimeout" | "setInterval",
+): asserts callback is (...args: unknown[]) => void {
+  if (typeof callback !== "function") {
+    throw new TimeError(
+      `FakeTime does not support non-function callbacks to ${fnName}`,
+    );
+  }
+}
+
+const fakeSetTimeout: typeof globalThis.setTimeout = function (
+  callback,
   delay = 0,
-  // deno-lint-ignore no-explicit-any
-  ...args: any[]
-): number {
+  ...args
+) {
+  assertIsCallbackFunction(callback, "setTimeout");
   if (!time) throw new TimeError("Cannot set timeout: time is not faked");
   return setTimer(callback, delay, args, false);
-}
+};
 
 function fakeClearTimeout(id?: unknown) {
   if (!time) throw new TimeError("Cannot clear timeout: time is not faked");
@@ -145,16 +155,15 @@ function fakeClearTimeout(id?: unknown) {
   }
 }
 
-function fakeSetInterval(
-  // deno-lint-ignore no-explicit-any
-  callback: (...args: any[]) => unknown,
+const fakeSetInterval: typeof globalThis.setInterval = function (
+  callback,
   delay = 0,
-  // deno-lint-ignore no-explicit-any
-  ...args: any[]
-): number {
+  ...args
+) {
+  assertIsCallbackFunction(callback, "setInterval");
   if (!time) throw new TimeError("Cannot set interval: time is not faked");
   return setTimer(callback, delay, args, true);
-}
+};
 
 function fakeClearInterval(id?: unknown) {
   if (!time) throw new TimeError("Cannot clear interval: time is not faked");

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -814,3 +814,19 @@ Deno.test("FakeTime regression test for issue #5499", async () => {
   await t.runMicrotasks();
   assertEquals(state, "rejected");
 });
+
+Deno.test("FakeTime throws custom error message if first argument to setTimeout/setInterval is string", () => {
+  using _ = new FakeTime();
+  assertThrows(
+    // @ts-ignore in environments that don't allow string in TS types
+    () => void setTimeout('console.log("oops");'),
+    TimeError,
+    "FakeTime does not support non-function callbacks to setTimeout",
+  );
+  assertThrows(
+    // @ts-ignore in environments that don't allow string in TS types
+    () => void setInterval('console.log("oops");'),
+    TimeError,
+    "FakeTime does not support non-function callbacks to setInterval",
+  );
+});


### PR DESCRIPTION
Fixes https://github.com/denoland/std/issues/6766.

The only runtime change is that a custom error is thrown when `setTimeout/setInterval` is called, rather than `TypeError: timer.callback.apply is not a function` being thrown when the callback runs.