### PR TITLE
perf(internal): build diff backtrace via `push`+`reverse` instead of `unshift`

### DIFF
--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -130,25 +130,26 @@ export function backTrace<T>(
     if (!j && !type) break;
     const prev = j!;
     if (type === REMOVED) {
-      result.unshift({
+      result.push({
         type: swapped ? "removed" : "added",
         value: B[b]!,
       });
       b -= 1;
     } else if (type === ADDED) {
-      result.unshift({
+      result.push({
         type: swapped ? "added" : "removed",
         value: A[a]!,
       });
       a -= 1;
     } else {
-      result.unshift({ type: "common", value: A[a]! });
+      result.push({ type: "common", value: A[a]! });
       a -= 1;
       b -= 1;
     }
     j = routes[prev];
     type = routes[prev + diffTypesPtrOffset];
   }
+  result.reverse();
   return result;
 }
 


### PR DESCRIPTION
In `backTrace`, results were prepended with `unshift`, which is O(n) per call and makes the whole loop O(n²) in edit-script length. Switching to `push` plus a single `reverse` at the end preserves output order at O(n), with no API change.

`backTrace` is only a small part of diff, so this gives overall a 5-10% perf gain.