### PR TITLE
fix(fs): support for Node.js v20

### DIFF
--- a/fs/_utils.ts
+++ b/fs/_utils.ts
@@ -4,7 +4,8 @@
 /**
  * True if the runtime is Deno, false otherwise.
  */
-export const isDeno = (globalThis as any).navigator.userAgent?.includes("Deno");
+export const isDeno = (globalThis as any).navigator
+  ?.userAgent?.includes("Deno");
 
 /**
  * @returns The Node.js `fs` module.


### PR DESCRIPTION
In Node.js, [navigator](https://developer.mozilla.org/en-US/docs/Web/API/Navigator#browser_compatibility) is added from v21, so this will cause an error in Node.js v20.x.
This change allows the code to run on Node.js versions newer than [Node.js v20.16.0](https://nodejs.org/ja/blog/release/v20.16.0), which added [`process.getBuiltinModule`](https://nodejs.org/api/process.html#processgetbuiltinmoduleid).