### PR TITLE
fix(fs): "Deno is not defined" when using the module in browser

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -533,7 +533,9 @@ export function* expandGlobSync(
   yield* currentMatches;
 }
 
-const globEscapeChar = Deno.build.os === "windows" ? "`" : `\\`;
+const globEscapeChar =
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).Deno?.build.os === "windows" ? "`" : `\\`;
 const globMetachars = "*?{}[]()|+@!";
 function unescapeGlobSegment(segment: string): string {
   let result = "";


### PR DESCRIPTION
related prs:
- fixed same problem
  - https://github.com/denoland/std/pull/6868
- but new same problem also shipped on `@std/fs@1.0.20`
  - https://github.com/denoland/std/pull/6788

how to reproduce
```sh
echo 'import "jsr:@std/fs@1.0.20";' > test.js
deno bundle --platform browser -o out.js test.js
cat out.js
```

`out.js`
```
// line 12
var globEscapeChar = Deno.build.os === "windows" ? "`" : `\\`;
//                   ^^^^ this makes problem in the web browser
```