### PR TITLE
docs(async/unstable): update semaphore docs to suggest try/finally

### DIFF
--- a/async/unstable_semaphore.ts
+++ b/async/unstable_semaphore.ts
@@ -18,7 +18,7 @@ interface Node {
  *
  * const sem = new Semaphore(2);
  * {
- *   const _permit = await sem.acquire();
+ *   using _permit = await sem.acquire();
  *   // critical section
  * } // permit is automatically released when exiting the block
  * ```


### PR DESCRIPTION
Too many beginner devs use semaphores incorrectly.

1. Suggest a using declaration in the main example.
2. Use `try / finally` for semaphore release examples.
3. Use an explicit block for the semaphore being acquired and released.