### PR TITLE
fix(path): support Node.js

### DIFF
--- a/internal/_os.ts
+++ b/internal/_os.ts
@@ -3,11 +3,10 @@
 export function checkWindows(): boolean {
   // deno-lint-ignore no-explicit-any
   const global = globalThis as any;
-  const os = global.Deno?.build?.os;
 
-  // Check Deno, then the remaining runtimes (e.g. Node, Bun and the browser)
-  return typeof os === "string"
-    ? os === "windows"
-    : global.navigator?.platform?.startsWith("Win") ??
-      global.process?.platform?.startsWith("win") ?? false;
+  const platform = global.process?.platform;
+  if (typeof platform === "string") return platform.startsWith("win");
+  const os = global.Deno?.build?.os;
+  if (typeof os === "string") return os === "windows";
+  return global.navigator?.platform?.startsWith("Win") ?? false;
 }

--- a/internal/_os.ts
+++ b/internal/_os.ts
@@ -4,6 +4,7 @@ export function checkWindows(): boolean {
   // deno-lint-ignore no-explicit-any
   const global = globalThis as any;
 
+  // Check Node/Bun/Deno via `process.platform`, then the Deno global, then the browser
   const platform = global.process?.platform;
   if (typeof platform === "string") return platform.startsWith("win");
   const os = global.Deno?.build?.os;

--- a/path/_common/env.ts
+++ b/path/_common/env.ts
@@ -1,0 +1,11 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+export function cwd(errorMessage: string): string {
+  // deno-lint-ignore no-explicit-any
+  const global = globalThis as any;
+  const getCwd = global.process?.cwd ?? global.Deno?.cwd;
+  if (typeof getCwd !== "function") {
+    throw new TypeError(errorMessage);
+  }
+  return getCwd();
+}

--- a/path/posix/resolve.ts
+++ b/path/posix/resolve.ts
@@ -3,6 +3,7 @@
 
 import { normalizeString } from "../_common/normalize_string.ts";
 import { assertPath } from "../_common/assert_path.ts";
+import { cwd } from "../_common/env.ts";
 import { isPosixPathSeparator } from "./_util.ts";
 
 /**
@@ -29,14 +30,9 @@ export function resolve(...pathSegments: string[]): string {
 
     if (i >= 0) path = pathSegments[i]!;
     else {
-      // deno-lint-ignore no-explicit-any
-      const { Deno } = globalThis as any;
-      if (typeof Deno?.cwd !== "function") {
-        throw new TypeError(
-          "Resolved a relative path without a current working directory (CWD)",
-        );
-      }
-      path = Deno.cwd();
+      path = cwd(
+        "Resolved a relative path without a current working directory (CWD)",
+      );
     }
 
     assertPath(path);
@@ -51,7 +47,7 @@ export function resolve(...pathSegments: string[]): string {
   }
 
   // At this point the path should be resolved to a full absolute path, but
-  // handle relative paths to be safe (might happen when Deno.cwd() fails)
+  // handle relative paths to be safe (might happen when cwd() fails)
 
   // Normalize the path
   resolvedPath = normalizeString(

--- a/path/windows/resolve.ts
+++ b/path/windows/resolve.ts
@@ -4,6 +4,7 @@
 import { CHAR_COLON } from "../_common/constants.ts";
 import { normalizeString } from "../_common/normalize_string.ts";
 import { assertPath } from "../_common/assert_path.ts";
+import { cwd } from "../_common/env.ts";
 import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 
 /**
@@ -28,26 +29,16 @@ export function resolve(...pathSegments: string[]): string {
 
   for (let i = pathSegments.length - 1; i >= -1; i--) {
     let path: string;
-    // deno-lint-ignore no-explicit-any
-    const { Deno } = globalThis as any;
     if (i >= 0) {
       path = pathSegments[i]!;
     } else if (!resolvedDevice) {
-      if (typeof Deno?.cwd !== "function") {
-        throw new TypeError(
-          "Resolved a drive-letter-less path without a current working directory (CWD)",
-        );
-      }
-      path = Deno.cwd();
+      path = cwd(
+        "Resolved a drive-letter-less path without a current working directory (CWD)",
+      );
     } else {
-      if (
-        typeof Deno?.env?.get !== "function" || typeof Deno?.cwd !== "function"
-      ) {
-        throw new TypeError(
-          "Resolved a relative path without a current working directory (CWD)",
-        );
-      }
-      path = Deno.cwd();
+      path = cwd(
+        "Resolved a relative path without a current working directory (CWD)",
+      );
 
       // Verify that a cwd was found and that it actually points
       // to our drive. If not, default to the drive's root.
@@ -161,8 +152,7 @@ export function resolve(...pathSegments: string[]): string {
   }
 
   // At this point the path should be resolved to a full absolute path,
-  // but handle relative paths to be safe (might happen when Deno.cwd()
-  // fails)
+  // but handle relative paths to be safe (might happen when cwd() fails)
 
   // Normalize the tail path
   resolvedTail = normalizeString(


### PR DESCRIPTION
Prefers using the `process` global since it exists on all runtimes, then falls back to the `Deno` global.