### PR TITLE
fix(cli): handle empty value in parseArgs

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -425,7 +425,7 @@ interface NestedMapping {
 }
 
 const FLAG_REGEXP =
-  /^(?:-(?:(?<doubleDash>-)(?<negated>no-)?)?)(?<key>.+?)(?:=(?<value>.+?))?$/s;
+  /^(?:-(?:(?<doubleDash>-)(?<negated>no-)?)?)(?<key>.+?)(?:=(?<value>.*))?$/s;
 const LETTER_REGEXP = /[A-Za-z]/;
 const NUMBER_REGEXP = /-?\d+(\.\d*)?(e-?\d+)?$/;
 const HYPHEN_REGEXP = /^(-|--)[^-]/;
@@ -758,7 +758,7 @@ export function parseArgs<
       let value: string | number | boolean | undefined = groups.value;
 
       if (doubleDash) {
-        if (value) {
+        if (value != null) {
           if (booleanSet.has(key)) value = parseBooleanString(value);
           setArgument(key, value, arg, true);
           continue;
@@ -807,6 +807,11 @@ export function parseArgs<
         if (next === "-") {
           setArgument(letter, next, arg, true);
           continue;
+        }
+
+        if (next === "=") {
+          setArgument(letter, "", arg, true);
+          continue argsLoop;
         }
 
         if (LETTER_REGEXP.test(letter)) {

--- a/cli/parse_args_test.ts
+++ b/cli/parse_args_test.ts
@@ -539,6 +539,14 @@ Deno.test("parseArgs() handles empty strings", function () {
   assertEquals(letters.t, "");
 });
 
+Deno.test("parseArgs() handles empty value after equals sign", function () {
+  assertEquals(parseArgs(["--foo="]), { _: [], foo: "" });
+});
+
+Deno.test("parseArgs() handles short flag combo with trailing equals sign", function () {
+  assertEquals(parseArgs(["-abc="]), { _: [], a: true, b: true, c: "" });
+});
+
 Deno.test("parseArgs() handles string and alias", function () {
   const x = parseArgs(["--str", "000123"], {
     string: "s",


### PR DESCRIPTION
Here's a sample script to showcase the bug:

```
import { parseArgs } from "jsr:@std/cli/parse-args";

const tests = [
  ["-f="],
  ["-abc="],
  ["--foo="],
  ["--foo=", "bar"],
];

for (const args of tests) {
  console.log(`parseArgs(${JSON.stringify(args)}):`);
  console.log(parseArgs(args));
  console.log();
}

// Bug 1 (short flags):
//
//   -f=
//     Actual:   { _: [], f: true, "=": true }
//     Expected: { _: [], f: "" }
//
//   -abc=
//     Actual:   { _: [], a: true, b: true, c: true, "=": true }
//     Expected: { _: [], a: true, b: true, c: "" }

// Bug 2 (long flags):
//
//   --foo=
//     Actual:   { _: [], "foo=": true }
//     Expected: { _: [], foo: "" }
//
//   --foo= bar
//     Actual:   { _: [], "foo=": "bar" }
//     Expected: { _: [ "bar" ], foo: "" }
```