### PR TITLE
docs(cbor): remove h2 and change spelling from UK -> US

### DIFF
--- a/cbor/mod.ts
+++ b/cbor/mod.ts
@@ -1,15 +1,14 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 /**
- * ## Overview
- * Concise Binary Object Representation (CBOR) is a binary data serialisation
- * format optimised for compactness and efficiency. It is designed to encode a
+ * Concise Binary Object Representation (CBOR) is a binary data serialization
+ * format optimized for compactness and efficiency. It is designed to encode a
  * wide range of data types, including integers, strings, arrays, and maps, in a
  * space-efficient manner.
  * [RFC 8949 - Concise Binary Object Representation (CBOR)](https://datatracker.ietf.org/doc/html/rfc8949)
  * spec.
  *
- * ## Limitations
+ * ### Limitations
  * - This implementation only supports the encoding and decoding of
  * "Text String" keys.
  * - This implementation encodes decimal numbers with 64 bits. It takes no


### PR DESCRIPTION
The Overview h2 does not appear in the other std packages and causes a different look/feel in this one in JSR (and now in deno docs)

I've removed the initial h2 and downgraded the second one to a h3.