### PR TITLE
deprecation(streams/unstable): AbortStream

### DIFF
--- a/streams/unstable_abort_stream.ts
+++ b/streams/unstable_abort_stream.ts
@@ -5,6 +5,8 @@
  * A transform stream that accepts a {@linkcode AbortSignal} to easily abort a
  * stream pipeThrough.
  *
+ * @deprecated Use [`readable.pipThrough`'s signal option](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough#signal) instead.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @typeparam T The type of the chunks passing through the AbortStream.


### PR DESCRIPTION
This pull request marks the `AbortStream` class for deprecation in place of `.pipeThrough`'s options to accept an AbortSignal: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough#signal

## Old Code:
```ts
import { AbortStream } from "jsr:@std/streams/unstable-abort-stream";

const controller = new AbortController();

const readable = (await Deno.open("deno.json"))
  .readable
  .pipeThrough(new CompressionStream("gzip"))
  .pipeThrough(new AbortStream(controller.signal));
```

## New Code:
```ts
const controller = new AbortController();

const readable = (await Deno.open("deno.json"))
  .readable
  .pipeThrough(new CompressionStream("gzip"), { signal: controller.signal });
```