### PR TITLE
fix(http): negotiation returns the specific type of supported outcomes (when provided)

### DIFF
--- a/http/negotiation.ts
+++ b/http/negotiation.ts
@@ -61,14 +61,15 @@ export function accepts(request: Pick<Request, "headers">): string[];
  * assertEquals(accepts(request, "text/html", "image/webp"), "text/html");
  * ```
  *
+ * @typeParam T The type of supported content-types (if provided).
  * @param request The request to get the acceptable media types for.
  * @param types An array of media types to find the best matching one from.
  * @returns The best matching media type, if any match.
  */
-export function accepts(
+export function accepts<T extends string = string>(
   request: Pick<Request, "headers">,
-  ...types: string[]
-): string | undefined;
+  ...types: T[]
+): T | undefined;
 export function accepts(
   request: Pick<Request, "headers">,
   ...types: string[]
@@ -123,14 +124,15 @@ export function acceptsEncodings(request: Pick<Request, "headers">): string[];
  * assertEquals(acceptsEncodings(request, "gzip", "identity"), "gzip");
  * ```
  *
+ * @typeParam T The type of supported encodings (if provided).
  * @param request The request to get the acceptable content encodings for.
  * @param encodings An array of encodings to find the best matching one from.
  * @returns The best matching encoding, if any match.
  */
-export function acceptsEncodings(
+export function acceptsEncodings<T extends string = string>(
   request: Pick<Request, "headers">,
-  ...encodings: string[]
-): string | undefined;
+  ...encodings: T[]
+): T | undefined;
 export function acceptsEncodings(
   request: Pick<Request, "headers">,
   ...encodings: string[]
@@ -186,14 +188,15 @@ export function acceptsLanguages(request: Pick<Request, "headers">): string[];
  * assertEquals(acceptsLanguages(request, "en-gb", "en-us", "en"), "en");
  * ```
  *
+ * @typeParam T The type of supported languages (if provided).
  * @param request The request to get the acceptable language for.
  * @param langs An array of languages to find the best matching one from.
  * @returns The best matching language, if any match.
  */
-export function acceptsLanguages(
+export function acceptsLanguages<T extends string = string>(
   request: Pick<Request, "headers">,
-  ...langs: string[]
-): string | undefined;
+  ...langs: T[]
+): T | undefined;
 export function acceptsLanguages(
   request: Pick<Request, "headers">,
   ...langs: string[]


### PR DESCRIPTION
This very simple PR adds a type parameter to all three negotiation functions (`accepts`, `acceptsEncoding`, `acceptsLanguage`) when they are called with more than one argument, so that the returned string will have the same specific type as the provided values.

This typing better reflects the actual behaviour (providing those arguments ensures that the returned value will be one of them, if any was *acceptable*) and improves type checking down the line when the content-types, encodings, or language code are used as keys (which is quite often, in my experience).

For example:
```typescript
import { accepts } from "jsr:@std/http@1.0.22/negotiation"

const serializers = {
  "text/csv"() { return new TransformStream(/*...*/) },
  "application/x-ndjson"() { return new TransformStream(/*...*/) },
} satisfies Record<string, () => TransformStream<MyData, Uint8Array>>

type SupportedContentType = keyof typeof serializers

/* handling some request... */
Deno.serve((req) => {
  // currently, this is a string | undefined, but should be a SupportedContentType | undefined
  const acceptable = accepts(req, ...Object.keys(serializers))
  if (!acceptable) return new Response("Not Acceptable", {status: 406})

  const myData: ReadableStream<MyData> = getMyData()
  // because acceptable is a generic string, TypeScript doesn't trust it to access one of the serializers
  return new Response(myData.pipeThrough(serializers[acceptable]()))
})
```