### PR TITLE
refactor(semver): reduce nesting in `testComparatorSet()`

### DIFF
--- a/semver/_test_comparator_set.ts
+++ b/semver/_test_comparator_set.ts
@@ -32,36 +32,29 @@ function testComparator(version: SemVer, comparator: Comparator): boolean {
   }
 }
 
-export function testComparatorSet(
-  version: SemVer,
-  set: Comparator[],
-): boolean {
+export function testComparatorSet(version: SemVer, set: Comparator[]): boolean {
   for (const comparator of set) {
-    if (!testComparator(version, comparator)) {
-      return false;
+    if (!testComparator(version, comparator)) return false;
+  }
+  if (!version.prerelease?.length) return true;
+
+  // Find the comparator that is allowed to have prereleases
+  // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
+  // That should allow `1.2.3-pr.2` to pass.
+  // However, `1.2.4-alpha.notready` should NOT be allowed,
+  // even though it's within the range set by the comparators.
+  for (const comparator of set) {
+    if (isWildcardComparator(comparator)) continue;
+    if (!comparator.prerelease?.length) continue;
+    const { major, minor, patch } = comparator;
+    if (
+      version.major === major &&
+      version.minor === minor &&
+      version.patch === patch
+    ) {
+      return true;
     }
   }
-  if (version.prerelease && version.prerelease.length > 0) {
-    // Find the comparator that is allowed to have prereleases
-    // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
-    // That should allow `1.2.3-pr.2` to pass.
-    // However, `1.2.4-alpha.notready` should NOT be allowed,
-    // even though it's within the range set by the comparators.
-    for (const comparator of set) {
-      if (isWildcardComparator(comparator)) {
-        continue;
-      }
-      const { major, minor, patch, prerelease } = comparator;
-      if (prerelease && prerelease.length > 0) {
-        if (
-          version.major === major && version.minor === minor &&
-          version.patch === patch
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-  return true;
+
+  return false;
 }


### PR DESCRIPTION
This PR adds early returns and reduces nesting in `testComparatorSet()` for better readability.