### PR TITLE
feat(collections/unstable): have `zip` accept `Iterable`

### DIFF
--- a/collections/deno.json
+++ b/collections/deno.json
@@ -49,6 +49,7 @@
     "./union": "./union.ts",
     "./unstable-binary-search": "./unstable_binary_search.ts",
     "./unstable-cycle": "./unstable_cycle.ts",
+    "./unstable-zip": "./unstable_zip.ts",
     "./unzip": "./unzip.ts",
     "./without-all": "./without_all.ts",
     "./zip": "./zip.ts"

--- a/collections/unstable_zip.ts
+++ b/collections/unstable_zip.ts
@@ -1,0 +1,84 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+/**
+ * Builds N-tuples of elements from the given N iterables with matching
+ * indices, stopping when the shortest iterable is exhausted. All input
+ * iterables are consumed eagerly.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @typeParam T The tuple of element types in the input iterables.
+ *
+ * @param iterables The iterables to zip.
+ *
+ * @returns A new array containing N-tuples of elements from the given
+ * iterables.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { zip } from "@std/collections/unstable-zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const numbers = [1, 2, 3, 4];
+ * const letters = ["a", "b", "c", "d"];
+ * const pairs = zip(numbers, letters);
+ *
+ * assertEquals(
+ *   pairs,
+ *   [
+ *     [1, "a"],
+ *     [2, "b"],
+ *     [3, "c"],
+ *     [4, "d"],
+ *   ],
+ * );
+ * ```
+ *
+ * @example With iterables
+ * ```ts
+ * import { zip } from "@std/collections/unstable-zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(
+ *   zip(new Set([1, 2, 3]), ["a", "b", "c"]),
+ *   [[1, "a"], [2, "b"], [3, "c"]],
+ * );
+ * ```
+ */
+export function zip<T extends unknown[]>(
+  ...iterables: { [K in keyof T]: Iterable<T[K]> }
+): T[] {
+  const arrayCount = iterables.length;
+  if (arrayCount === 0) return [];
+
+  const arrays = iterables.map((it) => Array.isArray(it) ? it : Array.from(it));
+
+  let minLength = arrays[0]!.length;
+  for (let i = 1; i < arrayCount; ++i) {
+    const len = arrays[i]!.length;
+    if (len < minLength) minLength = len;
+  }
+
+  const result: T[] = new Array(minLength);
+
+  // Fast path for two iterables
+  if (arrayCount === 2) {
+    const a = arrays[0]!;
+    const b = arrays[1]!;
+    for (let i = 0; i < minLength; ++i) {
+      result[i] = [a[i], b[i]] as T;
+    }
+    return result;
+  }
+
+  for (let i = 0; i < minLength; ++i) {
+    const tuple: unknown[] = new Array(arrayCount);
+    for (let j = 0; j < arrayCount; ++j) {
+      tuple[j] = arrays[j]![i];
+    }
+    result[i] = tuple as T;
+  }
+
+  return result;
+}

--- a/collections/unstable_zip.ts
+++ b/collections/unstable_zip.ts
@@ -3,8 +3,14 @@
 
 /**
  * Builds N-tuples of elements from the given N iterables with matching
- * indices, stopping when the shortest iterable is exhausted. All input
- * iterables are consumed eagerly.
+ * indices, stopping when the shortest iterable is exhausted.
+ *
+ * Notes:
+ * - Inputs are consumed eagerly. Non-array iterables are materialized via
+ *   `Array.from` before zipping, so passing an infinite iterable (such as an
+ *   unbounded generator) will hang.
+ * - Strings are iterables of code points. Passing a string zips it
+ *   character-by-character rather than treating it as a single scalar value.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
@@ -43,6 +49,18 @@
  * assertEquals(
  *   zip(new Set([1, 2, 3]), ["a", "b", "c"]),
  *   [[1, "a"], [2, "b"], [3, "c"]],
+ * );
+ * ```
+ *
+ * @example Strings are iterables
+ * ```ts
+ * import { zip } from "@std/collections/unstable-zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * // A string is zipped character-by-character, not as a single value.
+ * assertEquals(
+ *   zip("abc", [1, 2, 3]),
+ *   [["a", 1], ["b", 2], ["c", 3]],
  * );
  * ```
  */

