### PR TITLE
fix(io): re-export public type aliases

### DIFF
--- a/io/write_all.ts
+++ b/io/write_all.ts
@@ -3,6 +3,8 @@
 
 import type { Writer, WriterSync } from "./types.ts";
 
+export type { Writer, WriterSync } from "./types.ts";
+
 /**
  * Write all the content of the array buffer (`arr`) to the writer (`w`).
  *


### PR DESCRIPTION
This PR re-exports type aliases used by parameters in exported functions — which the consumer would otherwise have to locate and import from a separate module.

For example, to include the parameter type `WriterSync` used by `writeAllSync`:

```ts
export function writeAllSync(writer: WriterSync, data: Uint8Array) { … }
```
[Source](https://github.com/denoland/std/blob/release-2026.01.20/io/write_all.ts#L60)

…before this PR the user would need to write:

```ts
import { writeAllSync } from "@std/io/write-all";
import type { WriterSync } from "@std/io/types";
```

…after the user would need to write:
```ts
import { writeAllSync, type WriterSync } from "@std/io/write-all";
```

---

Ref: [Query for similar previous PRs from me](https://github.com/denoland/std/pulls?q=is%3Apr+author%3Ajsejcksn+export+type)