### PR TITLE
refactor(async): optimize delay() for common timeout durations

### DIFF
--- a/async/delay.ts
+++ b/async/delay.ts
@@ -18,8 +18,10 @@ declare const Deno: { unrefTimer(id: number): void };
 /**
  * Resolve a {@linkcode Promise} after a given amount of milliseconds.
  *
- * @throws {DOMException} If the optional signal is aborted before the delay
- * duration, and `signal.reason` is undefined.
+ * If the optional signal is aborted before the delay duration, the returned
+ * promise rejects with the signal's reason. If no reason is provided to
+ * `abort()`, the browser's default `DOMException` with name `"AbortError"` is used.
+ *
  * @param ms Duration in milliseconds for how long the delay should last.
  * @param options Additional options.
  *
@@ -82,12 +84,18 @@ function setArbitraryLengthTimeout(
   delay: number,
 ): { valueOf(): number } {
   // ensure non-negative integer (but > I32_MAX is OK, even if Infinity)
-  let currentDelay = delay = Math.trunc(Math.max(delay, 0) || 0);
+  delay = Math.trunc(Math.max(delay, 0) || 0);
+
+  if (delay <= I32_MAX) {
+    const id = Number(setTimeout(callback, delay));
+    return { valueOf: () => id };
+  }
+
   const start = Date.now();
   let timeoutId: number;
 
   const queueTimeout = () => {
-    currentDelay = delay - (Date.now() - start);
+    const currentDelay = delay - (Date.now() - start);
     timeoutId = currentDelay > I32_MAX
       ? Number(setTimeout(queueTimeout, I32_MAX))
       : Number(setTimeout(callback, currentDelay));

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -25,6 +25,20 @@ Deno.test("delay()", async () => {
   assert(diff >= 100);
 });
 
+Deno.test("delay() resolves immediately with ms = 0", async () => {
+  const start = new Date();
+  await delay(0);
+  const diff = new Date().getTime() - start.getTime();
+  assert(diff < 50);
+});
+
+Deno.test("delay() treats negative ms as 0", async () => {
+  const start = new Date();
+  await delay(-100);
+  const diff = new Date().getTime() - start.getTime();
+  assert(diff < 50);
+});
+
 Deno.test("delay() handles abort", async () => {
   const start = new Date();
   const abort = new AbortController();
@@ -164,6 +178,20 @@ Deno.test({
         assertEquals(result, 1);
       });
     }
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+Deno.test({
+  name: "delay() handles abort with ms > 0x7fffffff",
+  async fn() {
+    const abort = new AbortController();
+    const { signal } = abort;
+    const delayedPromise = delay(Number.MAX_SAFE_INTEGER, { signal });
+    setTimeout(() => abort.abort(), 10);
+    const cause = await assertRejects(() => delayedPromise);
+    assertIsDefaultAbortReason(cause);
   },
   sanitizeResources: false,
   sanitizeOps: false,


### PR DESCRIPTION
Added an early return for the "normal" path

Fixed unclear comment (delay does not throw, it returns a rejected promise)
