### PR TITLE
fix: preserve leading-zero numeric strings in YAML stringify

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -238,7 +238,7 @@ function chooseScalarStyle(
   if (!hasLineBreak && !hasFoldableLine) {
     // Strings interpretable as another type have to be quoted;
     // e.g. the string 'true' vs. the boolean true.
-    return plain && !implicitTypes.some((type) => type.resolve(string))
+    return plain && !implicitTypes.some((type) => type.resolve(string)) && !/^0[0-9]+$/.test(string)
       ? STYLE_PLAIN
       : quoteStyle === "'"
       ? STYLE_SINGLE

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -760,6 +760,12 @@ Deno.test("stringify() handles string", () => {
   assertEquals(stringify(new String("Hello World")), "Hello World\n");
 });
 
+Deno.test("stringify() preserves leading-zero numeric strings", () => {
+  assertEquals(stringify("08"), "'08'\n");
+  assertEquals(stringify("09"), "'09'\n");
+  assertEquals(stringify("007"), "'007'\n");
+});
+
 Deno.test("stringify() uses quotes around deprecated boolean notations when `compatMode: true`", () => {
   assertEquals(stringify("On", { compatMode: true }), "'On'\n");
   assertEquals(stringify("Off", { compatMode: true }), "'Off'\n");


### PR DESCRIPTION
## Summary
Fixes #7040.
**Root cause:** Strings like `'08'` and `'09'` were treated as numeric values during YAML stringify, losing their leading zeros. They should be quoted to preserve the original string representation.
**Fix:** Added a check for leading-zero numeric strings to ensure they are quoted during stringify.
## Changes
- Updated YAML stringify logic to detect and quote leading-zero numeric strings
## Testing
- Verified fix preserves `'08'`, `'09'`, and similar strings
- Change is minimal and follows YAML spec (leading-zero strings are not valid YAML numbers)

Made with [Cursor](https://cursor.com)