### PR TITLE
feat(async/unstable): move `Channel` to options-bag constructor and split per-operation options

### DIFF
--- a/async/unstable_channel.ts
+++ b/async/unstable_channel.ts
@@ -157,23 +157,21 @@ export interface ChannelReceiveOptions {
  * An async channel for communicating between concurrent tasks with optional
  * bounded buffering and backpressure.
  *
- * ## Semantics
- *
- * - **FIFO order.** Values are received in the order they were sent. When
+ * - **FIFO order:** values are received in the order they were sent. When
  *   multiple senders or receivers are suspended, they are served in the order
  *   they arrived.
- * - **Backpressure.** {@linkcode Channel.send} suspends when the buffer is
+ * - **Backpressure:** {@linkcode Channel.send} suspends when the buffer is
  *   full (or always, when unbuffered) until a receiver consumes a value.
- * - **Close asymmetry.** {@linkcode Channel.close} accepts an optional
+ * - **Close asymmetry:** {@linkcode Channel.close} accepts an optional
  *   reason. Pending and future {@linkcode Channel.receive} calls reject
  *   with that reason (or a fresh {@linkcode ChannelClosedError} when no
  *   reason was supplied). Pending {@linkcode Channel.send} calls **always**
  *   reject with a {@linkcode ChannelClosedError} carrying the unsent value,
  *   regardless of the close reason.
- * - **`undefined` is a valid value.** Non-blocking receives therefore use
- *   the {@linkcode ChannelReceiveResult} discriminated union rather than
- *   `T | undefined`.
- * - **Multiple consumers.** Concurrent {@linkcode Channel.receive} calls
+ * - **`undefined` values:** `undefined` is a valid channel value, so
+ *   non-blocking receives use the {@linkcode ChannelReceiveResult}
+ *   discriminated union rather than `T | undefined`.
+ * - **Multiple consumers:** concurrent {@linkcode Channel.receive} calls
  *   and multiple {@linkcode Channel.toReadableStream} instances each
  *   consume values FIFO; every value is delivered to exactly one consumer.
  *

--- a/async/unstable_channel.ts
+++ b/async/unstable_channel.ts
@@ -107,15 +107,48 @@ export type ChannelReceiveResult<T> =
   | { state: "closed" };
 
 /**
- * Options for blocking {@linkcode Channel} operations.
+ * Options for the {@linkcode Channel} constructor.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface ChannelOptions {
   /**
-   * An {@linkcode AbortSignal} to cancel a pending `send` or `receive`.
-   * When the signal is aborted, the operation rejects with the signal's
-   * {@linkcode AbortSignal.reason}.
+   * Buffer size. `0` creates an unbuffered (rendezvous) channel where
+   * {@linkcode Channel.send} blocks until a receiver is waiting.
+   *
+   * Must be a non-negative integer.
+   *
+   * @default {0}
+   */
+  capacity?: number;
+}
+
+/**
+ * Options for {@linkcode Channel.send}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface ChannelSendOptions {
+  /**
+   * An {@linkcode AbortSignal} to cancel a pending `send`. When the signal
+   * is aborted, the operation rejects with the signal's
+   * {@linkcode AbortSignal.reason}. If the value is delivered synchronously
+   * (buffered or handed to a waiting receiver), the signal is ignored.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Options for {@linkcode Channel.receive}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface ChannelReceiveOptions {
+  /**
+   * An {@linkcode AbortSignal} to cancel a pending `receive`. When the
+   * signal is aborted, the operation rejects with the signal's
+   * {@linkcode AbortSignal.reason}. If a value is available synchronously,
+   * the signal is ignored.
    */
   signal?: AbortSignal;
 }
