### PR TITLE
refactor(yaml): add `resolveTag()` method

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -196,7 +196,7 @@ export class LoaderState {
   checkLineBreaks = false;
   tagMap = new Map();
   anchorMap = new Map();
-  tag: string | null | undefined;
+  tag: string | null = null;
   anchor: string | null | undefined;
   kind: string | null | undefined;
   result: unknown[] | Record<string, unknown> | string | null = "";
@@ -1451,6 +1451,56 @@ export class LoaderState {
     return true;
   }
 
+  resolveTag() {
+    switch (this.tag) {
+      case null:
+      case "!":
+        return;
+      case "?":
+        for (const type of this.implicitTypes) {
+          // Implicit resolving is not allowed for non-scalar types, and '?'
+          // non-specific tag is only assigned to plain scalars. So, it isn't
+          // needed to check for 'kind' conformity.
+
+          if (!type.resolve(this.result)) continue;
+          // `state.result` updated in resolver if matched
+          this.result = type.construct(this.result);
+          this.tag = type.tag;
+          if (this.anchor !== null) {
+            this.anchorMap.set(this.anchor, this.result);
+          }
+          break;
+        }
+        return;
+    }
+
+    const kind = (this.kind ?? "fallback") as KindType;
+
+    const map = this.typeMap[kind];
+    const type = map.get(this.tag);
+
+    if (!type) {
+      throw this.#createError(`Cannot resolve unknown tag !<${this.tag}>`);
+    }
+
+    if (this.result !== null && type.kind !== this.kind) {
+      throw this.#createError(
+        `Unacceptable node kind for !<${this.tag}> tag: it should be "${type.kind}", not "${this.kind}"`,
+      );
+    }
+
+    if (!type.resolve(this.result)) {
+      // `state.result` updated in resolver if matched
+      throw this.#createError(
+        `Cannot resolve a node with !<${this.tag}> explicit tag`,
+      );
+    }
+
+    this.result = type.construct(this.result);
+    if (this.anchor !== null) {
+      this.anchorMap.set(this.anchor, this.result);
+    }
+  }
   composeNode(
     { parentIndent, nodeContext, allowToSeek, allowCompact }: {
       parentIndent: number;
@@ -1462,7 +1512,6 @@ export class LoaderState {
     let indentStatus = 1; // 1: this>parent, 0: this=parent, -1: this<parent
     let atNewLine = false;
     let hasContent = false;
-    let type: Type<KindType>;
 
     this.tag = null;
     this.anchor = null;
@@ -1564,54 +1613,7 @@ export class LoaderState {
       }
     }
 
-    if (this.tag !== null && this.tag !== "!") {
-      if (this.tag === "?") {
-        for (
-          let typeIndex = 0;
-          typeIndex < this.implicitTypes.length;
-          typeIndex++
-        ) {
-          type = this.implicitTypes[typeIndex]!;
-
-          // Implicit resolving is not allowed for non-scalar types, and '?'
-          // non-specific tag is only assigned to plain scalars. So, it isn't
-          // needed to check for 'kind' conformity.
-
-          if (type.resolve(this.result)) {
-            // `state.result` updated in resolver if matched
-            this.result = type.construct(this.result);
-            this.tag = type.tag;
-            if (this.anchor !== null) {
-              this.anchorMap.set(this.anchor, this.result);
-            }
-            break;
-          }
-        }
-      } else if (this.typeMap[this.kind ?? "fallback"].has(this.tag)) {
-        const map = this.typeMap[this.kind ?? "fallback"];
-        type = map.get(this.tag)!;
-
-        if (this.result !== null && type.kind !== this.kind) {
-          throw this.#createError(
-            `Unacceptable node kind for !<${this.tag}> tag: it should be "${type.kind}", not "${this.kind}"`,
-          );
-        }
-
-        if (!type.resolve(this.result)) {
-          // `state.result` updated in resolver if matched
-          throw this.#createError(
-            `Cannot resolve a node with !<${this.tag}> explicit tag`,
-          );
-        } else {
-          this.result = type.construct(this.result);
-          if (this.anchor !== null) {
-            this.anchorMap.set(this.anchor, this.result);
-          }
-        }
-      } else {
-        throw this.#createError(`Cannot resolve unknown tag !<${this.tag}>`);
-      }
-    }
+    this.resolveTag();
 
     return this.tag !== null || this.anchor !== null || hasContent;
   }


### PR DESCRIPTION
This PR moves bloat from `composeNode()` into a separate `resolveTag()` method.
That code is also rewritten to be more readable.