### PR TITLE
fix(assert): support `Request` objects in `equal()`

### DIFF
--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -110,6 +110,25 @@ export function equal(a: unknown, b: unknown): boolean {
     if (a instanceof Date && b instanceof Date) {
       return Object.is(a.getTime(), b.getTime());
     }
+    if (a instanceof Request && b instanceof Request) {
+      // `Request.body` properties aren't direct compared as doing so would
+      // consume the body streams. In most cases, this is caught anyway by other
+      // properties being different.
+      return a.bodyUsed === b.bodyUsed &&
+        a.cache === b.cache &&
+        a.credentials === b.credentials &&
+        a.destination === b.destination &&
+        equal(a.headers, b.headers) &&
+        a.integrity === b.integrity &&
+        a.keepalive === b.keepalive &&
+        a.method === b.method &&
+        a.mode === b.mode &&
+        a.redirect === b.redirect &&
+        a.referrer === b.referrer &&
+        a.referrerPolicy === b.referrerPolicy &&
+        equal(a.signal, b.signal) &&
+        a.url === b.url;
+    }
     if (a && typeof a === "object" && b && typeof b === "object") {
       if (!prototypesEqual(a, b)) {
         return false;

--- a/assert/equal_test.ts
+++ b/assert/equal_test.ts
@@ -509,3 +509,33 @@ Deno.test("equal() with ArrayBuffer", async (t) => {
     });
   });
 });
+
+Deno.test("equal() with Requests", async (t) => {
+  await t.step("equal", () => {
+    const reqA = new Request("https://example.com/foo", {
+      method: "POST",
+      headers: { "x-foo": "bar" },
+      body: "hello world",
+    });
+    const reqB = new Request("https://example.com/foo", {
+      method: "POST",
+      headers: { "x-foo": "bar" },
+      body: "hello world",
+    });
+    assert(equal(reqA, reqB));
+  });
+
+  await t.step("not equal", () => {
+    const reqA = new Request("https://example.com/foo", {
+      method: "POST",
+      headers: { "x-foo": "bar" },
+      body: "hello world",
+    });
+    const reqB = new Request("https://example.com/foo", {
+      method: "PUT",
+      headers: { "x-foo": "bar" },
+      body: "hello world",
+    });
+    assertFalse(equal(reqA, reqB));
+  });
+});


### PR DESCRIPTION
Previously, this would evaluate to `false` because of internal symbols within `Request` objects being unequal:
```ts
import { equal } from "jsr:@std/assert/equal`;
equal(
  new Request("https://example.com"),
  new Request("https://example.com")
); // false
```

This would have knock-on effects due to `equal()` being the underlying function for comparison within [`assertEquals()`](https://jsr.io/@std/assert/doc/~/assertEquals), [`assertSpyCall()`](https://jsr.io/@std/testing/doc/mock/~/assertSpyCall), etc.

This PR is a quick and dirty fix for handling the comparison of said `Request` objects in `equal()`. I'm sure there's a better way to do this, but at least this improves `equal()` a little.