### PR TITLE
fix(csv): return empty array for empty input with skipFirstRow

### DIFF
--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -513,7 +513,7 @@ export function parse<const T extends ParseOptions>(
     if (options.skipFirstRow) {
       const head = r.shift();
       if (head === undefined) {
-        throw new TypeError("Cannot parse input: headers must be defined");
+        return [] as ParseResult<ParseOptions, T>;
       }
       headers = head;
     }


### PR DESCRIPTION
## Description
Fixes #6809

When parsing an empty string with `skipFirstRow: true`, the function was throwing a TypeError because there were no headers to extract. This is inconsistent with parsing an empty string without options, which returns an empty array.

## Problem
```ts
parse('');                          // [] ✓
parse(' ', { skipFirstRow: true }); // [] ✓
parse('', { skipFirstRow: true });  // TypeError: Cannot parse input: headers must be defined ✗
```

## Solution
Return an empty array when there's no data to parse, instead of throwing an error.

## Changes
```diff
if (options.skipFirstRow) {
  const head = r.shift();
  if (head === undefined) {
-   throw new TypeError("Cannot parse input: headers must be defined");
+   return [] as ParseResult<ParseOptions, T>;
  }
  headers = head;
}
```

## After
```ts
parse('');                          // [] ✓
parse('', { skipFirstRow: true });  // [] ✓
```