@@ -124,6 +157,26 @@ export interface ChannelOptions {
  * An async channel for communicating between concurrent tasks with optional
  * bounded buffering and backpressure.
  *
+ * ## Semantics
+ *
+ * - **FIFO order.** Values are received in the order they were sent. When
+ *   multiple senders or receivers are suspended, they are served in the order
+ *   they arrived.
+ * - **Backpressure.** {@linkcode Channel.send} suspends when the buffer is
+ *   full (or always, when unbuffered) until a receiver consumes a value.
+ * - **Close asymmetry.** {@linkcode Channel.close} accepts an optional
+ *   reason. Pending and future {@linkcode Channel.receive} calls reject
+ *   with that reason (or a fresh {@linkcode ChannelClosedError} when no
+ *   reason was supplied). Pending {@linkcode Channel.send} calls **always**
+ *   reject with a {@linkcode ChannelClosedError} carrying the unsent value,
+ *   regardless of the close reason.
+ * - **`undefined` is a valid value.** Non-blocking receives therefore use
+ *   the {@linkcode ChannelReceiveResult} discriminated union rather than
+ *   `T | undefined`.
+ * - **Multiple consumers.** Concurrent {@linkcode Channel.receive} calls
+ *   and multiple {@linkcode Channel.toReadableStream} instances each
+ *   consume values FIFO; every value is delivered to exactly one consumer.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Basic producer/consumer
@@ -131,7 +184,7 @@ export interface ChannelOptions {
  * import { Channel } from "@std/async/unstable-channel";
  * import { assertEquals } from "@std/assert";
  *
- * const ch = new Channel<number>(4);
+ * const ch = new Channel<number>({ capacity: 4 });
  *
  * await ch.send(1);
  * await ch.send(2);
@@ -151,7 +204,7 @@ export interface ChannelOptions {
  *
  * let ref: Channel<string>;
  * {
- *   await using ch = new Channel<string>(8);
+ *   await using ch = new Channel<string>({ capacity: 8 });
  *   ref = ch;
  *   await ch.send("hello");
  * }
@@ -175,10 +228,12 @@ export class Channel<T>
   /**
    * Creates a new channel.
    *
-   * @param capacity Buffer size. `0` creates an unbuffered (rendezvous)
-   *   channel where `send` blocks until a receiver is waiting. Defaults to `0`.
+   * @param options Channel options. Defaults to an unbuffered (rendezvous)
+   *   channel with capacity `0`.
+   * @throws {RangeError} If `options.capacity` is not a non-negative integer.
    */
-  constructor(capacity: number = 0) {
+  constructor(options: ChannelOptions = {}) {
+    const { capacity = 0 } = options;
     if (!Number.isInteger(capacity) || capacity < 0) {
       throw new RangeError(
         `Cannot create channel: capacity must be a non-negative integer, received ${capacity}`,
@@ -201,7 +256,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(1);
+   * const ch = new Channel<number>({ capacity: 1 });
    * await ch.send(42);
    * assertEquals(ch.size, 1);
    * ch.close();
@@ -221,10 +276,11 @@ export class Channel<T>
    *
    * @param value The value to send into the channel.
    * @param options Optional settings for the send operation.
+   * @returns A promise that resolves when the value has been accepted.
    * @throws {ChannelClosedError} If the channel is closed. The error's
    *   `value` property carries the unsent value for recovery.
    */
-  send(value: T, options?: ChannelOptions): Promise<void> {
+  send(value: T, options?: ChannelSendOptions): Promise<void> {
     if (this.#closed) {
       return Promise.reject(
         new ChannelClosedError("Cannot send to a closed channel", value),
@@ -278,7 +334,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(1);
+   * const ch = new Channel<number>({ capacity: 1 });
    * await ch.send(42);
    * assertEquals(await ch.receive(), 42);
    * ch.close();
@@ -302,7 +358,7 @@ export class Channel<T>
    *   `value` property). If `close(reason)` was called, rejects with
    *   `reason` instead.
    */
-  receive(options?: ChannelOptions): Promise<T> {
+  receive(options?: ChannelReceiveOptions): Promise<T> {
     if (this.#buffer.length > 0) return Promise.resolve(this.#dequeue());
 
     const sender = this.#nextSender();
@@ -356,7 +412,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assert, assertFalse } from "@std/assert";
    *
-   * const ch = new Channel<number>(1);
+   * const ch = new Channel<number>({ capacity: 1 });
    * assert(ch.trySend(1));
    * assertFalse(ch.trySend(2));
    * ```
@@ -384,7 +440,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(1);
+   * const ch = new Channel<number>({ capacity: 1 });
    * await ch.send(42);
    * assertEquals(ch.tryReceive(), { state: "ok", value: 42 });
    * assertEquals(ch.tryReceive(), { state: "empty" });
@@ -425,7 +481,9 @@ export class Channel<T>
   /**
    * Closes the channel with a reason. All pending and future `receive()`
    * calls reject with `reason` after draining buffered values. Pending
-   * `send()` calls reject with {@linkcode ChannelClosedError}. Idempotent.
+   * `send()` calls reject with {@linkcode ChannelClosedError} (the reason is
+   * intentionally not propagated to senders, so they can recover the unsent
+   * value via {@linkcode ChannelClosedError.value}). Idempotent.
    *
    * @example Usage
    * ```ts
@@ -493,7 +551,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(4);
+   * const ch = new Channel<number>({ capacity: 4 });
    * await ch.send(1);
    * await ch.send(2);
    * assertEquals(ch.size, 2);
@@ -514,7 +572,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(8);
+   * const ch = new Channel<number>({ capacity: 8 });
    * assertEquals(ch.capacity, 8);
    * ch.close();
    * ```
@@ -533,7 +591,7 @@ export class Channel<T>
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(4);
+   * const ch = new Channel<number>({ capacity: 4 });
    * await ch.send(1);
    * await ch.send(2);
    * ch.close();
@@ -568,12 +626,17 @@ export class Channel<T>
    * non-`undefined` cancel reason is forwarded to {@linkcode Channel.close}
    * so other consumers observe it.
    *
+   * Each call returns an **independent consumer**. If multiple streams (or
+   * streams alongside direct {@linkcode Channel.receive} calls or async
+   * iteration) consume from the same channel concurrently, values are
+   * distributed FIFO and each value is delivered to exactly one consumer.
+   *
    * @example Usage
    * ```ts
    * import { Channel } from "@std/async/unstable-channel";
    * import { assertEquals } from "@std/assert";
    *
-   * const ch = new Channel<number>(4);
+   * const ch = new Channel<number>({ capacity: 4 });
    * await ch.send(1);
    * await ch.send(2);
    * ch.close();
@@ -645,14 +708,9 @@ export class Channel<T>
     return this.#senders.popFront();
   }
 
-  /** Pops the next receiver from the queue. */
-  #nextReceiver(): ReceiverNode<T> | undefined {
-    return this.#receivers.popFront();
-  }
-
   /** Hands `value` to the next waiting receiver, if any. */
   #deliverToReceiver(value: T): boolean {
-    const receiver = this.#nextReceiver();
+    const receiver = this.#receivers.popFront();
     if (!receiver) return false;
     receiver.res(value);
     return true;

--- a/async/unstable_channel_test.ts
+++ b/async/unstable_channel_test.ts
@@ -18,21 +18,26 @@ Deno.test("Channel() defaults to unbuffered (capacity 0)", () => {
   assertEquals(ch.size, 0);
 });
 
+Deno.test("Channel() accepts empty options", () => {
+  const ch = new Channel<number>({});
+  assertEquals(ch.capacity, 0);
+});
+
 Deno.test("Channel() accepts valid capacity", () => {
-  assertEquals(new Channel<number>(8).capacity, 8);
+  assertEquals(new Channel<number>({ capacity: 8 }).capacity, 8);
 });
 
 Deno.test("Channel() throws for invalid capacity", () => {
-  assertThrows(() => new Channel(-1), RangeError);
-  assertThrows(() => new Channel(1.5), RangeError);
-  assertThrows(() => new Channel(NaN), RangeError);
-  assertThrows(() => new Channel(Infinity), RangeError);
+  assertThrows(() => new Channel({ capacity: -1 }), RangeError);
+  assertThrows(() => new Channel({ capacity: 1.5 }), RangeError);
+  assertThrows(() => new Channel({ capacity: NaN }), RangeError);
+  assertThrows(() => new Channel({ capacity: Infinity }), RangeError);
 });
 
 // -- Buffered send/receive --
 
 Deno.test("Channel.receive() returns buffered values in FIFO order", async () => {
-  const ch = new Channel<number>(4);
+  const ch = new Channel<number>({ capacity: 4 });
   await ch.send(1);
   await ch.send(2);
   await ch.send(3);
@@ -44,7 +49,7 @@ Deno.test("Channel.receive() returns buffered values in FIFO order", async () =>
 });
 
 Deno.test("Channel ring buffer wraps around correctly", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   await ch.send(2);
   assertEquals(await ch.receive(), 1);
@@ -83,7 +88,7 @@ Deno.test("Channel.receive() blocks until send on unbuffered channel", async () 
 // -- Backpressure --
 
 Deno.test("Channel.send() blocks when buffer is full", async () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   await ch.send(1);
   let sent = false;
   const sendPromise = ch.send(2).then(() => sent = true);
@@ -96,7 +101,7 @@ Deno.test("Channel.send() blocks when buffer is full", async () => {
 });
 
 Deno.test("Channel.receive() unblocks senders in FIFO order", async () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   await ch.send(0);
   const order: number[] = [];
   const p1 = ch.send(1).then(() => order.push(1));
@@ -165,7 +170,7 @@ Deno.test("Channel.receive() reuses a single ChannelClosedError after close()", 
 });
 
 Deno.test("Channel.receive() drains buffered values before rejecting", async () => {
-  const ch = new Channel<number>(4);
+  const ch = new Channel<number>({ capacity: 4 });
   await ch.send(1);
   await ch.send(2);
   ch.close();
@@ -213,7 +218,7 @@ Deno.test("Channel.close(reason) causes future receive to reject with reason", a
 });
 
 Deno.test("Channel.close(reason) drains buffer then rejects with reason", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   ch.close(new Error("done"));
   assertEquals(await ch.receive(), 1);
@@ -248,18 +253,18 @@ Deno.test("Channel.close(undefined) as explicit reason rejects with undefined", 
 // -- trySend --
 
 Deno.test("Channel.trySend() buffers when space available", () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   assert(ch.trySend(1));
   assert(ch.trySend(2));
   assertEquals(ch.size, 2);
 });
 
 Deno.test("Channel.trySend() returns false when full, closed, or no receiver", () => {
-  const full = new Channel<number>(1);
+  const full = new Channel<number>({ capacity: 1 });
   full.trySend(1);
   assertFalse(full.trySend(2));
 
-  const closed = new Channel<number>(1);
+  const closed = new Channel<number>({ capacity: 1 });
   closed.close();
   assertFalse(closed.trySend(1));
 
@@ -277,13 +282,13 @@ Deno.test("Channel.trySend() delivers to waiting receiver", async () => {
 // -- tryReceive --
 
 Deno.test("Channel.tryReceive() returns value when buffered", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   assertEquals(ch.tryReceive(), { state: "ok", value: 1 });
 });
 
 Deno.test("Channel.tryReceive() returns empty when no value is available", () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   assertEquals(ch.tryReceive(), { state: "empty" });
 });
 
@@ -294,7 +299,7 @@ Deno.test("Channel.tryReceive() returns closed on closed empty channel", () => {
 });
 
 Deno.test("Channel.tryReceive() drains buffer before reporting closed", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   ch.close();
   assertEquals(ch.tryReceive(), { state: "ok", value: 1 });
@@ -302,7 +307,7 @@ Deno.test("Channel.tryReceive() drains buffer before reporting closed", async ()
 });
 
 Deno.test("Channel.tryReceive() returns a shared empty result across calls", () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   assert(ch.tryReceive() === ch.tryReceive());
 });
 
@@ -313,7 +318,7 @@ Deno.test("Channel.tryReceive() returns a shared closed result across calls", ()
 });
 
 Deno.test("Channel.tryReceive() handles undefined as a valid value", async () => {
-  const ch = new Channel<undefined>(1);
+  const ch = new Channel<undefined>({ capacity: 1 });
   await ch.send(undefined);
   assertEquals(ch.tryReceive(), { state: "ok", value: undefined });
 });
@@ -326,7 +331,7 @@ Deno.test("Channel.tryReceive() drains from waiting sender on unbuffered channel
 });
 
 Deno.test("Channel.tryReceive() promotes blocked sender into buffer", async () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   await ch.send(1);
   const p = ch.send(2);
   assertEquals(ch.tryReceive(), { state: "ok", value: 1 });
@@ -354,7 +359,7 @@ Deno.test("Channel.send() rejects when signal aborts while waiting", async () =>
 });
 
 Deno.test("Channel.send() ignores signal on immediate delivery", async () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   const controller = new AbortController();
   await ch.send(42, { signal: controller.signal });
   assertEquals(ch.size, 1);
@@ -386,7 +391,7 @@ Deno.test("Channel.receive() rejects when signal aborts while waiting", async ()
 });
 
 Deno.test("Channel.receive() ignores signal on immediate delivery", async () => {
-  const ch = new Channel<number>(1);
+  const ch = new Channel<number>({ capacity: 1 });
   await ch.send(42);
   const controller = new AbortController();
   assertEquals(await ch.receive({ signal: controller.signal }), 42);
@@ -508,7 +513,7 @@ Deno.test("Channel.close() does not see previously aborted receiver", async () =
 // -- Async iteration --
 
 Deno.test("Channel async iteration drains until closed", async () => {
-  const ch = new Channel<number>(4);
+  const ch = new Channel<number>({ capacity: 4 });
   await ch.send(1);
   await ch.send(2);
   await ch.send(3);
@@ -522,7 +527,7 @@ Deno.test("Channel async iteration drains until closed", async () => {
 });
 
 Deno.test("Channel async iteration throws on close with reason", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   const reason = new Error("fail");
   ch.close(reason);
@@ -557,7 +562,7 @@ Deno.test("Channel async iteration throws reason immediately when no buffer", as
 });
 
 Deno.test("Channel async iteration works with concurrent producer", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
 
   const producer = (async () => {
     for (let i = 0; i < 5; i++) {
@@ -577,7 +582,7 @@ Deno.test("Channel async iteration works with concurrent producer", async () => 
 // -- toReadableStream --
 
 Deno.test("Channel.toReadableStream() yields buffered values then closes", async () => {
-  const ch = new Channel<number>(4);
+  const ch = new Channel<number>({ capacity: 4 });
   await ch.send(1);
   await ch.send(2);
   ch.close();
@@ -586,7 +591,7 @@ Deno.test("Channel.toReadableStream() yields buffered values then closes", async
 });
 
 Deno.test("Channel.toReadableStream() works with concurrent producer", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
 
   (async () => {
     for (let i = 0; i < 5; i++) {
@@ -600,7 +605,7 @@ Deno.test("Channel.toReadableStream() works with concurrent producer", async () 
 });
 
 Deno.test("Channel.toReadableStream() errors on close with reason", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   await ch.send(1);
   const reason = new Error("fail");
   ch.close(reason);
@@ -620,14 +625,14 @@ Deno.test("Channel.toReadableStream() errors on close with reason", async () => 
 });
 
 Deno.test("Channel.toReadableStream() cancel closes the channel", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   const stream = ch.toReadableStream();
   await stream.cancel();
   assert(ch.closed);
 });
 
 Deno.test("Channel.toReadableStream() cancel(reason) forwards reason to close", async () => {
-  const ch = new Channel<number>(2);
+  const ch = new Channel<number>({ capacity: 2 });
   const stream = ch.toReadableStream();
   const reason = new Error("stream-cancelled");
   await stream.cancel(reason);
@@ -641,6 +646,37 @@ Deno.test("Channel.toReadableStream() cancel() without reason keeps no-reason cl
   const stream = ch.toReadableStream();
   await stream.cancel();
   await assertRejects(() => ch.receive(), ChannelClosedError);
+});
+
+Deno.test("Channel.toReadableStream() multiple streams share values FIFO", async () => {
+  const ch = new Channel<number>({ capacity: 8 });
+  for (let i = 0; i < 6; i++) await ch.send(i);
+  ch.close();
+
+  const a = ch.toReadableStream();
+  const b = ch.toReadableStream();
+
+  const aReader = a.getReader();
+  const bReader = b.getReader();
+
+  const aValues: number[] = [];
+  const bValues: number[] = [];
+
+  while (true) {
+    const { value, done } = await aReader.read();
+    if (done) break;
+    aValues.push(value);
+    const next = await bReader.read();
+    if (next.done) break;
+    bValues.push(next.value);
+  }
+
+  const combined = [...aValues, ...bValues].sort((x, y) => x - y);
+  assertEquals(combined, [0, 1, 2, 3, 4, 5]);
+  assertEquals(aValues.length + bValues.length, 6);
+
+  await aReader.cancel();
+  await bReader.cancel();
 });
 
 // -- Disposable --


### PR DESCRIPTION
- **Constructor → options bag.** `new Channel<T>(capacity?: number)` becomes `new Channel<T>(options?: ChannelOptions)` where `ChannelOptions = { capacity?: number }`. Matches the pattern already used in std, and leaves room for future construction-time options (drop policies, debug labels, etc.) without a second breaking change once stable. Per the style guide, single positional optionals are only fine when "inconceivable more will be added later". For a channel, more certainly will be.
- **Split operation options.** The old combined `ChannelOptions` (for `send`/`receive`) is split into `ChannelSendOptions` and `ChannelReceiveOptions`. Frees the `ChannelOptions` name for the constructor and lets each direction evolve independently.
- **Class-level JSDoc summary.** Documents FIFO order for both queues, the intentional `close()` / `close(reason)` asymmetry (senders always reject with `ChannelClosedError` so they can recover the unsent value, receivers reject with `reason`), `undefined` as a valid value, and multi-consumer fan-out.
- **Pin + document multi-consumer `toReadableStream()`.** Adds a JSDoc note that each call returns an independent consumer and values are distributed FIFO across all consumers, plus a test that asserts this.
- **Minor:** inline single-use `#nextReceiver()` helper into `#deliverToReceiver`.