### PR TITLE
feat(data-structures/unstable): align RollingCounter with other data structures, add `at()` and `toArray()`

### DIFF
--- a/data_structures/unstable_rolling_counter.ts
+++ b/data_structures/unstable_rolling_counter.ts
@@ -11,7 +11,7 @@
  */
 export interface RollingCounterSnapshot {
   /** Segment counts ordered from oldest to newest. */
-  segments: number[];
+  readonly segments: readonly number[];
 }
 
 /**
@@ -23,6 +23,21 @@ export interface RollingCounterSnapshot {
  * window on your own schedule.
  *
  * The class is iterable and yields segment counts from oldest to newest.
+ *
+ * | Method            | Time complexity                        |
+ * | ----------------- | -------------------------------------- |
+ * | increment(n)      | Constant                               |
+ * | rotate(steps)     | Linear in min(steps, segment count)    |
+ * | current           | Constant                               |
+ * | total             | Constant                               |
+ * | segmentCount      | Constant                               |
+ * | at(index)         | Constant                               |
+ * | clear()           | Linear in the number of segments       |
+ * | toArray()         | Linear in the number of segments       |
+ * | toJSON()          | Linear in the number of segments       |
+ * | [Symbol.iterator] | Linear in the number of segments       |
+ * | RollingCounter()  | Linear in the number of segments       |
+ * | RollingCounter.from(snapshot) | Linear in the number of segments |
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
@@ -51,13 +66,15 @@ export interface RollingCounterSnapshot {
  * assertEquals([...counter], [3, 0, 0]);
  * ```
  */
