### PR TITLE
feat(cache): add cleanup callback to `LruCache` and `TtlCache`

### DIFF
--- a/cache/lru_cache_test.ts
+++ b/cache/lru_cache_test.ts
@@ -25,8 +25,7 @@ Deno.test("LruCache deletes least-recently-used", () => {
 
 Deno.test("LruCache onEject()", () => {
   let called = 0;
-  const cache = new LruCache<number, string>(3)
-    .onEject(() => called++);
+  const cache = new LruCache<number, string>(3, { onEject: () => called++ });
 
   cache.set(1, "!");
   cache.set(2, "!");

--- a/cache/ttl_cache_test.ts
+++ b/cache/ttl_cache_test.ts
@@ -110,8 +110,7 @@ Deno.test("TtlCache deletes entries", async (t) => {
 Deno.test("TtlCache onEject()", () => {
   using time = new FakeTime(0);
   let called = 0;
-  const cache = new TtlCache<number, string>(10)
-    .onEject(() => called++);
+  const cache = new TtlCache<number, string>(10, { onEject: () => called++ });
 
   cache.set(1, "one");
   cache.set(2, "two");


### PR DESCRIPTION
Closes #6851 

This PR adds a `option: { onEject: (ejectedKey: K, ejectedValue: V) => void) }` param to `LruCache` and `TtlCache` constructor.
