### PR TITLE
fix(expect): scope toMatchObject diff to only keys present in expected

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -21,6 +21,7 @@ import { getMockCalls } from "./_mock_util.ts";
 import { inspectArg, inspectArgs } from "./_inspect_args.ts";
 import {
   buildEqualOptions,
+  getObjectSubset,
   iterableEquality,
   subsetEquality,
 } from "./_utils.ts";
@@ -601,7 +602,8 @@ export function toMatchObject(
           : defaultMessage,
       );
     } else {
-      const defaultMessage = buildEqualErrorMessage(received, expected);
+      const subset = getObjectSubset(received, expected, context.customTesters);
+      const defaultMessage = buildEqualErrorMessage(subset, expected);
       throw new AssertionError(
         context.customMessage
           ? `${context.customMessage}: ${defaultMessage}`

--- a/expect/_to_match_object_test.ts
+++ b/expect/_to_match_object_test.ts
@@ -227,4 +227,21 @@ Deno.test("expect().toMatchObject() displays a diff", async (t) => {
       );
     },
   );
+
+  await t.step("omits keys not in expected", () => {
+    const e = assertThrows(
+      () =>
+        expect({ a: 1, b: 2, c: 3, d: { e: 4, f: 5 } }).toMatchObject({
+          a: 1,
+          d: { e: 999 },
+        }),
+      AssertionError,
+    );
+    // The diff should mention the mismatched value
+    assertMatch(e.message, /999/);
+    // The diff should NOT mention keys absent from expected
+    assertNotMatch(e.message, /b:/);
+    assertNotMatch(e.message, /c:/);
+    assertNotMatch(e.message, /f:/);
+  });
 });

--- a/expect/_to_match_object_test.ts
+++ b/expect/_to_match_object_test.ts
@@ -244,4 +244,58 @@ Deno.test("expect().toMatchObject() displays a diff", async (t) => {
     assertNotMatch(e.message, /c:/);
     assertNotMatch(e.message, /f:/);
   });
+
+  await t.step("omits keys not in expected with arrays", () => {
+    const e = assertThrows(
+      () =>
+        expect([{ a: 1, extra: true }, { b: 2 }]).toMatchObject([
+          { a: 999 },
+          { b: 2 },
+        ]),
+      AssertionError,
+    );
+    assertMatch(e.message, /999/);
+    assertNotMatch(e.message, /extra/);
+  });
+
+  await t.step("omits keys not in expected with Date values", () => {
+    const e = assertThrows(
+      () =>
+        expect({
+          d: new Date("2020-01-01"),
+          extra: "noise",
+        }).toMatchObject({ d: new Date("2025-01-01") }),
+      AssertionError,
+    );
+    assertNotMatch(e.message, /noise/);
+  });
+
+  await t.step("omits keys not in expected with equal nested subset", () => {
+    const e = assertThrows(
+      () =>
+        expect({
+          a: { x: 1, y: 2 },
+          b: 999,
+          extra: true,
+        }).toMatchObject({ a: { x: 1 }, b: 42 }),
+      AssertionError,
+    );
+    // b is the mismatch
+    assertMatch(e.message, /999/);
+    assertMatch(e.message, /42/);
+    // extra top-level key should be omitted
+    assertNotMatch(e.message, /extra/);
+    // y should be omitted (not in expected.a)
+    assertNotMatch(e.message, /y:/);
+  });
+
+  await t.step("handles circular references without throwing", () => {
+    const received: Record<string, unknown> = { a: 1 };
+    received.self = received;
+    const e = assertThrows(
+      () => expect(received).toMatchObject({ a: 999, self: {} }),
+      AssertionError,
+    );
+    assertMatch(e.message, /999/);
+  });
 });

--- a/expect/_utils.ts
+++ b/expect/_utils.ts
@@ -281,3 +281,53 @@ export function subsetEquality(
 
   return subsetEqualityWithContext()(object, subset);
 }
+
+// Ported from https://github.com/jestjs/jest/blob/442c7f692e3a92f14a2fb56c1737b26fc663a0ef/packages/expect-utils/src/utils.ts#L82
+export function getObjectSubset(
+  object: unknown,
+  subset: unknown,
+  customTesters: Tester[] = [],
+  seenReferences: WeakMap<object, boolean> = new WeakMap(),
+): unknown {
+  if (Array.isArray(object)) {
+    if (Array.isArray(subset) && subset.length === object.length) {
+      return subset.map((_: unknown, i: number) =>
+        getObjectSubset(object[i], subset[i], customTesters, seenReferences)
+      );
+    }
+  } else if (object instanceof Date) {
+    return object;
+  } else if (isObject(object) && isObject(subset)) {
+    if (
+      equal(object, subset, {
+        customTesters: [...customTesters, iterableEquality, subsetEquality],
+      })
+    ) {
+      return subset;
+    }
+
+    const obj = object as Record<string, unknown>;
+    const sub = subset as Record<string, unknown>;
+    const trimmed: Record<string, unknown> = {};
+    seenReferences.set(object as object, true);
+
+    for (const key of Object.keys(obj)) {
+      if (!Object.prototype.hasOwnProperty.call(sub, key)) continue;
+
+      const val = obj[key];
+      if (typeof val === "object" && val !== null && seenReferences.has(val)) {
+        trimmed[key] = val;
+      } else {
+        trimmed[key] = getObjectSubset(
+          val,
+          sub[key],
+          customTesters,
+          seenReferences,
+        );
+      }
+    }
+
+    if (Object.keys(trimmed).length > 0) return trimmed;
+  }
+  return object;
+}


### PR DESCRIPTION
Fixes #7077

When `expect(received).toMatchObject(expected)` fails, the error diff dumps every key from `received`, including keys that were not specified in `expected`. For large objects, this buries the actual mismatch in noise.

**Root cause:** `toMatchObject` passes the full `received` to `buildEqualErrorMessage`, so every extra key shows up as a `−` line.

**Fix:** Port `getObjectSubset` from Jest's `@jest/expect-utils` into `expect/_utils.ts`. Before building the error message, prune `received` to only the keys present in `expected`, then diff the pruned object instead against `expected`.

Authored with Claude Opus 4.6.