### PR TITLE
fix(streams/unstable): use relative path for in-package import

### DIFF
--- a/streams/unstable_capped_delimiter_stream.ts
+++ b/streams/unstable_capped_delimiter_stream.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { toByteStream } from "@std/streams/unstable-to-byte-stream";
+import { toByteStream } from "./unstable_to_byte_stream.ts";
 
 /**
  * Represents an entry in a CappedDelimiterStream.


### PR DESCRIPTION
It looks like JSR is unhappy with the specifier `@std/streams/unstable-to-byte-stream` in `streams/unstable_capped_delimiter_stream.ts` (probably because it is jsr: specifier referencing in-package path)

This PR tries to avoid the error above by using a relative path.