### PR TITLE
feat(async/unstable): add support for AbortSignal in retry

### DIFF
--- a/async/unstable_retry.ts
+++ b/async/unstable_retry.ts
@@ -52,6 +52,17 @@ export interface RetryOptions {
    * @returns `true` if the error is retriable, `false` otherwise.
    */
   isRetriable?: (err: unknown) => boolean;
+
+  /**
+   * An AbortSignal to cancel the retry operation.
+   *
+   * If the signal is aborted, the retry will stop and reject with the signal's
+   * reason. The signal is checked before each attempt and during the delay
+   * between attempts.
+   *
+   * @default {undefined}
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -109,6 +120,9 @@ export interface RetryOptions {
  * @param fn The function to retry.
  * @param options Additional options.
  * @returns The promise that resolves with the value returned by the function to retry.
+ * @throws {RetryError} If the function fails after `maxAttempts` attempts.
+ * @throws If the `signal` is aborted, throws the signal's reason.
+ * @throws If `isRetriable` returns `false` for an error, throws that error immediately.
  */
 export async function retry<T>(
   fn: (() => Promise<T>) | (() => T),
@@ -121,6 +135,7 @@ export async function retry<T>(
     minTimeout = 1000,
     jitter = 1,
     isRetriable = () => true,
+    signal,
   } = options ?? {};
 
   if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
@@ -156,6 +171,10 @@ export async function retry<T>(
 
   let attempt = 0;
   while (true) {
+    if (signal?.aborted) {
+      throw signal.reason;
+    }
+
     try {
       return await fn();
     } catch (error) {
@@ -174,7 +193,7 @@ export async function retry<T>(
         multiplier,
         jitter,
       );
-      await delay(timeout);
+      await delay(timeout, signal ? { signal } : undefined);
     }
     attempt++;
   }

--- a/async/unstable_retry_test.ts
+++ b/async/unstable_retry_test.ts
@@ -382,3 +382,53 @@ Deno.test("retry() only retries errors that are retriable with `isRetriable` opt
     }, options), HttpError);
   assertEquals(numCalls, 3);
 });
+
+// Tests specific to unstable retry (signal option)
+
+Deno.test("retry() aborts during delay when signal is aborted", async () => {
+  using time = new FakeTime();
+  const controller = new AbortController();
+  let attempts = 0;
+
+  const promise = retry(() => {
+    attempts++;
+    throw new Error("fail");
+  }, { signal: controller.signal, jitter: 0 });
+
+  await time.nextAsync(); // First delay starts (1000ms)
+  controller.abort("cancelled");
+
+  const error = await assertRejects(() => promise);
+  assertEquals(error, "cancelled");
+  assertEquals(attempts, 2); // Only 2 attempts, not 5
+});
+
+Deno.test("retry() throws immediately if signal is already aborted", async () => {
+  const controller = new AbortController();
+  controller.abort("pre-aborted");
+  let called = false;
+
+  const error = await assertRejects(
+    () =>
+      retry(() => {
+        called = true;
+        return "ok";
+      }, { signal: controller.signal }),
+  );
+  assertEquals(error, "pre-aborted");
+  assertEquals(called, false); // fn was never called
+});
+
+Deno.test("retry() throws AbortError when signal is aborted without reason", async () => {
+  const controller = new AbortController();
+  controller.abort(); // No reason = DOMException with name "AbortError"
+
+  const error = await assertRejects(
+    () =>
+      retry(() => {
+        throw new Error();
+      }, { signal: controller.signal }),
+    DOMException,
+  );
+  assertEquals(error.name, "AbortError");
+});


### PR DESCRIPTION
Sorry, the diff is quite big. I had to bring the unstable code up to speed first.