### PR TITLE
feat(collections): add `"union"` to `DeepMergeOptions.arrays`

### DIFF
--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // This module is browser compatible.
 
+import { union } from "./union.ts";
+
 /** Default merging options - cached to avoid object allocation on each call */
 const DEFAULT_OPTIONS: DeepMergeOptions = {
   arrays: "merge",
@@ -303,6 +305,8 @@ function mergeObjects(
     if ((Array.isArray(left)) && (Array.isArray(right))) {
       if (options.arrays === "merge") {
         return left.concat(right);
+      } else if (options.arrays === "union") {
+        return union(left, right);
       }
 
       return right;
@@ -380,6 +384,9 @@ function getKeys<T extends Record<string, unknown>>(record: T): Array<keyof T> {
 /** Merging strategy */
 export type MergingStrategy = "replace" | "merge";
 
+/** Arrays Merging strategy */
+export type ArraysMergingStrategy = MergingStrategy | "union";
+
 /** Options for {@linkcode deepMerge}. */
 export type DeepMergeOptions = {
   /**
@@ -387,7 +394,7 @@ export type DeepMergeOptions = {
    *
    * @default {"merge"}
    */
-  arrays?: MergingStrategy;
+  arrays?: ArraysMergingStrategy;
   /**
    * Merging strategy for maps.
    *

--- a/collections/deep_merge_test.ts
+++ b/collections/deep_merge_test.ts
@@ -247,6 +247,19 @@ Deno.test("deepMerge() handles array merge (merge)", () => {
   );
 });
 
+Deno.test("deepMerge() handles array merge (union)", () => {
+  assertEquals(
+    deepMerge({
+      foo: [1, 2, 3],
+    }, {
+      foo: [3, 4, 5],
+    }, { arrays: "union" }),
+    {
+      foo: [1, 2, 3, 4, 5],
+    },
+  );
+});
+
 Deno.test("deepMerge() handles maps merge (replace)", () => {
   assertEquals(
     deepMerge({


### PR DESCRIPTION
Adds a `"union"` `MergingStrategy` for `arrays` only, through a new exported type `ArraysMergingStrategy`. Implementation uses the `union` `function` imported from `"./union.ts"`

closes: #7048 