### PR TITLE
fix(assert): preserve Date instances in assertObjectMatch filter

### DIFF
--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -100,6 +100,11 @@ function filter(a: Loose, b: Loose): Loose {
         defineProperty(filtered, key, value);
         continue;
       }
+      // On date references, keep value as it to avoid losing the timestamp
+      if (value instanceof Date) {
+        defineProperty(filtered, key, value);
+        continue;
+      }
 
       const subset = (b as Loose)[key];
 
@@ -167,6 +172,11 @@ function filter(a: Loose, b: Loose): Loose {
 
       // On regexp references, keep value as it to avoid losing pattern and flags
       if (value instanceof RegExp) {
+        filtered.push(value);
+        continue;
+      }
+      // On date references, keep value as it to avoid losing the timestamp
+      if (value instanceof Date) {
         filtered.push(value);
         continue;
       }

--- a/assert/object_match_test.ts
+++ b/assert/object_match_test.ts
@@ -119,6 +119,26 @@ Deno.test("assertObjectMatch() matches subset with regexp", () => {
   assertObjectMatch(m, { bar: [/abc/g, /abc/m] });
 });
 
+Deno.test("assertObjectMatch() matches when expected has shared Date references", () => {
+  const timestamp = 1700000000000;
+  const startTime = new Date(timestamp);
+  assertObjectMatch(
+    { startTime: new Date(timestamp), data: [{ t: new Date(timestamp) }] },
+    { startTime, data: [{ t: startTime }] },
+  );
+});
+
+Deno.test("assertObjectMatch() throws when date mismatches", () => {
+  assertThrows(
+    () =>
+      assertObjectMatch(
+        { startTime: new Date(1000) },
+        { startTime: new Date(2000) },
+      ),
+    AssertionError,
+  );
+});
+
 Deno.test("assertObjectMatch() matches subset with built-in data structures", () => {
   assertObjectMatch(n, { foo: new Set(["foo"]) });
   assertObjectMatch(n, { bar: new Map([["bar", 2]]) });


### PR DESCRIPTION
Fix: https://github.com/denoland/std/issues/6986

Match Date handling with existing RegExp handling