### PR TITLE
test(async): assert TimeoutError name instead of message

### DIFF
--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -19,12 +19,12 @@
  *
  * const promise = delay(1_000);
  *
- * // Rejects with `DOMException` after 100 ms
- * await assertRejects(
+ * // Rejects with `DOMException` (name `"TimeoutError"`) after 100 ms
+ * const error = await assertRejects(
  *   () => abortable(promise, AbortSignal.timeout(100)),
  *   DOMException,
- *   "Signal timed out."
  * );
+ * assertEquals(error.name, "TimeoutError");
  * ```
  *
  * @example Error-handling an abort
@@ -67,16 +67,17 @@ export function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T>;
  * };
  *
  * const items: string[] = [];
- * // Below throws `DOMException` after 100 ms and items become `["Hello"]`
- * await assertRejects(
+ * // Below throws `DOMException` (name `"TimeoutError"`) after 100 ms and items
+ * // become `["Hello"]`
+ * const error = await assertRejects(
  *   async () => {
  *     for await (const item of abortable(asyncIter(), AbortSignal.timeout(100))) {
  *       items.push(item);
  *     }
  *   },
  *   DOMException,
- *   "Signal timed out."
  * );
+ * assertEquals(error.name, "TimeoutError");
  * assertEquals(items, ["Hello"]);
  * ```
  *

--- a/async/deadline_test.ts
+++ b/async/deadline_test.ts
@@ -23,7 +23,6 @@ Deno.test("deadline() throws DOMException", async () => {
   const error = await assertRejects(
     () => deadline(p, 100),
     DOMException,
-    "Signal timed out.",
   );
   assertEquals(error.name, "TimeoutError");
   controller.abort();

--- a/async/unstable_abortable.ts
+++ b/async/unstable_abortable.ts
@@ -25,12 +25,12 @@ export interface AbortableOptions {
  *
  * const promise = delay(1_000);
  *
- * // Rejects with `DOMException` after 100 ms
- * await assertRejects(
+ * // Rejects with `DOMException` (name `"TimeoutError"`) after 100 ms
+ * const error = await assertRejects(
  *   () => abortable(promise, AbortSignal.timeout(100)),
  *   DOMException,
- *   "Signal timed out."
  * );
+ * assertEquals(error.name, "TimeoutError");
  * ```
  *
  * @example Error-handling an abort
@@ -76,16 +76,17 @@ export function abortable<T>(
  * };
  *
  * const items: string[] = [];
- * // Below throws `DOMException` after 100 ms and items become `["Hello"]`
- * await assertRejects(
+ * // Below throws `DOMException` (name `"TimeoutError"`) after 100 ms and items
+ * // become `["Hello"]`
+ * const error = await assertRejects(
  *   async () => {
  *     for await (const item of abortable(asyncIter(), AbortSignal.timeout(100))) {
  *       items.push(item);
  *     }
  *   },
  *   DOMException,
- *   "Signal timed out."
  * );
+ * assertEquals(error.name, "TimeoutError");
  * assertEquals(items, ["Hello"]);
  * ```
  *


### PR DESCRIPTION
On the latest Deno canary, `AbortSignal.timeout()` now throws a `DOMException` with the message `"The operation was aborted due to timeout"` instead of `"Signal timed out."`, breaking three tests in `async/` that asserted on the runtime-internal message string: `deadline() throws DOMException` plus the async-iterable doc-test snippets in `async/abortable.ts` and `async/unstable_abortable.ts`. The `name` is still the spec-defined `"TimeoutError"`, which is the only part of the contract std should rely on, so this PR drops the message argument from `assertRejects(...)` in those three places and asserts `error.name === "TimeoutError"` instead. Behavior of `abortable`, `deadline`, and `waitFor` is unchanged; this only decouples the test suite from a runtime-implementation detail. Tests using `FakeTime` continue to assert on `"Signal timed out."` since that string is constructed by `testing/time.ts` itself and is part of std's own contract.