### PR TITLE
refactor(datetime): rename abbreviated month and weekday constants to full names

### DIFF
--- a/datetime/constants.ts
+++ b/datetime/constants.ts
@@ -61,45 +61,45 @@ export const WEEK: number = DAY * 7;
  *
  * @example
  * ```ts
- * import { JAN } from "@std/datetime/constants";
+ * import { JANUARY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 1); // 2025-01-01
+ * new Date(2025, JANUARY, 1); // 2025-01-01
  * ```
  */
-export const JAN = 0;
+export const JANUARY = 0;
 /**
  * The month index for February.
  *
  * @example
  * ```ts
- * import { FEB } from "@std/datetime/constants";
+ * import { FEBRUARY } from "@std/datetime/constants";
  *
- * new Date(2025, FEB, 1); // 2025-02-01
+ * new Date(2025, FEBRUARY, 1); // 2025-02-01
  * ```
  */
-export const FEB = 1;
+export const FEBRUARY = 1;
 /**
  * The month index for March.
  *
  * @example
  * ```ts
- * import { MAR } from "@std/datetime/constants";
+ * import { MARCH } from "@std/datetime/constants";
  *
- * new Date(2025, MAR, 1); // 2025-03-01
+ * new Date(2025, MARCH, 1); // 2025-03-01
  * ```
  */
-export const MAR = 2;
+export const MARCH = 2;
 /**
  * The month index for April.
  *
  * @example
  * ```ts
- * import { APR } from "@std/datetime/constants";
+ * import { APRIL } from "@std/datetime/constants";
  *
- * new Date(2025, APR, 1); // 2025-04-01
+ * new Date(2025, APRIL, 1); // 2025-04-01
  * ```
  */
-export const APR = 3;
+export const APRIL = 3;
 /**
  * The month index for May.
  *
@@ -116,152 +116,152 @@ export const MAY = 4;
  *
  * @example
  * ```ts
- * import { JUN } from "@std/datetime/constants";
+ * import { JUNE } from "@std/datetime/constants";
  *
- * new Date(2025, JUN, 1); // 2025-06-01
+ * new Date(2025, JUNE, 1); // 2025-06-01
  * ```
  */
-export const JUN = 5;
+export const JUNE = 5;
 /**
  * The month index for July.
  *
  * @example
  * ```ts
- * import { JUL } from "@std/datetime/constants";
+ * import { JULY } from "@std/datetime/constants";
  *
- * new Date(2025, JUL, 1); // 2025-07-01
+ * new Date(2025, JULY, 1); // 2025-07-01
  * ```
  */
-export const JUL = 6;
+export const JULY = 6;
 /**
  * The month index for August.
  *
  * @example
  * ```ts
- * import { AUG } from "@std/datetime/constants";
+ * import { AUGUST } from "@std/datetime/constants";
  *
- * new Date(2025, AUG, 1); // 2025-08-01
+ * new Date(2025, AUGUST, 1); // 2025-08-01
  * ```
  */
-export const AUG = 7;
+export const AUGUST = 7;
 /**
  * The month index for September.
  *
  * @example
  * ```ts
- * import { SEP } from "@std/datetime/constants";
+ * import { SEPTEMBER } from "@std/datetime/constants";
  *
- * new Date(2025, SEP, 1); // 2025-09-01
+ * new Date(2025, SEPTEMBER, 1); // 2025-09-01
  * ```
  */
-export const SEP = 8;
+export const SEPTEMBER = 8;
 /**
  * The month index for October.
  *
  * @example
  * ```ts
- * import { OCT } from "@std/datetime/constants";
+ * import { OCTOBER } from "@std/datetime/constants";
  *
- * new Date(2025, OCT, 1); // 2025-10-01
+ * new Date(2025, OCTOBER, 1); // 2025-10-01
  * ```
  */
