### PR TITLE
fix(tar): receiving empty buffers

### DIFF
--- a/tar/tar_stream.ts
+++ b/tar/tar_stream.ts
@@ -253,8 +253,10 @@ export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
         if ("size" in chunk) {
           let size = 0;
           for await (const value of chunk.readable) {
-            size += value.length;
-            yield value;
+            if (value.length) {
+              size += value.length;
+              yield value;
+            }
           }
           if (chunk.size !== size) {
             throw new RangeError(

--- a/tar/tar_stream_test.ts
+++ b/tar/tar_stream_test.ts
@@ -313,6 +313,20 @@ Deno.test("TarStream() with mismatching sizes", async () => {
   );
 });
 
+Deno.test("TarStream() with empty buffers", async () => {
+  const text = new TextEncoder().encode("Hello World!");
+  const readable = ReadableStream.from<TarStreamInput>([
+    {
+      type: "file",
+      path: "potato",
+      size: text.length,
+      readable: ReadableStream.from([new Uint8Array(), text, new Uint8Array()]),
+    },
+  ]).pipeThrough(new TarStream());
+
+  assertEquals((await new Response(readable).bytes()).length % 512, 0);
+});
+
 Deno.test("parsePath() with too long path", async () => {
   const readable = ReadableStream.from<TarStreamInput>([{
     type: "directory",


### PR DESCRIPTION
This pull request fixes a bug where the code couldn't handle receiving empty buffers from the readable stream when appending a file. It originally expected to receive nothing if there was nothing to give, but some things appear to be giving empty buffers and due to that, causing an error to be thrown.

This below code triggers the error on the latest published version, but works with this pull request's changes.
```ts
import { TarStream, type TarStreamInput } from "@std/tar";

await new Response(
  ReadableStream.from<TarStreamInput>([{
    type: "file",
    path: "potato",
    size: 0,
    readable: ReadableStream.from([new Uint8Array()]), // Empty buffer not expected.
  }])
    .pipeThrough(new TarStream()),
).bytes();
```