### PR TITLE
feat(http/unstable): add RFC 9421 message signatures

### DIFF
--- a/badge.svg
+++ b/badge.svg
@@ -6,35 +6,51 @@
   role="img"
   aria-label="Built with deno_std"
 >
-  <title>Built with deno_std</title><a
+  <title>Built with deno_std</title>
+  <a
     target="_blank"
     xlink:href="https://jsr.io/@std"
-  ><linearGradient id="s" x2="0" y2="100%"><stop
+  >
+    <linearGradient id="s" x2="0" y2="100%">
+      <stop
         offset="0"
         stop-color="#bbb"
         stop-opacity=".1"
-      /><stop offset="1" stop-opacity=".1" /></linearGradient><clipPath
+      />
+      <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath
       id="r"
-    ><rect width="135" height="20" rx="3" fill="#fff" /></clipPath><g
+    >
+      <rect width="135" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g
       clip-path="url(#r)"
-    ><rect width="0" height="20" fill="#555" /><rect
+    >
+      <rect width="0" height="20" fill="#555" />
+      <rect
         x="0"
         width="135"
         height="20"
         fill="#007ec6"
-      /><rect width="135" height="20" fill="url(#s)" /></g><g
+      />
+      <rect width="135" height="20" fill="url(#s)" />
+    </g>
+    <g
       fill="#fff"
       text-anchor="middle"
       font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
       text-rendering="geometricPrecision"
       font-size="110"
-    ><image
+    >
+      <image
         x="5"
         y="3"
         width="14"
         height="14"
         xlink:href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZXNtb2tlIiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+RGVubzwvdGl0bGU+PHBhdGggZD0iTTEyIDBjNi42MjcgMCAxMiA1LjM3MyAxMiAxMnMtNS4zNzMgMTItMTIgMTJTMCAxOC42MjcgMCAxMiA1LjM3MyAwIDEyIDBabS0uNDY5IDYuNzkzYy0zLjQ5IDAtNi4yMDQgMi4xOTYtNi4yMDQgNC45MjggMCAyLjU4IDIuNDk4IDQuMjI4IDYuMzcgNC4xNDVsLjExOC0uMDAzLjQyNS0uMDEyLS4xMDkuMjc5LjAxMy4wMjljLjAzMS4wNzIuMDYuMTQ1LjA4NC4yMmwuMDEuMDI4LjAxNS4wNDUuMDIxLjA2NS4wMTQuMDQ1LjAxNC4wNDcuMDE1LjA0OS4wMjEuMDc1LjAyMi4wNzkuMDE1LjA1NC4wMjMuMDg0LjAyMi4wODguMDIzLjA5MS4wMjMuMDk1LjAxNS4wNjUuMDI0LjEuMDIzLjEwMy4wMzIuMTQzLjAxNy4wNzQuMDI0LjExNC4wMjQuMTE3LjAyNS4xMi4wMzUuMTc0LjAyOS4xNDIuMDM3LjE5NS4wMi4xLjAyOC4xNTUuMDMuMTU4LjAzOS4yMTcuMDQuMjI1LjA0LjIzMS4wNDEuMjQuMDQyLjI0Ni4wNDIuMjU0LjA0Mi4yNi4wMzIuMjAxLjA1NS4zNDQuMDIyLjE0LjA1NS4zNi4wNDUuMjk1LjAzNC4yMjcuMDQ2LjMwOC4wMjMuMTU2YTEwLjc1OCAxMC43NTggMCAwIDAgNi41MjktMy40MTJsLjA1LS4wNTUtLjIzOC0uODkxLS42MzMtMi4zNy0uMzk1LTEuNDctLjM0OC0xLjI5Ni0uMjEzLS43ODctLjEzNi0uNDk4LS4wODEtLjI5Ny0uMDczLS4yNjQtLjAzMi0uMTEtLjAxOC0uMDY0LS4wMS0uMDM0LS4wMDgtLjAyNmE2LjA0MiA2LjA0MiAwIDAgMC0yLjAzOC0yLjk3Yy0xLjEzNC0uODg3LTIuNTczLTEuMzUxLTQuMjUyLTEuMzUxWk04LjQ2NyAxOS4zYS41ODYuNTg2IDAgMCAwLS43MTQuNGwtLjAwNC4wMTMtLjUyNyAxLjk1M2MuMzI4LjE2My42NjUuMzA5IDEuMDA4LjQzN2wuMDguMDMuNTctMi4xMTQuMDA0LS4wMTVhLjU4Ni41ODYgMCAwIDAtLjQxNy0uNzA0Wm0zLjI2NC0xLjQzYS41ODYuNTg2IDAgMCAwLS43MTUuNGwtLjAwNC4wMTQtLjc5NiAyLjk1My0uMDA0LjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0Ljc5Ny0yLjk1My4wMDMtLjAxNGEuNTg1LjU4NSAwIDAgMCAuMDEzLS4wNjdsLjAwMi0uMDIyLS4wMTktLjA5Ni0uMDI3LS4xMzgtLjAxOC0uMDg2YS41ODQuNTg0IDAgMCAwLS4zNjctLjI5NVptLTUuNTUzLTMuMDRhLjU5LjU5IDAgMCAwLS4wMzcuMDlsLS4wMDUuMDItLjc5NyAyLjk1My0uMDA0LjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDZsLjAwNC0uMDE0LjcyMy0yLjY3OGE1LjI5NSA1LjI5NSAwIDAgMS0xLjAxNS0uNjkyWm0tMS45LTMuMzk3YS41ODYuNTg2IDAgMCAwLS43MTUuNGwtLjAwNC4wMTMtLjc5NyAyLjk1My0uMDAzLjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzLjMwNWwuMDA1LS4wMTQuNzk3LTIuOTUzLjAwMy0uMDE1YS41ODYuNTg2IDAgMCAwLS40MTYtLjcwNFptMTcuODY4LS42N2EuNTg2LjU4NiAwIDAgMC0uNzE1LjM5OWwtLjAwNC4wMTQtLjc5NyAyLjk1My0uMDAzLjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzLjMwNWwuMDA1LS4wMTQuNzk3LTIuOTUzLjAwMy0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTYtLjcwNFpNMi41NDIgNi44MmExMC43MDcgMTAuNzA3IDAgMCAwLTEuMjUxIDMuOTI2LjU4Ni41ODYgMCAwIDAgMS4wMDItLjIybC4wMDQtLjAxNC43OTctMi45NTMuMDAzLS4wMTRhLjU4Ni41ODYgMCAwIDAtLjU1NS0uNzI1Wm0xNy41ODUuMDJhLjU4Ni41ODYgMCAwIDAtLjcxNC40bC0uMDA0LjAxNC0uNzk3IDIuOTUzLS4wMDQuMDE0YS41ODYuNTg2IDAgMCAwIDEuMTMxLjMwNWwuMDA0LS4wMTQuNzk3LTIuOTUzLjAwNC0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTctLjcwNFptLTcuODQ2IDEuOTI2YS43NS43NSAwIDEgMSAwIDEuNS43NS43NSAwIDAgMSAwLTEuNVptLTYuMjctNC43MzNhLjU4Ni41ODYgMCAwIDAtLjcxNS4zOThsLS4wMDQuMDE1LS43OTcgMi45NTMtLjAwNC4wMTRhLjU4Ni41ODYgMCAwIDAgMS4xMzIuMzA1bC4wMDMtLjAxNC43OTctMi45NTMuMDA0LS4wMTRhLjU4Ni41ODYgMCAwIDAtLjQxNy0uNzA0Wm0xMC4yMzguNTU4YS41ODYuNTg2IDAgMCAwLS43MTQuMzk5bC0uMDA0LjAxNC0uNTM2IDEuOTg0Yy4zNDcuMTcxLjY3OC4zNzMuOTkuNjAzbC4wNTEuMDM4LjYyNi0yLjMyLjAwNC0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTctLjcwNFptLTUuMjExLTMuMzNjLS4zNzQuMDMzLS43NDYuMDg2LTEuMTE1LjE1OGwtLjA3OC4wMTUtLjc0MiAyLjc1My0uMDA0LjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0Ljc5Ny0yLjk1My4wMDQtLjAxNWEuNTgzLjU4MyAwIDAgMCAuMDAzLS4yNjRabTcuMzMyIDIuMDQtLjE1Ni41OC0uMDA0LjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0LjAxNy0uMDYzYTEwLjgzOCAxMC44MzggMCAwIDAtLjkyMy0uNzcybC0uMDY5LS4wNTFabS00LjYzNi0xLjk0NC0uMjgzIDEuMDQ4LS4wMDMuMDE0YS41ODYuNTg2IDAgMCAwIDEuMTMuMzA1bC4wMDUtLjAxNC4yOTctMS4xMDJjLS4zNS0uMDk3LS43MDUtLjE3Ni0xLjA2My0uMjM3bC0uMDgzLS4wMTRaIi8+PC9zdmc+"
-      /><text
+      />
+      <text
         aria-hidden="true"
         x="765"
         y="150"
@@ -42,11 +58,14 @@
         fill-opacity=".3"
         transform="scale(.1)"
         textLength="1070"
-      >Built with deno_std</text><text
+      >Built with deno_std</text>
+      <text
         x="765"
         y="140"
         transform="scale(.1)"
         fill="#fff"
         textLength="1070"
-      >Built with deno_std</text></g></a>
+      >Built with deno_std</text>
+    </g>
+  </a>
 </svg>

--- a/badge.svg
+++ b/badge.svg
@@ -6,51 +6,35 @@
   role="img"
   aria-label="Built with deno_std"
 >
-  <title>Built with deno_std</title>
-  <a
+  <title>Built with deno_std</title><a
     target="_blank"
     xlink:href="https://jsr.io/@std"
-  >
-    <linearGradient id="s" x2="0" y2="100%">
-      <stop
+  ><linearGradient id="s" x2="0" y2="100%"><stop
         offset="0"
         stop-color="#bbb"
         stop-opacity=".1"
-      />
-      <stop offset="1" stop-opacity=".1" />
-    </linearGradient>
-    <clipPath
+      /><stop offset="1" stop-opacity=".1" /></linearGradient><clipPath
       id="r"
-    >
-      <rect width="135" height="20" rx="3" fill="#fff" />
-    </clipPath>
-    <g
+    ><rect width="135" height="20" rx="3" fill="#fff" /></clipPath><g
       clip-path="url(#r)"
-    >
-      <rect width="0" height="20" fill="#555" />
-      <rect
+    ><rect width="0" height="20" fill="#555" /><rect
         x="0"
         width="135"
         height="20"
         fill="#007ec6"
-      />
-      <rect width="135" height="20" fill="url(#s)" />
-    </g>
-    <g
+      /><rect width="135" height="20" fill="url(#s)" /></g><g
       fill="#fff"
       text-anchor="middle"
       font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
       text-rendering="geometricPrecision"
       font-size="110"
-    >
-      <image
+    ><image
         x="5"
         y="3"
         width="14"
         height="14"
         xlink:href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZXNtb2tlIiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+RGVubzwvdGl0bGU+PHBhdGggZD0iTTEyIDBjNi42MjcgMCAxMiA1LjM3MyAxMiAxMnMtNS4zNzMgMTItMTIgMTJTMCAxOC42MjcgMCAxMiA1LjM3MyAwIDEyIDBabS0uNDY5IDYuNzkzYy0zLjQ5IDAtNi4yMDQgMi4xOTYtNi4yMDQgNC45MjggMCAyLjU4IDIuNDk4IDQuMjI4IDYuMzcgNC4xNDVsLjExOC0uMDAzLjQyNS0uMDEyLS4xMDkuMjc5LjAxMy4wMjljLjAzMS4wNzIuMDYuMTQ1LjA4NC4yMmwuMDEuMDI4LjAxNS4wNDUuMDIxLjA2NS4wMTQuMDQ1LjAxNC4wNDcuMDE1LjA0OS4wMjEuMDc1LjAyMi4wNzkuMDE1LjA1NC4wMjMuMDg0LjAyMi4wODguMDIzLjA5MS4wMjMuMDk1LjAxNS4wNjUuMDI0LjEuMDIzLjEwMy4wMzIuMTQzLjAxNy4wNzQuMDI0LjExNC4wMjQuMTE3LjAyNS4xMi4wMzUuMTc0LjAyOS4xNDIuMDM3LjE5NS4wMi4xLjAyOC4xNTUuMDMuMTU4LjAzOS4yMTcuMDQuMjI1LjA0LjIzMS4wNDEuMjQuMDQyLjI0Ni4wNDIuMjU0LjA0Mi4yNi4wMzIuMjAxLjA1NS4zNDQuMDIyLjE0LjA1NS4zNi4wNDUuMjk1LjAzNC4yMjcuMDQ2LjMwOC4wMjMuMTU2YTEwLjc1OCAxMC43NTggMCAwIDAgNi41MjktMy40MTJsLjA1LS4wNTUtLjIzOC0uODkxLS42MzMtMi4zNy0uMzk1LTEuNDctLjM0OC0xLjI5Ni0uMjEzLS43ODctLjEzNi0uNDk4LS4wODEtLjI5Ny0uMDczLS4yNjQtLjAzMi0uMTEtLjAxOC0uMDY0LS4wMS0uMDM0LS4wMDgtLjAyNmE2LjA0MiA2LjA0MiAwIDAgMC0yLjAzOC0yLjk3Yy0xLjEzNC0uODg3LTIuNTczLTEuMzUxLTQuMjUyLTEuMzUxWk04LjQ2NyAxOS4zYS41ODYuNTg2IDAgMCAwLS43MTQuNGwtLjAwNC4wMTMtLjUyNyAxLjk1M2MuMzI4LjE2My42NjUuMzA5IDEuMDA4LjQzN2wuMDguMDMuNTctMi4xMTQuMDA0LS4wMTVhLjU4Ni41ODYgMCAwIDAtLjQxNy0uNzA0Wm0zLjI2NC0xLjQzYS41ODYuNTg2IDAgMCAwLS43MTUuNGwtLjAwNC4wMTQtLjc5NiAyLjk1My0uMDA0LjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0Ljc5Ny0yLjk1My4wMDMtLjAxNGEuNTg1LjU4NSAwIDAgMCAuMDEzLS4wNjdsLjAwMi0uMDIyLS4wMTktLjA5Ni0uMDI3LS4xMzgtLjAxOC0uMDg2YS41ODQuNTg0IDAgMCAwLS4zNjctLjI5NVptLTUuNTUzLTMuMDRhLjU5LjU5IDAgMCAwLS4wMzcuMDlsLS4wMDUuMDItLjc5NyAyLjk1My0uMDA0LjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDZsLjAwNC0uMDE0LjcyMy0yLjY3OGE1LjI5NSA1LjI5NSAwIDAgMS0xLjAxNS0uNjkyWm0tMS45LTMuMzk3YS41ODYuNTg2IDAgMCAwLS43MTUuNGwtLjAwNC4wMTMtLjc5NyAyLjk1My0uMDAzLjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzLjMwNWwuMDA1LS4wMTQuNzk3LTIuOTUzLjAwMy0uMDE1YS41ODYuNTg2IDAgMCAwLS40MTYtLjcwNFptMTcuODY4LS42N2EuNTg2LjU4NiAwIDAgMC0uNzE1LjM5OWwtLjAwNC4wMTQtLjc5NyAyLjk1My0uMDAzLjAxNGEuNTg2LjU4NiAwIDAgMCAxLjEzLjMwNWwuMDA1LS4wMTQuNzk3LTIuOTUzLjAwMy0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTYtLjcwNFpNMi41NDIgNi44MmExMC43MDcgMTAuNzA3IDAgMCAwLTEuMjUxIDMuOTI2LjU4Ni41ODYgMCAwIDAgMS4wMDItLjIybC4wMDQtLjAxNC43OTctMi45NTMuMDAzLS4wMTRhLjU4Ni41ODYgMCAwIDAtLjU1NS0uNzI1Wm0xNy41ODUuMDJhLjU4Ni41ODYgMCAwIDAtLjcxNC40bC0uMDA0LjAxNC0uNzk3IDIuOTUzLS4wMDQuMDE0YS41ODYuNTg2IDAgMCAwIDEuMTMxLjMwNWwuMDA0LS4wMTQuNzk3LTIuOTUzLjAwNC0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTctLjcwNFptLTcuODQ2IDEuOTI2YS43NS43NSAwIDEgMSAwIDEuNS43NS43NSAwIDAgMSAwLTEuNVptLTYuMjctNC43MzNhLjU4Ni41ODYgMCAwIDAtLjcxNS4zOThsLS4wMDQuMDE1LS43OTcgMi45NTMtLjAwNC4wMTRhLjU4Ni41ODYgMCAwIDAgMS4xMzIuMzA1bC4wMDMtLjAxNC43OTctMi45NTMuMDA0LS4wMTRhLjU4Ni41ODYgMCAwIDAtLjQxNy0uNzA0Wm0xMC4yMzguNTU4YS41ODYuNTg2IDAgMCAwLS43MTQuMzk5bC0uMDA0LjAxNC0uNTM2IDEuOTg0Yy4zNDcuMTcxLjY3OC4zNzMuOTkuNjAzbC4wNTEuMDM4LjYyNi0yLjMyLjAwNC0uMDE0YS41ODYuNTg2IDAgMCAwLS40MTctLjcwNFptLTUuMjExLTMuMzNjLS4zNzQuMDMzLS43NDYuMDg2LTEuMTE1LjE1OGwtLjA3OC4wMTUtLjc0MiAyLjc1My0uMDA0LjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0Ljc5Ny0yLjk1My4wMDQtLjAxNWEuNTgzLjU4MyAwIDAgMCAuMDAzLS4yNjRabTcuMzMyIDIuMDQtLjE1Ni41OC0uMDA0LjAxNWEuNTg2LjU4NiAwIDAgMCAxLjEzMS4zMDVsLjAwNC0uMDE0LjAxNy0uMDYzYTEwLjgzOCAxMC44MzggMCAwIDAtLjkyMy0uNzcybC0uMDY5LS4wNTFabS00LjYzNi0xLjk0NC0uMjgzIDEuMDQ4LS4wMDMuMDE0YS41ODYuNTg2IDAgMCAwIDEuMTMuMzA1bC4wMDUtLjAxNC4yOTctMS4xMDJjLS4zNS0uMDk3LS43MDUtLjE3Ni0xLjA2My0uMjM3bC0uMDgzLS4wMTRaIi8+PC9zdmc+"
