### PR TITLE
fix(testing): strip relative paths (as well as file:// paths) from snapshot test subprocess stderr

### DIFF
--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -26,9 +26,9 @@ function formatTestOutput(string: string) {
 }
 
 function formatTestError(string: string) {
-  // Strip colors and remove "Check file:///workspaces/deno_std/testing/.tmp/test.ts"
+  // Strip colors and remove "Check <path>" lines
   // as this is always output to stderr
-  return stripAnsiCode(string).replace(/^Check file:\/\/(.+)\n/gm, "");
+  return stripAnsiCode(string).replace(/^Check .+\n/gm, "");
 }
 
 function testFnWithTempDir(


### PR DESCRIPTION
Fix #7080.

`formatTestError` in `snapshot_test.ts` strips Deno's `Check <path>` diagnostic lines from subprocess stderr, but the
regex only matched `file://` URLs. Deno outputs file:// URLs when the working dir is 3+ levels from the filesystem root, but it outputs relative paths (e.g. `../../tmp/…`) when the working directory is fewer than 3 levels from /. That left the line unstripped and caused `assertNoError` to throw.

This fix broadens the regex from `/^Check file:\/\/(.+)\n/gm` to `/^Check .+\n/gm` so it matches any path format Deno emits.

Authored with help from Claude 4.6.