### PR TITLE
BREAKING(cli/unstable): make `ProgressBarFormatter.styledData` a getter

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -12,11 +12,10 @@ export interface ProgressBarFormatter {
    */
   styledTime: string;
   /**
-   * A function that returns a formatted version of the data received.
+   * A formatted version of the data received.
    * `0.40/97.66 KiB`
-   * @param fractions The number of decimal places the values should have.
    */
-  styledData: (fractions?: number) => string;
+  styledData: string;
   /**
    * The progress bar string.
    * Default Style: `###-------`
@@ -104,7 +103,7 @@ export interface ProgressBarOptions {
 const LINE_CLEAR = "\r\u001b[K";
 
 function defaultFormatter(formatter: ProgressBarFormatter) {
-  return `[${formatter.styledTime}] [${formatter.progressBar}] [${formatter.styledData()}]`;
+  return `[${formatter.styledTime}] [${formatter.progressBar}] [${formatter.styledData}]`;
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -260,7 +259,7 @@ export class ProgressBar {
         const seconds = (this.time / 1000 % 60 | 0).toString().padStart(2, "0");
         return `${minutes}:${seconds}`;
       },
-      styledData() {
+      get styledData() {
         return formatUnitFraction(this.value, this.max);
       },
       progressBar: `${fillChars}${emptyChars}`,


### PR DESCRIPTION
This PR makes `ProgressBarFormatter.styledData` a getter instead of a function. It seems the function call and the `fractions` param don't do anything.