### PR TITLE
refactor(yaml): cleanup `composeNode()` statements

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -1556,9 +1556,8 @@ export class LoaderState {
         CONTEXT_FLOW_OUT === nodeContext;
       const flowIndent = cond ? parentIndent : parentIndent + 1;
 
-      const blockIndent = this.position - this.lineStart;
-
       if (allowBlockCollections) {
+        const blockIndent = this.position - this.lineStart;
         if (this.readBlockSequence(blockIndent)) {
           this.resolveTag();
           return true;


### PR DESCRIPTION
Dependent on https://github.com/denoland/std/pull/6904

This PR refactors `composeNode()` by using early returns. Some lines code are repeated in order to do that, which can be abstracted further in future PRs.