### PR TITLE
feat(cache/unstable): improve `LruCache` callback and add `peek()`

### DIFF
--- a/cache/lru_cache.ts
+++ b/cache/lru_cache.ts
@@ -2,6 +2,7 @@
 // This module is browser compatible.
 
 import type { MemoizationCache } from "./memoize.ts";
+export type { MemoizationCache };
 
 /**
  * The reason an entry was removed from the cache.
@@ -262,7 +263,7 @@ export class LruCache<K, V> extends Map<K, V>
    */
   override set(key: K, value: V): this {
     if (this.#ejecting) {
-      throw new Error(
+      throw new TypeError(
         "Cannot set entry in LruCache: cache is not re-entrant during onEject callbacks",
       );
     }
@@ -294,7 +295,7 @@ export class LruCache<K, V> extends Map<K, V>
    */
   override delete(key: K): boolean {
     if (this.#ejecting) {
-      throw new Error(
+      throw new TypeError(
         "Cannot delete entry in LruCache: cache is not re-entrant during onEject callbacks",
       );
     }
@@ -333,7 +334,7 @@ export class LruCache<K, V> extends Map<K, V>
    */
   override clear(): void {
     if (this.#ejecting) {
-      throw new Error(
+      throw new TypeError(
         "Cannot clear LruCache: cache is not re-entrant during onEject callbacks",
       );
     }

--- a/cache/lru_cache_test.ts
+++ b/cache/lru_cache_test.ts
@@ -260,7 +260,7 @@ Deno.test("LruCache onEject is not re-entrant", async (t) => {
     cache.set("b", 2);
     assertThrows(
       () => cache.set("c", 3),
-      Error,
+      TypeError,
       "cache is not re-entrant during onEject callbacks",
     );
   });
@@ -276,7 +276,7 @@ Deno.test("LruCache onEject is not re-entrant", async (t) => {
     cache.set("b", 2);
     assertThrows(
       () => cache.delete("a"),
-      Error,
+      TypeError,
       "cache is not re-entrant during onEject callbacks",
     );
   });
@@ -291,7 +291,7 @@ Deno.test("LruCache onEject is not re-entrant", async (t) => {
     cache.set("a", 1);
     assertThrows(
       () => cache.delete("a"),
-      Error,
+      TypeError,
       "cache is not re-entrant during onEject callbacks",
     );
   });


### PR DESCRIPTION
- `onEject` callback now receives a reason parameter ("evicted", "deleted", or "cleared") so callers can distinguish why an entry was removed. 
- New `peek()` method for reading a value without promoting it. 
- `has()` no longer promotes entries in the eviction order
- Constructor validates `maxSize`, rejecting zero, negative, non-integer, and non-finite values. 
- `maxSize` is now a readonly getter backed by a private field. 
- `onEject` callback is now optional, and `clear()` calls it for every entry
- calling `set`, `delete`, or `clear` inside an `onEject` callback throws instead of corrupting state. 
- `delete()` returns false immediately for non-existent keys and fires `onEject` only after the entry is fully removed. 
- Test coverage improved.

BEHAVIORAL CHANGES:
`has()` no longer promotes entries in the eviction order. Previously, calling `has()` on a key would mark it as recently used and keep it alive longer. Now it only checks whether the key exists. Code that relies on `has()` to prevent eviction should switch to `get()`.

`set()` does not fire `onEject` when overwriting an existing key with a new value. The old value is silently replaced. Callers that need to clean up old values on overwrite should handle that themselves before calling `set()`.