-export class RollingCounter {
+export class RollingCounter implements Iterable<number> {
   #segments: number[];
   #cursor: number;
   #total: number;
 
   /**
    * Creates a counter with the given number of segments, all starting at zero.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @param segmentCount The number of segments. Must be a positive integer.
    */
@@ -104,11 +121,23 @@ export class RollingCounter {
    * assertEquals(restored.segmentCount, original.segmentCount);
    * ```
    */
-  static from(snapshot: { segments: readonly number[] }): RollingCounter {
+  static from(snapshot: RollingCounterSnapshot): RollingCounter {
+    if (snapshot === null || typeof snapshot !== "object") {
+      throw new TypeError(
+        `Cannot restore RollingCounter: "snapshot" must be an object, got ${
+          snapshot === null ? "null" : typeof snapshot
+        }`,
+      );
+    }
     const { segments } = snapshot;
-    if (!Array.isArray(segments) || segments.length < 1) {
+    if (!Array.isArray(segments)) {
+      throw new TypeError(
+        `Cannot restore RollingCounter: "segments" must be an array, got ${typeof segments}`,
+      );
+    }
+    if (segments.length < 1) {
       throw new RangeError(
-        "Cannot restore RollingCounter: segments must be a non-empty array",
+        'Cannot restore RollingCounter: "segments" must be a non-empty array',
       );
     }
     const counter = new RollingCounter(segments.length);
@@ -127,6 +156,8 @@ export class RollingCounter {
 
   /**
    * Adds `n` to the current segment.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @param n The amount to add. Defaults to `1`. Must be a non-negative integer.
    * @returns The new total across all segments.
@@ -155,6 +186,8 @@ export class RollingCounter {
   /**
    * Advances the window by `steps`, dropping the oldest segments. If `steps`
    * is at least {@linkcode segmentCount}, all segments are cleared.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @param steps How many steps to advance. Defaults to `1`. Must be a
    * non-negative integer.
@@ -214,6 +247,8 @@ export class RollingCounter {
   /**
    * The count in the current (newest) segment.
    *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
    * @returns The count in the current segment.
    *
    * @example Usage
@@ -239,6 +274,8 @@ export class RollingCounter {
   /**
    * The sum of all segment counts.
    *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
    * @returns The sum of all segment counts.
    *
    * @example Usage
@@ -260,6 +297,8 @@ export class RollingCounter {
   /**
    * The number of segments in the window.
    *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
    * @returns The number of segments.
    *
    * @example Usage
@@ -276,7 +315,46 @@ export class RollingCounter {
   }
 
   /**
+   * Returns the segment count at `index`, where index `0` is the oldest
+   * segment and index `segmentCount - 1` is the current (newest) segment.
+   * Negative indices count from the newest end (`at(-1)` is the current
+   * segment, same as {@linkcode RollingCounter.prototype.current | current}).
+   * Returns `undefined` for out-of-range indices.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
+   * @param index The zero-based index in oldest-to-newest order. Negative
+   * values count from the newest end.
+   * @returns The count at the index, or `undefined` if out of range.
+   *
+   * @example Usage
+   * ```ts
+   * import { RollingCounter } from "@std/data-structures/unstable-rolling-counter";
+   * import { assertEquals } from "@std/assert";
+   *
+   * const counter = new RollingCounter(3);
+   * counter.increment(5);
+   * counter.rotate();
+   * counter.increment(3);
+   *
+   * assertEquals(counter.at(0), 0);
+   * assertEquals(counter.at(1), 5);
+   * assertEquals(counter.at(2), 3);
+   * assertEquals(counter.at(-1), 3);
+   * assertEquals(counter.at(99), undefined);
+   * ```
+   */
+  at(index: number): number | undefined {
+    const len = this.#segments.length;
+    if (index < 0) index += len;
+    if (index < 0 || index >= len) return undefined;
+    return this.#segments[(this.#cursor + 1 + index) % len]!;
+  }
+
+  /**
    * Resets all segments to zero, as if the counter were just created.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @example Usage
    * ```ts
@@ -293,6 +371,40 @@ export class RollingCounter {
     this.#segments.fill(0);
     this.#cursor = this.#segments.length - 1;
     this.#total = 0;
+  }
+
+  /**
+   * Returns a fresh array of segment counts ordered from oldest to newest
+   * (matching iteration order). The returned array is owned by the caller;
+   * mutating it does not affect the counter.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
+   *
+   * @returns A new array of segment counts in oldest-to-newest order.
+   *
+   * @example Usage
+   * ```ts
+   * import { RollingCounter } from "@std/data-structures/unstable-rolling-counter";
+   * import { assertEquals } from "@std/assert";
+   *
+   * const counter = new RollingCounter(3);
+   * counter.increment(5);
+   * counter.rotate();
+   * counter.increment(3);
+   *
+   * assertEquals(counter.toArray(), [0, 5, 3]);
+   * ```
+   */
+  toArray(): number[] {
+    const segs = this.#segments;
+    const len = segs.length;
+    let start = this.#cursor + 1;
+    if (start >= len) start = 0;
+    const result = new Array<number>(len);
+    const firstLen = len - start;
+    for (let i = 0; i < firstLen; i++) result[i] = segs[start + i]!;
+    for (let i = 0; i < start; i++) result[firstLen + i] = segs[i]!;
+    return result;
   }
 
   /**
@@ -321,19 +433,13 @@ export class RollingCounter {
    * ```
    */
   toJSON(): RollingCounterSnapshot {
-    const segs = this.#segments;
-    const len = segs.length;
-    let start = this.#cursor + 1;
-    if (start >= len) start = 0;
-    const result = new Array<number>(len);
-    const firstLen = len - start;
-    for (let i = 0; i < firstLen; i++) result[i] = segs[start + i]!;
-    for (let i = 0; i < start; i++) result[firstLen + i] = segs[i]!;
-    return { segments: result };
+    return { segments: this.toArray() };
   }
 
   /**
    * Yields segment counts from oldest to newest.
+   *
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @returns An iterator over segment counts.
    *
@@ -357,9 +463,9 @@ export class RollingCounter {
   }
 
   /**
-   * The string tag used by `Object.prototype.toString`.
+   * A string tag for the class, used by `Object.prototype.toString()`.
    *
-   * @returns `"RollingCounter"`.
+   * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @example Usage
    * ```ts
@@ -373,7 +479,5 @@ export class RollingCounter {
    * );
    * ```
    */
-  get [Symbol.toStringTag](): string {
-    return "RollingCounter";
-  }
+  readonly [Symbol.toStringTag] = "RollingCounter" as const;
 }

--- a/data_structures/unstable_rolling_counter_test.ts
+++ b/data_structures/unstable_rolling_counter_test.ts
@@ -253,6 +253,86 @@ Deno.test("RollingCounter handles many rotations without data loss", () => {
   assertEquals([...counter], [0, 0, 1]);
 });
 
+// -- toArray --
+
+Deno.test("RollingCounter.toArray() returns segments oldest-to-newest", () => {
+  const counter = new RollingCounter(3);
+  counter.increment(5);
+  counter.rotate();
+  counter.increment(3);
+  assertEquals(counter.toArray(), [0, 5, 3]);
+});
+
+Deno.test("RollingCounter.toArray() matches [...counter]", () => {
+  const counter = new RollingCounter(4);
+  counter.increment(1);
+  counter.rotate();
+  counter.increment(2);
+  counter.rotate();
+  counter.increment(3);
+  assertEquals(counter.toArray(), [...counter]);
+});
+
+Deno.test("RollingCounter.toArray() returns a fresh array", () => {
+  const counter = new RollingCounter(3);
+  counter.increment(10);
+  const arr = counter.toArray();
+  arr[0] = 999;
+  assertEquals(counter.toArray(), [0, 0, 10]);
+});
+
+// -- at --
+
+Deno.test("RollingCounter.at() indexes oldest-to-newest", () => {
+  const counter = new RollingCounter(3);
+  counter.increment(5);
+  counter.rotate();
+  counter.increment(3);
+  assertEquals(counter.at(0), 0);
+  assertEquals(counter.at(1), 5);
+  assertEquals(counter.at(2), 3);
+});
+
+Deno.test("RollingCounter.at() supports negative indices", () => {
+  const counter = new RollingCounter(3);
+  counter.increment(5);
+  counter.rotate();
+  counter.increment(3);
+  assertEquals(counter.at(-1), counter.current);
+  assertEquals(counter.at(-1), 3);
+  assertEquals(counter.at(-2), 5);
+  assertEquals(counter.at(-3), 0);
+});
+
+Deno.test("RollingCounter.at() returns undefined for out-of-range indices", () => {
+  const counter = new RollingCounter(3);
+  counter.increment(1);
+  assertEquals(counter.at(3), undefined);
+  assertEquals(counter.at(99), undefined);
+  assertEquals(counter.at(-4), undefined);
+  assertEquals(counter.at(-99), undefined);
+});
+
+Deno.test("RollingCounter.at() tracks rotation", () => {
+  const counter = new RollingCounter(4);
+  counter.increment(10);
+  counter.rotate();
+  counter.increment(20);
+  counter.rotate();
+  counter.increment(30);
+  counter.rotate();
+  counter.increment(40);
+  assertEquals(counter.toArray(), [10, 20, 30, 40]);
+  assertEquals(counter.at(0), 10);
+  assertEquals(counter.at(-1), 40);
+
+  counter.rotate(2);
+  assertEquals(counter.toArray(), [30, 40, 0, 0]);
+  assertEquals(counter.at(0), 30);
+  assertEquals(counter.at(1), 40);
+  assertEquals(counter.at(-1), 0);
+});
+
 // -- toJSON / from --
 
 Deno.test("RollingCounter.toJSON() and from() round-trip through JSON", () => {
@@ -312,8 +392,18 @@ Deno.test("RollingCounter.from() throws on non-array segments", () => {
   assertThrows(
     // deno-lint-ignore no-explicit-any
     () => RollingCounter.from({ segments: "no" as any }),
-    RangeError,
+    TypeError,
   );
+});
+
+Deno.test("RollingCounter.from() throws on null / undefined / non-object snapshot", () => {
+  for (const bad of [null, undefined, 42, "snap", true]) {
+    assertThrows(
+      // deno-lint-ignore no-explicit-any
+      () => RollingCounter.from(bad as any),
+      TypeError,
+    );
+  }
 });
 
 Deno.test("RollingCounter.from() throws on invalid segment values", () => {


### PR DESCRIPTION
This PR is mostly about aligning RollingCounter with Deque, IndexedHeap, MultiMap and other data-structures.

- RollingCounter now implements Iterable<number>.
- [Symbol.toStringTag] is a readonly "RollingCounter" as const property (was a getter).
- @experimental tag added to every public-member JSDoc.
- Class JSDoc gained a complexity table.
- New at(index) with Array.prototype.at semantics (oldest→newest, negatives from newest end, out-of-range → undefined).
- New toArray(); toJSON() delegates to it.
- RollingCounterSnapshot.segments is readonly number[]; field is readonly.
- from() accepts RollingCounterSnapshot, guards null/undefined/non-object, throws TypeError for shape errors, keeps RangeError for per-element numeric errors.
- Tests: two RangeError cases flipped to TypeError; added null/undefined snapshot, toArray, and at tests.