-      />
-      <text
+      /><text
         aria-hidden="true"
         x="765"
         y="150"
@@ -58,14 +42,11 @@
         fill-opacity=".3"
         transform="scale(.1)"
         textLength="1070"
-      >Built with deno_std</text>
-      <text
+      >Built with deno_std</text><text
         x="765"
         y="140"
         transform="scale(.1)"
         fill="#fff"
         textLength="1070"
-      >Built with deno_std</text>
-    </g>
-  </a>
+      >Built with deno_std</text></g></a>
 </svg>

--- a/http/_types.ts
+++ b/http/_types.ts
@@ -1,0 +1,11 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+/**
+ * Proxy type of {@code Uint8Array<ArrayBuffer>} or {@code Uint8Array} in TypeScript 5.7 or below respectively.
+ *
+ * This type is internal utility type and should not be used directly.
+ *
+ * @internal @private
+ */
+
+export type Uint8Array_ = ReturnType<Uint8Array["slice"]>;

--- a/http/deno.json
+++ b/http/deno.json
@@ -20,6 +20,7 @@
     "./unstable-structured-fields": "./unstable_structured_fields.ts",
     "./user-agent": "./user_agent.ts",
     "./unstable-route": "./unstable_route.ts",
-    "./unstable-cache-control": "./unstable_cache_control.ts"
+    "./unstable-cache-control": "./unstable_cache_control.ts",
+    "./unstable-message-signatures": "./unstable_message_signatures.ts"
   }
 }

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -192,7 +192,12 @@ export interface SignatureParams {
   nonce?: string;
   /** Application-specific tag. */
   tag?: string;
-  /** Signature label, defaults to `"sig"`. Must be a valid sf-key (lowercase alphanumeric, `_`, `-`, `.`, `*`). */
+  /**
+   * Signature label, defaults to `"sig"`. Must be a valid sf-key (lowercase
+   * alphanumeric, `_`, `-`, `.`, `*`). Must also be unique among existing
+   * signatures on the target message per RFC 9421 section 4; a `TypeError`
+   * is thrown on collision.
+   */
   label?: string;
 }
 
