### PR TITLE
BREAKING(cache/unstable): remove re-export in `LruCache`

### DIFF
--- a/cache/lru_cache.ts
+++ b/cache/lru_cache.ts
@@ -2,7 +2,6 @@
 // This module is browser compatible.
 
 import type { MemoizationCache } from "./memoize.ts";
-export type { MemoizationCache };
 
 /**
  * The reason an entry was removed from the cache.


### PR DESCRIPTION
`MemoizationCache` is defined in and documented as part of `@std/cache/memoize`. The re-export from `@std/cache/lru-cache` was maybe done as a convenience, but should be cleaned up:
- `MemoizationCache` is available from its own path (`@std/cache/memoize`) and the barrel (`@std/cache`)
- `ttl_cache.ts` also imports the same type but does not re-export it, creating an asymmetry.
- `lru-cache.ts` should export only LRU-specific symbols.