### PR TITLE
fix(cli/unstable): typo in ProgressBar example

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -144,7 +144,7 @@ function clamp(value: number, min: number, max: number) {
  * const bar = new ProgressBar({
  *   max: 100,
  *   formatter(formatter) {
- *     return `[${formatter.styledTime()}] [${formatter.progressBar}] [${formatter.value}/${formatter.max} files]`;
+ *     return `[${formatter.styledTime}] [${formatter.progressBar}] [${formatter.value}/${formatter.max} files]`;
  *   },
  * });
  *


### PR DESCRIPTION
Fix example to use formatter.styledTime instead of calling formatter.styledTime().