### PR TITLE
fix(cli): prevent prototype pollution in parseArgs

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -439,6 +439,11 @@ function isNumber(string: string): boolean {
   return NON_WHITESPACE_REGEXP.test(string) && Number.isFinite(Number(string));
 }
 
+function isConstructorOrProto(obj: NestedMapping, key: string): boolean {
+  return (key === "constructor" && typeof obj[key] === "function") ||
+    key === "__proto__";
+}
+
 function setNested(
   object: NestedMapping,
   keys: string[],
@@ -448,7 +453,12 @@ function setNested(
   keys = [...keys];
   const key = keys.pop()!;
 
-  keys.forEach((key) => object = (object[key] ??= {}) as NestedMapping);
+  for (const k of keys) {
+    if (isConstructorOrProto(object, k)) return;
+    object = (object[k] ??= {}) as NestedMapping;
+  }
+
+  if (isConstructorOrProto(object, key)) return;
 
   if (collect) {
     const v = object[key];


### PR DESCRIPTION
See: https://github.com/minimistjs/minimist/compare/v1.2.5...v1.2.6