### PR TITLE
chore: update assertion of NotCapable error

### DIFF
--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -8,7 +8,6 @@ import {
 } from "@std/assert";
 import { load, type LoadOptions, loadSync } from "./mod.ts";
 import * as path from "@std/path";
-import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
@@ -174,11 +173,8 @@ Deno.test(
     };
     assertThrows(
       () => loadSync(loadOptions),
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
       `Requires env access to "EMPTY", run again with the --allow-env flag`,
     );
   },

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -3,7 +3,6 @@ import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import * as path from "@std/path";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
-import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata", "ensure_dir");
@@ -184,11 +183,8 @@ Deno.test({
     // but don't swallow that error.
     await assertRejects(
       async () => await ensureDir(baseDir),
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 });
@@ -206,11 +202,8 @@ Deno.test({
     // but don't swallow that error.
     assertThrows(
       () => ensureDirSync(baseDir),
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 });

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -2,7 +2,6 @@
 import { assertRejects, assertThrows } from "@std/assert";
 import * as path from "@std/path";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
-import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
@@ -134,11 +133,8 @@ Deno.test({
     // but don't swallow that error.
     await assertRejects(
       async () => await ensureFile(testFile),
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 });
@@ -154,11 +150,8 @@ Deno.test({
     // but don't swallow that error.
     assertThrows(
       () => ensureFileSync(testFile),
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 });

--- a/fs/ensure_symlink_test.ts
+++ b/fs/ensure_symlink_test.ts
@@ -9,7 +9,6 @@ import {
 } from "@std/assert";
 import * as path from "@std/path";
 import { ensureSymlink, ensureSymlinkSync } from "./ensure_symlink.ts";
-import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
@@ -357,11 +356,8 @@ Deno.test(
       async () => {
         await ensureSymlink(testFile, linkFile);
       },
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 );
@@ -377,11 +373,8 @@ Deno.test(
       () => {
         ensureSymlinkSync(testFile, linkFile);
       },
-      IS_DENO_2
-        // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-        // deno-lint-ignore no-explicit-any
-        ? (Deno as any).errors.NotCapable
-        : Deno.errors.PermissionDenied,
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
     );
   },
 );

--- a/fs/expand_glob_test.ts
+++ b/fs/expand_glob_test.ts
@@ -2,8 +2,8 @@
 import {
   assert,
   assertEquals,
+  assertMatch,
   assertRejects,
-  assertStringIncludes,
   assertThrows,
 } from "@std/assert";
 import { fromFileUrl, join, joinGlobs, normalize, relative } from "@std/path";
@@ -12,7 +12,6 @@ import {
   type ExpandGlobOptions,
   expandGlobSync,
 } from "./expand_glob.ts";
-import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
 
 async function expandGlobArray(
   globString: string,
@@ -117,11 +116,8 @@ Deno.test(
         async () => {
           await expandGlobArray("*", EG_OPTIONS);
         },
-        IS_DENO_2
-          // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-          // deno-lint-ignore no-explicit-any
-          ? (Deno as any).errors.NotCapable
-          : Deno.errors.PermissionDenied,
+        // deno-lint-ignore no-explicit-any
+        (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
         "run again with the --allow-read flag",
       );
     }
@@ -131,11 +127,8 @@ Deno.test(
         () => {
           expandGlobSyncArray("*", EG_OPTIONS);
         },
-        IS_DENO_2
-          // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-          // deno-lint-ignore no-explicit-any
-          ? (Deno as any).errors.NotCapable
-          : Deno.errors.PermissionDenied,
+        // deno-lint-ignore no-explicit-any
+        (Deno as any).errors.NotCapable ?? Deno.errors.PermissionDenied,
         "run again with the --allow-read flag",
       );
     }
@@ -311,10 +304,9 @@ Deno.test(
     assert(!success);
     assertEquals(code, 1);
     assertEquals(decoder.decode(stdout), "");
-    assertStringIncludes(
+    assertMatch(
       decoder.decode(stderr),
-      // TODO(iuioiua): Just use `Deno.errors.NotCapable` once Deno 2 is released.
-      IS_DENO_2 ? "NotCapable" : "PermissionDenied",
+      /(NotCapable|PermissionDenied)/,
     );
   },
 );

--- a/internal/_is_deno_2.ts
+++ b/internal/_is_deno_2.ts
@@ -1,3 +1,0 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
-// TODO(iuioiua): Remove this file when Deno 2 is released.
-export const IS_DENO_2 = Deno.version.deno.startsWith("2.");


### PR DESCRIPTION
We use Deno version detection for choosing between `NotCapable` and `PermissionDenied` to use in testing. This stopped working with Deno CLI canary as it updated the version to 3.x https://github.com/denoland/deno/pull/31258

This PR stops using version detection, instead just checks `Deno.errors.NotCapable` property for detecting availablility of it.