### PR TITLE
fix(assert,streams): handle SharedArrayBuffer being disabled in some browser context

### DIFF
--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -117,7 +117,10 @@ export function equal(a: unknown, b: unknown): boolean {
       if (a instanceof TypedArray) {
         return compareTypedArrays(a as TypedArray, b as TypedArray);
       }
-      if (a instanceof ArrayBuffer || a instanceof SharedArrayBuffer) {
+      if (
+        a instanceof ArrayBuffer ||
+        (globalThis.SharedArrayBuffer && a instanceof SharedArrayBuffer)
+      ) {
         return compareTypedArrays(
           new Uint8Array(a),
           new Uint8Array(b as ArrayBuffer | SharedArrayBuffer),

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -135,11 +135,8 @@ export class Buffer {
   constructor(ab?: ArrayBufferLike | ArrayLike<number>) {
     if (ab === undefined) {
       this.#buf = new Uint8Array(0);
-    } else if (ab instanceof SharedArrayBuffer) {
-      // Note: This is necessary to avoid type error
-      this.#buf = new Uint8Array(ab);
     } else {
-      this.#buf = new Uint8Array(ab);
+      this.#buf = new Uint8Array(ab as ArrayBuffer | SharedArrayBuffer);
     }
   }
 


### PR DESCRIPTION
[Per MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) SharedArrayBuffer require secure context and cross-origin isolated. When these contextes are not given then equal and new Buffer fail (as SharedArrayBuffer is undefined) when called in the Web.