### PR TITLE
feat(cache/unstable): add `maxSize` to `TtlCache`

### DIFF
--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -31,8 +31,19 @@ export interface TtlCacheSetOptions {
  */
 export interface TtlCacheOptions<K, V> {
   /**
+   * Maximum number of entries the cache may hold. When a new entry would
+   * exceed this limit, the entry that was
+   * {@linkcode TtlCache.prototype.set | set()} least recently is evicted
+   * before the new one is added. Must be a positive integer when provided.
+   */
+  maxSize?: number;
+  /**
    * Callback invoked when an entry is removed, whether by TTL expiry,
-   * manual deletion, or clearing the cache.
+   * capacity eviction, manual deletion, or clearing the cache. The entry is
+   * already removed from the cache when this callback fires. Overwriting an
+   * existing key via {@linkcode TtlCache.prototype.set | set()} does **not**
+   * trigger this callback. The cache is not re-entrant during this callback:
+   * calling `set`, `delete`, or `clear` will throw.
    */
   onEject?: (ejectedKey: K, ejectedValue: V) => void;
   /**
@@ -93,7 +104,9 @@ export interface TtlCacheOptions<K, V> {
 export class TtlCache<K, V> extends Map<K, V>
   implements MemoizationCache<K, V> {
   #defaultTtl: number;
+  #maxSize: number;
   #timeouts = new Map<K, number>();
+  #ejecting = false;
   #eject?: ((ejectedKey: K, ejectedValue: V) => void) | undefined;
   #slidingExpiration: boolean;
   #entryTtls?: Map<K, number>;
@@ -119,13 +132,41 @@ export class TtlCache<K, V> extends Map<K, V>
         `Cannot create TtlCache: defaultTtl must be a finite, non-negative number: received ${defaultTtl}`,
       );
     }
+    const maxSize = options?.maxSize;
+    if (maxSize !== undefined && (!Number.isInteger(maxSize) || maxSize < 1)) {
+      throw new RangeError(
+        `Cannot create TtlCache: maxSize must be a positive integer: received ${maxSize}`,
+      );
+    }
     this.#defaultTtl = defaultTtl;
+    this.#maxSize = maxSize ?? Infinity;
     this.#eject = options?.onEject;
     this.#slidingExpiration = options?.slidingExpiration ?? false;
     if (this.#slidingExpiration) {
       this.#entryTtls = new Map();
       this.#absoluteDeadlines = new Map();
     }
+  }
+
+  /**
+   * The maximum number of entries the cache may hold, or `Infinity` if no
+   * limit was set.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
+   * @returns The maximum number of entries in the cache.
+   *
+   * @example Usage
+   * ```ts
+   * import { TtlCache } from "@std/cache/ttl-cache";
+   * import { assertEquals } from "@std/assert/equals";
+   *
+   * const cache = new TtlCache<string, number>(1000, { maxSize: 5 });
+   * assertEquals(cache.maxSize, 5);
+   * ```
+   */
+  get maxSize(): number {
+    return this.#maxSize;
   }
 
   /**
@@ -158,6 +199,11 @@ export class TtlCache<K, V> extends Map<K, V>
     value: V,
     options?: TtlCacheSetOptions,
   ): this {
+    if (this.#ejecting) {
+      throw new TypeError(
+        "Cannot set entry in TtlCache: cache is not re-entrant during onEject callbacks",
+      );
+    }
     if (options?.absoluteExpiration !== undefined && !this.#slidingExpiration) {
       throw new TypeError(
         "Cannot set entry in TtlCache: absoluteExpiration requires slidingExpiration to be enabled",
@@ -178,8 +224,14 @@ export class TtlCache<K, V> extends Map<K, V>
       );
     }
 
+    const isNew = !super.has(key);
+    if (isNew && this.size >= this.#maxSize) {
+      this.delete(super.keys().next().value as K);
+    }
+
     const existing = this.#timeouts.get(key);
     if (existing !== undefined) clearTimeout(existing);
+    super.delete(key);
     super.set(key, value);
     this.#timeouts.set(key, setTimeout(() => this.delete(key), ttl));
 
@@ -285,6 +337,11 @@ export class TtlCache<K, V> extends Map<K, V>
    * ```
    */
   override delete(key: K): boolean {
+    if (this.#ejecting) {
+      throw new TypeError(
+        "Cannot delete entry in TtlCache: cache is not re-entrant during onEject callbacks",
+      );
+    }
     const value = super.get(key);
     const existed = super.delete(key);
     if (!existed) return false;
@@ -294,7 +351,14 @@ export class TtlCache<K, V> extends Map<K, V>
     this.#timeouts.delete(key);
     this.#entryTtls?.delete(key);
     this.#absoluteDeadlines?.delete(key);
-    this.#eject?.(key, value!);
+    if (this.#eject) {
+      this.#ejecting = true;
+      try {
+        this.#eject(key, value!);
+      } finally {
+        this.#ejecting = false;
+      }
+    }
     return true;
   }
 
@@ -317,6 +381,11 @@ export class TtlCache<K, V> extends Map<K, V>
    * ```
    */
   override clear(): void {
+    if (this.#ejecting) {
+      throw new TypeError(
+        "Cannot clear TtlCache: cache is not re-entrant during onEject callbacks",
+      );
+    }
     for (const timeout of this.#timeouts.values()) {
       clearTimeout(timeout);
     }
@@ -325,13 +394,19 @@ export class TtlCache<K, V> extends Map<K, V>
     this.#absoluteDeadlines?.clear();
     const entries = [...super.entries()];
     super.clear();
+    if (!this.#eject) return;
+    this.#ejecting = true;
     let error: unknown;
-    for (const [key, value] of entries) {
-      try {
-        this.#eject?.(key, value);
-      } catch (e) {
-        error ??= e;
+    try {
+      for (const [key, value] of entries) {
+        try {
+          this.#eject(key, value);
+        } catch (e) {
+          error ??= e;
+        }
       }
+    } finally {
+      this.#ejecting = false;
     }
     if (error !== undefined) throw error;
   }
@@ -361,9 +436,7 @@ export class TtlCache<K, V> extends Map<K, V>
   }
 
   #resetTtl(key: K): void {
-    const ttl = this.#entryTtls!.get(key);
-    if (ttl === undefined) return;
-
+    const ttl = this.#entryTtls!.get(key)!;
     const deadline = this.#absoluteDeadlines!.get(key);
     const effectiveTtl = deadline !== undefined
       ? Math.min(ttl, Math.max(0, deadline - Date.now()))

--- a/cache/ttl_cache_test.ts
+++ b/cache/ttl_cache_test.ts
@@ -471,6 +471,228 @@ Deno.test("TtlCache sliding expiration", async (t) => {
   });
 });
 
+Deno.test("TtlCache maxSize", async (t) => {
+  await t.step("evicts oldest entry when full", () => {
+    using _time = new FakeTime(0);
+    const cache = new TtlCache<string, number>(1000, { maxSize: 3 });
+    assertEquals(cache.maxSize, 3);
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    assertEquals(cache.size, 3);
+
+    cache.set("d", 4);
+    assertEquals(cache.size, 3);
+    assertEquals(cache.has("a"), false);
+    assertEntries(cache, [["a", UNSET], ["b", 2], ["c", 3], ["d", 4]]);
+  });
+
+  await t.step("overwriting existing key does not evict", () => {
+    using _time = new FakeTime(0);
+    const cache = new TtlCache<string, number>(1000, { maxSize: 2 });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("a", 10);
+
+    assertEquals(cache.size, 2);
+    assertEquals(cache.get("a"), 10);
+    assertEquals(cache.get("b"), 2);
+
+    // "a" was overwritten so it moved to the newest position; "b" is now
+    // the oldest and gets evicted next
+    cache.set("c", 3);
+    assertEquals(cache.size, 2);
+    assertEquals(cache.has("b"), false);
+    assertEquals(cache.get("a"), 10);
+    assertEquals(cache.get("c"), 3);
+  });
+
+  await t.step("calls onEject for evicted entry", () => {
+    using _time = new FakeTime(0);
+    const ejected: [string, number][] = [];
+    const cache = new TtlCache<string, number>(1000, {
+      maxSize: 2,
+      onEject: (k, v) => ejected.push([k, v]),
+    });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    assertEquals(ejected, [["a", 1]]);
+  });
+
+  await t.step("evicted entries have their timeouts cleared", () => {
+    using time = new FakeTime(0);
+    const ejected: string[] = [];
+    const cache = new TtlCache<string, number>(100, {
+      maxSize: 1,
+      onEject: (k) => ejected.push(k),
+    });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    assertEquals(ejected, ["a"]);
+
+    time.now = 100;
+    assertEquals(ejected, ["a", "b"]);
+    assertEquals(cache.size, 0);
+  });
+
+  await t.step("works with slidingExpiration", () => {
+    using time = new FakeTime(0);
+    const cache = new TtlCache<string, number>(100, {
+      maxSize: 2,
+      slidingExpiration: true,
+    });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    time.now = 80;
+    cache.get("a");
+
+    // "a" is the oldest by insertion order, so it gets evicted
+    cache.set("c", 3);
+    assertEquals(cache.has("a"), false);
+    assertEquals(cache.get("b"), 2);
+    assertEquals(cache.get("c"), 3);
+  });
+
+  await t.step("eviction cleans up absoluteExpiration metadata", () => {
+    using time = new FakeTime(0);
+    const ejected: string[] = [];
+    const cache = new TtlCache<string, number>(1000, {
+      maxSize: 2,
+      slidingExpiration: true,
+      onEject: (k) => ejected.push(k),
+    });
+
+    cache.set("a", 1, { absoluteExpiration: 2000 });
+    cache.set("b", 2);
+
+    // Evicts "a" (oldest by insertion order), including its absoluteExpiration
+    cache.set("c", 3);
+    assertEquals(ejected, ["a"]);
+    assertEquals(cache.has("a"), false);
+
+    // "b" and "c" remain and eventually expire via TTL
+    time.now = 1000;
+    assertEquals(ejected, ["a", "b", "c"]);
+    assertEquals(cache.size, 0);
+  });
+
+  await t.step("validates maxSize in constructor", () => {
+    assertThrows(
+      () => new TtlCache(1000, { maxSize: 0 }),
+      RangeError,
+      "maxSize must be a positive integer",
+    );
+    assertThrows(
+      () => new TtlCache(1000, { maxSize: -1 }),
+      RangeError,
+      "maxSize must be a positive integer",
+    );
+    assertThrows(
+      () => new TtlCache(1000, { maxSize: 1.5 }),
+      RangeError,
+      "maxSize must be a positive integer",
+    );
+    assertThrows(
+      () => new TtlCache(1000, { maxSize: NaN }),
+      RangeError,
+      "maxSize must be a positive integer",
+    );
+    assertThrows(
+      () => new TtlCache(1000, { maxSize: Infinity }),
+      RangeError,
+      "maxSize must be a positive integer",
+    );
+  });
+
+  await t.step("maxSize of 1 always keeps only the latest entry", () => {
+    using _time = new FakeTime(0);
+    const cache = new TtlCache<string, number>(1000, { maxSize: 1 });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    assertEquals(cache.size, 1);
+    assertEquals(cache.has("a"), false);
+    assertEquals(cache.has("b"), false);
+    assertEquals(cache.get("c"), 3);
+  });
+});
+
+Deno.test("TtlCache is not re-entrant during onEject", async (t) => {
+  await t.step("set() throws during onEject from delete()", () => {
+    using cache = new TtlCache<string, number>(1000, {
+      onEject: () => {
+        assertThrows(
+          () => cache.set("x", 99),
+          TypeError,
+          "cache is not re-entrant during onEject callbacks",
+        );
+      },
+    });
+
+    cache.set("a", 1);
+    cache.delete("a");
+  });
+
+  await t.step("delete() throws during onEject", () => {
+    using cache = new TtlCache<string, number>(1000, {
+      onEject: () => {
+        assertThrows(
+          () => cache.delete("b"),
+          TypeError,
+          "cache is not re-entrant during onEject callbacks",
+        );
+      },
+    });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.delete("a");
+  });
+
+  await t.step("clear() throws during onEject", () => {
+    using cache = new TtlCache<string, number>(1000, {
+      onEject: () => {
+        assertThrows(
+          () => cache.clear(),
+          TypeError,
+          "cache is not re-entrant during onEject callbacks",
+        );
+      },
+    });
+
+    cache.set("a", 1);
+    cache.delete("a");
+  });
+
+  await t.step("set() throws during onEject from maxSize eviction", () => {
+    using _time = new FakeTime(0);
+    using cache = new TtlCache<string, number>(1000, {
+      maxSize: 1,
+      onEject: () => {
+        assertThrows(
+          () => cache.set("x", 99),
+          TypeError,
+          "cache is not re-entrant during onEject callbacks",
+        );
+      },
+    });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+  });
+});
+
 Deno.test("TtlCache clear() calls all onEject callbacks even if one throws", () => {
   const ejected: string[] = [];
   using cache = new TtlCache<string, number>(1000, {


### PR DESCRIPTION
- Adds optional `maxSize` option to `TtlCache` that evicts the oldest entry (by insertion order) when capacity is exceeded
- Adds `maxSize` getter (returns `Infinity` when unset)
- Adds `#ejecting` re-entrancy guard on `set()`, `delete()`, and `clear()` during `onEject` callbacks, matching `LruCache`