### PR TITLE
refactor(yaml): eliminate shared class state by passing parameters in `LoaderState` 

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -196,7 +196,7 @@ function writeFoldedLines(count: number) {
 interface State {
   tag: string | null;
   anchor: string | null;
-  kind: string | null;
+  kind: KindType | null;
   result: unknown[] | Record<string, unknown> | string | null;
 }
 export class LoaderState {
@@ -1477,7 +1477,7 @@ export class LoaderState {
       }
     }
 
-    const kind = (state.kind ?? "fallback") as KindType;
+    const kind = state.kind ?? "fallback";
 
     const map = this.typeMap[kind];
     const type = map.get(state.tag);


### PR DESCRIPTION
This PR removes the `tag`, `anchor`, `kind` and `result` class properties in `LoaderState` and passes a `State` object to methods that change these properties.
It also makes `read*()` methods return a `State` to which automatically entangles lots of nested if/else statements.

This reduces the code complexity massively because these properties are changed recursively and sometimes also backtracked which makes the code very hard to follow and methods not 
This also opens the door to reduce the code further in future PRs because it makes redundant code and simplifications obvious.