### PR TITLE
test(async): make debounce tests deterministic

### DIFF
--- a/async/debounce_test.ts
+++ b/async/debounce_test.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import { debounce, type DebouncedFunction } from "./debounce.ts";
-import { delay } from "./delay.ts";
 
-Deno.test("debounce() handles called", async () => {
+Deno.test("debounce() handles called", () => {
   let called = 0;
   const d = debounce(() => called++, 100);
   d();
@@ -11,12 +10,12 @@ Deno.test("debounce() handles called", async () => {
   d();
   assertEquals(called, 0);
   assertEquals(d.pending, true);
-  await delay(200);
+  d.flush();
   assertEquals(called, 1);
   assertEquals(d.pending, false);
 });
 
-Deno.test("debounce() handles cancelled", async () => {
+Deno.test("debounce() handles cancelled", () => {
   let called = 0;
   const d = debounce(() => called++, 100);
   d();
@@ -25,7 +24,6 @@ Deno.test("debounce() handles cancelled", async () => {
   assertEquals(called, 0);
   assertEquals(d.pending, true);
   d.clear();
-  await delay(200);
   assertEquals(called, 0);
   assertEquals(d.pending, false);
 });
@@ -43,7 +41,7 @@ Deno.test("debounce() handles flush", () => {
   assertEquals(d.pending, false);
 });
 
-Deno.test("debounce() handles params and context", async () => {
+Deno.test("debounce() handles params and context", () => {
   const params: Array<string | number> = [];
   const d: DebouncedFunction<[string, number]> = debounce(
     function (param1: string, param2: number) {
@@ -61,12 +59,12 @@ Deno.test("debounce() handles params and context", async () => {
   d("baz", 1);
   assertEquals(params.length, 0);
   assertEquals(d.pending, true);
-  await delay(200);
+  d.flush();
   assertEquals(params, ["baz", 1]);
   assertEquals(d.pending, false);
 });
 
-Deno.test("debounce() handles number and string types", async () => {
+Deno.test("debounce() handles number and string types", () => {
   const params: Array<string> = [];
   const fn = (param: string) => params.push(param);
   const d: DebouncedFunction<[string]> = debounce(fn, 100);
@@ -75,7 +73,7 @@ Deno.test("debounce() handles number and string types", async () => {
   d("foo");
   assertEquals(params.length, 0);
   assertEquals(d.pending, true);
-  await delay(200);
+  d.flush();
   assertEquals(params, ["foo"]);
   assertEquals(d.pending, false);
 });
@@ -117,7 +115,7 @@ Deno.test("debounce() throws on invalid wait values", () => {
   }
 });
 
-Deno.test("debounce() re-invocation after flush re-schedules", async () => {
+Deno.test("debounce() re-invocation after flush re-schedules", () => {
   let called = 0;
   const d = debounce(() => called++, 50);
   d();
@@ -126,7 +124,7 @@ Deno.test("debounce() re-invocation after flush re-schedules", async () => {
   assertEquals(d.pending, false);
   d();
   assertEquals(d.pending, true);
-  await delay(100);
+  d.flush();
   assertEquals(called, 2);
   assertEquals(d.pending, false);
 });


### PR DESCRIPTION
Ref: https://github.com/denoland/std/pull/7022#discussion_r2894014649

Replace `await delay()` with synchronous `flush()`/`clear()` calls in debounce tests. Real timers can be unreliable in CI, making these tests flaky. Every behaviour under test can be verified deterministically without waiting for timers to fire.