### PR TITLE
refactor(async/unstable): make circuit breaker resilient to throwing callbacks

### DIFF
--- a/async/unstable_circuit_breaker.ts
+++ b/async/unstable_circuit_breaker.ts
@@ -704,6 +704,7 @@ export class CircuitBreaker<T = unknown> {
   /** Records a success and potentially closes the circuit from half-open. */
   #handleSuccess(previousState: CircuitState): void {
     if (previousState === "closed") return;
+    if (this.#state.state !== "half_open") return;
 
     const newSuccessCount = this.#state.consecutiveSuccesses + 1;
     if (newSuccessCount >= this.#successThreshold) {


### PR DESCRIPTION
- fixed a bug where a throwing callback (e.g. `onFailure`, `onStateChange`) would crash the circuit breaker mid-update, hiding the original error that your code was trying to throw.
- fixed a bug where failure detection (e.g. flagging HTTP 500 responses as failures) was silently blocked by custom error filters (`isFailure`), so those results would never trip the circuit breaker
- fixed a bug where two requests racing during recovery could cause a failed request to reopen the circuit, only for a concurrent successful request to immediately close it again.
