### PR TITLE
feat(expect): support async extended matchers

### DIFF
--- a/expect/_types.ts
+++ b/expect/_types.ts
@@ -12,7 +12,7 @@ export interface MatcherContext {
 export type Matcher = (
   context: MatcherContext,
   ...args: any[]
-) => MatchResult | ExtendMatchResult;
+) => MatchResult | ExtendMatchResult | Promise<ExtendMatchResult>;
 
 export type Matchers = {
   [key: string]: Matcher;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -211,13 +211,29 @@ export function expect<T extends Expected = Expected>(
             context.isNot = true;
           }
           if (name in extendMatchers) {
-            const result = matcher(context, ...args) as ExtendMatchResult;
-            if (context.isNot) {
-              if (result.pass) {
+            const result = matcher(context, ...args) as
+              | ExtendMatchResult
+              | Promise<ExtendMatchResult>;
+
+            if (result instanceof Promise) {
+              return result.then((result) => {
+                if (context.isNot) {
+                  if (result.pass) {
+                    throw new AssertionError(result.message());
+                  }
+                } else if (!result.pass) {
+                  throw new AssertionError(result.message());
+                }
+                emitAssertionTrigger();
+              });
+            } else {
+              if (context.isNot) {
+                if (result.pass) {
+                  throw new AssertionError(result.message());
+                }
+              } else if (!result.pass) {
                 throw new AssertionError(result.message());
               }
-            } else if (!result.pass) {
-              throw new AssertionError(result.message());
             }
           } else {
             matcher(context, ...args);


### PR DESCRIPTION
This allows extended matchers in `expect` to return either `ExtendMatchResult` or `Promise<ExtendMatchResult>` 

This changes provides additional possibilities for custom matchers, like implementing a `expect(value).toBeResolved()` matcher.

Example:
```ts
const { promise, resolve } = Promise.withResolvers<void>();
await expect(promise).not.toBeResolved();
resolve();
await expect(promise).toBeResolved();

// NB: this is different from expect(promise).resolves.toBe()
// Here we test the actual promise state, not its resolved value
```

This is just an example, but it can be used for any custom matcher that requires async operations on the right side
(for example one could image matching agains dynamically fetched files, database query results, etc.)

**Side note:** While this PR doesn't address specifically the following issues, the example (in the diff of the test file) shows how to implement a matcher to test promise states
- #3759
- #5727

*Needs rebase after #6807 for lint issues*