### PR TITLE
fix(yaml): tighten `parse()` and `parseAll()` types

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -64,7 +64,7 @@ export interface LoaderStateOptions {
   /** compatibility with JSON.parse behaviour. */
   allowDuplicateKeys?: boolean;
   /** function to call on warning messages. */
-  onWarning?(error: Error): void;
+  onWarning?(error: SyntaxError): void;
 }
 
 const ESCAPED_HEX_LENGTHS = new Map<number, number>([
@@ -229,7 +229,7 @@ export class LoaderState {
   lineIndent = 0;
   lineStart = 0;
   line = 0;
-  onWarning: ((error: Error) => void) | undefined;
+  onWarning: ((error: SyntaxError) => void) | undefined;
   allowDuplicateKeys: boolean;
   implicitTypes: Type<"scalar">[];
   typeMap: TypeMap;

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -26,10 +26,10 @@ export interface ParseOptions {
    */
   allowDuplicateKeys?: boolean;
   /**
-   * If defined, a function to call on warning messages taking an
-   * {@linkcode Error} as its only argument.
+   * If defined, a function to call on warning messages taking a
+   * {@linkcode SyntaxError} as its only argument.
    */
-  onWarning?(error: Error): void;
+  onWarning?(error: SyntaxError): void;
 }
 
 function sanitizeInput(input: string) {
@@ -64,7 +64,8 @@ function sanitizeInput(input: string) {
  * assertEquals(data, { id: 1, name: "Alice" });
  * ```
  *
- * @throws {SyntaxError} Throws error on invalid YAML.
+ * @throws {SyntaxError} Throws if the YAML is invalid or contains more than
+ * one document.
  * @param content YAML string to parse.
  * @param options Parsing options.
  * @returns Parsed document.
@@ -111,11 +112,15 @@ export function parse(
  * assertEquals(data, [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" }]);
  * ```
  *
+ * @throws {SyntaxError} Throws if the YAML is invalid.
  * @param content YAML string to parse.
  * @param options Parsing options.
  * @returns Array of parsed documents.
  */
-export function parseAll(content: string, options: ParseOptions = {}): unknown {
+export function parseAll(
+  content: string,
+  options: ParseOptions = {},
+): unknown[] {
   content = sanitizeInput(content);
   const state = new LoaderState(content, {
     ...options,

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -137,6 +137,14 @@ regexp: !!js/regexp bar
 });
 
 Deno.test({
+  name: "parseAll() throws SyntaxError on invalid YAML",
+  fn() {
+    assertThrows(() => parseAll(`"`), SyntaxError);
+    assertThrows(() => parseAll(`---\nfoo: bar\n---\n"`), SyntaxError);
+  },
+});
+
+Deno.test({
   name: "parse() handles __proto__",
   async fn() {
     // Tests if the value is set using `Object.defineProperty(target, key, {value})`

--- a/yaml/unstable_parse.ts
+++ b/yaml/unstable_parse.ts
@@ -52,7 +52,8 @@ function sanitizeInput(input: string) {
  * assertEquals(data, { id: 1, name: "Alice" });
  * ```
  *
- * @throws {SyntaxError} Throws error on invalid YAML.
+ * @throws {SyntaxError} Throws if the YAML is invalid or contains more than
+ * one document.
  * @param content YAML string to parse.
  * @param options Parsing options.
  * @returns Parsed document.
@@ -99,11 +100,15 @@ export function parse(
  * assertEquals(data, [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" }]);
  * ```
  *
+ * @throws {SyntaxError} Throws if the YAML is invalid.
  * @param content YAML string to parse.
  * @param options Parsing options.
  * @returns Array of parsed documents.
  */
-export function parseAll(content: string, options: ParseOptions = {}): unknown {
+export function parseAll(
+  content: string,
+  options: ParseOptions = {},
+): unknown[] {
   content = sanitizeInput(content);
   const state = new LoaderState(content, {
     ...options,


### PR DESCRIPTION
fix(yaml): tighten parse() and parseAll() types

- `parseAll()` is typed `unknown[]` to match its implementation.
- `ParseOptions.onWarning` is narrowed from `Error` to `SyntaxError`, matching what the loader actually dispatches.
- `@throws {SyntaxError}` is documented on `parseAll()`, and `parse()`'s `@throws` clarifies the multi-document case.

Mirrored in `unstable_parse.ts`. All changes are non-breaking by subtyping (`unknown[]` ⊆ `unknown`) and function-parameter contravariance (`(Error) => void` is assignable to `(SyntaxError) => void`).