### PR TITLE
fix(fs): "Deno is not defined" when using the module in browser

### DIFF
--- a/fs/move.ts
+++ b/fs/move.ts
@@ -2,8 +2,6 @@
 import { isSubdir } from "./_is_subdir.ts";
 import { isSamePath } from "./_is_same_path.ts";
 
-const EXISTS_ERROR = new Deno.errors.AlreadyExists("dest already exists.");
-
 /** Options for {@linkcode move} and {@linkcode moveSync}. */
 export interface MoveOptions {
   /**
@@ -79,6 +77,7 @@ export async function move(
       }
     }
   } else {
+    const EXISTS_ERROR = new Deno.errors.AlreadyExists("dest already exists.");
     try {
       await Deno.lstat(dest);
       return Promise.reject(EXISTS_ERROR);
@@ -155,6 +154,7 @@ export function moveSync(
       }
     }
   } else {
+    const EXISTS_ERROR = new Deno.errors.AlreadyExists("dest already exists.");
     try {
       Deno.lstatSync(dest);
       throw EXISTS_ERROR;


### PR DESCRIPTION
my env
```
deno --version
deno 2.5.6 (stable, release, aarch64-apple-darwin)
v8 14.0.365.5-rusty
typescript 5.9.2
```

how to reproduce
```sh
echo 'import "jsr:@std/fs@1.0.19";' > test.js
deno bundle --platform browser -o out.js test.js
cat out.js
```

`out.js`
```
// line 12
var EXISTS_ERROR = new Deno.errors.AlreadyExists("dest already exists.");
//                     ^^^^ this makes problem in the web browser
```