### PR TITLE
refactor(internal): tidy up `diffStr` inner loop

### DIFF
--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -177,18 +177,18 @@ export function diffStr(A: string, B: string): DiffResult<string>[] {
   const hasMoreRemovedLines = added.length < removed.length;
   const aLines = hasMoreRemovedLines ? added : removed;
   const bLines = hasMoreRemovedLines ? removed : added;
+  let bIdx = 0;
   for (const a of aLines) {
     let tokens = [] as Array<DiffResult<string>>;
     let b: undefined | ChangedDiffResult<string>;
+    const aTokens = tokenize(a.value, true);
     // Search another diff line with at least one common token
-    while (bLines.length) {
-      b = bLines.shift();
-      const tokenized = [
-        tokenize(a.value, true),
-        tokenize(b!.value, true),
-      ] as [string[], string[]];
-      if (hasMoreRemovedLines) tokenized.reverse();
-      tokens = diff(tokenized[0], tokenized[1]);
+    while (bIdx < bLines.length) {
+      b = bLines[bIdx++];
+      const bTokens = tokenize(b!.value, true);
+      tokens = hasMoreRemovedLines
+        ? diff(bTokens, aTokens)
+        : diff(aTokens, bTokens);
       if (
         tokens.some(({ type, value }) =>
           type === "common" && NON_WHITESPACE_REGEXP.test(value)


### PR DESCRIPTION
Three small structural cleanups in the word-diff inner loop of `diffStr`
- consume bLines via an index pointer instead of `shift` (removes an O(n²) pattern and the in-place mutation)
- hoist the fixed `aTokens = tokenize(a.value, true)` above the inner while
- replace the 2-element tokenized `array` + `.reverse()` with a ternary on `diff(...)`. Drops the `as [string[], string[]]` cast

Benhmarks show only modest gains.