### PR TITLE
fix(http): guard top-level Deno global access for browser compatibility

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -63,15 +63,20 @@ interface EntryInfo {
   name: string;
 }
 
-const ENV_PERM_STATUS =
-  Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
-    .state ?? "granted"; // for deno deploy
-const NET_PERM_STATUS =
-  Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
-    .state ?? "granted"; // for deno deploy
-const DENO_DEPLOYMENT_ID = ENV_PERM_STATUS === "granted"
-  ? Deno.env.get("DENO_DEPLOYMENT_ID")
-  : undefined;
+const ENV_PERM_STATUS = typeof Deno !== "undefined"
+  ? Deno.permissions.querySync?.({
+    name: "env",
+    variable: "DENO_DEPLOYMENT_ID",
+  }).state ?? "granted"
+  : "granted"; // for deno deploy
+const NET_PERM_STATUS = typeof Deno !== "undefined"
+  ? Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
+    .state ?? "granted"
+  : "granted"; // for deno deploy
+const DENO_DEPLOYMENT_ID =
+  ENV_PERM_STATUS === "granted" && typeof Deno !== "undefined"
+    ? Deno.env.get("DENO_DEPLOYMENT_ID")
+    : undefined;
 const HASHED_DENO_DEPLOYMENT_ID = DENO_DEPLOYMENT_ID
   ? eTag(DENO_DEPLOYMENT_ID, { weak: true })
   : undefined;


### PR DESCRIPTION
**Problem:**
When importing `UserAgent` or other utilities from `@std/http` in a browser environment (e.g., via Vite), the application crashes. This occurs because `file_server.ts` performs top-level execution of code accessing the `Deno` global namespace (specifically `Deno.permissions` and `Deno.env`) which does not exist in the browser.
 **Solution:**
 This PR adds a `typeof Deno !== "undefined"` check before attempting to access permission queries or environment variables. This ensures the module can be loaded in non-Deno environments without throwing a `ReferenceError`.
 
If there is anything else I can do to help this merge, please let me know.