### PR TITLE
test(datetime): adding test for potential null-state of 'months'

### DIFF
--- a/datetime/difference_test.ts
+++ b/datetime/difference_test.ts
@@ -23,6 +23,12 @@ Deno.test({
     assertEquals(diff.quarters, 7);
     assertEquals(diff.years, 1);
 
+    // test for 'months' potential null-state when calculating quarters only
+    diff = difference(denoInit, denoReleaseV1, {
+      units: ["quarters"],
+    });
+    assertEquals(diff.quarters, 7);
+
     // Default units
     diff = difference(denoReleaseV1, denoInit);
     assertEquals(diff.days, 730);


### PR DESCRIPTION
Adds simple test to exercise null-state logic of `months` variable when calculating quarters only.  Brings `datetime/difference.ts` coverage to 100%.