@@ -825,6 +830,7 @@ export async function signMessage<T extends Request | Response>(
   const label = params.label ?? "sig";
 
   validateSignParams(params);
+  assertUniqueLabel(message.headers, label);
 
   const algorithm = params.algorithm ?? inferAlgorithm(key);
 
@@ -861,6 +867,32 @@ function appendHeader(headers: Headers, name: string, value: string): void {
     headers.set(name, `${existing}, ${value}`);
   } else {
     headers.set(name, value);
+  }
+}
+
+// Per RFC 9421 §4, signature labels MUST be unique within an HTTP message
+// across both the Signature-Input and Signature dictionaries. Appending a
+// signature with a colliding label would produce duplicate dictionary keys
+// that silently corrupt prior signatures on parse (last value wins per
+// RFC 8941).
+function assertUniqueLabel(headers: Headers, label: string): void {
+  for (const name of ["Signature-Input", "Signature"] as const) {
+    const value = headers.get(name);
+    if (value === null) continue;
+    let dict: Dictionary;
+    try {
+      dict = parseDictionary(value);
+    } catch (cause) {
+      throw new TypeError(
+        `Cannot parse existing "${name}" header on message to check label uniqueness`,
+        { cause },
+      );
+    }
+    if (dict.has(label)) {
+      throw new TypeError(
+        `Signature label "${label}" is already present in the "${name}" header on the message; choose a unique label (RFC 9421 section 4)`,
+      );
+    }
   }
 }
 

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -1,0 +1,1059 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+/**
+ * Utilities for creating and verifying
+ * {@link https://www.rfc-editor.org/rfc/rfc9421 | RFC 9421} HTTP Message Signatures.
+ *
+ * HTTP Message Signatures provide end-to-end integrity and authenticity for
+ * components of an HTTP message by using detached digital signatures or MACs.
+ * The `Signature-Input` and `Signature` headers are serialized as Structured
+ * Fields Dictionaries ({@link https://www.rfc-editor.org/rfc/rfc9651 | RFC 9651}).
+ *
+ * @example Signing a request
+ * ```ts
+ * import { signMessage } from "@std/http/unstable-message-signatures";
+ *
+ * const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
+ * const request = new Request("https://example.com/api", {
+ *   method: "POST",
+ *   headers: { "Content-Type": "application/json" },
+ *   body: '{"hello":"world"}',
+ * });
+ *
+ * const signed = await signMessage({
+ *   message: request,
+ *   params: {
+ *     components: ["@method", "@authority", "@path", "content-type"],
+ *     keyId: "my-key",
+ *     created: Math.floor(Date.now() / 1000),
+ *   },
+ *   key: key.privateKey,
+ * });
+ * ```
+ *
+ * @example Verifying a signed request
+ * ```ts ignore
+ * import { verifyMessage } from "@std/http/unstable-message-signatures";
+ *
+ * const results = await verifyMessage(
+ *   signedRequest,
+ *   async (keyId) => lookupPublicKey(keyId),
+ * );
+ * ```
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @module
+ */
+
+import type {
+  BareItem,
+  Dictionary,
+  InnerList,
+  Item,
+} from "@std/http/unstable-structured-fields";
+import {
+  binary,
+  innerList as sfInnerList,
+  integer as sfInteger,
+  isInnerList,
+  isItem,
+  item as sfItem,
+  parseDictionary,
+  parseItem,
+  parseList,
+  serializeDictionary,
+  serializeItem,
+  serializeList,
+  string as sfString,
+} from "@std/http/unstable-structured-fields";
+
+const UTF8_ENCODER = new TextEncoder();
+
+// =============================================================================
+// Public Types
+// =============================================================================
+
+/**
+ * Algorithm identifiers per
+ * {@link https://www.rfc-editor.org/rfc/rfc9421#section-3.3 | RFC 9421 section 3.3}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export type SignatureAlgorithm =
+  | "rsa-pss-sha512"
+  | "rsa-v1_5-sha256"
+  | "hmac-sha256"
+  | "ecdsa-p256-sha256"
+  | "ecdsa-p384-sha384"
+  | "ed25519";
+
+/**
+ * Parameters that can be attached to a component identifier.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9421#section-2.1}
+ */
+export interface ComponentParameters {
+  /** Strict Structured Field serialization. */
+  sf?: boolean;
+  /** Dictionary member key. */
+  key?: string;
+  /** Binary-wrapped field values. */
+  bs?: boolean;
+  /** Derive value from the related request. */
+  req?: boolean;
+  /** Derive value from trailer fields. */
+  tr?: boolean;
+  /** Query parameter name (for `@query-param`). */
+  name?: string;
+}
+
+/**
+ * A component identifier consisting of a name and optional parameters.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9421#section-2}
+ */
+export interface ComponentIdentifier {
+  /** Lowercased field name or derived component name (e.g. `"@method"`). */
+  name: string;
+  /** Optional parameters per RFC 9421 section 2.1. */
+  parameters?: ComponentParameters;
+}
+
+/**
+ * Convenience type accepting either a plain string or a full
+ * {@linkcode ComponentIdentifier}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export type ComponentInput = string | ComponentIdentifier;
+
+/**
+ * Signature parameters used when signing a message.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9421#section-2.3}
+ */
+export interface SignatureParams {
+  /** Ordered list of covered components. */
+  components: ComponentInput[];
+  /** Signature algorithm. */
+  algorithm?: SignatureAlgorithm;
+  /** Key identifier. Mapped to/from the wire-format parameter name `keyid`. */
+  keyId?: string;
+  /** Creation time as seconds since Unix epoch (not milliseconds). */
+  created?: number;
+  /** Expiration time as seconds since Unix epoch (not milliseconds). */
+  expires?: number;
+  /** Nonce for replay protection. */
+  nonce?: string;
+  /** Application-specific tag. */
+  tag?: string;
+  /** Signature label, defaults to `"sig"`. */
+  label?: string;
+}
+
+/**
+ * Parsed signature parameters returned from verification. Components are always
+ * fully resolved {@linkcode ComponentIdentifier} objects.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface ParsedSignatureParams {
+  /** Ordered list of covered components. */
+  components: ComponentIdentifier[];
+  /** Signature algorithm, if specified. */
+  algorithm?: SignatureAlgorithm;
+  /** Key identifier. */
+  keyId?: string;
+  /** Creation time as seconds since Unix epoch. */
+  created?: number;
+  /** Expiration time as seconds since Unix epoch. */
+  expires?: number;
+  /** Nonce value. */
+  nonce?: string;
+  /** Application-specific tag. */
+  tag?: string;
+}
+
+/**
+ * Options for {@linkcode signMessage}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface SignOptions<T extends Request | Response = Request | Response> {
+  /** The HTTP request or response to sign. */
+  message: T;
+  /** Signature parameters. */
+  params: SignatureParams;
+  /** The signing key. */
+  key: CryptoKey;
+  /** The originating request, needed when signing a response with `;req` components. */
+  request?: Request;
+}
+
+/**
+ * Options for {@linkcode verifyMessage}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface VerifyOptions {
+  /** Maximum allowed age of the signature in seconds. */
+  maxAge?: number;
+  /** Components that must be covered by each verified signature. */
+  requiredComponents?: ComponentInput[];
+  /** Specific signature label(s) to verify. If omitted, all are verified. */
+  labels?: string[];
+  /** The originating request, needed when verifying response signatures with `;req` components. */
+  request?: Request;
+}
+
+/**
+ * Result of a successful signature verification.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface VerifyResult {
+  /** The label of the verified signature. */
+  label: string;
+  /** The parsed signature parameters. */
+  params: ParsedSignatureParams;
+}
+
+// =============================================================================
+// Algorithm Dispatch
+// =============================================================================
+
+const SIGNATURE_ALGORITHMS: Record<string, boolean> = {
+  "rsa-pss-sha512": true,
+  "rsa-v1_5-sha256": true,
+  "hmac-sha256": true,
+  "ecdsa-p256-sha256": true,
+  "ecdsa-p384-sha384": true,
+  "ed25519": true,
+};
+
+function isSupportedAlgorithm(value: string): value is SignatureAlgorithm {
+  return value in SIGNATURE_ALGORITHMS;
+}
+
+function getSignParams(
+  algorithm: SignatureAlgorithm,
+): AlgorithmIdentifier | RsaPssParams | EcdsaParams {
+  switch (algorithm) {
+    case "rsa-pss-sha512":
+      return { name: "RSA-PSS", saltLength: 64 } as RsaPssParams;
+    case "rsa-v1_5-sha256":
+      return { name: "RSASSA-PKCS1-v1_5" };
+    case "hmac-sha256":
+      return { name: "HMAC" };
+    case "ecdsa-p256-sha256":
+      return { name: "ECDSA", hash: "SHA-256" } as EcdsaParams;
+    case "ecdsa-p384-sha384":
+      return { name: "ECDSA", hash: "SHA-384" } as EcdsaParams;
+    case "ed25519":
+      return { name: "Ed25519" };
+  }
+}
+
+function inferAlgorithm(key: CryptoKey): SignatureAlgorithm {
+  const alg = key.algorithm;
+  const name = alg.name;
+  if (name === "Ed25519") return "ed25519";
+  if (name === "HMAC") return "hmac-sha256";
+  if (name === "RSA-PSS") return "rsa-pss-sha512";
+  if (name === "RSASSA-PKCS1-v1_5") return "rsa-v1_5-sha256";
+  if (name === "ECDSA") {
+    const hash = (alg as EcKeyAlgorithm & { namedCurve: string }).namedCurve;
+    if (hash === "P-384") return "ecdsa-p384-sha384";
+    return "ecdsa-p256-sha256";
+  }
+  throw new TypeError(`Cannot infer signature algorithm from key: "${name}"`);
+}
+
+// =============================================================================
+// Component Value Resolution
+// =============================================================================
+
+function normalizeIdentifier(input: ComponentInput): ComponentIdentifier {
+  if (typeof input === "string") {
+    return { name: input };
+  }
+  return input;
+}
+
+function resolveComponentValue(
+  id: ComponentIdentifier,
+  message: Request | Response,
+  relatedRequest?: Request,
+): string {
+  const params = id.parameters ?? {};
+
+  // Validate incompatible parameter combinations
+  if (params.bs && params.sf) {
+    throw new TypeError(
+      `Cannot combine "bs" and "sf" parameters on component "${id.name}"`,
+    );
+  }
+  if (params.bs && params.key !== undefined) {
+    throw new TypeError(
+      `Cannot combine "bs" and "key" parameters on component "${id.name}"`,
+    );
+  }
+
+  // Handle ;req parameter
+  if (params.req) {
+    if (message instanceof Request) {
+      throw new TypeError(
+        `Cannot use "req" parameter on component "${id.name}" for a request message`,
+      );
+    }
+    if (!relatedRequest) {
+      throw new TypeError(
+        `Cannot resolve "req" parameter on component "${id.name}": no related request provided`,
+      );
+    }
+    const { req: _, ...restParams } = params;
+    return resolveComponentValue(
+      { name: id.name, parameters: restParams },
+      relatedRequest,
+    );
+  }
+
+  if (id.name.startsWith("@")) {
+    return resolveDerivedComponent(id.name, message, params);
+  }
+
+  return resolveFieldComponent(id.name, message, params);
+}
+
+function resolveDerivedComponent(
+  name: string,
+  message: Request | Response,
+  params: ComponentParameters,
+): string {
+  switch (name) {
+    case "@method": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      return message.method;
+    }
+    case "@target-uri": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      return message.url;
+    }
+    case "@authority": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      const url = new URL(message.url);
+      return url.host;
+    }
+    case "@scheme": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      const url = new URL(message.url);
+      return url.protocol.slice(0, -1);
+    }
+    case "@request-target": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      const url = new URL(message.url);
+      return url.pathname + url.search;
+    }
+    case "@path": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      const url = new URL(message.url);
+      return url.pathname || "/";
+    }
+    case "@query": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      const url = new URL(message.url);
+      // search includes the "?" prefix, but if absent we return "?"
+      return url.search || "?";
+    }
+    case "@query-param": {
+      if (!(message instanceof Request)) {
+        throw new TypeError(
+          `Cannot use "${name}" on a response message`,
+        );
+      }
+      if (params.name === undefined) {
+        throw new TypeError(
+          `Component "${name}" requires "name" parameter`,
+        );
+      }
+      const url = new URL(message.url);
+      const decoded = decodeURIComponent(params.name);
+      const searchParams = new URLSearchParams(url.search);
+      const values: string[] = [];
+      for (const [k, v] of searchParams) {
+        if (k === decoded) {
+          values.push(v);
+        }
+      }
+      if (values.length === 0) {
+        throw new TypeError(
+          `Query parameter "${params.name}" not found in request URL`,
+        );
+      }
+      if (values.length > 1) {
+        throw new TypeError(
+          `Query parameter "${params.name}" occurs multiple times`,
+        );
+      }
+      // Re-encode per the spec's application/x-www-form-urlencoded serializing
+      return encodeQueryParamValue(values[0]!);
+    }
+    case "@status": {
+      if (message instanceof Request) {
+        throw new TypeError(
+          `Cannot use "${name}" on a request message`,
+        );
+      }
+      return String(message.status);
+    }
+    default:
+      throw new TypeError(
+        `Unknown derived component "${name}"`,
+      );
+  }
+}
+
+function encodeQueryParamValue(value: string): string {
+  // Percent-encode per application/x-www-form-urlencoded serializing
+  // then convert + back to %20 for the signature base
+  return encodeURIComponent(value).replace(/%20/g, "%20");
+}
+
+function resolveFieldComponent(
+  name: string,
+  message: Request | Response,
+  params: ComponentParameters,
+): string {
+  const headerValue = message.headers.get(name);
+  if (headerValue === null) {
+    throw new TypeError(`Missing "${name}" header field`);
+  }
+
+  if (params.sf) {
+    return resolveStrictStructuredField(headerValue, name);
+  }
+
+  if (params.key !== undefined) {
+    return resolveDictionaryMember(headerValue, name, params.key);
+  }
+
+  if (params.bs) {
+    return resolveBinaryWrapped(headerValue);
+  }
+
+  return headerValue;
+}
+
+function resolveStrictStructuredField(
+  headerValue: string,
+  fieldName: string,
+): string {
+  // Try Dictionary, then List, then Item — the first successful parse wins
+  try {
+    return serializeDictionary(parseDictionary(headerValue));
+  } catch { /* not a dictionary */ }
+  try {
+    return serializeList(parseList(headerValue));
+  } catch { /* not a list */ }
+  try {
+    return serializeItem(parseItem(headerValue));
+  } catch { /* not an item */ }
+  throw new TypeError(
+    `Cannot apply "sf" parameter to field "${fieldName}": unknown Structured Field type`,
+  );
+}
+
+function resolveDictionaryMember(
+  headerValue: string,
+  fieldName: string,
+  key: string,
+): string {
+  let dict: Dictionary;
+  try {
+    dict = parseDictionary(headerValue);
+  } catch (cause) {
+    throw new TypeError(
+      `Cannot parse "${fieldName}" as Dictionary for "key" parameter`,
+      { cause },
+    );
+  }
+  const member = dict.get(key);
+  if (member === undefined) {
+    throw new TypeError(
+      `Dictionary key "${key}" not found in "${fieldName}" header`,
+    );
+  }
+  if (isItem(member)) {
+    return serializeItem(member);
+  }
+  // Inner list member — serialize as inner list value (member_value)
+  return serializeList([member]);
+}
+
+function resolveBinaryWrapped(headerValue: string): string {
+  // Each field value is individually wrapped as a Byte Sequence
+  // For the Fetch API, headers.get() already combines multiple values
+  // We split on ", " to get individual values, then wrap each as binary
+  const values = headerValue.split(", ");
+  const items: Item[] = values.map((v) => {
+    const bytes = UTF8_ENCODER.encode(v.trim());
+    return sfItem(binary(bytes));
+  });
+  return serializeList(items);
+}
+
+// =============================================================================
+// Signature Base Construction
+// =============================================================================
+
+function serializeComponentIdentifier(id: ComponentIdentifier): string {
+  let result = `"${id.name}"`;
+  const params = id.parameters ?? {};
+  if (params.sf) result += ";sf";
+  if (params.key !== undefined) result += `;key="${params.key}"`;
+  if (params.bs) result += ";bs";
+  if (params.req) result += ";req";
+  if (params.tr) result += ";tr";
+  if (params.name !== undefined) result += `;name="${params.name}"`;
+  return result;
+}
+
+function buildSignatureParamsValue(
+  components: ComponentIdentifier[],
+  params: SignatureParams,
+): string {
+  // Build the inner list items (component identifiers as String items with params)
+  const items: Item[] = components.map((id) => {
+    const sfParams = new Map<string, BareItem>();
+    const p = id.parameters ?? {};
+    if (p.sf) sfParams.set("sf", { type: "boolean", value: true });
+    if (p.key !== undefined) sfParams.set("key", { type: "string", value: p.key });
+    if (p.bs) sfParams.set("bs", { type: "boolean", value: true });
+    if (p.req) sfParams.set("req", { type: "boolean", value: true });
+    if (p.tr) sfParams.set("tr", { type: "boolean", value: true });
+    if (p.name !== undefined) sfParams.set("name", { type: "string", value: p.name });
+    return sfItem(sfString(id.name), sfParams);
+  });
+
+  // Build the inner list parameters (signature metadata)
+  const listParams = new Map<string, BareItem>();
+  if (params.created !== undefined) {
+    listParams.set("created", sfInteger(params.created));
+  }
+  if (params.expires !== undefined) {
+    listParams.set("expires", sfInteger(params.expires));
+  }
+  if (params.nonce !== undefined) {
+    listParams.set("nonce", sfString(params.nonce));
+  }
+  if (params.algorithm !== undefined) {
+    listParams.set("alg", sfString(params.algorithm));
+  }
+  if (params.keyId !== undefined) {
+    listParams.set("keyid", sfString(params.keyId));
+  }
+  if (params.tag !== undefined) {
+    listParams.set("tag", sfString(params.tag));
+  }
+
+  const il = sfInnerList(items, listParams);
+  // Serialize just the inner list (not as a dictionary member)
+  return serializeInnerListValue(il);
+}
+
+function serializeInnerListValue(il: InnerList): string {
+  const items = il.items.map((i) => serializeItem(i)).join(" ");
+  let result = `(${items})`;
+  for (const [key, value] of il.parameters) {
+    result += `;${key}=${serializeBareItemValue(value)}`;
+  }
+  return result;
+}
+
+function serializeBareItemValue(bareItem: BareItem): string {
+  switch (bareItem.type) {
+    case "integer":
+      return String(bareItem.value);
+    case "string":
+      return `"${bareItem.value}"`;
+    default:
+      return serializeItem(sfItem(bareItem));
+  }
+}
+
+/** Options for {@linkcode createSignatureBase}. */
+export interface CreateSignatureBaseOptions {
+  /** The HTTP request or response. */
+  message: Request | Response;
+  /** Signature parameters including covered components. */
+  params: SignatureParams;
+  /** The originating request when signing a response with `;req` components. */
+  request?: Request;
+}
+
+/**
+ * Construct the signature base string for a message per
+ * {@link https://www.rfc-editor.org/rfc/rfc9421#section-2.5 | RFC 9421 section 2.5}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { createSignatureBase } from "@std/http/unstable-message-signatures";
+ * import { assert } from "@std/assert";
+ *
+ * const request = new Request("https://example.com/path", {
+ *   method: "GET",
+ *   headers: { "Content-Type": "text/plain" },
+ * });
+ * const base = createSignatureBase({
+ *   message: request,
+ *   params: {
+ *     components: ["@method", "@authority"],
+ *     keyId: "my-key",
+ *     created: 1618884473,
+ *   },
+ * });
+ *
+ * assert(base.includes('"@method": GET'));
+ * ```
+ *
+ * @param options The message, signature parameters, and optional related request.
+ * @returns The signature base string.
+ */
+export function createSignatureBase(
+  options: CreateSignatureBaseOptions,
+): string {
+  const { message, params, request: relatedRequest } = options;
+  const components = params.components.map(normalizeIdentifier);
+
+  // Check for duplicate component identifiers
+  const seen = new Set<string>();
+  for (const id of components) {
+    const key = serializeComponentIdentifier(id);
+    if (seen.has(key)) {
+      throw new TypeError(
+        `Duplicate component identifier ${key} in covered components`,
+      );
+    }
+    seen.add(key);
+  }
+
+  const lines: string[] = [];
+  for (const id of components) {
+    const serializedId = serializeComponentIdentifier(id);
+    const value = resolveComponentValue(id, message, relatedRequest);
+    lines.push(`${serializedId}: ${value}`);
+  }
+
+  const sigParamsValue = buildSignatureParamsValue(components, params);
+  lines.push(`"@signature-params": ${sigParamsValue}`);
+
+  return lines.join("\n");
+}
+
+// =============================================================================
+// Input Validation
+// =============================================================================
+
+function validateTimestamp(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(
+      `${name} must be a non-negative integer, got ${value}`,
+    );
+  }
+}
+
+function validateSignParams(params: SignatureParams): void {
+  if (params.created !== undefined) {
+    validateTimestamp(params.created, "created");
+  }
+  if (params.expires !== undefined) {
+    validateTimestamp(params.expires, "expires");
+  }
+  if (
+    params.algorithm !== undefined && !isSupportedAlgorithm(params.algorithm)
+  ) {
+    throw new TypeError(
+      `Unsupported signature algorithm: "${params.algorithm}"`,
+    );
+  }
+}
+
+// =============================================================================
+// signMessage
+// =============================================================================
+
+/**
+ * Sign an HTTP message per
+ * {@link https://www.rfc-editor.org/rfc/rfc9421 | RFC 9421}.
+ *
+ * Returns a new Request/Response with `Signature` and `Signature-Input`
+ * headers appended. The original message is not mutated.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { signMessage } from "@std/http/unstable-message-signatures";
+ * import { assert } from "@std/assert";
+ *
+ * const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
+ * const request = new Request("https://example.com/", { method: "POST" });
+ * const signed = await signMessage({
+ *   message: request,
+ *   params: {
+ *     components: ["@method", "@authority"],
+ *     keyId: "test-key",
+ *     created: Math.floor(Date.now() / 1000),
+ *   },
+ *   key: key.privateKey,
+ * });
+ *
+ * assert(signed.headers.has("Signature"));
+ * assert(signed.headers.has("Signature-Input"));
+ * ```
+ *
+ * @typeParam T The type of the message (Request or Response).
+ * @param options Signing options.
+ * @returns A new message with signature headers appended.
+ */
+export async function signMessage<T extends Request | Response>(
+  options: SignOptions<T>,
+): Promise<T> {
+  const { message, params, key, request } = options;
+  const label = params.label ?? "sig";
+
+  validateSignParams(params);
+
+  const algorithm = params.algorithm ?? inferAlgorithm(key);
+
+  const baseOpts: CreateSignatureBaseOptions = { message, params };
+  if (request) baseOpts.request = request;
+  const base = createSignatureBase(baseOpts);
+  const baseBytes = UTF8_ENCODER.encode(base);
+
+  const signParams = getSignParams(algorithm);
+  const signatureBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
+    await crypto.subtle.sign(signParams, key, baseBytes),
+  );
+  // Web Crypto in Deno/browsers already produces raw (r, s) for ECDSA,
+  // which is the format RFC 9421 requires. No DER conversion needed.
+
+  // Build Signature-Input value
+  const components = params.components.map(normalizeIdentifier);
+  const sigParamsValue = buildSignatureParamsValue(components, params);
+
+  // Build headers
+  const sigInputHeader = `${label}=${sigParamsValue}`;
+  const sigHeader = serializeDictionary(
+    new Map([[label, sfItem(binary(signatureBytes))]]),
+  );
+
+  // Clone the message and append headers
+  if (message instanceof Request) {
+    const clone = new Request(message, {
+      headers: new Headers(message.headers),
+    });
+    appendHeader(clone.headers, "Signature-Input", sigInputHeader);
+    appendHeader(clone.headers, "Signature", sigHeader);
+    return clone as T;
+  } else {
+    const bodyBytes = message.body
+      ? await message.clone().arrayBuffer()
+      : null;
+    const clone = new Response(bodyBytes, {
+      status: message.status,
+      statusText: message.statusText,
+      headers: new Headers(message.headers),
+    });
+    appendHeader(clone.headers, "Signature-Input", sigInputHeader);
+    appendHeader(clone.headers, "Signature", sigHeader);
+    return clone as T;
+  }
+}
+
+function appendHeader(headers: Headers, name: string, value: string): void {
+  const existing = headers.get(name);
+  if (existing) {
+    headers.set(name, `${existing}, ${value}`);
+  } else {
+    headers.set(name, value);
+  }
+}
+
+// =============================================================================
+// verifyMessage
+// =============================================================================
+
+/**
+ * Verify one or more signatures on an HTTP message per
+ * {@link https://www.rfc-editor.org/rfc/rfc9421 | RFC 9421}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { verifyMessage } from "@std/http/unstable-message-signatures";
+ *
+ * const results = await verifyMessage(
+ *   signedRequest,
+ *   async (keyId) => lookupPublicKey(keyId),
+ *   { requiredComponents: ["@method", "@authority"] },
+ * );
+ * ```
+ *
+ * @param message The HTTP request or response to verify.
+ * @param keyLookup Resolves a key identifier to a CryptoKey.
+ * @param options Optional verification constraints.
+ * @returns Array of verified signature results.
+ */
+export async function verifyMessage(
+  message: Request | Response,
+  keyLookup: (
+    keyId: string,
+    algorithm?: SignatureAlgorithm,
+  ) => Promise<CryptoKey> | CryptoKey,
+  options?: VerifyOptions,
+): Promise<VerifyResult[]> {
+  if (options?.maxAge !== undefined) {
+    if (!Number.isInteger(options.maxAge) || options.maxAge < 0) {
+      throw new RangeError(
+        `maxAge must be a non-negative integer, got ${options.maxAge}`,
+      );
+    }
+  }
+
+  const sigInputHeader = message.headers.get("Signature-Input");
+  if (sigInputHeader === null) {
+    throw new TypeError('Missing "Signature-Input" header');
+  }
+  const sigHeader = message.headers.get("Signature");
+  if (sigHeader === null) {
+    throw new TypeError('Missing "Signature" header');
+  }
+
+  const sigInputDict = parseDictionary(sigInputHeader);
+  const sigDict = parseDictionary(sigHeader);
+
+  // Validate label consistency
+  for (const [label] of sigInputDict) {
+    if (!sigDict.has(label)) {
+      throw new TypeError(
+        `Label "${label}" found in Signature-Input but missing in Signature`,
+      );
+    }
+  }
+  for (const [label] of sigDict) {
+    if (!sigInputDict.has(label)) {
+      throw new TypeError(
+        `Label "${label}" found in Signature but missing in Signature-Input`,
+      );
+    }
+  }
+
+  const results: VerifyResult[] = [];
+
+  for (const [label, sigInputMember] of sigInputDict) {
+    // Filter by labels option
+    if (options?.labels && !options.labels.includes(label)) continue;
+
+    if (!isInnerList(sigInputMember)) {
+      throw new TypeError(
+        `Signature-Input member "${label}" is not an Inner List`,
+      );
+    }
+
+    // Parse covered components from the inner list
+    const parsedParams = parseSignatureInput(sigInputMember, label);
+
+    // Enforce required components
+    if (options?.requiredComponents) {
+      for (const required of options.requiredComponents) {
+        const reqId = normalizeIdentifier(required);
+        const reqKey = serializeComponentIdentifier(reqId);
+        const found = parsedParams.components.some(
+          (c) => serializeComponentIdentifier(c) === reqKey,
+        );
+        if (!found) {
+          throw new Error(
+            `Signature "${label}" does not cover required component ${reqKey}`,
+          );
+        }
+      }
+    }
+
+    // Check maxAge
+    if (options?.maxAge !== undefined && parsedParams.created !== undefined) {
+      const now = Math.floor(Date.now() / 1000);
+      if (now - parsedParams.created > options.maxAge) {
+        throw new Error(`Signature "${label}" has expired`);
+      }
+    }
+
+    // Reconstruct signature base
+    const reconstructedParams: SignatureParams = {
+      components: parsedParams.components,
+      ...(parsedParams.algorithm !== undefined && { algorithm: parsedParams.algorithm }),
+      ...(parsedParams.keyId !== undefined && { keyId: parsedParams.keyId }),
+      ...(parsedParams.created !== undefined && { created: parsedParams.created }),
+      ...(parsedParams.expires !== undefined && { expires: parsedParams.expires }),
+      ...(parsedParams.nonce !== undefined && { nonce: parsedParams.nonce }),
+      ...(parsedParams.tag !== undefined && { tag: parsedParams.tag }),
+    };
+    const verifyBaseOpts: CreateSignatureBaseOptions = {
+      message,
+      params: reconstructedParams,
+    };
+    if (options?.request) verifyBaseOpts.request = options.request;
+    const base = createSignatureBase(verifyBaseOpts);
+    const baseBytes = UTF8_ENCODER.encode(base);
+
+    // Get signature bytes
+    const sigMember = sigDict.get(label);
+    if (!sigMember || !isItem(sigMember)) {
+      throw new TypeError(
+        `Signature member "${label}" is not an Item`,
+      );
+    }
+    if (sigMember.value.type !== "binary") {
+      throw new TypeError(
+        `Signature member "${label}" is not a Byte Sequence`,
+      );
+    }
+    const sigBytes: Uint8Array<ArrayBuffer> = new Uint8Array(sigMember.value.value);
+
+    // Look up key
+    const algorithm = parsedParams.algorithm ?? undefined;
+    const keyId = parsedParams.keyId ?? "";
+    const verifyKey = await keyLookup(keyId, algorithm);
+
+    const verifyAlgorithm = algorithm ?? inferAlgorithm(verifyKey);
+    const verifyParams = getSignParams(verifyAlgorithm);
+
+    // Web Crypto in Deno/browsers accepts raw (r, s) for ECDSA directly,
+    // which is the format RFC 9421 uses. No DER conversion needed.
+    const valid = await crypto.subtle.verify(
+      verifyParams,
+      verifyKey,
+      sigBytes,
+      baseBytes,
+    );
+
+    if (!valid) {
+      throw new Error(
+        `Signature verification failed for label "${label}"`,
+      );
+    }
+
+    results.push({ label, params: parsedParams });
+  }
+
+  return results;
+}
+
+function parseSignatureInput(
+  il: InnerList,
+  label: string,
+): ParsedSignatureParams {
+  const components: ComponentIdentifier[] = [];
+
+  for (const member of il.items) {
+    if (member.value.type !== "string") {
+      throw new TypeError(
+        `Component identifier in "${label}" is not a String`,
+      );
+    }
+    const name = member.value.value;
+    const params: ComponentParameters = {};
+    for (const [key, value] of member.parameters) {
+      switch (key) {
+        case "sf":
+          params.sf = value.type === "boolean" ? value.value : true;
+          break;
+        case "key":
+          if (value.type === "string") params.key = value.value;
+          break;
+        case "bs":
+          params.bs = value.type === "boolean" ? value.value : true;
+          break;
+        case "req":
+          params.req = value.type === "boolean" ? value.value : true;
+          break;
+        case "tr":
+          params.tr = value.type === "boolean" ? value.value : true;
+          break;
+        case "name":
+          if (value.type === "string") params.name = value.value;
+          break;
+      }
+    }
+    const hasParams = Object.values(params).some((v) => v !== undefined);
+    components.push(hasParams ? { name, parameters: params } : { name });
+  }
+
+  const result: ParsedSignatureParams = { components };
+
+  for (const [key, value] of il.parameters) {
+    switch (key) {
+      case "created":
+        if (value.type === "integer") result.created = value.value;
+        break;
+      case "expires":
+        if (value.type === "integer") result.expires = value.value;
+        break;
+      case "nonce":
+        if (value.type === "string") result.nonce = value.value;
+        break;
+      case "alg":
+        if (value.type === "string" && isSupportedAlgorithm(value.value)) {
+          result.algorithm = value.value;
+        }
+        break;
+      case "keyid":
+        if (value.type === "string") result.keyId = value.value;
+        break;
+      case "tag":
+        if (value.type === "string") result.tag = value.value;
+        break;
+    }
+  }
+
+  return result;
+}

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -47,6 +47,8 @@
  * @module
  */
 