--- a/collections/unstable_zip_test.ts
+++ b/collections/unstable_zip_test.ts
@@ -1,0 +1,191 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { zip } from "./unstable_zip.ts";
+
+function zip1Test<T>(
+  input: [Array<T>],
+  expected: Array<[T]>,
+  message?: string,
+) {
+  const actual = zip(...input);
+  assertEquals(actual, expected, message);
+}
+
+assertEquals(zip([]), []);
+
+Deno.test({
+  name: "zip() handles one array",
+  fn() {
+    zip1Test([
+      [1, 2, 3],
+    ], [[1], [2], [3]]);
+  },
+});
+
+function zipTest<T, U>(
+  input: [ReadonlyArray<T>, ReadonlyArray<U>],
+  expected: Array<[T, U]>,
+  message?: string,
+) {
+  const actual = zip(...input);
+  assertEquals(actual, expected, message);
+}
+
+function zip3Test<T, U, V>(
+  input: [Array<T>, Array<U>, Array<V>],
+  expected: Array<[T, U, V]>,
+  message?: string,
+) {
+  const actual = zip(...input);
+  assertEquals(actual, expected, message);
+}
+
+Deno.test({
+  name: "zip() handles three arrays",
+  fn() {
+    zip3Test([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ], [[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles three arrays when the first is the shortest",
+  fn() {
+    zip3Test([
+      [1, 2],
+      [4, 5, 6],
+      [7, 8, 9],
+    ], [[1, 4, 7], [2, 5, 8]]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles no mutation",
+  fn() {
+    const arrayA = [1, 4, 5];
+    const arrayB = ["foo", "bar"];
+    zip(arrayA, arrayB);
+
+    assertEquals(arrayA, [1, 4, 5]);
+    assertEquals(arrayB, ["foo", "bar"]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles empty input",
+  fn() {
+    zipTest(
+      [[], []],
+      [],
+    );
+    zipTest(
+      [[1, 2, 3], []],
+      [],
+    );
+    zipTest(
+      [[], [{}, []]],
+      [],
+    );
+    assertEquals(zip(), []);
+  },
+});
+
+Deno.test({
+  name: "zip() handles same length",
+  fn() {
+    zipTest(
+      [
+        [1, 4, 5],
+        ["foo", "bar", "lorem"],
+      ],
+      [
+        [1, "foo"],
+        [4, "bar"],
+        [5, "lorem"],
+      ],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles first shorter",
+  fn() {
+    zipTest(
+      [
+        [1],
+        ["foo", "bar", "lorem"],
+      ],
+      [[1, "foo"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles second shorter",
+  fn() {
+    zipTest(
+      [
+        [1, 4, 5],
+        ["foo"],
+      ],
+      [[1, "foo"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles sparse arrays",
+  fn() {
+    // deno-lint-ignore no-sparse-arrays
+    const sparse = [1, , 3];
+    const result = zip(sparse, ["a", "b", "c"]);
+    assertEquals(result, [
+      [1, "a"],
+      [undefined, "b"],
+      [3, "c"],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles non-array iterables",
+  fn() {
+    function* numbers() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    assertEquals(
+      zip(numbers(), ["a", "b", "c"]),
+      [[1, "a"], [2, "b"], [3, "c"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles Set iterables",
+  fn() {
+    assertEquals(
+      zip(new Set([1, 2, 3]), ["a", "b", "c"]),
+      [[1, "a"], [2, "b"], [3, "c"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles iterables of different lengths",
+  fn() {
+    function* numbers() {
+      yield 1;
+      yield 2;
+    }
+    assertEquals(
+      zip(numbers(), ["a", "b", "c"]),
+      [[1, "a"], [2, "b"]],
+    );
+  },
+});

--- a/collections/unstable_zip_test.ts
+++ b/collections/unstable_zip_test.ts
@@ -12,7 +12,12 @@ function zip1Test<T>(
   assertEquals(actual, expected, message);
 }
 
-assertEquals(zip([]), []);
+Deno.test({
+  name: "zip() handles a single empty array",
+  fn() {
+    assertEquals(zip([]), []);
+  },
+});
 
 Deno.test({
   name: "zip() handles one array",
@@ -172,6 +177,24 @@ Deno.test({
     assertEquals(
       zip(new Set([1, 2, 3]), ["a", "b", "c"]),
       [[1, "a"], [2, "b"], [3, "c"]],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles a single non-array iterable",
+  fn() {
+    assertEquals(
+      zip(new Set([1, 2, 3])),
+      [[1], [2], [3]],
+    );
+    function* gen() {
+      yield "a";
+      yield "b";
+    }
+    assertEquals(
+      zip(gen()),
+      [["a"], ["b"]],
     );
   },
 });


### PR DESCRIPTION
## Summary
Adds an unstable `zip` (`@std/collections/unstable-zip`) that accepts any
`Iterable`, aligning its signature with the now-stable iterable-based
`interleave` (stabilized in #7115). Both share the identical shape
`...iterables: { [K in keyof T]: Iterable<T[K]> }`, whereas the stable
`zip` still takes `ReadonlyArray<T[K]>`.
This lives alongside the stable `zip` to bake before any decision about
widening or replacing the stable version.
## Behavior
- Builds N-tuples from matching indices, stopping at the shortest input
  (unchanged semantics from stable `zip`).
- Non-array iterables are materialized eagerly via `Array.from`; actual
  arrays are passed through untouched, so the no-mutation invariant of the
  stable `zip` is preserved.
- Includes a two-iterable fast path that mirrors `interleave`.
## Caveats (documented in JSDoc)
- **Infinite iterables hang.** Because inputs are consumed eagerly, passing
  an unbounded generator will never return.
- **Strings are iterables.** `zip("abc", [1, 2, 3])` zips
  character-by-character rather than treating the string as a single scalar.
## Notes
- Not exported from `mod.ts`, per the unstable-API convention.
- The 2-arity fast path is retained intentionally. It skips the per-row
  `new Array(2)` allocation; microbenchmark (Apple M5 Pro, Deno 2.8.0):
  | n       | fast path | generic  | speedup |
  | ------- | --------- | -------- | ------- |
  | 100     | 233.8 ns  | 253.6 ns | 1.08x   |
  | 1,000   | 2.3 µs    | 2.6 µs   | 1.14x   |
  | 10,000  | 22.4 µs   | 24.3 µs  | 1.08x   |
  | 100,000 | 538.5 µs  | 699.2 µs | 1.30x   |
  Stable `interleave` kept the same 2-arity branch through stabilization in
  #7115, so the precedent is symmetrical.
Rebased onto `main`; the `collections/deno.json` conflict with the
stabilization in #7119 is resolved.