### PR TITLE
feat(front-matter/unstable): add `test` to each subpackage, including JSON, TOML, and YAML

### DIFF
--- a/front_matter/deno.json
+++ b/front_matter/deno.json
@@ -8,6 +8,8 @@
     "./test": "./test.ts",
     "./toml": "./toml.ts",
     "./yaml": "./yaml.ts",
+    "./unstable-json": "./unstable_json.ts",
+    "./unstable-toml": "./unstable_toml.ts",
     "./unstable-yaml": "./unstable_yaml.ts",
     "./types": "./types.ts"
   }

--- a/front_matter/json_test.ts
+++ b/front_matter/json_test.ts
@@ -1,9 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+import { assert } from "@std/assert";
 import { assertThrows } from "../assert/throws.ts";
 import { extract } from "./json.ts";
 
 import { assertEquals } from "@std/assert/equals";
+import { test as unstableTest } from "@std/front-matter/unstable-json";
 
 Deno.test("json() extracts type error on invalid input", () => {
   assertThrows(() => extract(""));
@@ -79,4 +81,21 @@ Deno.test("extractJson() throws at missing newline before body", () => {
     TypeError,
     "Unexpected end of input",
   );
+});
+
+Deno.test("(unstable)test() handles valid json input", () => {
+  assert(unstableTest("---json\nname = 'deno'\n---\n"));
+  assert(unstableTest("= json =\nname = 'deno'\n= json =\n"));
+  assert(unstableTest("= json =\nname = 'deno'\n= json =\ndeno is awesome\n"));
+});
+
+Deno.test("(unstable)test() handles invalid json input", () => {
+  assert(!unstableTest(""));
+  assert(!unstableTest("---"));
+  assert(!unstableTest("---json"));
+  assert(!unstableTest("= json ="));
+  assert(!unstableTest("---\n"));
+  assert(!unstableTest("---json\n"));
+  assert(!unstableTest("= json =\n"));
+  assert(!unstableTest("---\nasdasdasd"));
 });

--- a/front_matter/json_test.ts
+++ b/front_matter/json_test.ts
@@ -5,7 +5,7 @@ import { assertThrows } from "../assert/throws.ts";
 import { extract } from "./json.ts";
 
 import { assertEquals } from "@std/assert/equals";
-import { test as unstableTest } from "@std/front-matter/unstable-json";
+import { test as unstableTest } from "./unstable_json.ts";
 
 Deno.test("json() extracts type error on invalid input", () => {
   assertThrows(() => extract(""));

--- a/front_matter/toml_test.ts
+++ b/front_matter/toml_test.ts
@@ -1,8 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+import { assert } from "@std/assert";
 import { assertThrows } from "../assert/throws.ts";
 import { extract } from "./toml.ts";
 import { assertEquals } from "@std/assert/equals";
+import { test as unstableTest } from "./unstable_toml.ts";
 
 Deno.test("toml() extracts type error on invalid input", () => {
   assertThrows(() => extract(""));
@@ -100,4 +102,21 @@ Deno.test("extractToml() throws at missing newline before body", () => {
     TypeError,
     "Unexpected end of input",
   );
+});
+
+Deno.test("(unstable)test() handles valid toml input", () => {
+  assert(unstableTest("---toml\nname = 'deno'\n---\n"));
+  assert(unstableTest("= toml =\nname = 'deno'\n= toml =\n"));
+  assert(unstableTest("= toml =\nname = 'deno'\n= toml =\ndeno is awesome\n"));
+});
+
+Deno.test("(unstable)test() handles invalid toml input", () => {
+  assert(!unstableTest(""));
+  assert(!unstableTest("---"));
+  assert(!unstableTest("---toml"));
+  assert(!unstableTest("= toml ="));
+  assert(!unstableTest("---\n"));
+  assert(!unstableTest("---toml\n"));
+  assert(!unstableTest("= toml =\n"));
+  assert(!unstableTest("---\nasdasdasd"));
 });

--- a/front_matter/unstable_json.ts
+++ b/front_matter/unstable_json.ts
@@ -1,44 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // This module is browser compatible.
 
-import { extractFrontMatter } from "./_shared.ts";
-import { EXTRACT_JSON_REGEXP } from "./_formats.ts";
-import type { Extract } from "./types.ts";
 import { test as _test } from "./test.ts";
-
-export type { Extract };
-
-/**
- * Extracts and parses {@link https://www.json.org/ | JSON } from the metadata
- * of front matter content.
- *
- * @example Extract JSON front matter
- * ```ts
- * import { extract } from "@std/front-matter/json";
- * import { assertEquals } from "@std/assert";
- *
- * const output = `---json
- * { "title": "Three dashes marks the spot" }
- * ---
- * Hello, world!`;
- * const result = extract(output);
- *
- * assertEquals(result, {
- *   frontMatter: '{ "title": "Three dashes marks the spot" }',
- *   body: "Hello, world!",
- *   attrs: { title: "Three dashes marks the spot" },
- * });
- * ```
- *
- * @typeParam T The type of the parsed front matter.
- * @param text The text to extract JSON front matter from.
- * @returns The extracted JSON front matter and body content.
- */
-export function extract<T>(text: string): Extract<T> {
-  const { frontMatter, body } = extractFrontMatter(text, EXTRACT_JSON_REGEXP);
-  const attrs = (frontMatter ? JSON.parse(frontMatter) : {}) as T;
-  return { frontMatter, body, attrs };
-}
 
 /**
  * Tests if a string has valid front matter.

--- a/front_matter/unstable_json.ts
+++ b/front_matter/unstable_json.ts
@@ -44,12 +44,14 @@ export function extract<T>(text: string): Extract<T> {
  * Tests if a string has valid front matter.
  * Supports {@link https://www.json.org/ | JSON}.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @param str String to test.
  * @returns `true` if the string has valid JSON front matter, otherwise `false`.
  *
  * @example Test for valid JSON front matter
  * ```ts
- * import { test } from "@std/front-matter/json";
+ * import { test } from "@std/front-matter/unstable-json";
  * import { assert } from "@std/assert";
  *
  * const result = test(
@@ -62,8 +64,8 @@ export function extract<T>(text: string): Extract<T> {
  *
  * @example TOML front matter is not valid as JSON
  * ```ts
- * import { test } from "@std/front-matter/json";
- * import { assert } from "@std/assert";
+ * import { test } from "@std/front-matter/unstable-json";
+ * import { assertFalse } from "@std/assert";
  *
  * const result = test(
  * `---toml

--- a/front_matter/unstable_json.ts
+++ b/front_matter/unstable_json.ts
@@ -73,6 +73,6 @@ export function extract<T>(text: string): Extract<T> {
  * assertFalse(result);
  * ```
  */
-export function test(str: string) {
+export function test(str: string): boolean {
   return _test(str, ["json"]);
 }

--- a/front_matter/unstable_json.ts
+++ b/front_matter/unstable_json.ts
@@ -1,0 +1,78 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+import { extractFrontMatter } from "./_shared.ts";
+import { EXTRACT_JSON_REGEXP } from "./_formats.ts";
+import type { Extract } from "./types.ts";
+import { test as _test } from "./test.ts";
+
+export type { Extract };
+
+/**
+ * Extracts and parses {@link https://www.json.org/ | JSON } from the metadata
+ * of front matter content.
+ *
+ * @example Extract JSON front matter
+ * ```ts
+ * import { extract } from "@std/front-matter/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const output = `---json
+ * { "title": "Three dashes marks the spot" }
+ * ---
+ * Hello, world!`;
+ * const result = extract(output);
+ *
+ * assertEquals(result, {
+ *   frontMatter: '{ "title": "Three dashes marks the spot" }',
+ *   body: "Hello, world!",
+ *   attrs: { title: "Three dashes marks the spot" },
+ * });
+ * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract JSON front matter from.
+ * @returns The extracted JSON front matter and body content.
+ */
+export function extract<T>(text: string): Extract<T> {
+  const { frontMatter, body } = extractFrontMatter(text, EXTRACT_JSON_REGEXP);
+  const attrs = (frontMatter ? JSON.parse(frontMatter) : {}) as T;
+  return { frontMatter, body, attrs };
+}
+
+/**
+ * Tests if a string has valid front matter.
+ * Supports {@link https://www.json.org/ | JSON}.
+ *
+ * @param str String to test.
+ * @returns `true` if the string has valid JSON front matter, otherwise `false`.
+ *
+ * @example Test for valid JSON front matter
+ * ```ts
+ * import { test } from "@std/front-matter/json";
+ * import { assert } from "@std/assert";
+ *
+ * const result = test(
+ * `---json
+ * {"title": "Three dashes followed by format marks the spot"}
+ * ---
+ * `);
+ * assert(result);
+ * ```
+ *
+ * @example TOML front matter is not valid as JSON
+ * ```ts
+ * import { test } from "@std/front-matter/json";
+ * import { assert } from "@std/assert";
+ *
+ * const result = test(
+ * `---toml
+ * title = 'Three dashes followed by format marks the spot'
+ * ---
+ * `);
+ * assertFalse(result);
+ * ```
+*/
+export function test(str: string) {
+  return _test(str, ["json"]);
+}

--- a/front_matter/unstable_json.ts
+++ b/front_matter/unstable_json.ts
@@ -72,7 +72,7 @@ export function extract<T>(text: string): Extract<T> {
  * `);
  * assertFalse(result);
  * ```
-*/
+ */
 export function test(str: string) {
   return _test(str, ["json"]);
 }

--- a/front_matter/unstable_toml.ts
+++ b/front_matter/unstable_toml.ts
@@ -46,12 +46,14 @@ export function extract<T>(text: string): Extract<T> {
  * Tests if a string has valid TOML front matter.
  * Supports {@link https://toml.io | TOML}.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @param str String to test.
  * @returns `true` if the string has valid TOML front matter, otherwise `false`.
  *
  * @example Test for valid TOML front matter
  * ```ts
- * import { test } from "@std/front-matter/toml";
+ * import { test } from "@std/front-matter/unstable-toml";
  * import { assert } from "@std/assert";
  *
  * const result = test(
@@ -64,7 +66,7 @@ export function extract<T>(text: string): Extract<T> {
  *
  * @example JSON front matter is not valid as TOML
  * ```ts
- * import { test } from "@std/front-matter/toml";
+ * import { test } from "@std/front-matter/unstable-toml";
  * import { assertFalse } from "@std/assert";
  *
  * const result = test(

--- a/front_matter/unstable_toml.ts
+++ b/front_matter/unstable_toml.ts
@@ -71,10 +71,10 @@ export function extract<T>(text: string): Extract<T> {
  * `---json
  * {"title": "Three dashes followed by format marks the spot"}
  * ---
- * `;
+ * `);
  * assertFalse(result);
  * ```
  */
-export function test(str: string) {
+export function test(str: string): boolean {
   return _test(str, ["toml"]);
 }

--- a/front_matter/unstable_toml.ts
+++ b/front_matter/unstable_toml.ts
@@ -74,7 +74,7 @@ export function extract<T>(text: string): Extract<T> {
  * `;
  * assertFalse(result);
  * ```
-*/
+ */
 export function test(str: string) {
   return _test(str, ["toml"]);
 }

--- a/front_matter/unstable_toml.ts
+++ b/front_matter/unstable_toml.ts
@@ -1,46 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // This module is browser compatible.
 
-import { extractFrontMatter } from "./_shared.ts";
-import { parse } from "@std/toml/parse";
-import type { Extract } from "./types.ts";
-import { EXTRACT_TOML_REGEXP } from "./_formats.ts";
 import { test as _test } from "./test.ts";
-
-export type { Extract };
-
-/**
- * Extracts and parses {@link https://toml.io | TOML} from the metadata of
- * front matter content.
- *
- * @example Extract TOML front matter
- * ```ts
- * import { extract } from "@std/front-matter/toml";
- * import { assertEquals } from "@std/assert";
- *
- * const output = `---toml
- * title = "Three dashes marks the spot"
- * ---
- * Hello, world!`;
- * const result = extract(output);
- *
- * assertEquals(result, {
- *   frontMatter: 'title = "Three dashes marks the spot"',
- *   body: "Hello, world!",
- *   attrs: { title: "Three dashes marks the spot" },
- * });
- * ```
- *
- * @typeParam T The type of the parsed front matter.
- * @param text The text to extract TOML front matter from.
- * @returns The extracted TOML front matter and body content.
- */
-export function extract<T>(text: string): Extract<T> {
-  const { frontMatter, body } = extractFrontMatter(text, EXTRACT_TOML_REGEXP);
-
-  const attrs = (frontMatter ? parse(frontMatter) : {}) as T;
-  return { frontMatter, body, attrs };
-}
 
 /**
  * Tests if a string has valid TOML front matter.

--- a/front_matter/unstable_toml.ts
+++ b/front_matter/unstable_toml.ts
@@ -1,0 +1,80 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+import { extractFrontMatter } from "./_shared.ts";
+import { parse } from "@std/toml/parse";
+import type { Extract } from "./types.ts";
+import { EXTRACT_TOML_REGEXP } from "./_formats.ts";
+import { test as _test } from "./test.ts";
+
+export type { Extract };
+
+/**
+ * Extracts and parses {@link https://toml.io | TOML} from the metadata of
+ * front matter content.
+ *
+ * @example Extract TOML front matter
+ * ```ts
+ * import { extract } from "@std/front-matter/toml";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const output = `---toml
+ * title = "Three dashes marks the spot"
+ * ---
+ * Hello, world!`;
+ * const result = extract(output);
+ *
+ * assertEquals(result, {
+ *   frontMatter: 'title = "Three dashes marks the spot"',
+ *   body: "Hello, world!",
+ *   attrs: { title: "Three dashes marks the spot" },
+ * });
+ * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract TOML front matter from.
+ * @returns The extracted TOML front matter and body content.
+ */
+export function extract<T>(text: string): Extract<T> {
+  const { frontMatter, body } = extractFrontMatter(text, EXTRACT_TOML_REGEXP);
+
+  const attrs = (frontMatter ? parse(frontMatter) : {}) as T;
+  return { frontMatter, body, attrs };
+}
+
+/**
+ * Tests if a string has valid TOML front matter.
+ * Supports {@link https://toml.io | TOML}.
+ *
+ * @param str String to test.
+ * @returns `true` if the string has valid TOML front matter, otherwise `false`.
+ *
+ * @example Test for valid TOML front matter
+ * ```ts
+ * import { test } from "@std/front-matter/toml";
+ * import { assert } from "@std/assert";
+ *
+ * const result = test(
+ * `---toml
+ * title = 'Three dashes followed by format marks the spot'
+ * ---
+ * `);
+ * assert(result);
+ * ```
+ *
+ * @example JSON front matter is not valid as TOML
+ * ```ts
+ * import { test } from "@std/front-matter/toml";
+ * import { assertFalse } from "@std/assert";
+ *
+ * const result = test(
+ * `---json
+ * {"title": "Three dashes followed by format marks the spot"}
+ * ---
+ * `;
+ * assertFalse(result);
+ * ```
+*/
+export function test(str: string) {
+  return _test(str, ["toml"]);
+}

--- a/front_matter/unstable_yaml.ts
+++ b/front_matter/unstable_yaml.ts
@@ -5,6 +5,7 @@ import { extractFrontMatter } from "./_shared.ts";
 import { parse, type ParseOptions } from "@std/yaml/parse";
 import type { Extract } from "./types.ts";
 import { EXTRACT_YAML_REGEXP } from "./_formats.ts";
+import { test as _test } from "./test.ts";
 
 export type { Extract };
 
@@ -41,4 +42,41 @@ export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
   const { frontMatter, body } = extractFrontMatter(text, EXTRACT_YAML_REGEXP);
   const attrs = parse(frontMatter, options) as T;
   return { frontMatter, body, attrs };
+}
+
+/**
+ * Tests if a string has valid YAML front matter.
+ * Supports {@link https://yaml.org | YAML}.
+ *
+ * @param str String to test.
+ * @returns `true` if the string has valid YAML front matter, otherwise `false`.
+ *
+ * @example Test for valid YAML front matter
+ * ```ts
+ * import { test } from "@std/front-matter/yaml";
+ * import { assert } from "@std/assert";
+ *
+ * const result = test(
+ * `---
+ * title: Three dashes marks the spot
+ * ---
+ * `);
+ * assert(result);
+ * ```
+ *
+ * @example JSON front matter is not valid as YAML
+ * ```ts
+ * import { test } from "@std/front-matter/yaml";
+ * import { assertFalse } from "@std/assert";
+ *
+ * const result = test(
+ * `---json
+ * {"title": "Three dashes followed by format marks the spot"}
+ * ---
+ * `;
+ * assertFalse(result);
+ * ```
+*/
+export function test(str: string) {
+  return _test(str, ["yaml"]);
 }

--- a/front_matter/unstable_yaml.ts
+++ b/front_matter/unstable_yaml.ts
@@ -73,10 +73,10 @@ export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
  * `---json
  * {"title": "Three dashes followed by format marks the spot"}
  * ---
- * `;
+ * `);
  * assertFalse(result);
  * ```
  */
-export function test(str: string) {
+export function test(str: string): boolean {
   return _test(str, ["yaml"]);
 }

--- a/front_matter/unstable_yaml.ts
+++ b/front_matter/unstable_yaml.ts
@@ -48,12 +48,14 @@ export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
  * Tests if a string has valid YAML front matter.
  * Supports {@link https://yaml.org | YAML}.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @param str String to test.
  * @returns `true` if the string has valid YAML front matter, otherwise `false`.
  *
  * @example Test for valid YAML front matter
  * ```ts
- * import { test } from "@std/front-matter/yaml";
+ * import { test } from "@std/front-matter/unstable-yaml";
  * import { assert } from "@std/assert";
  *
  * const result = test(
@@ -66,7 +68,7 @@ export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
  *
  * @example JSON front matter is not valid as YAML
  * ```ts
- * import { test } from "@std/front-matter/yaml";
+ * import { test } from "@std/front-matter/unstable-yaml";
  * import { assertFalse } from "@std/assert";
  *
  * const result = test(

--- a/front_matter/unstable_yaml.ts
+++ b/front_matter/unstable_yaml.ts
@@ -76,7 +76,7 @@ export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
  * `;
  * assertFalse(result);
  * ```
-*/
+ */
 export function test(str: string) {
   return _test(str, ["yaml"]);
 }

--- a/front_matter/yaml_test.ts
+++ b/front_matter/yaml_test.ts
@@ -1,7 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { extract } from "./yaml.ts";
-import { extract as unstableExtract } from "./unstable_yaml.ts";
+import {
+  extract as unstableExtract,
+  test as unstableTest,
+} from "./unstable_yaml.ts";
+import { assert } from "../assert/mod.ts";
 import { assertEquals } from "@std/assert/equals";
 import { assertThrows } from "../assert/throws.ts";
 
@@ -125,4 +129,22 @@ Deno.test("extractYaml() throws at missing newline before body", () => {
     TypeError,
     "Unexpected end of input",
   );
+});
+
+Deno.test("(unstable)test() handles valid yaml input", () => {
+  assert(unstableTest("---yaml\nname = 'deno'\n---\n"));
+  assert(unstableTest("= yaml =\nname = 'deno'\n= yaml =\n"));
+  assert(unstableTest("= yaml =\nname = 'deno'\n= yaml =\ndeno is awesome\n"));
+  assert(unstableTest("---\nname: deno\n---\n"));
+});
+
+Deno.test("(unstable)test() handles invalid yaml input", () => {
+  assert(!unstableTest(""));
+  assert(!unstableTest("---"));
+  assert(!unstableTest("---yaml"));
+  assert(!unstableTest("= yaml ="));
+  assert(!unstableTest("---\n"));
+  assert(!unstableTest("---yaml\n"));
+  assert(!unstableTest("= yaml =\n"));
+  assert(!unstableTest("---\nasdasdasd"));
 });


### PR DESCRIPTION
Let people use the `test` function more easily when they want to check a specific format of frontmatter.