### PR TITLE
feat(datetime): add month and day of week constants

### DIFF
--- a/datetime/constants.ts
+++ b/datetime/constants.ts
@@ -56,3 +56,212 @@ export const DAY: number = HOUR * 24;
  * ```
  */
 export const WEEK: number = DAY * 7;
+/**
+ * The month index for January.
+ *
+ * @example
+ * ```ts
+ * import { JAN } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 1); // 2025-01-01
+ * ```
+ */
+export const JAN = 0;
+/**
+ * The month index for February.
+ *
+ * @example
+ * ```ts
+ * import { FEB } from "@std/datetime/constants";
+ *
+ * new Date(2025, FEB, 1); // 2025-02-01
+ * ```
+ */
+export const FEB = 1;
+/**
+ * The month index for March.
+ *
+ * @example
+ * ```ts
+ * import { MAR } from "@std/datetime/constants";
+ *
+ * new Date(2025, MAR, 1); // 2025-03-01
+ * ```
+ */
+export const MAR = 2;
+/**
+ * The month index for April.
+ *
+ * @example
+ * ```ts
+ * import { APR } from "@std/datetime/constants";
+ *
+ * new Date(2025, APR, 1); // 2025-04-01
+ * ```
+ */
+export const APR = 3;
+/**
+ * The month index for May.
+ *
+ * @example
+ * ```ts
+ * import { MAY } from "@std/datetime/constants";
+ *
+ * new Date(2025, MAY, 1); // 2025-05-01
+ * ```
+ */
+export const MAY = 4;
+/**
+ * The month index for June.
+ *
+ * @example
+ * ```ts
+ * import { JUN } from "@std/datetime/constants";
+ *
+ * new Date(2025, JUN, 1); // 2025-06-01
+ * ```
+ */
+export const JUN = 5;
+/**
+ * The month index for July.
+ *
+ * @example
+ * ```ts
+ * import { JUL } from "@std/datetime/constants";
+ *
+ * new Date(2025, JUL, 1); // 2025-07-01
+ * ```
+ */
+export const JUL = 6;
+/**
+ * The month index for August.
+ *
+ * @example
+ * ```ts
+ * import { AUG } from "@std/datetime/constants";
+ *
+ * new Date(2025, AUG, 1); // 2025-08-01
+ * ```
+ */
+export const AUG = 7;
+/**
+ * The month index for September.
+ *
+ * @example
+ * ```ts
+ * import { SEP } from "@std/datetime/constants";
+ *
+ * new Date(2025, SEP, 1); // 2025-09-01
+ * ```
+ */
+export const SEP = 8;
+/**
+ * The month index for October.
+ *
+ * @example
+ * ```ts
+ * import { OCT } from "@std/datetime/constants";
+ *
+ * new Date(2025, OCT, 1); // 2025-10-01
+ * ```
+ */
+export const OCT = 9;
+/**
+ * The month index for November.
+ *
+ * @example
+ * ```ts
+ * import { NOV } from "@std/datetime/constants";
+ *
+ * new Date(2025, NOV, 1); // 2025-11-01
+ * ```
+ */
+export const NOV = 10;
+/**
+ * The month index for December.
+ *
+ * @example
+ * ```ts
+ * import { DEC } from "@std/datetime/constants";
+ *
+ * new Date(2025, DEC, 1); // 2025-12-01
+ * ```
+ */
+export const DEC = 11;
+/**
+ * The day of week index for Sunday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, SUN } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 5).getDay() === SUN; // true
+ * ```
+ */
+export const SUN = 0;
+/**
+ * The day of week index for Monday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, MON } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 6).getDay() === MON; // true
+ * ```
+ */
+export const MON = 1;
+/**
+ * The day of week index for Tuesday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, TUE } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 7).getDay() === TUE; // true
+ * ```
+ */
+export const TUE = 2;
+/**
+ * The day of week index for Wednesday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, WED } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 1).getDay() === WED; // true
+ * ```
+ */
+export const WED = 3;
+/**
+ * The day of week index for Thursday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, THU } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 2).getDay() === THU; // true
+ * ```
+ */
+export const THU = 4;
+/**
+ * The day of week index for Friday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, FRI } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 3).getDay() === FRI; // true
+ * ```
+ */
+export const FRI = 5;
+/**
+ * The day of week index for Saturday.
+ *
+ * @example
+ * ```ts
+ * import { JAN, SAT } from "@std/datetime/constants";
+ *
+ * new Date(2025, JAN, 4).getDay() === SAT; // true
+ * ```
+ */
+export const SAT = 6;


### PR DESCRIPTION
## Summary

Add month index constants (JAN-DEC) and day of week constants (SUN-SAT) to `@std/datetime/constants`.

## Motivation

In many languages and cultures (such as Japanese, Chinese, and Korean), months are referred to by their ordinal numbers: January is "1月" (month 1), February is "2月" (month 2), and so on.

However, JavaScript's `Date` object uses 0-based indices for months (0 = January, 11 = December). This mismatch between human intuition and the API frequently leads to off-by-one bugs:

```ts
// Intended: March 1st, 2025
// Actual: April 1st, 2025 (oops!)
new Date(2025, 3, 1)
```

By providing named constants, developers can write clearer, less error-prone code:

```ts
import { MAR } from "@std/datetime/constants";

new Date(2025, MAR, 1)  // unambiguously March
```

```ts
import { SAT, SUN } from "@std/datetime/constants";

const day = date.getDay();
if (day === SAT || day === SUN) {
    console.log("It's the weekend!");
}
```

Changes

- Add month constants: JAN (0) through DEC (11)
- Add day of week constants: SUN (0) through SAT (6)