-export const OCT = 9;
+export const OCTOBER = 9;
 /**
  * The month index for November.
  *
  * @example
  * ```ts
- * import { NOV } from "@std/datetime/constants";
+ * import { NOVEMBER } from "@std/datetime/constants";
  *
- * new Date(2025, NOV, 1); // 2025-11-01
+ * new Date(2025, NOVEMBER, 1); // 2025-11-01
  * ```
  */
-export const NOV = 10;
+export const NOVEMBER = 10;
 /**
  * The month index for December.
  *
  * @example
  * ```ts
- * import { DEC } from "@std/datetime/constants";
+ * import { DECEMBER } from "@std/datetime/constants";
  *
- * new Date(2025, DEC, 1); // 2025-12-01
+ * new Date(2025, DECEMBER, 1); // 2025-12-01
  * ```
  */
-export const DEC = 11;
+export const DECEMBER = 11;
 /**
  * The day of week index for Sunday.
  *
  * @example
  * ```ts
- * import { JAN, SUN } from "@std/datetime/constants";
+ * import { JANUARY, SUNDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 5).getDay() === SUN; // true
+ * new Date(2025, JANUARY, 5).getDay() === SUNDAY; // true
  * ```
  */
-export const SUN = 0;
+export const SUNDAY = 0;
 /**
  * The day of week index for Monday.
  *
  * @example
  * ```ts
- * import { JAN, MON } from "@std/datetime/constants";
+ * import { JANUARY, MONDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 6).getDay() === MON; // true
+ * new Date(2025, JANUARY, 6).getDay() === MONDAY; // true
  * ```
  */
-export const MON = 1;
+export const MONDAY = 1;
 /**
  * The day of week index for Tuesday.
  *
  * @example
  * ```ts
- * import { JAN, TUE } from "@std/datetime/constants";
+ * import { JANUARY, TUESDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 7).getDay() === TUE; // true
+ * new Date(2025, JANUARY, 7).getDay() === TUESDAY; // true
  * ```
  */
-export const TUE = 2;
+export const TUESDAY = 2;
 /**
  * The day of week index for Wednesday.
  *
  * @example
  * ```ts
- * import { JAN, WED } from "@std/datetime/constants";
+ * import { JANUARY, WEDNESDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 1).getDay() === WED; // true
+ * new Date(2025, JANUARY, 1).getDay() === WEDNESDAY; // true
  * ```
  */
-export const WED = 3;
+export const WEDNESDAY = 3;
 /**
  * The day of week index for Thursday.
  *
  * @example
  * ```ts
- * import { JAN, THU } from "@std/datetime/constants";
+ * import { JANUARY, THURSDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 2).getDay() === THU; // true
+ * new Date(2025, JANUARY, 2).getDay() === THURSDAY; // true
  * ```
  */
-export const THU = 4;
+export const THURSDAY = 4;
 /**
  * The day of week index for Friday.
  *
  * @example
  * ```ts
- * import { JAN, FRI } from "@std/datetime/constants";
+ * import { JANUARY, FRIDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 3).getDay() === FRI; // true
+ * new Date(2025, JANUARY, 3).getDay() === FRIDAY; // true
  * ```
  */
-export const FRI = 5;
+export const FRIDAY = 5;
 /**
  * The day of week index for Saturday.
  *
  * @example
  * ```ts
- * import { JAN, SAT } from "@std/datetime/constants";
+ * import { JANUARY, SATURDAY } from "@std/datetime/constants";
  *
- * new Date(2025, JAN, 4).getDay() === SAT; // true
+ * new Date(2025, JANUARY, 4).getDay() === SATURDAY; // true
  * ```
  */
-export const SAT = 6;
+export const SATURDAY = 6;


### PR DESCRIPTION
  ## Summary
  - Rename month constants from abbreviated to full names (e.g., `JAN` → `JANUARY`)
  - Rename weekday constants from abbreviated to full names (e.g., `SUN` → `SUNDAY`)

  ## Motivation
  Addresses feedback from @timreichen in https://github.com/denoland/std/pull/6910#issuecomment-3694103693

