### PR TITLE
fix(path): handle file separator in group

### DIFF
--- a/path/_common/glob_to_reg_exp.ts
+++ b/path/_common/glob_to_reg_exp.ts
@@ -89,7 +89,12 @@ export function _globToRegExp(
     let i = j;
 
     // Terminates with `i` at the non-inclusive end of the current segment.
-    for (; i < glob.length && !c.seps.includes(glob[i]!); i++) {
+    for (
+      ;
+      i < glob.length &&
+      !(c.seps.includes(glob[i]!) && groupStack.length === 0);
+      i++
+    ) {
       if (inEscape) {
         inEscape = false;
         const escapeChars = (inRange

--- a/path/glob_to_regexp_test.ts
+++ b/path/glob_to_regexp_test.ts
@@ -493,3 +493,17 @@ Deno.test({
     assertEquals("Foo/Bar".match(pattern2)?.[0], "Foo/Bar");
   },
 });
+
+Deno.test({
+  name: "globToRegExp() path seperator in middle of group",
+  fn() {
+    assert(match("**/{foo/*.json,*.txt}", "/c/Users/me/foo/bar.json"));
+    assert(match("**/{foo/*.json,*.txt}", "/c/Users/me/file.txt"));
+    assert(!match("!(foo/*.json|*.txt)", "/foo/bar.json"));
+    assert(!match("!(foo/*.json|*.txt)", "/file.json"));
+    assert(match("**/@(foo/*.json|*.txt)", "/c/Users/me/foo/bar.json"));
+    assert(match("**/@(foo/*.json|*.txt)", "/c/Users/me/file.txt"));
+    assert(match("**/+(foo/*.json|*.txt)", "/c/Users/me/foo/bar.json"));
+    assert(match("**/+(foo/*.json|*.txt)", "/c/Users/me/file.txt"));
+  },
+});


### PR DESCRIPTION
# Summary
Fixes issue #6871 

# Problem
globToRegExp split the segment immediately when encounter `/`  (in posix) character, and split the segment despite being in the middle of a group

# Solution
Split the segment only when groupStack is empty

# Changes
- `path/_common/glob_to_reg_exp.ts`: update the loop condition to handle grouping case
- `path/glob_to_regexp_test.ts`: add separator in middle of group tests

# Test Plan
- New test passed
- Old test still passed