+import type { Uint8Array_ } from "./_types.ts";
+export type { Uint8Array_ };
 import type {
   BareItem,
   Dictionary,
@@ -768,7 +770,7 @@ function validateSignParams(params: SignatureParams): void {
  * import { signMessage } from "@std/http/unstable-message-signatures";
  * import { assert } from "@std/assert";
  *
- * const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
+ * const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]) as CryptoKeyPair;
  * const request = new Request("https://example.com/", { method: "POST" });
  * const signed = await signMessage({
  *   message: request,
@@ -804,7 +806,7 @@ export async function signMessage<T extends Request | Response>(
   const baseBytes = UTF8_ENCODER.encode(base);
 
   const signParams = getSignParams(algorithm);
-  const signatureBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
+  const signatureBytes: Uint8Array_ = new Uint8Array(
     await crypto.subtle.sign(signParams, key, baseBytes),
   );
 
@@ -993,7 +995,7 @@ export async function verifyMessage(
         `Signature member "${label}" is not a Byte Sequence`,
       );
     }
-    const sigBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
+    const sigBytes: Uint8Array_ = new Uint8Array(
       sigMember.value.value,
     );
 

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -42,6 +42,13 @@
  * );
  * ```
  *
+ * Note: The `;bs` (Binary-wrapped Structured Field) parameter relies on
+ * splitting header values by `", "` because the Fetch API `Headers.get()`
+ * joins multiple values with this separator and does not expose `getAll()`.
+ * This means `;bs` will produce incorrect results for headers whose single
+ * value contains a literal `", "` (e.g. the `Date` header). Avoid using `;bs`
+ * on such fields; prefer `;sf` where the field is a known Structured Field.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @module
@@ -104,7 +111,13 @@ export interface ComponentParameters {
   sf?: true;
   /** Dictionary member key. */
   key?: string;
-  /** Binary-wrapped field values. */
+  /**
+   * Binary-wrapped field values. Each field value is individually wrapped as
+   * a Byte Sequence. Because the Fetch API `Headers.get()` joins multiple
+   * values with `", "`, this flag will produce incorrect results for headers
+   * whose single value contains a literal `", "` (e.g. `Date`). Avoid using
+   * `;bs` on such fields.
+   */
   bs?: true;
   /** Derive value from the related request. */
   req?: true;
@@ -297,8 +310,9 @@ function inferAlgorithm(key: CryptoKey): SignatureAlgorithm {
   if (name === "RSASSA-PKCS1-v1_5") return "rsa-v1_5-sha256";
   if (name === "ECDSA") {
     const curve = (alg as EcKeyAlgorithm).namedCurve;
+    if (curve === "P-256") return "ecdsa-p256-sha256";
     if (curve === "P-384") return "ecdsa-p384-sha384";
-    return "ecdsa-p256-sha256";
+    throw new TypeError(`Unsupported ECDSA curve: "${curve}"`);
   }
   throw new TypeError(`Cannot infer signature algorithm from key: "${name}"`);
 }
@@ -440,6 +454,8 @@ function resolveRequestDerived(
           `Query parameter "${params.name}" not found in request URL`,
         );
       }
+      // RFC 9421 section 2.2.8: "If a parameter name occurs multiple times
+      // in a request, the named query parameter MUST NOT be included."
       if (values.length > 1) {
         throw new TypeError(
           `Query parameter "${params.name}" occurs multiple times`,

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -11,7 +11,7 @@
  * Fields Dictionaries ({@link https://www.rfc-editor.org/rfc/rfc9651 | RFC 9651}).
  *
  * @example Signing a request
- * ```ts
+ * ```ts ignore
  * import { signMessage } from "@std/http/unstable-message-signatures";
  *
  * const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
@@ -70,6 +70,7 @@ import {
 } from "@std/http/unstable-structured-fields";
 
 const UTF8_ENCODER = new TextEncoder();
+const SF_KEY_REGEXP = /^[a-z*][a-z0-9_\-.*]*$/;
 
 // =============================================================================
 // Public Types
@@ -98,15 +99,15 @@ export type SignatureAlgorithm =
  */
 export interface ComponentParameters {
   /** Strict Structured Field serialization. */
-  sf?: boolean;
+  sf?: true;
   /** Dictionary member key. */
   key?: string;
   /** Binary-wrapped field values. */
-  bs?: boolean;
+  bs?: true;
   /** Derive value from the related request. */
-  req?: boolean;
+  req?: true;
   /** Derive value from trailer fields. */
-  tr?: boolean;
+  tr?: true;
   /** Query parameter name (for `@query-param`). */
   name?: string;
 }
@@ -126,12 +127,33 @@ export interface ComponentIdentifier {
 }
 
 /**
- * Convenience type accepting either a plain string or a full
- * {@linkcode ComponentIdentifier}.
+ * Known derived component names per
+ * {@link https://www.rfc-editor.org/rfc/rfc9421#section-2.2 | RFC 9421 section 2.2}.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
-export type ComponentInput = string | ComponentIdentifier;
+export type DerivedComponent =
+  | "@method"
+  | "@target-uri"
+  | "@authority"
+  | "@scheme"
+  | "@request-target"
+  | "@path"
+  | "@query"
+  | "@query-param"
+  | "@status";
+
+/**
+ * Convenience type accepting either a plain string or a full
+ * {@linkcode ComponentIdentifier}. Known derived component names are
+ * autocompleted.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export type ComponentInput =
+  | DerivedComponent
+  | (string & NonNullable<unknown>)
+  | ComponentIdentifier;
 
 /**
  * Signature parameters used when signing a message.
@@ -155,7 +177,7 @@ export interface SignatureParams {
   nonce?: string;
   /** Application-specific tag. */
   tag?: string;
-  /** Signature label, defaults to `"sig"`. */
+  /** Signature label, defaults to `"sig"`. Must be a valid sf-key (lowercase alphanumeric, `_`, `-`, `.`, `*`). */
   label?: string;
 }
 
@@ -187,7 +209,9 @@ export interface ParsedSignatureParams {
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
-export interface SignOptions<T extends Request | Response = Request | Response> {
+export interface SignOptions<
+  T extends Request | Response = Request | Response,
+> {
   /** The HTTP request or response to sign. */
   message: T;
   /** Signature parameters. */
@@ -230,17 +254,17 @@ export interface VerifyResult {
 // Algorithm Dispatch
 // =============================================================================
 
-const SIGNATURE_ALGORITHMS: Record<string, boolean> = {
-  "rsa-pss-sha512": true,
-  "rsa-v1_5-sha256": true,
-  "hmac-sha256": true,
-  "ecdsa-p256-sha256": true,
-  "ecdsa-p384-sha384": true,
-  "ed25519": true,
-};
+const SUPPORTED_ALGORITHMS: ReadonlySet<string> = new Set([
+  "rsa-pss-sha512",
+  "rsa-v1_5-sha256",
+  "hmac-sha256",
+  "ecdsa-p256-sha256",
+  "ecdsa-p384-sha384",
+  "ed25519",
+]);
 
 function isSupportedAlgorithm(value: string): value is SignatureAlgorithm {
-  return value in SIGNATURE_ALGORITHMS;
+  return SUPPORTED_ALGORITHMS.has(value);
 }
 
 function getSignParams(
@@ -270,8 +294,8 @@ function inferAlgorithm(key: CryptoKey): SignatureAlgorithm {
   if (name === "RSA-PSS") return "rsa-pss-sha512";
   if (name === "RSASSA-PKCS1-v1_5") return "rsa-v1_5-sha256";
   if (name === "ECDSA") {
-    const hash = (alg as EcKeyAlgorithm & { namedCurve: string }).namedCurve;
-    if (hash === "P-384") return "ecdsa-p384-sha384";
+    const curve = (alg as EcKeyAlgorithm).namedCurve;
+    if (curve === "P-384") return "ecdsa-p384-sha384";
     return "ecdsa-p256-sha256";
   }
   throw new TypeError(`Cannot infer signature algorithm from key: "${name}"`);
@@ -291,7 +315,9 @@ function normalizeIdentifier(input: ComponentInput): ComponentIdentifier {
 function resolveComponentValue(
   id: ComponentIdentifier,
   message: Request | Response,
+  parsedUrl: { value?: URL },
   relatedRequest?: Request,
+  relatedParsedUrl?: { value?: URL },
 ): string {
   const params = id.parameters ?? {};
 
@@ -304,6 +330,12 @@ function resolveComponentValue(
   if (params.bs && params.key !== undefined) {
     throw new TypeError(
       `Cannot combine "bs" and "key" parameters on component "${id.name}"`,
+    );
+  }
+
+  if (params.tr) {
+    throw new TypeError(
+      `Trailer field resolution (";tr") is not supported for component "${id.name}"`,
     );
   }
 
@@ -323,103 +355,83 @@ function resolveComponentValue(
     return resolveComponentValue(
       { name: id.name, parameters: restParams },
       relatedRequest,
+      relatedParsedUrl ?? {},
     );
   }
 
   if (id.name.startsWith("@")) {
-    return resolveDerivedComponent(id.name, message, params);
+    return resolveDerivedComponent(id.name, message, params, parsedUrl);
   }
 
   return resolveFieldComponent(id.name, message, params);
 }
 
+const REQUEST_ONLY_DERIVED: ReadonlySet<string> = new Set<DerivedComponent>([
+  "@method",
+  "@target-uri",
+  "@authority",
+  "@scheme",
+  "@request-target",
+  "@path",
+  "@query",
+  "@query-param",
+]);
+
 function resolveDerivedComponent(
   name: string,
   message: Request | Response,
   params: ComponentParameters,
+  parsedUrl: { value?: URL },
 ): string {
+  if (REQUEST_ONLY_DERIVED.has(name)) {
+    if (!(message instanceof Request)) {
+      throw new TypeError(`Cannot use "${name}" on a response message`);
+    }
+    return resolveRequestDerived(name, message, params, parsedUrl);
+  }
+
+  if (name === "@status") {
+    if (message instanceof Request) {
+      throw new TypeError(`Cannot use "${name}" on a request message`);
+    }
+    return String(message.status);
+  }
+
+  throw new TypeError(`Unknown derived component "${name}"`);
+}
+
+function resolveRequestDerived(
+  name: string,
+  request: Request,
+  params: ComponentParameters,
+  parsedUrl: { value?: URL },
+): string {
+  if (name === "@method") return request.method.toUpperCase();
+  if (name === "@target-uri") return request.url;
+
+  const url = parsedUrl.value ??= new URL(request.url);
   switch (name) {
-    case "@method": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      return message.method;
-    }
-    case "@target-uri": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      return message.url;
-    }
-    case "@authority": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      const url = new URL(message.url);
+    case "@authority":
       return url.host;
-    }
-    case "@scheme": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      const url = new URL(message.url);
+    case "@scheme":
       return url.protocol.slice(0, -1);
-    }
-    case "@request-target": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      const url = new URL(message.url);
+    case "@request-target":
       return url.pathname + url.search;
-    }
-    case "@path": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      const url = new URL(message.url);
+    case "@path":
       return url.pathname || "/";
-    }
-    case "@query": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
-      const url = new URL(message.url);
-      // search includes the "?" prefix, but if absent we return "?"
+    case "@query":
       return url.search || "?";
-    }
     case "@query-param": {
-      if (!(message instanceof Request)) {
-        throw new TypeError(
-          `Cannot use "${name}" on a response message`,
-        );
-      }
       if (params.name === undefined) {
         throw new TypeError(
           `Component "${name}" requires "name" parameter`,
         );
       }
-      const url = new URL(message.url);
       const decoded = decodeURIComponent(params.name);
       const searchParams = new URLSearchParams(url.search);
       const values: string[] = [];
       for (const [k, v] of searchParams) {
-        if (k === decoded) {
-          values.push(v);
-        }
+        if (k === decoded) values.push(v);
       }
       if (values.length === 0) {
         throw new TypeError(
@@ -431,28 +443,22 @@ function resolveDerivedComponent(
           `Query parameter "${params.name}" occurs multiple times`,
         );
       }
-      // Re-encode per the spec's application/x-www-form-urlencoded serializing
       return encodeQueryParamValue(values[0]!);
     }
-    case "@status": {
-      if (message instanceof Request) {
-        throw new TypeError(
-          `Cannot use "${name}" on a request message`,
-        );
-      }
-      return String(message.status);
-    }
     default:
-      throw new TypeError(
-        `Unknown derived component "${name}"`,
-      );
+      throw new TypeError(`Unknown derived component "${name}"`);
   }
 }
 
 function encodeQueryParamValue(value: string): string {
-  // Percent-encode per application/x-www-form-urlencoded serializing
-  // then convert + back to %20 for the signature base
-  return encodeURIComponent(value).replace(/%20/g, "%20");
+  // RFC 9421 section 2.2.8: use "percent-encode after encoding" from the
+  // WHATWG URL spec (application/x-www-form-urlencoded serializing), which
+  // differs from encodeURIComponent in that it also encodes !'()* characters.
+  // URLSearchParams serializes with + for spaces; convert back to %20.
+  return new URLSearchParams([["", value]]).toString().slice(1).replaceAll(
+    "+",
+    "%20",
+  );
 }
 
 function resolveFieldComponent(
@@ -527,9 +533,11 @@ function resolveDictionaryMember(
 }
 
 function resolveBinaryWrapped(headerValue: string): string {
-  // Each field value is individually wrapped as a Byte Sequence
-  // For the Fetch API, headers.get() already combines multiple values
-  // We split on ", " to get individual values, then wrap each as binary
+  // Each field value is individually wrapped as a Byte Sequence.
+  // The Fetch API Headers.get() joins multiple values with ", " and does not
+  // expose getAll(). Splitting on ", " is therefore the best we can do, but
+  // it will mishandle single header values that contain a literal ", " (e.g.
+  // the Date header). Avoid using ;bs on such fields.
   const values = headerValue.split(", ");
   const items: Item[] = values.map((v) => {
     const bytes = UTF8_ENCODER.encode(v.trim());
@@ -563,11 +571,15 @@ function buildSignatureParamsValue(
     const sfParams = new Map<string, BareItem>();
     const p = id.parameters ?? {};
     if (p.sf) sfParams.set("sf", { type: "boolean", value: true });
-    if (p.key !== undefined) sfParams.set("key", { type: "string", value: p.key });
+    if (p.key !== undefined) {
+      sfParams.set("key", { type: "string", value: p.key });
+    }
     if (p.bs) sfParams.set("bs", { type: "boolean", value: true });
     if (p.req) sfParams.set("req", { type: "boolean", value: true });
     if (p.tr) sfParams.set("tr", { type: "boolean", value: true });
-    if (p.name !== undefined) sfParams.set("name", { type: "string", value: p.name });
+    if (p.name !== undefined) {
+      sfParams.set("name", { type: "string", value: p.name });
+    }
     return sfItem(sfString(id.name), sfParams);
   });
 
@@ -617,7 +629,11 @@ function serializeBareItemValue(bareItem: BareItem): string {
   }
 }
 
-/** Options for {@linkcode createSignatureBase}. */
+/**
+ * Options for {@linkcode createSignatureBase}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
 export interface CreateSignatureBaseOptions {
   /** The HTTP request or response. */
   message: Request | Response;
@@ -663,22 +679,35 @@ export function createSignatureBase(
   const { message, params, request: relatedRequest } = options;
   const components = params.components.map(normalizeIdentifier);
 
-  // Check for duplicate component identifiers
   const seen = new Set<string>();
+  const lines: string[] = [];
+  const parsedUrl: { value?: URL } = {};
+  const relatedParsedUrl: { value?: URL } = {};
   for (const id of components) {
-    const key = serializeComponentIdentifier(id);
-    if (seen.has(key)) {
+    if (id.name === "@signature-params") {
       throw new TypeError(
-        `Duplicate component identifier ${key} in covered components`,
+        `"@signature-params" must not be listed in covered components`,
       );
     }
-    seen.add(key);
-  }
-
-  const lines: string[] = [];
-  for (const id of components) {
+    if (id.name !== id.name.toLowerCase()) {
+      throw new TypeError(
+        `Component name "${id.name}" must be lowercase`,
+      );
+    }
     const serializedId = serializeComponentIdentifier(id);
-    const value = resolveComponentValue(id, message, relatedRequest);
+    if (seen.has(serializedId)) {
+      throw new TypeError(
+        `Duplicate component identifier ${serializedId} in covered components`,
+      );
+    }
+    seen.add(serializedId);
+    const value = resolveComponentValue(
+      id,
+      message,
+      parsedUrl,
+      relatedRequest,
+      relatedParsedUrl,
+    );
     lines.push(`${serializedId}: ${value}`);
   }
 
@@ -701,6 +730,11 @@ function validateTimestamp(value: number, name: string): void {
 }
 
 function validateSignParams(params: SignatureParams): void {
+  if (params.label !== undefined && !SF_KEY_REGEXP.test(params.label)) {
+    throw new TypeError(
+      `Invalid signature label "${params.label}": must be a valid sf-key (lowercase alphanumeric, _, -, ., *)`,
+    );
+  }
   if (params.created !== undefined) {
     validateTimestamp(params.created, "created");
   }
@@ -750,7 +784,7 @@ function validateSignParams(params: SignatureParams): void {
  * assert(signed.headers.has("Signature-Input"));
  * ```
  *
- * @typeParam T The type of the message (Request or Response).
+ * @typeParam T The message type ({@linkcode Request} or {@linkcode Response}).
  * @param options Signing options.
  * @returns A new message with signature headers appended.
  */
@@ -773,8 +807,6 @@ export async function signMessage<T extends Request | Response>(
   const signatureBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
     await crypto.subtle.sign(signParams, key, baseBytes),
   );
-  // Web Crypto in Deno/browsers already produces raw (r, s) for ECDSA,
-  // which is the format RFC 9421 requires. No DER conversion needed.
 
   // Build Signature-Input value
   const components = params.components.map(normalizeIdentifier);
@@ -786,27 +818,11 @@ export async function signMessage<T extends Request | Response>(
     new Map([[label, sfItem(binary(signatureBytes))]]),
   );
 
-  // Clone the message and append headers
-  if (message instanceof Request) {
-    const clone = new Request(message, {
-      headers: new Headers(message.headers),
-    });
-    appendHeader(clone.headers, "Signature-Input", sigInputHeader);
-    appendHeader(clone.headers, "Signature", sigHeader);
-    return clone as T;
-  } else {
-    const bodyBytes = message.body
-      ? await message.clone().arrayBuffer()
-      : null;
-    const clone = new Response(bodyBytes, {
-      status: message.status,
-      statusText: message.statusText,
-      headers: new Headers(message.headers),
-    });
-    appendHeader(clone.headers, "Signature-Input", sigInputHeader);
-    appendHeader(clone.headers, "Signature", sigHeader);
-    return clone as T;
-  }
+  // clone() preserves the concrete type at runtime
+  const clone = message.clone() as T;
+  appendHeader(clone.headers, "Signature-Input", sigInputHeader);
+  appendHeader(clone.headers, "Signature", sigHeader);
+  return clone;
 }
 
 function appendHeader(headers: Headers, name: string, value: string): void {
@@ -840,7 +856,9 @@ function appendHeader(headers: Headers, name: string, value: string): void {
  * ```
  *
  * @param message The HTTP request or response to verify.
- * @param keyLookup Resolves a key identifier to a CryptoKey.
+ * @param keyLookup Resolves a key identifier to a CryptoKey, or `null` if the
+ *   key is not found. When the signature has no `keyid` parameter, the empty
+ *   string `""` is passed.
  * @param options Optional verification constraints.
  * @returns Array of verified signature results.
  */
@@ -849,15 +867,16 @@ export async function verifyMessage(
   keyLookup: (
     keyId: string,
     algorithm?: SignatureAlgorithm,
-  ) => Promise<CryptoKey> | CryptoKey,
+  ) => Promise<CryptoKey | null> | CryptoKey | null,
   options?: VerifyOptions,
 ): Promise<VerifyResult[]> {
-  if (options?.maxAge !== undefined) {
-    if (!Number.isInteger(options.maxAge) || options.maxAge < 0) {
-      throw new RangeError(
-        `maxAge must be a non-negative integer, got ${options.maxAge}`,
-      );
-    }
+  if (
+    options?.maxAge !== undefined &&
+    (!Number.isInteger(options.maxAge) || options.maxAge < 0)
+  ) {
+    throw new RangeError(
+      `maxAge must be a non-negative integer, got ${options.maxAge}`,
+    );
   }
 
   const sigInputHeader = message.headers.get("Signature-Input");
@@ -889,6 +908,7 @@ export async function verifyMessage(
   }
 
   const results: VerifyResult[] = [];
+  const now = Math.floor(Date.now() / 1000);
 
   for (const [label, sigInputMember] of sigInputDict) {
     // Filter by labels option
@@ -919,9 +939,22 @@ export async function verifyMessage(
       }
     }
 
+    // Check expires
+    if (parsedParams.expires !== undefined) {
+      if (now > parsedParams.expires) {
+        throw new Error(
+          `Signature "${label}" has expired (past "expires" timestamp)`,
+        );
+      }
+    }
+
     // Check maxAge
-    if (options?.maxAge !== undefined && parsedParams.created !== undefined) {
-      const now = Math.floor(Date.now() / 1000);
+    if (options?.maxAge !== undefined) {
+      if (parsedParams.created === undefined) {
+        throw new Error(
+          `Signature "${label}" has no "created" timestamp but maxAge was requested`,
+        );
+      }
       if (now - parsedParams.created > options.maxAge) {
         throw new Error(`Signature "${label}" has expired`);
       }
@@ -930,10 +963,13 @@ export async function verifyMessage(
     // Reconstruct signature base
     const reconstructedParams: SignatureParams = {
       components: parsedParams.components,
-      ...(parsedParams.algorithm !== undefined && { algorithm: parsedParams.algorithm }),
+      ...(parsedParams.algorithm !== undefined &&
+        { algorithm: parsedParams.algorithm }),
       ...(parsedParams.keyId !== undefined && { keyId: parsedParams.keyId }),
-      ...(parsedParams.created !== undefined && { created: parsedParams.created }),
-      ...(parsedParams.expires !== undefined && { expires: parsedParams.expires }),
+      ...(parsedParams.created !== undefined &&
+        { created: parsedParams.created }),
+      ...(parsedParams.expires !== undefined &&
+        { expires: parsedParams.expires }),
       ...(parsedParams.nonce !== undefined && { nonce: parsedParams.nonce }),
       ...(parsedParams.tag !== undefined && { tag: parsedParams.tag }),
     };
@@ -957,18 +993,21 @@ export async function verifyMessage(
         `Signature member "${label}" is not a Byte Sequence`,
       );
     }
-    const sigBytes: Uint8Array<ArrayBuffer> = new Uint8Array(sigMember.value.value);
+    const sigBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
+      sigMember.value.value,
+    );
 
     // Look up key
     const algorithm = parsedParams.algorithm ?? undefined;
     const keyId = parsedParams.keyId ?? "";
     const verifyKey = await keyLookup(keyId, algorithm);
+    if (verifyKey === null) {
+      throw new TypeError(`Key not found for keyId "${keyId}"`);
+    }
 
     const verifyAlgorithm = algorithm ?? inferAlgorithm(verifyKey);
     const verifyParams = getSignParams(verifyAlgorithm);
 
-    // Web Crypto in Deno/browsers accepts raw (r, s) for ECDSA directly,
-    // which is the format RFC 9421 uses. No DER conversion needed.
     const valid = await crypto.subtle.verify(
       verifyParams,
       verifyKey,
@@ -1005,19 +1044,19 @@ function parseSignatureInput(
     for (const [key, value] of member.parameters) {
       switch (key) {
         case "sf":
-          params.sf = value.type === "boolean" ? value.value : true;
+          if (value.type === "boolean" && value.value) params.sf = true;
           break;
         case "key":
           if (value.type === "string") params.key = value.value;
           break;
         case "bs":
-          params.bs = value.type === "boolean" ? value.value : true;
+          if (value.type === "boolean" && value.value) params.bs = true;
           break;
         case "req":
-          params.req = value.type === "boolean" ? value.value : true;
+          if (value.type === "boolean" && value.value) params.req = true;
           break;
         case "tr":
-          params.tr = value.type === "boolean" ? value.value : true;
+          if (value.type === "boolean" && value.value) params.tr = true;
           break;
         case "name":
           if (value.type === "string") params.name = value.value;

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -481,6 +481,7 @@ function resolveRequestDerived(
       return encodeQueryParamValue(values[0]!);
     }
     default:
+      // Unreachable: gated by REQUEST_ONLY_DERIVED; kept for exhaustiveness.
       throw new TypeError(`Unknown derived component "${name}"`);
   }
 }
@@ -611,7 +612,7 @@ function buildSignatureParamsValue(
     }
     if (p.bs) sfParams.set("bs", { type: "boolean", value: true });
     if (p.req) sfParams.set("req", { type: "boolean", value: true });
-    if (p.tr) sfParams.set("tr", { type: "boolean", value: true });
+    // `;tr` is rejected upstream; add handling here when trailer support lands.
     if (p.name !== undefined) {
       sfParams.set("name", { type: "string", value: p.name });
     }
@@ -648,20 +649,13 @@ function serializeInnerListValue(il: InnerList): string {
   const items = il.items.map((i) => serializeItem(i)).join(" ");
   let result = `(${items})`;
   for (const [key, value] of il.parameters) {
-    result += `;${key}=${serializeBareItemValue(value)}`;
+    // buildSignatureParamsValue only ever puts integer (created/expires) or
+    // string (nonce/alg/keyid/tag) bare items into listParams.
+    result += `;${key}=${
+      value.type === "integer" ? String(value.value) : `"${value.value}"`
+    }`;
   }
   return result;
-}
-
-function serializeBareItemValue(bareItem: BareItem): string {
-  switch (bareItem.type) {
-    case "integer":
-      return String(bareItem.value);
-    case "string":
-      return `"${bareItem.value}"`;
-    default:
-      return serializeItem(sfItem(bareItem));
-  }
 }
 
 /**

--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -305,9 +305,21 @@ function inferAlgorithm(key: CryptoKey): SignatureAlgorithm {
   const alg = key.algorithm;
   const name = alg.name;
   if (name === "Ed25519") return "ed25519";
-  if (name === "HMAC") return "hmac-sha256";
-  if (name === "RSA-PSS") return "rsa-pss-sha512";
-  if (name === "RSASSA-PKCS1-v1_5") return "rsa-v1_5-sha256";
+  if (name === "HMAC") {
+    const hash = (alg as HmacKeyAlgorithm).hash.name;
+    if (hash === "SHA-256") return "hmac-sha256";
+    throw new TypeError(`Unsupported HMAC hash: "${hash}"`);
+  }
+  if (name === "RSA-PSS") {
+    const hash = (alg as RsaHashedKeyAlgorithm).hash.name;
+    if (hash === "SHA-512") return "rsa-pss-sha512";
+    throw new TypeError(`Unsupported RSA-PSS hash: "${hash}"`);
+  }
+  if (name === "RSASSA-PKCS1-v1_5") {
+    const hash = (alg as RsaHashedKeyAlgorithm).hash.name;
+    if (hash === "SHA-256") return "rsa-v1_5-sha256";
+    throw new TypeError(`Unsupported RSASSA-PKCS1-v1_5 hash: "${hash}"`);
+  }
   if (name === "ECDSA") {
     const curve = (alg as EcKeyAlgorithm).namedCurve;
     if (curve === "P-256") return "ecdsa-p256-sha256";
@@ -1016,7 +1028,7 @@ export async function verifyMessage(
     );
 
     // Look up key
-    const algorithm = parsedParams.algorithm ?? undefined;
+    const algorithm = parsedParams.algorithm;
     const keyId = parsedParams.keyId ?? "";
     const verifyKey = await keyLookup(keyId, algorithm);
     if (verifyKey === null) {

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -743,6 +743,24 @@ Deno.test("signMessage() rejects invalid params", async () => {
     TypeError,
     'Unsupported RSASSA-PKCS1-v1_5 hash: "SHA-512"',
   );
+
+  // Completely unknown algorithm name
+  const fakeUnknownKey = {
+    algorithm: { name: "X-Custom" },
+    type: "private",
+    extractable: false,
+    usages: ["sign"],
+  } as unknown as CryptoKey;
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: fakeUnknownKey,
+      }),
+    TypeError,
+    'Cannot infer signature algorithm from key: "X-Custom"',
+  );
 });
 
 // =============================================================================

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -1,0 +1,810 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  createSignatureBase,
+  signMessage,
+  verifyMessage,
+} from "./unstable_message_signatures.ts";
+import type { SignatureAlgorithm } from "./unstable_message_signatures.ts";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeRequest(
+  url = "https://example.com/foo?param=Value&Pet=dog",
+  init?: RequestInit,
+): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Host": "example.com",
+      "Date": "Tue, 20 Apr 2021 02:07:55 GMT",
+      "Content-Type": "application/json",
+      "Content-Digest":
+        "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:",
+      "Content-Length": "18",
+    },
+    body: '{"hello": "world"}',
+    ...init,
+  });
+}
+
+async function generateEd25519(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+}
+
+async function generateHmacKey(): Promise<CryptoKey> {
+  return await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  );
+}
+
+async function generateEcdsaP256(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+}
+
+async function generateEcdsaP384(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-384" },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+}
+
+async function generateRsaPss(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey(
+    {
+      name: "RSA-PSS",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-512",
+    },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+}
+
+async function generateRsaPkcs1(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+}
+
+// =============================================================================
+// Layer 1: Component value resolution — derived components
+// =============================================================================
+
+Deno.test("createSignatureBase() resolves @method", () => {
+  const request = new Request("https://example.com/path", { method: "POST" });
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@method"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@method": POST');
+});
+
+Deno.test("createSignatureBase() resolves @target-uri", () => {
+  const request = new Request("https://www.example.com/path?param=value");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@target-uri"], created: 1618884473 },
+  });
+  assertEquals(
+    base.split("\n")[0],
+    '"@target-uri": https://www.example.com/path?param=value',
+  );
+});
+
+Deno.test("createSignatureBase() resolves @authority with default port omitted", () => {
+  const request = new Request("https://www.example.com/path");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@authority"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@authority": www.example.com');
+});
+
+Deno.test("createSignatureBase() resolves @scheme", () => {
+  const request = new Request("https://example.com/");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@scheme"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@scheme": https');
+});
+
+Deno.test("createSignatureBase() resolves @request-target", () => {
+  const request = new Request("https://example.com/path?param=value");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@request-target"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@request-target": /path?param=value');
+});
+
+Deno.test("createSignatureBase() resolves @path with empty path normalized to slash", () => {
+  const request = new Request("https://example.com");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@path"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@path": /');
+});
+
+Deno.test("createSignatureBase() resolves @query with absent query as ?", () => {
+  const request = new Request("https://example.com/path");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@query"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@query": ?');
+});
+
+Deno.test("createSignatureBase() resolves @query-param with percent-encoding", () => {
+  const request = new Request(
+    "https://example.com/path?param=value&foo=bar",
+  );
+  const base = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "@query-param", parameters: { name: "param" } }],
+      created: 1618884473,
+    },
+  });
+  assertEquals(base.split("\n")[0], '"@query-param";name="param": value');
+});
+
+Deno.test("createSignatureBase() resolves @status from response", () => {
+  const response = new Response(null, { status: 200 });
+  const base = createSignatureBase({
+    message: response,
+    params: { components: ["@status"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"@status": 200');
+});
+
+// =============================================================================
+// Layer 1b: Field component parameters
+// =============================================================================
+
+Deno.test("createSignatureBase() resolves plain header field value", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Content-Type": "application/json" },
+  });
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["content-type"], created: 1618884473 },
+  });
+  assertEquals(base.split("\n")[0], '"content-type": application/json');
+});
+
+Deno.test("createSignatureBase() resolves ;sf strict serialization", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Example-Dict": "a=1,    b=2;x=1;y=2,   c=(a   b   c)" },
+  });
+  const base = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "example-dict", parameters: { sf: true } }],
+      created: 1618884473,
+    },
+  });
+  assertEquals(
+    base.split("\n")[0],
+    '"example-dict";sf: a=1, b=2;x=1;y=2, c=(a b c)',
+  );
+});
+
+Deno.test("createSignatureBase() resolves ;key dictionary member", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Example-Dict": "a=1, b=2;x=1;y=2, c=(a b c), d" },
+  });
+  const base = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "example-dict", parameters: { key: "a" } }],
+      created: 1618884473,
+    },
+  });
+  assertEquals(base.split("\n")[0], '"example-dict";key="a": 1');
+});
+
+Deno.test("createSignatureBase() resolves ;bs binary-wrapped field", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Example-Header": "value, with, lots" },
+  });
+  const base = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "example-header", parameters: { bs: true } }],
+      created: 1618884473,
+    },
+  });
+  const line = base.split("\n")[0]!;
+  // The bs parameter wraps each value as a Byte Sequence
+  assertEquals(line.startsWith('"example-header";bs: :'), true);
+});
+
+// =============================================================================
+// Layer 1c: Component resolution errors
+// =============================================================================
+
+Deno.test("createSignatureBase() throws TypeError on missing header field", () => {
+  const request = new Request("https://example.com/");
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["x-nonexistent"] },
+      }),
+    TypeError,
+    'Missing "x-nonexistent" header field',
+  );
+});
+
+Deno.test("createSignatureBase() throws TypeError on unknown derived component", () => {
+  const request = new Request("https://example.com/");
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["@unknown"] },
+      }),
+    TypeError,
+    'Unknown derived component "@unknown"',
+  );
+});
+
+Deno.test("createSignatureBase() throws TypeError on @status for request message", () => {
+  const request = new Request("https://example.com/");
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["@status"] },
+      }),
+    TypeError,
+    'Cannot use "@status" on a request message',
+  );
+});
+
+Deno.test("createSignatureBase() throws TypeError on incompatible ;bs and ;sf", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Example": "value" },
+  });
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: {
+          components: [
+            { name: "example", parameters: { bs: true, sf: true } },
+          ],
+        },
+      }),
+    TypeError,
+    'Cannot combine "bs" and "sf"',
+  );
+});
+
+// =============================================================================
+// Layer 1d: ;req parameter
+// =============================================================================
+
+Deno.test("createSignatureBase() resolves ;req from related request", () => {
+  const request = new Request("https://example.com/foo", { method: "POST" });
+  const response = new Response(null, { status: 200 });
+  const base = createSignatureBase({
+    message: response,
+    params: {
+      components: [
+        "@status",
+        { name: "@method", parameters: { req: true } },
+      ],
+      created: 1618884473,
+    },
+    request,
+  });
+  const lines = base.split("\n");
+  assertEquals(lines[0], '"@status": 200');
+  assertEquals(lines[1], '"@method";req: POST');
+});
+
+// =============================================================================
+// Layer 2: Signature base construction
+// =============================================================================
+
+Deno.test("createSignatureBase() builds correct base for RFC 9421 section 2.5 example", () => {
+  const request = makeRequest();
+  const base = createSignatureBase({
+    message: request,
+    params: {
+      components: [
+        "@method",
+        "@authority",
+        "@path",
+        "content-digest",
+        "content-length",
+        "content-type",
+      ],
+      created: 1618884473,
+      keyId: "test-key-rsa-pss",
+    },
+  });
+
+  const expected = [
+    '"@method": POST',
+    '"@authority": example.com',
+    '"@path": /foo',
+    '"content-digest": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:',
+    '"content-length": 18',
+    '"content-type": application/json',
+    '"@signature-params": ("@method" "@authority" "@path" "content-digest" "content-length" "content-type");created=1618884473;keyid="test-key-rsa-pss"',
+  ].join("\n");
+
+  assertEquals(base, expected);
+});
+
+Deno.test("createSignatureBase() rejects duplicate component identifier", () => {
+  const request = new Request("https://example.com/", {
+    headers: { "Content-Type": "text/plain" },
+  });
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["content-type", "content-type"] },
+      }),
+    TypeError,
+    "Duplicate component identifier",
+  );
+});
+
+// =============================================================================
+// Layer 2b: ECDSA DER/raw conversion (tested via round-trip)
+// =============================================================================
+
+Deno.test("signMessage() and verifyMessage() round-trip with ecdsa-p256-sha256 exercises DER/raw conversion", async () => {
+  const keys = await generateEcdsaP256();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "test-ecdsa-p256",
+      algorithm: "ecdsa-p256-sha256",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  const results = await verifyMessage(
+    signed,
+    () => keys.publicKey,
+  );
+  assertEquals(results.length, 1);
+  assertEquals(results[0]!.label, "sig");
+});
+
+// =============================================================================
+// Layer 3: Sign and verify integration — one per algorithm
+// =============================================================================
+
+Deno.test("signMessage() and verifyMessage() round-trip with ed25519", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "POST" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method", "@authority"],
+      keyId: "test-ed25519",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => keys.publicKey);
+  assertEquals(results.length, 1);
+  assertEquals(results[0]!.params.keyId, "test-ed25519");
+});
+
+Deno.test("signMessage() and verifyMessage() round-trip with hmac-sha256", async () => {
+  const key = await generateHmacKey();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "test-hmac",
+      algorithm: "hmac-sha256",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key,
+  });
+
+  const results = await verifyMessage(signed, () => key);
+  assertEquals(results.length, 1);
+});
+
+Deno.test("signMessage() and verifyMessage() round-trip with ecdsa-p384-sha384", async () => {
+  const keys = await generateEcdsaP384();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "test-ecdsa-p384",
+      algorithm: "ecdsa-p384-sha384",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => keys.publicKey);
+  assertEquals(results.length, 1);
+});
+
+Deno.test("signMessage() and verifyMessage() round-trip with rsa-pss-sha512", async () => {
+  const keys = await generateRsaPss();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "test-rsa-pss",
+      algorithm: "rsa-pss-sha512",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => keys.publicKey);
+  assertEquals(results.length, 1);
+});
+
+Deno.test("signMessage() and verifyMessage() round-trip with rsa-v1_5-sha256", async () => {
+  const keys = await generateRsaPkcs1();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "test-rsa-pkcs1",
+      algorithm: "rsa-v1_5-sha256",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => keys.publicKey);
+  assertEquals(results.length, 1);
+});
+
+// =============================================================================
+// Layer 3b: signMessage behaviour
+// =============================================================================
+
+Deno.test("signMessage() preserves existing headers on the message", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "X-Custom": "preserved" },
+  });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+  assertEquals(signed.headers.get("X-Custom"), "preserved");
+  assertEquals(signed.headers.has("Signature"), true);
+  assertEquals(signed.headers.has("Signature-Input"), true);
+});
+
+Deno.test("signMessage() defaults label to sig", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+  const sigInput = signed.headers.get("Signature-Input")!;
+  assertEquals(sigInput.startsWith("sig="), true);
+});
+
+Deno.test("signMessage() throws TypeError on unsupported algorithm", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: {
+          components: ["@method"],
+          algorithm: "invalid-algo" as SignatureAlgorithm,
+        },
+        key: keys.privateKey,
+      }),
+    TypeError,
+    "Unsupported signature algorithm",
+  );
+});
+
+Deno.test("signMessage() throws RangeError on negative created timestamp", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: {
+          components: ["@method"],
+          keyId: "k",
+          created: -1,
+        },
+        key: keys.privateKey,
+      }),
+    RangeError,
+    "created must be a non-negative integer",
+  );
+});
+
+// =============================================================================
+// Layer 3c: verifyMessage behaviour
+// =============================================================================
+
+Deno.test("verifyMessage() throws Error on tampered header value", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method", "content-type"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  // Tamper with the content-type header
+  const tampered = new Request(signed.url, {
+    method: signed.method,
+    headers: new Headers(signed.headers),
+  });
+  tampered.headers.set("Content-Type", "text/plain");
+
+  await assertRejects(
+    () => verifyMessage(tampered, () => keys.publicKey),
+    Error,
+    "Signature verification failed",
+  );
+});
+
+Deno.test("verifyMessage() throws Error on wrong key", async () => {
+  const keys1 = await generateEd25519();
+  const keys2 = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys1.privateKey,
+  });
+
+  await assertRejects(
+    () => verifyMessage(signed, () => keys2.publicKey),
+    Error,
+    "Signature verification failed",
+  );
+});
+
+Deno.test("verifyMessage() throws Error on expired signature when maxAge is set", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000) - 3600,
+    },
+    key: keys.privateKey,
+  });
+
+  await assertRejects(
+    () => verifyMessage(signed, () => keys.publicKey, { maxAge: 60 }),
+    Error,
+    "has expired",
+  );
+});
+
+Deno.test("verifyMessage() throws Error when requiredComponents are not covered", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  await assertRejects(
+    () =>
+      verifyMessage(signed, () => keys.publicKey, {
+        requiredComponents: ["@authority"],
+      }),
+    Error,
+    "does not cover required component",
+  );
+});
+
+Deno.test("verifyMessage() filters by labels option", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      label: "mysig",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  // Verify only "mysig" — should succeed
+  const results = await verifyMessage(signed, () => keys.publicKey, {
+    labels: ["mysig"],
+  });
+  assertEquals(results.length, 1);
+
+  // Verify only "other" — should return empty (no matching labels)
+  const empty = await verifyMessage(signed, () => keys.publicKey, {
+    labels: ["other"],
+  });
+  assertEquals(empty.length, 0);
+});
+
+Deno.test("verifyMessage() throws TypeError on missing Signature-Input header", async () => {
+  const request = new Request("https://example.com/", { method: "GET" });
+  await assertRejects(
+    () => verifyMessage(request, () => { throw new Error("unreachable"); }),
+    TypeError,
+    'Missing "Signature-Input" header',
+  );
+});
+
+Deno.test("verifyMessage() throws RangeError on negative maxAge", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+  });
+
+  await assertRejects(
+    () => verifyMessage(signed, () => keys.publicKey, { maxAge: -1 }),
+    RangeError,
+    "maxAge must be a non-negative integer",
+  );
+});
+
+// =============================================================================
+// Layer 3d: Advanced scenarios
+// =============================================================================
+
+Deno.test("signMessage() supports multiple signatures with different labels", async () => {
+  const keys1 = await generateEd25519();
+  const keys2 = await generateEd25519();
+  const request = new Request("https://example.com/", { method: "GET" });
+
+  const signed1 = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "key1",
+      label: "sig1",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys1.privateKey,
+  });
+
+  const signed2 = await signMessage({
+    message: signed1,
+    params: {
+      components: ["@method", "@authority"],
+      keyId: "key2",
+      label: "sig2",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys2.privateKey,
+  });
+
+  const sigInput = signed2.headers.get("Signature-Input")!;
+  assertEquals(sigInput.includes("sig1="), true);
+  assertEquals(sigInput.includes("sig2="), true);
+
+  // Verify both
+  const results = await verifyMessage(
+    signed2,
+    (keyId) => {
+      if (keyId === "key1") return keys1.publicKey;
+      return keys2.publicKey;
+    },
+  );
+  assertEquals(results.length, 2);
+});
+
+Deno.test("verifyMessage() verifies response signature with ;req components", async () => {
+  const keys = await generateEd25519();
+  const request = new Request("https://example.com/foo", { method: "POST" });
+  const response = new Response('{"ok":true}', {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const signed = await signMessage({
+    message: response,
+    params: {
+      components: [
+        "@status",
+        "content-type",
+        { name: "@method", parameters: { req: true } },
+        { name: "@path", parameters: { req: true } },
+      ],
+      keyId: "server-key",
+      created: Math.floor(Date.now() / 1000),
+    },
+    key: keys.privateKey,
+    request,
+  });
+
+  const results = await verifyMessage(
+    signed,
+    () => keys.publicKey,
+    { request },
+  );
+  assertEquals(results.length, 1);
+  assertEquals(results[0]!.params.keyId, "server-key");
+});

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -160,6 +160,7 @@ Deno.test("createSignatureBase() resolves plain header, ;sf, ;key item, ;key inn
       "List-Dict": "items=(1 2 3), other=4",
       "Example-Header": "value, with, lots",
       "X-Num": "42",
+      "X-List": "1,    2,   3",
     },
   });
 
@@ -175,6 +176,16 @@ Deno.test("createSignatureBase() resolves plain header, ;sf, ;key item, ;key inn
     sfDict.split("\n")[0],
     '"example-dict";sf: a=1, b=2;x=1;y=2, c=(a b c)',
   );
+
+  // ;sf — list fallback (header fails Dictionary parse, succeeds as List)
+  const sfList = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "x-list", parameters: { sf: true } }],
+      created: 1618884473,
+    },
+  });
+  assertEquals(sfList.split("\n")[0], '"x-list";sf: 1, 2, 3');
 
   // ;sf — item fallback
   const sfItem = createSignatureBase({
@@ -833,6 +844,98 @@ Deno.test("signMessage() supports multiple signatures with different labels", as
     (keyId) => keyId === "key1" ? k1.publicKey : k2.publicKey,
   );
   assertEquals(results.length, 2);
+});
+
+Deno.test("signMessage() rejects duplicate labels on already-signed messages", async () => {
+  const { privateKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", { method: "GET" });
+
+  const signed = await signMessage({
+    message: request,
+    params: { components: ["@method"], keyId: "k", created: NOW },
+    key: privateKey,
+  });
+
+  // Default label collision ("sig" on both calls).
+  await assertRejects(
+    () =>
+      signMessage({
+        message: signed,
+        params: { components: ["@authority"], keyId: "k", created: NOW },
+        key: privateKey,
+      }),
+    TypeError,
+    'Signature label "sig" is already present',
+  );
+
+  // Explicit label collision.
+  const signedNamed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      label: "proxy",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+  await assertRejects(
+    () =>
+      signMessage({
+        message: signedNamed,
+        params: {
+          components: ["@authority"],
+          keyId: "k",
+          label: "proxy",
+          created: NOW,
+        },
+        key: privateKey,
+      }),
+    TypeError,
+    'Signature label "proxy" is already present',
+  );
+});
+
+Deno.test("signMessage() rejects messages with malformed Signature-Input header", async () => {
+  const { privateKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Signature-Input": "!!not a valid dictionary!!" },
+  });
+
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: privateKey,
+      }),
+    TypeError,
+    'Cannot parse existing "Signature-Input" header',
+  );
+});
+
+Deno.test("signMessage() rejects label collision in Signature header alone", async () => {
+  const { privateKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  // Construct a message where only the Signature header carries the label.
+  // Such a message is already malformed per RFC 9421 section 4 (labels MUST
+  // match between the two headers), but signMessage should still refuse to
+  // further corrupt it.
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Signature": "sig=:AAAA:" },
+  });
+
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: privateKey,
+      }),
+    TypeError,
+    'Signature label "sig" is already present in the "Signature" header',
+  );
 });
 
 // =============================================================================

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -673,7 +673,7 @@ Deno.test("signMessage() rejects invalid params", async () => {
   );
 
   // Unsupported ECDSA curve
-  const fakeKey = {
+  const fakeEcdsaKey = {
     algorithm: { name: "ECDSA", namedCurve: "P-521" },
     type: "private",
     extractable: false,
@@ -684,10 +684,64 @@ Deno.test("signMessage() rejects invalid params", async () => {
       signMessage({
         message: request,
         params: { components: ["@method"], keyId: "k", created: NOW },
-        key: fakeKey,
+        key: fakeEcdsaKey,
       }),
     TypeError,
     'Unsupported ECDSA curve: "P-521"',
+  );
+
+  // Unsupported HMAC hash
+  const fakeHmacKey = {
+    algorithm: { name: "HMAC", hash: { name: "SHA-512" } },
+    type: "secret",
+    extractable: false,
+    usages: ["sign"],
+  } as unknown as CryptoKey;
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: fakeHmacKey,
+      }),
+    TypeError,
+    'Unsupported HMAC hash: "SHA-512"',
+  );
+
+  // Unsupported RSA-PSS hash
+  const fakeRsaPssKey = {
+    algorithm: { name: "RSA-PSS", hash: { name: "SHA-256" } },
+    type: "private",
+    extractable: false,
+    usages: ["sign"],
+  } as unknown as CryptoKey;
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: fakeRsaPssKey,
+      }),
+    TypeError,
+    'Unsupported RSA-PSS hash: "SHA-256"',
+  );
+
+  // Unsupported RSASSA-PKCS1-v1_5 hash
+  const fakePkcs1Key = {
+    algorithm: { name: "RSASSA-PKCS1-v1_5", hash: { name: "SHA-512" } },
+    type: "private",
+    extractable: false,
+    usages: ["sign"],
+  } as unknown as CryptoKey;
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: fakePkcs1Key,
+      }),
+    TypeError,
+    'Unsupported RSASSA-PKCS1-v1_5 hash: "SHA-512"',
   );
 });
 

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -12,6 +12,8 @@ import type { SignatureAlgorithm } from "./unstable_message_signatures.ts";
 // Helpers
 // =============================================================================
 
+const NOW = Math.floor(Date.now() / 1000);
+
 function makeRequest(
   url = "https://example.com/foo?param=Value&Pet=dog",
   init?: RequestInit,
@@ -31,146 +33,110 @@ function makeRequest(
   });
 }
 
-async function generateEd25519(): Promise<CryptoKeyPair> {
-  return await crypto.subtle.generateKey(
-    "Ed25519",
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-}
+type KeyGenerator = () => Promise<CryptoKeyPair | CryptoKey>;
 
-async function generateHmacKey(): Promise<CryptoKey> {
-  return await crypto.subtle.generateKey(
-    { name: "HMAC", hash: "SHA-256" },
-    true,
-    ["sign", "verify"],
-  );
-}
+const KEY_GENERATORS: Record<string, KeyGenerator> = {
+  ed25519: () =>
+    crypto.subtle.generateKey("Ed25519", true, [
+      "sign",
+      "verify",
+    ]) as Promise<CryptoKeyPair>,
+  "hmac-sha256": () =>
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256" }, true, [
+      "sign",
+      "verify",
+    ]),
+  "ecdsa-p256-sha256": () =>
+    crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"],
+    ) as Promise<CryptoKeyPair>,
+  "ecdsa-p384-sha384": () =>
+    crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-384" },
+      true,
+      ["sign", "verify"],
+    ) as Promise<CryptoKeyPair>,
+  "rsa-pss-sha512": () =>
+    crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-512",
+      },
+      true,
+      ["sign", "verify"],
+    ) as Promise<CryptoKeyPair>,
+  "rsa-v1_5-sha256": () =>
+    crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    ) as Promise<CryptoKeyPair>,
+};
 
-async function generateEcdsaP256(): Promise<CryptoKeyPair> {
-  return await crypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-}
-
-async function generateEcdsaP384(): Promise<CryptoKeyPair> {
-  return await crypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-384" },
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-}
-
-async function generateRsaPss(): Promise<CryptoKeyPair> {
-  return await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-512",
-    },
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-}
-
-async function generateRsaPkcs1(): Promise<CryptoKeyPair> {
-  return await crypto.subtle.generateKey(
-    {
-      name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
+function keys(
+  keyOrPair: CryptoKeyPair | CryptoKey,
+): { privateKey: CryptoKey; publicKey: CryptoKey } {
+  if ("privateKey" in keyOrPair) return keyOrPair;
+  return { privateKey: keyOrPair, publicKey: keyOrPair };
 }
 
 // =============================================================================
-// Layer 1: Component value resolution — derived components
+// createSignatureBase — derived components
 // =============================================================================
 
-Deno.test("createSignatureBase() resolves @method", () => {
-  const request = new Request("https://example.com/path", { method: "POST" });
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@method"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@method": POST');
-});
-
-Deno.test("createSignatureBase() resolves @target-uri", () => {
-  const request = new Request("https://www.example.com/path?param=value");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@target-uri"], created: 1618884473 },
-  });
-  assertEquals(
-    base.split("\n")[0],
-    '"@target-uri": https://www.example.com/path?param=value',
-  );
-});
-
-Deno.test("createSignatureBase() resolves @authority with default port omitted", () => {
-  const request = new Request("https://www.example.com/path");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@authority"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@authority": www.example.com');
-});
-
-Deno.test("createSignatureBase() resolves @scheme", () => {
-  const request = new Request("https://example.com/");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@scheme"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@scheme": https');
-});
-
-Deno.test("createSignatureBase() resolves @request-target", () => {
-  const request = new Request("https://example.com/path?param=value");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@request-target"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@request-target": /path?param=value');
-});
-
-Deno.test("createSignatureBase() resolves @path with empty path normalized to slash", () => {
-  const request = new Request("https://example.com");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@path"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@path": /');
-});
-
-Deno.test("createSignatureBase() resolves @query with absent query as ?", () => {
-  const request = new Request("https://example.com/path");
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["@query"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"@query": ?');
-});
-
-Deno.test("createSignatureBase() resolves @query-param with percent-encoding", () => {
+Deno.test("createSignatureBase() resolves all request-derived components", () => {
   const request = new Request(
-    "https://example.com/path?param=value&foo=bar",
+    "https://www.example.com/path?param=value",
+    { method: "POST" },
   );
   const base = createSignatureBase({
     message: request,
     params: {
-      components: [{ name: "@query-param", parameters: { name: "param" } }],
+      components: [
+        "@method",
+        "@target-uri",
+        "@authority",
+        "@scheme",
+        "@request-target",
+        "@path",
+        "@query",
+        { name: "@query-param", parameters: { name: "param" } },
+      ],
       created: 1618884473,
     },
   });
-  assertEquals(base.split("\n")[0], '"@query-param";name="param": value');
+  const lines = base.split("\n");
+  assertEquals(lines[0], '"@method": POST');
+  assertEquals(
+    lines[1],
+    '"@target-uri": https://www.example.com/path?param=value',
+  );
+  assertEquals(lines[2], '"@authority": www.example.com');
+  assertEquals(lines[3], '"@scheme": https');
+  assertEquals(lines[4], '"@request-target": /path?param=value');
+  assertEquals(lines[5], '"@path": /path');
+  assertEquals(lines[6], '"@query": ?param=value');
+  assertEquals(lines[7], '"@query-param";name="param": value');
+});
+
+Deno.test("createSignatureBase() normalizes empty path to / and absent query to ?", () => {
+  const request = new Request("https://example.com");
+  const base = createSignatureBase({
+    message: request,
+    params: { components: ["@path", "@query"], created: 1618884473 },
+  });
+  const lines = base.split("\n");
+  assertEquals(lines[0], '"@path": /');
+  assertEquals(lines[1], '"@query": ?');
 });
 
 Deno.test("createSignatureBase() resolves @status from response", () => {
@@ -183,25 +149,22 @@ Deno.test("createSignatureBase() resolves @status from response", () => {
 });
 
 // =============================================================================
-// Layer 1b: Field component parameters
+// createSignatureBase — field component parameters (;sf, ;key, ;bs)
 // =============================================================================
 
-Deno.test("createSignatureBase() resolves plain header field value", () => {
+Deno.test("createSignatureBase() resolves plain header, ;sf, ;key item, ;key inner-list, and ;bs", () => {
   const request = new Request("https://example.com/", {
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "Example-Dict": "a=1,    b=2;x=1;y=2,   c=(a   b   c)",
+      "List-Dict": "items=(1 2 3), other=4",
+      "Example-Header": "value, with, lots",
+      "X-Num": "42",
+    },
   });
-  const base = createSignatureBase({
-    message: request,
-    params: { components: ["content-type"], created: 1618884473 },
-  });
-  assertEquals(base.split("\n")[0], '"content-type": application/json');
-});
 
-Deno.test("createSignatureBase() resolves ;sf strict serialization", () => {
-  const request = new Request("https://example.com/", {
-    headers: { "Example-Dict": "a=1,    b=2;x=1;y=2,   c=(a   b   c)" },
-  });
-  const base = createSignatureBase({
+  // ;sf — dictionary
+  const sfDict = createSignatureBase({
     message: request,
     params: {
       components: [{ name: "example-dict", parameters: { sf: true } }],
@@ -209,105 +172,53 @@ Deno.test("createSignatureBase() resolves ;sf strict serialization", () => {
     },
   });
   assertEquals(
-    base.split("\n")[0],
+    sfDict.split("\n")[0],
     '"example-dict";sf: a=1, b=2;x=1;y=2, c=(a b c)',
   );
-});
 
-Deno.test("createSignatureBase() resolves ;key dictionary member", () => {
-  const request = new Request("https://example.com/", {
-    headers: { "Example-Dict": "a=1, b=2;x=1;y=2, c=(a b c), d" },
+  // ;sf — item fallback
+  const sfItem = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "x-num", parameters: { sf: true } }],
+      created: 1618884473,
+    },
   });
-  const base = createSignatureBase({
+  assertEquals(sfItem.split("\n")[0], '"x-num";sf: 42');
+
+  // ;key — scalar member
+  const keyScalar = createSignatureBase({
     message: request,
     params: {
       components: [{ name: "example-dict", parameters: { key: "a" } }],
       created: 1618884473,
     },
   });
-  assertEquals(base.split("\n")[0], '"example-dict";key="a": 1');
-});
+  assertEquals(keyScalar.split("\n")[0], '"example-dict";key="a": 1');
 
-Deno.test("createSignatureBase() resolves ;bs binary-wrapped field", () => {
-  const request = new Request("https://example.com/", {
-    headers: { "Example-Header": "value, with, lots" },
+  // ;key — inner list member
+  const keyList = createSignatureBase({
+    message: request,
+    params: {
+      components: [{ name: "list-dict", parameters: { key: "items" } }],
+      created: 1618884473,
+    },
   });
-  const base = createSignatureBase({
+  assertEquals(keyList.split("\n")[0], '"list-dict";key="items": (1 2 3)');
+
+  // ;bs
+  const bs = createSignatureBase({
     message: request,
     params: {
       components: [{ name: "example-header", parameters: { bs: true } }],
       created: 1618884473,
     },
   });
-  const line = base.split("\n")[0]!;
-  // The bs parameter wraps each value as a Byte Sequence
-  assertEquals(line.startsWith('"example-header";bs: :'), true);
+  assertEquals(bs.split("\n")[0]!.startsWith('"example-header";bs: :'), true);
 });
 
 // =============================================================================
-// Layer 1c: Component resolution errors
-// =============================================================================
-
-Deno.test("createSignatureBase() throws TypeError on missing header field", () => {
-  const request = new Request("https://example.com/");
-  assertThrows(
-    () =>
-      createSignatureBase({
-        message: request,
-        params: { components: ["x-nonexistent"] },
-      }),
-    TypeError,
-    'Missing "x-nonexistent" header field',
-  );
-});
-
-Deno.test("createSignatureBase() throws TypeError on unknown derived component", () => {
-  const request = new Request("https://example.com/");
-  assertThrows(
-    () =>
-      createSignatureBase({
-        message: request,
-        params: { components: ["@unknown"] },
-      }),
-    TypeError,
-    'Unknown derived component "@unknown"',
-  );
-});
-
-Deno.test("createSignatureBase() throws TypeError on @status for request message", () => {
-  const request = new Request("https://example.com/");
-  assertThrows(
-    () =>
-      createSignatureBase({
-        message: request,
-        params: { components: ["@status"] },
-      }),
-    TypeError,
-    'Cannot use "@status" on a request message',
-  );
-});
-
-Deno.test("createSignatureBase() throws TypeError on incompatible ;bs and ;sf", () => {
-  const request = new Request("https://example.com/", {
-    headers: { "Example": "value" },
-  });
-  assertThrows(
-    () =>
-      createSignatureBase({
-        message: request,
-        params: {
-          components: [
-            { name: "example", parameters: { bs: true, sf: true } },
-          ],
-        },
-      }),
-    TypeError,
-    'Cannot combine "bs" and "sf"',
-  );
-});
-
-// =============================================================================
-// Layer 1d: ;req parameter
+// createSignatureBase — ;req parameter
 // =============================================================================
 
 Deno.test("createSignatureBase() resolves ;req from related request", () => {
@@ -330,7 +241,7 @@ Deno.test("createSignatureBase() resolves ;req from related request", () => {
 });
 
 // =============================================================================
-// Layer 2: Signature base construction
+// createSignatureBase — full RFC 9421 section 2.5 example
 // =============================================================================
 
 Deno.test("createSignatureBase() builds correct base for RFC 9421 section 2.5 example", () => {
@@ -364,10 +275,130 @@ Deno.test("createSignatureBase() builds correct base for RFC 9421 section 2.5 ex
   assertEquals(base, expected);
 });
 
-Deno.test("createSignatureBase() rejects duplicate component identifier", () => {
+// =============================================================================
+// createSignatureBase — error paths
+// =============================================================================
+
+Deno.test("createSignatureBase() rejects invalid component configurations", () => {
   const request = new Request("https://example.com/", {
-    headers: { "Content-Type": "text/plain" },
+    headers: { "Example": "value", "Content-Type": "text/plain" },
   });
+  const response = new Response(null, { status: 200 });
+
+  // Missing header
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["x-nonexistent"] },
+      }),
+    TypeError,
+    'Missing "x-nonexistent" header field',
+  );
+
+  // Unknown derived component
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["@unknown"] },
+      }),
+    TypeError,
+    'Unknown derived component "@unknown"',
+  );
+
+  // @status on request
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["@status"] },
+      }),
+    TypeError,
+    'Cannot use "@status" on a request message',
+  );
+
+  // Request-only component on response
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: response,
+        params: { components: ["@method"] },
+      }),
+    TypeError,
+    'Cannot use "@method" on a response message',
+  );
+
+  // ;bs + ;sf
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: {
+          components: [
+            { name: "example", parameters: { bs: true, sf: true } },
+          ],
+        },
+      }),
+    TypeError,
+    'Cannot combine "bs" and "sf"',
+  );
+
+  // ;bs + ;key
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: {
+          components: [
+            { name: "example", parameters: { bs: true, key: "a" } },
+          ],
+        },
+      }),
+    TypeError,
+    'Cannot combine "bs" and "key"',
+  );
+
+  // ;tr unsupported
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: {
+          components: [{ name: "example", parameters: { tr: true } }],
+        },
+      }),
+    TypeError,
+    "Trailer field resolution",
+  );
+
+  // ;req on a request
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: {
+          components: [{ name: "@method", parameters: { req: true } }],
+        },
+      }),
+    TypeError,
+    'Cannot use "req" parameter',
+  );
+
+  // ;req without related request
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: response,
+        params: {
+          components: [{ name: "@method", parameters: { req: true } }],
+        },
+      }),
+    TypeError,
+    "no related request provided",
+  );
+
+  // Duplicate component
   assertThrows(
     () =>
       createSignatureBase({
@@ -377,189 +408,225 @@ Deno.test("createSignatureBase() rejects duplicate component identifier", () => 
     TypeError,
     "Duplicate component identifier",
   );
-});
 
-// =============================================================================
-// Layer 2b: ECDSA DER/raw conversion (tested via round-trip)
-// =============================================================================
-
-Deno.test("signMessage() and verifyMessage() round-trip with ecdsa-p256-sha256 exercises DER/raw conversion", async () => {
-  const keys = await generateEcdsaP256();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "test-ecdsa-p256",
-      algorithm: "ecdsa-p256-sha256",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  const results = await verifyMessage(
-    signed,
-    () => keys.publicKey,
+  // @signature-params in components
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["@signature-params"] },
+      }),
+    TypeError,
+    '"@signature-params" must not be listed',
   );
-  assertEquals(results.length, 1);
-  assertEquals(results[0]!.label, "sig");
+
+  // Uppercase component name
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: request,
+        params: { components: ["Content-Type"] },
+      }),
+    TypeError,
+    "must be lowercase",
+  );
+});
+
+Deno.test("createSignatureBase() rejects @query-param edge cases", () => {
+  // Missing name parameter
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/path?foo=bar"),
+        params: { components: [{ name: "@query-param" }] },
+      }),
+    TypeError,
+    'requires "name" parameter',
+  );
+
+  // Non-existent parameter
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/path?foo=bar"),
+        params: {
+          components: [
+            { name: "@query-param", parameters: { name: "nonexistent" } },
+          ],
+        },
+      }),
+    TypeError,
+    "not found in request URL",
+  );
+
+  // Duplicate parameter
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/path?foo=1&foo=2"),
+        params: {
+          components: [
+            { name: "@query-param", parameters: { name: "foo" } },
+          ],
+        },
+      }),
+    TypeError,
+    "occurs multiple times",
+  );
+});
+
+Deno.test("createSignatureBase() rejects ;sf and ;key errors", () => {
+  // ;sf with unparseable value
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/", {
+          headers: { "X-Bad": "@@@ not a structured field @@@" },
+        }),
+        params: {
+          components: [{ name: "x-bad", parameters: { sf: true } }],
+        },
+      }),
+    TypeError,
+    'Cannot apply "sf" parameter',
+  );
+
+  // ;key with non-dictionary header
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/", {
+          headers: { "X-Simple": "just a plain value" },
+        }),
+        params: {
+          components: [{ name: "x-simple", parameters: { key: "a" } }],
+        },
+      }),
+    TypeError,
+    'Cannot parse "x-simple" as Dictionary',
+  );
+
+  // ;key with missing key
+  assertThrows(
+    () =>
+      createSignatureBase({
+        message: new Request("https://example.com/", {
+          headers: { "Example-Dict": "a=1, b=2" },
+        }),
+        params: {
+          components: [
+            { name: "example-dict", parameters: { key: "nonexistent" } },
+          ],
+        },
+      }),
+    TypeError,
+    'Dictionary key "nonexistent" not found',
+  );
 });
 
 // =============================================================================
-// Layer 3: Sign and verify integration — one per algorithm
+// Sign and verify round-trip — all algorithms (inferred from key)
 // =============================================================================
 
-Deno.test("signMessage() and verifyMessage() round-trip with ed25519", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "POST" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method", "@authority"],
-      keyId: "test-ed25519",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
+for (
+  const algorithm of [
+    "ed25519",
+    "hmac-sha256",
+    "ecdsa-p256-sha256",
+    "ecdsa-p384-sha384",
+    "rsa-pss-sha512",
+    "rsa-v1_5-sha256",
+  ] as const
+) {
+  Deno.test(`signMessage() and verifyMessage() round-trip with ${algorithm}`, async () => {
+    const keyOrPair = await KEY_GENERATORS[algorithm]!();
+    const { privateKey, publicKey } = keys(keyOrPair);
+    const request = new Request("https://example.com/", { method: "POST" });
+
+    const signed = await signMessage({
+      message: request,
+      params: {
+        components: ["@method", "@authority"],
+        keyId: `test-${algorithm}`,
+        created: NOW,
+      },
+      key: privateKey,
+    });
+
+    const results = await verifyMessage(signed, () => publicKey);
+    assertEquals(results.length, 1);
+    assertEquals(results[0]!.label, "sig");
+    assertEquals(results[0]!.params.keyId, `test-${algorithm}`);
   });
-
-  const results = await verifyMessage(signed, () => keys.publicKey);
-  assertEquals(results.length, 1);
-  assertEquals(results[0]!.params.keyId, "test-ed25519");
-});
-
-Deno.test("signMessage() and verifyMessage() round-trip with hmac-sha256", async () => {
-  const key = await generateHmacKey();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "test-hmac",
-      algorithm: "hmac-sha256",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key,
-  });
-
-  const results = await verifyMessage(signed, () => key);
-  assertEquals(results.length, 1);
-});
-
-Deno.test("signMessage() and verifyMessage() round-trip with ecdsa-p384-sha384", async () => {
-  const keys = await generateEcdsaP384();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "test-ecdsa-p384",
-      algorithm: "ecdsa-p384-sha384",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  const results = await verifyMessage(signed, () => keys.publicKey);
-  assertEquals(results.length, 1);
-});
-
-Deno.test("signMessage() and verifyMessage() round-trip with rsa-pss-sha512", async () => {
-  const keys = await generateRsaPss();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "test-rsa-pss",
-      algorithm: "rsa-pss-sha512",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  const results = await verifyMessage(signed, () => keys.publicKey);
-  assertEquals(results.length, 1);
-});
-
-Deno.test("signMessage() and verifyMessage() round-trip with rsa-v1_5-sha256", async () => {
-  const keys = await generateRsaPkcs1();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "test-rsa-pkcs1",
-      algorithm: "rsa-v1_5-sha256",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  const results = await verifyMessage(signed, () => keys.publicKey);
-  assertEquals(results.length, 1);
-});
+}
 
 // =============================================================================
-// Layer 3b: signMessage behaviour
+// signMessage — behaviour and validation
 // =============================================================================
 
-Deno.test("signMessage() preserves existing headers on the message", async () => {
-  const keys = await generateEd25519();
+Deno.test("signMessage() preserves headers, defaults label, and returns correct type", async () => {
+  const keyOrPair = await KEY_GENERATORS["ed25519"]!();
+  const { privateKey, publicKey } = keys(keyOrPair);
+
+  // Request: preserves existing headers, defaults label to "sig"
   const request = new Request("https://example.com/", {
     method: "GET",
     headers: { "X-Custom": "preserved" },
   });
-  const signed = await signMessage({
+  const signedReq = await signMessage({
     message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
+    params: { components: ["@method"], keyId: "k", created: NOW },
+    key: privateKey,
   });
-  assertEquals(signed.headers.get("X-Custom"), "preserved");
-  assertEquals(signed.headers.has("Signature"), true);
-  assertEquals(signed.headers.has("Signature-Input"), true);
+  assertEquals(signedReq instanceof Request, true);
+  assertEquals(signedReq.headers.get("X-Custom"), "preserved");
+  assertEquals(
+    signedReq.headers.get("Signature-Input")!.startsWith("sig="),
+    true,
+  );
+
+  // Response: returns Response type, signs correctly
+  const response = new Response("body", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  });
+  const signedRes = await signMessage({
+    message: response,
+    params: {
+      components: ["@status", "content-type"],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+  assertEquals(signedRes instanceof Response, true);
+  assertEquals(signedRes.status, 200);
+
+  const results = await verifyMessage(signedRes, () => publicKey);
+  assertEquals(results.length, 1);
 });
 
-Deno.test("signMessage() defaults label to sig", async () => {
-  const keys = await generateEd25519();
+Deno.test("signMessage() rejects invalid params", async () => {
+  const keyOrPair = await KEY_GENERATORS["ed25519"]!();
+  const { privateKey } = keys(keyOrPair);
   const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-  const sigInput = signed.headers.get("Signature-Input")!;
-  assertEquals(sigInput.startsWith("sig="), true);
-});
 
-Deno.test("signMessage() throws TypeError on unsupported algorithm", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
+  // Unsupported algorithm
   await assertRejects(
     () =>
       signMessage({
         message: request,
         params: {
           components: ["@method"],
-          algorithm: "invalid-algo" as SignatureAlgorithm,
+          algorithm: "invalid" as SignatureAlgorithm,
         },
-        key: keys.privateKey,
+        key: privateKey,
       }),
     TypeError,
     "Unsupported signature algorithm",
   );
-});
 
-Deno.test("signMessage() throws RangeError on negative created timestamp", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
+  // Invalid label
   await assertRejects(
     () =>
       signMessage({
@@ -567,179 +634,83 @@ Deno.test("signMessage() throws RangeError on negative created timestamp", async
         params: {
           components: ["@method"],
           keyId: "k",
-          created: -1,
+          label: "INVALID",
+          created: NOW,
         },
-        key: keys.privateKey,
+        key: privateKey,
+      }),
+    TypeError,
+    "Invalid signature label",
+  );
+
+  // Negative created
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: -1 },
+        key: privateKey,
       }),
     RangeError,
     "created must be a non-negative integer",
   );
-});
 
-// =============================================================================
-// Layer 3c: verifyMessage behaviour
-// =============================================================================
-
-Deno.test("verifyMessage() throws Error on tampered header value", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method", "content-type"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  // Tamper with the content-type header
-  const tampered = new Request(signed.url, {
-    method: signed.method,
-    headers: new Headers(signed.headers),
-  });
-  tampered.headers.set("Content-Type", "text/plain");
-
-  await assertRejects(
-    () => verifyMessage(tampered, () => keys.publicKey),
-    Error,
-    "Signature verification failed",
-  );
-});
-
-Deno.test("verifyMessage() throws Error on wrong key", async () => {
-  const keys1 = await generateEd25519();
-  const keys2 = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys1.privateKey,
-  });
-
-  await assertRejects(
-    () => verifyMessage(signed, () => keys2.publicKey),
-    Error,
-    "Signature verification failed",
-  );
-});
-
-Deno.test("verifyMessage() throws Error on expired signature when maxAge is set", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000) - 3600,
-    },
-    key: keys.privateKey,
-  });
-
-  await assertRejects(
-    () => verifyMessage(signed, () => keys.publicKey, { maxAge: 60 }),
-    Error,
-    "has expired",
-  );
-});
-
-Deno.test("verifyMessage() throws Error when requiredComponents are not covered", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
+  // Negative expires
   await assertRejects(
     () =>
-      verifyMessage(signed, () => keys.publicKey, {
-        requiredComponents: ["@authority"],
+      signMessage({
+        message: request,
+        params: {
+          components: ["@method"],
+          keyId: "k",
+          created: NOW,
+          expires: -1,
+        },
+        key: privateKey,
       }),
-    Error,
-    "does not cover required component",
-  );
-});
-
-Deno.test("verifyMessage() filters by labels option", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      label: "mysig",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  // Verify only "mysig" — should succeed
-  const results = await verifyMessage(signed, () => keys.publicKey, {
-    labels: ["mysig"],
-  });
-  assertEquals(results.length, 1);
-
-  // Verify only "other" — should return empty (no matching labels)
-  const empty = await verifyMessage(signed, () => keys.publicKey, {
-    labels: ["other"],
-  });
-  assertEquals(empty.length, 0);
-});
-
-Deno.test("verifyMessage() throws TypeError on missing Signature-Input header", async () => {
-  const request = new Request("https://example.com/", { method: "GET" });
-  await assertRejects(
-    () =>
-      verifyMessage(request, () => {
-        throw new Error("unreachable");
-      }),
-    TypeError,
-    'Missing "Signature-Input" header',
-  );
-});
-
-Deno.test("verifyMessage() throws RangeError on negative maxAge", async () => {
-  const keys = await generateEd25519();
-  const request = new Request("https://example.com/", { method: "GET" });
-  const signed = await signMessage({
-    message: request,
-    params: {
-      components: ["@method"],
-      keyId: "k",
-      created: Math.floor(Date.now() / 1000),
-    },
-    key: keys.privateKey,
-  });
-
-  await assertRejects(
-    () => verifyMessage(signed, () => keys.publicKey, { maxAge: -1 }),
     RangeError,
-    "maxAge must be a non-negative integer",
+    "expires must be a non-negative integer",
   );
 });
 
 // =============================================================================
-// Layer 3d: Advanced scenarios
+// signMessage — metadata round-trip (nonce, tag, expires)
+// =============================================================================
+
+Deno.test("signMessage() and verifyMessage() round-trip preserves nonce, tag, and expires", async () => {
+  const keyOrPair = await KEY_GENERATORS["ed25519"]!();
+  const { privateKey, publicKey } = keys(keyOrPair);
+  const request = new Request("https://example.com/", { method: "GET" });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      algorithm: "ed25519",
+      created: NOW,
+      expires: NOW + 3600,
+      nonce: "abc123",
+      tag: "my-app",
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey);
+  assertEquals(results.length, 1);
+  assertEquals(results[0]!.params.algorithm, "ed25519");
+  assertEquals(results[0]!.params.nonce, "abc123");
+  assertEquals(results[0]!.params.tag, "my-app");
+  assertEquals(results[0]!.params.expires, NOW + 3600);
+});
+
+// =============================================================================
+// signMessage — multiple signatures
 // =============================================================================
 
 Deno.test("signMessage() supports multiple signatures with different labels", async () => {
-  const keys1 = await generateEd25519();
-  const keys2 = await generateEd25519();
+  const k1 = keys(await KEY_GENERATORS["ed25519"]!());
+  const k2 = keys(await KEY_GENERATORS["ed25519"]!());
   const request = new Request("https://example.com/", { method: "GET" });
 
   const signed1 = await signMessage({
@@ -748,39 +719,282 @@ Deno.test("signMessage() supports multiple signatures with different labels", as
       components: ["@method"],
       keyId: "key1",
       label: "sig1",
-      created: Math.floor(Date.now() / 1000),
+      created: NOW,
     },
-    key: keys1.privateKey,
+    key: k1.privateKey,
   });
-
   const signed2 = await signMessage({
     message: signed1,
     params: {
       components: ["@method", "@authority"],
       keyId: "key2",
       label: "sig2",
-      created: Math.floor(Date.now() / 1000),
+      created: NOW,
     },
-    key: keys2.privateKey,
+    key: k2.privateKey,
   });
 
   const sigInput = signed2.headers.get("Signature-Input")!;
   assertEquals(sigInput.includes("sig1="), true);
   assertEquals(sigInput.includes("sig2="), true);
 
-  // Verify both
   const results = await verifyMessage(
     signed2,
-    (keyId) => {
-      if (keyId === "key1") return keys1.publicKey;
-      return keys2.publicKey;
-    },
+    (keyId) => keyId === "key1" ? k1.publicKey : k2.publicKey,
   );
   assertEquals(results.length, 2);
 });
 
+// =============================================================================
+// verifyMessage — tampering and wrong key
+// =============================================================================
+
+Deno.test("verifyMessage() rejects tampered message and wrong key", async () => {
+  const k1 = keys(await KEY_GENERATORS["ed25519"]!());
+  const k2 = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method", "content-type"],
+      keyId: "k",
+      created: NOW,
+    },
+    key: k1.privateKey,
+  });
+
+  // Tampered header
+  const tampered = new Request(signed.url, {
+    method: signed.method,
+    headers: new Headers(signed.headers),
+  });
+  tampered.headers.set("Content-Type", "text/plain");
+  await assertRejects(
+    () => verifyMessage(tampered, () => k1.publicKey),
+    Error,
+    "Signature verification failed",
+  );
+
+  // Wrong key
+  await assertRejects(
+    () => verifyMessage(signed, () => k2.publicKey),
+    Error,
+    "Signature verification failed",
+  );
+});
+
+// =============================================================================
+// verifyMessage — constraint enforcement
+// =============================================================================
+
+Deno.test("verifyMessage() enforces maxAge, requiredComponents, labels, and expires", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+
+  // maxAge exceeded
+  const old = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: { components: ["@method"], keyId: "k", created: NOW - 3600 },
+    key: privateKey,
+  });
+  await assertRejects(
+    () => verifyMessage(old, () => publicKey, { maxAge: 60 }),
+    Error,
+    "has expired",
+  );
+
+  // maxAge without created
+  const noCreated = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: { components: ["@method"], keyId: "k" },
+    key: privateKey,
+  });
+  await assertRejects(
+    () => verifyMessage(noCreated, () => publicKey, { maxAge: 60 }),
+    Error,
+    'no "created" timestamp but maxAge was requested',
+  );
+
+  // Expired via expires param
+  const expired = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      created: 1000,
+      expires: 1001,
+    },
+    key: privateKey,
+  });
+  await assertRejects(
+    () => verifyMessage(expired, () => publicKey),
+    Error,
+    'past "expires" timestamp',
+  );
+
+  // Required component not covered
+  const minimal = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: { components: ["@method"], keyId: "k", created: NOW },
+    key: privateKey,
+  });
+  await assertRejects(
+    () =>
+      verifyMessage(minimal, () => publicKey, {
+        requiredComponents: ["@authority"],
+      }),
+    Error,
+    "does not cover required component",
+  );
+
+  // Labels filter — match vs no match
+  const labeled = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: {
+      components: ["@method"],
+      keyId: "k",
+      label: "mysig",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+  const matched = await verifyMessage(labeled, () => publicKey, {
+    labels: ["mysig"],
+  });
+  assertEquals(matched.length, 1);
+  const unmatched = await verifyMessage(labeled, () => publicKey, {
+    labels: ["other"],
+  });
+  assertEquals(unmatched.length, 0);
+});
+
+// =============================================================================
+// verifyMessage — input validation and malformed headers
+// =============================================================================
+
+Deno.test("verifyMessage() rejects invalid inputs and malformed headers", async () => {
+  const { privateKey } = keys(await KEY_GENERATORS["ed25519"]!());
+
+  // Negative maxAge
+  const signed = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: { components: ["@method"], keyId: "k", created: NOW },
+    key: privateKey,
+  });
+  await assertRejects(
+    () =>
+      verifyMessage(signed, () => {
+        throw new Error("unreachable");
+      }, { maxAge: -1 }),
+    RangeError,
+    "maxAge must be a non-negative integer",
+  );
+
+  // Missing Signature-Input
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", { method: "GET" }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    'Missing "Signature-Input" header',
+  );
+
+  // Missing Signature
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: { "Signature-Input": 'sig=("@method");created=1618884473' },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    'Missing "Signature" header',
+  );
+
+  // Label in Signature-Input but not Signature
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Signature-Input": 'sig=("@method");created=1618884473',
+            "Signature": "other=:AAAA:",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "found in Signature-Input but missing in Signature",
+  );
+
+  // Label in Signature but not Signature-Input
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Signature-Input": 'sig=("@method");created=1618884473',
+            "Signature": "sig=:AAAA:, extra=:BBBB:",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "found in Signature but missing in Signature-Input",
+  );
+
+  // Signature-Input member is not an inner list
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: { "Signature-Input": "sig=42", "Signature": "sig=:AAAA:" },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "is not an Inner List",
+  );
+
+  // keyLookup returns null
+  const signedForNull = await signMessage({
+    message: new Request("https://example.com/", { method: "GET" }),
+    params: { components: ["@method"], keyId: "unknown", created: NOW },
+    key: privateKey,
+  });
+  await assertRejects(
+    () => verifyMessage(signedForNull, () => null),
+    TypeError,
+    "Key not found",
+  );
+});
+
+// =============================================================================
+// Response signing with ;req components (end-to-end)
+// =============================================================================
+
 Deno.test("verifyMessage() verifies response signature with ;req components", async () => {
-  const keys = await generateEd25519();
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
   const request = new Request("https://example.com/foo", { method: "POST" });
   const response = new Response('{"ok":true}', {
     status: 200,
@@ -797,17 +1011,13 @@ Deno.test("verifyMessage() verifies response signature with ;req components", as
         { name: "@path", parameters: { req: true } },
       ],
       keyId: "server-key",
-      created: Math.floor(Date.now() / 1000),
+      created: NOW,
     },
-    key: keys.privateKey,
+    key: privateKey,
     request,
   });
 
-  const results = await verifyMessage(
-    signed,
-    () => keys.publicKey,
-    { request },
-  );
+  const results = await verifyMessage(signed, () => publicKey, { request });
   assertEquals(results.length, 1);
   assertEquals(results[0]!.params.keyId, "server-key");
 });

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -990,6 +990,224 @@ Deno.test("verifyMessage() rejects invalid inputs and malformed headers", async 
 });
 
 // =============================================================================
+// verifyMessage — round-trip with component parameters (;sf, ;key, ;bs, ;name)
+// =============================================================================
+
+Deno.test("verifyMessage() round-trips with ;sf component parameter", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Example-Dict": "a=1, b=2;x=1;y=2, c=(a b c)" },
+  });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: [
+        "@method",
+        { name: "example-dict", parameters: { sf: true } },
+      ],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey);
+  assertEquals(results.length, 1);
+  const comp = results[0]!.params.components[1]!;
+  assertEquals(comp.name, "example-dict");
+  assertEquals(comp.parameters?.sf, true);
+});
+
+Deno.test("verifyMessage() round-trips with ;key component parameter", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "Example-Dict": "a=1, b=2" },
+  });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: [
+        "@method",
+        { name: "example-dict", parameters: { key: "a" } },
+      ],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey);
+  assertEquals(results.length, 1);
+  const comp = results[0]!.params.components[1]!;
+  assertEquals(comp.parameters?.key, "a");
+});
+
+Deno.test("verifyMessage() round-trips with ;bs component parameter", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", {
+    method: "GET",
+    headers: { "X-Value": "some-value" },
+  });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: [
+        "@method",
+        { name: "x-value", parameters: { bs: true } },
+      ],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey);
+  assertEquals(results.length, 1);
+  const comp = results[0]!.params.components[1]!;
+  assertEquals(comp.parameters?.bs, true);
+});
+
+Deno.test("verifyMessage() round-trips with ;name component parameter (@query-param)", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/path?foo=bar", {
+    method: "GET",
+  });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: [
+        "@method",
+        { name: "@query-param", parameters: { name: "foo" } },
+      ],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey);
+  assertEquals(results.length, 1);
+  const comp = results[0]!.params.components[1]!;
+  assertEquals(comp.parameters?.name, "foo");
+});
+
+// =============================================================================
+// verifyMessage — requiredComponents success path
+// =============================================================================
+
+Deno.test("verifyMessage() passes when all requiredComponents are covered", async () => {
+  const { privateKey, publicKey } = keys(await KEY_GENERATORS["ed25519"]!());
+  const request = new Request("https://example.com/", { method: "GET" });
+
+  const signed = await signMessage({
+    message: request,
+    params: {
+      components: ["@method", "@authority"],
+      keyId: "k",
+      created: NOW,
+    },
+    key: privateKey,
+  });
+
+  const results = await verifyMessage(signed, () => publicKey, {
+    requiredComponents: ["@method"],
+  });
+  assertEquals(results.length, 1);
+});
+
+// =============================================================================
+// verifyMessage — malformed Signature header values
+// =============================================================================
+
+Deno.test("verifyMessage() rejects Signature member that is not an Item", async () => {
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Signature-Input": 'sig=("@method");created=1618884473',
+            "Signature": "sig=(1 2 3)",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "is not an Item",
+  );
+});
+
+Deno.test("verifyMessage() rejects Signature member that is not a Byte Sequence", async () => {
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Signature-Input": 'sig=("@method");created=1618884473',
+            "Signature": "sig=42",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "is not a Byte Sequence",
+  );
+});
+
+Deno.test("verifyMessage() parses ;tr parameter then rejects during base construction", async () => {
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Example": "value",
+            "Signature-Input":
+              'sig=("example";tr);created=1618884473;keyid="k"',
+            "Signature": "sig=:AAAA:",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "Trailer field resolution",
+  );
+});
+
+Deno.test("verifyMessage() rejects non-string component identifier in Signature-Input", async () => {
+  await assertRejects(
+    () =>
+      verifyMessage(
+        new Request("https://example.com/", {
+          method: "GET",
+          headers: {
+            "Signature-Input": "sig=(42);created=1618884473",
+            "Signature": "sig=:AAAA:",
+          },
+        }),
+        () => {
+          throw new Error("unreachable");
+        },
+      ),
+    TypeError,
+    "is not a String",
+  );
+});
+
+// =============================================================================
 // Response signing with ;req components (end-to-end)
 // =============================================================================
 

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -704,7 +704,10 @@ Deno.test("verifyMessage() filters by labels option", async () => {
 Deno.test("verifyMessage() throws TypeError on missing Signature-Input header", async () => {
   const request = new Request("https://example.com/", { method: "GET" });
   await assertRejects(
-    () => verifyMessage(request, () => { throw new Error("unreachable"); }),
+    () =>
+      verifyMessage(request, () => {
+        throw new Error("unreachable");
+      }),
     TypeError,
     'Missing "Signature-Input" header',
   );

--- a/http/unstable_message_signatures_test.ts
+++ b/http/unstable_message_signatures_test.ts
@@ -671,6 +671,24 @@ Deno.test("signMessage() rejects invalid params", async () => {
     RangeError,
     "expires must be a non-negative integer",
   );
+
+  // Unsupported ECDSA curve
+  const fakeKey = {
+    algorithm: { name: "ECDSA", namedCurve: "P-521" },
+    type: "private",
+    extractable: false,
+    usages: ["sign"],
+  } as unknown as CryptoKey;
+  await assertRejects(
+    () =>
+      signMessage({
+        message: request,
+        params: { components: ["@method"], keyId: "k", created: NOW },
+        key: fakeKey,
+      }),
+    TypeError,
+    'Unsupported ECDSA curve: "P-521"',
+  );
 });
 
 // =============================================================================


### PR DESCRIPTION
Add HTTP Message Signatures ([RFC 9421](https://datatracker.ietf.org/doc/html/rfc9421)) for signing and verifying HTTP requests and responses. Builds on the structured fields module (RFC 8941) already in std.

Coverage is as good as I can get it. There are a few lines of unreachable code.