### PR TITLE
BREAKING(cli/unstable): rename `refreshMilliseconds` to `interval`

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -94,11 +94,11 @@ export interface ProgressBarOptions {
    */
   keepOpen?: boolean;
   /**
-   * How often the progress bar updates. The progress bar will be updated every
-   * `refreshMilliseconds` milliseconds.
-   * @default {1000}
+   * The time between each frame of the progress bar in milliseconds.
+   *
+   * @default {75}
    */
-  refreshMilliseconds?: number;
+  interval?: number;
 }
 
 const LINE_CLEAR = "\r\u001b[K";
@@ -223,7 +223,7 @@ export class ProgressBar {
       clear = false,
       formatter = defaultFormatter,
       keepOpen = true,
-      refreshMilliseconds = 1000,
+      interval = 1000,
     } = options;
     this.value = value;
     this.max = max;
@@ -243,7 +243,7 @@ export class ProgressBar {
     this.#previousTime = 0;
     this.#previousValue = this.value;
 
-    this.#id = setInterval(() => this.#print(), refreshMilliseconds);
+    this.#id = setInterval(() => this.#print(), interval);
     this.#print();
   }
   #createFormatterObject() {

--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -96,7 +96,7 @@ export interface ProgressBarOptions {
   /**
    * The time between each frame of the progress bar in milliseconds.
    *
-   * @default {75}
+   * @default {1000}
    */
   interval?: number;
 }

--- a/cli/unstable_progress_bar_test.ts
+++ b/cli/unstable_progress_bar_test.ts
@@ -69,7 +69,7 @@ Deno.test("ProgressBar() prints twice every second", async () => {
   const bar = new ProgressBar({
     writable,
     max: 10 * 1000,
-    refreshMilliseconds: 500,
+    interval: 500,
   });
   fakeTime.tick(3000);
   bar.stop().then(() => writable.close());


### PR DESCRIPTION
This PR renames `ProgressBarOptions.refreshMilliseconds` to `ProgressBarOptions.interval`  in order to align with `PollOptions.interval` and `SpinnerOptions.interval`.