### PR TITLE
docs(async): list exact API names in module document

### DIFF
--- a/async/mod.ts
+++ b/async/mod.ts
@@ -2,9 +2,9 @@
 // This module is browser compatible.
 
 /**
- * Provide helpers with asynchronous tasks like {@linkcode delay | delays},
- * {@linkcode debounce | debouncing}, {@linkcode retry | retrying}, or
- * {@linkcode pooledMap | pooling}.
+ * Provide helpers with asynchronous tasks, like {@linkcode delay},
+ * {@linkcode debounce}, {@linkcode retry}, or
+ * {@linkcode pooledMap}.
  *
  * ```ts no-assert
  * import { delay } from "@std/async/delay";


### PR DESCRIPTION
I was just reading the docs on <https://jsr.io/@std/async>. The links are plural, but also formatted inside `<code>` elements.

Not a big deal, but it’s nicer when the link to docs for a function/module/class/etc. exactly matches the name of the linked target.

With the addition of a single comma, the pluralized links can be restored to their singular counterparts, and the sentence still makes sense.