### PR TITLE
feat(csv): add parseLine() convenience for single-line CSV records (refs #3765)

### DIFF
--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -529,3 +529,75 @@ export function parse<const T extends ParseOptions>(
   }
   return r as ParseResult<ParseOptions, T>;
 }
+
+/** Options for {@linkcode parseLine}. */
+export interface ParseLineOptions {
+  /** Character which separates values.
+   *
+   * @default {","}
+   */
+  separator?: string;
+  /** Flag to trim the leading space of the value.
+   *
+   * This is done even if the field delimiter, `separator`, is white space.
+   *
+   * @default {false}
+   */
+  trimLeadingSpace?: boolean;
+  /**
+   * Allow unquoted quote in a quoted field or non-double-quoted quotes in
+   * quoted field.
+   *
+   * @default {false}
+   */
+  lazyQuotes?: boolean;
+}
+
+/**
+ * Parses a single CSV-encoded line into an array of fields.
+ *
+ * This is a small, synchronous convenience for cases where a caller already
+ * has individual lines (for example, after splitting a buffer) and just wants
+ * the field array. Unlike {@linkcode parse}, no row-count validation,
+ * comment-line handling, or multi-line quoted-field continuation is performed:
+ * a quoted field containing a newline cannot span across calls. For full RFC
+ * 4180 support, use {@linkcode parse} or {@linkcode CsvParseStream} instead.
+ *
+ * @example Usage
+ * ```ts
+ * import { parseLine } from "@std/csv/parse";
+ * import { assertEquals } from "@std/assert/equals";
+ *
+ * assertEquals(parseLine("a,b,c"), ["a", "b", "c"]);
+ * assertEquals(parseLine(`"a","b,c","d"`), ["a", "b,c", "d"]);
+ * ```
+ *
+ * @example Custom separator
+ * ```ts
+ * import { parseLine } from "@std/csv/parse";
+ * import { assertEquals } from "@std/assert/equals";
+ *
+ * assertEquals(parseLine("a\tb\tc", { separator: "\t" }), ["a", "b", "c"]);
+ * ```
+ *
+ * @param line The single CSV line to parse. Should not contain a trailing
+ * newline.
+ * @param options Parsing options.
+ * @returns The fields parsed from the line.
+ */
+export function parseLine(
+  line: string,
+  options: ParseLineOptions = {},
+): string[] {
+  const stripped = line.startsWith(BYTE_ORDER_MARK) ? line.slice(1) : line;
+  // Strip a single trailing CR/LF/CRLF so callers that forgot to trim are not
+  // surprised by a phantom trailing field.
+  const normalized = stripped.endsWith("\r\n")
+    ? stripped.slice(0, -2)
+    : stripped.endsWith("\n") || stripped.endsWith("\r")
+    ? stripped.slice(0, -1)
+    : stripped;
+  const parser = new Parser(options);
+  const rows = parser.parse(normalized);
+  return rows[0] ?? [];
+}

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -5,7 +5,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { assert, assertEquals, assertThrows } from "@std/assert";
-import { parse, type ParseOptions } from "./parse.ts";
+import { parse, parseLine, type ParseOptions } from "./parse.ts";
 import type { AssertTrue, IsExact } from "@std/testing/types";
 
 const BYTE_ORDER_MARK = "\ufeff";
@@ -1021,5 +1021,71 @@ Deno.test({
         IsExact<typeof parsed, Record<"aaa", string>[]>
       >;
     }
+  },
+});
+
+Deno.test({
+  name: "parseLine() parses a single line into fields",
+  async fn(t) {
+    await t.step("simple", () => {
+      assertEquals(parseLine("a,b,c"), ["a", "b", "c"]);
+    });
+
+    await t.step("empty string returns empty array", () => {
+      assertEquals(parseLine(""), []);
+    });
+
+    await t.step("single field", () => {
+      assertEquals(parseLine("hello"), ["hello"]);
+    });
+
+    await t.step("trailing separator yields empty trailing field", () => {
+      assertEquals(parseLine("a,b,"), ["a", "b", ""]);
+    });
+
+    await t.step("quoted fields with embedded separator", () => {
+      assertEquals(parseLine(`"a","b,c","d"`), ["a", "b,c", "d"]);
+    });
+
+    await t.step("escaped quotes inside quoted field", () => {
+      assertEquals(parseLine(`"a ""word""",x`), [`a "word"`, "x"]);
+    });
+
+    await t.step("custom separator (TSV)", () => {
+      assertEquals(parseLine("a\tb\tc", { separator: "\t" }), ["a", "b", "c"]);
+    });
+
+    await t.step("trimLeadingSpace option", () => {
+      assertEquals(
+        parseLine("  a, b ,  c", { trimLeadingSpace: true }),
+        ["a", "b ", "c"],
+      );
+    });
+
+    await t.step("lazyQuotes allows bare quotes", () => {
+      assertEquals(
+        parseLine(`a "word",b`, { lazyQuotes: true }),
+        [`a "word"`, "b"],
+      );
+    });
+
+    await t.step("strips trailing newline", () => {
+      assertEquals(parseLine("a,b,c\n"), ["a", "b", "c"]);
+      assertEquals(parseLine("a,b,c\r\n"), ["a", "b", "c"]);
+      assertEquals(parseLine("a,b,c\r"), ["a", "b", "c"]);
+    });
+
+    await t.step("strips leading byte-order mark", () => {
+      assertEquals(parseLine("﻿a,b,c"), ["a", "b", "c"]);
+    });
+
+    await t.step("invalid bare quote without lazyQuotes throws", () => {
+      assertThrows(() => parseLine(`a "word",b`), SyntaxError);
+    });
+
+    await t.step("return type is string[]", () => {
+      const out = parseLine("a,b");
+      type _ = AssertTrue<IsExact<typeof out, string[]>>;
+    });
   },
 });


### PR DESCRIPTION
## Summary
Refs #3765. Adds `parseLine(line: string, options?: ParseLineOptions): string[]` — a small synchronous convenience for single-record CSV input. Defaults to comma separator, no trim, strict quotes. Strips leading BOM and a single trailing CR/LF/CRLF.

## API
```ts
parseLine("a,b,c")                       // ["a", "b", "c"]
parseLine("a\tb", { separator: "\t" })   // ["a", "b"]
parseLine('"a,b","c"')                   // ["a,b", "c"]
```

Documents the trade-off vs full `parse()` — `parseLine` doesn't continue multi-line quoted fields, doesn't validate field count across records, and doesn't honor `comment` lines. For those use `parse`.

## Files changed
- `csv/parse.ts` — new `ParseLineOptions` interface and `parseLine()` function. Reuses internal `Parser` class. No breaking changes to existing `parse()` signature.
- `csv/parse_test.ts` — 12 new sub-steps covering basic parsing, quoting, escaped quotes, custom separator (TSV), `trimLeadingSpace`, `lazyQuotes`, trailing newline strip, BOM strip, error case, and return-type assertion.

## Test plan
- `deno fmt`, `deno lint`, `deno check`, `deno test` all clean
- 11 passed, 0 failed (205 steps)
- Doc tests pass
