### PR TITLE
fix(testing): support canary timer return types

### DIFF
--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -130,7 +130,7 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
   const c = new AbortController();
   let returnCalled = false;
-  let timeoutId: ReturnType<typeof setTimeout>;
+  let timeoutId;
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -130,7 +130,7 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
   const c = new AbortController();
   let returnCalled = false;
-  let timeoutId: number;
+  let timeoutId: ReturnType<typeof setTimeout>;
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>

--- a/async/unstable_abortable_test.ts
+++ b/async/unstable_abortable_test.ts
@@ -130,7 +130,7 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
   const c = new AbortController();
   let returnCalled = false;
-  let timeoutId: ReturnType<typeof setTimeout>;
+  let timeoutId;
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>

--- a/async/unstable_abortable_test.ts
+++ b/async/unstable_abortable_test.ts
@@ -130,7 +130,7 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
   const c = new AbortController();
   let returnCalled = false;
-  let timeoutId: number;
+  let timeoutId: ReturnType<typeof setTimeout>;
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>

--- a/async/unstable_throttle.ts
+++ b/async/unstable_throttle.ts
@@ -106,7 +106,7 @@ export function throttle<T extends Array<any>>(
   options?: ThrottleOptions,
 ): ThrottledFunction<T> {
   const ensureLast = Boolean(options?.ensureLastCall);
-  let timeout = -1;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
 
   let lastExecution = -Infinity;
   let flush: (() => void) | null = null;

--- a/async/unstable_wait_for.ts
+++ b/async/unstable_wait_for.ts
@@ -51,7 +51,7 @@ export function waitFor(
   const { step = 100 } = options;
 
   // Create a new promise that resolves when the predicate is true
-  let timer: number;
+  let timer: ReturnType<typeof setTimeout>;
   const p: Promise<void> = new Promise(function (resolve) {
     const setTimer = () => {
       timer = setTimeout(async () => {

--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -93,7 +93,7 @@ export interface TtlCacheOptions<K, V> {
 export class TtlCache<K, V> extends Map<K, V>
   implements MemoizationCache<K, V> {
   #defaultTtl: number;
-  #timeouts = new Map<K, ReturnType<typeof setTimeout>>();
+  #timeouts = new Map();
   #eject?: ((ejectedKey: K, ejectedValue: V) => void) | undefined;
   #slidingExpiration: boolean;
   #entryTtls?: Map<K, number>;

--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -93,7 +93,7 @@ export interface TtlCacheOptions<K, V> {
 export class TtlCache<K, V> extends Map<K, V>
   implements MemoizationCache<K, V> {
   #defaultTtl: number;
-  #timeouts = new Map<K, number>();
+  #timeouts = new Map<K, ReturnType<typeof setTimeout>>();
   #eject?: ((ejectedKey: K, ejectedValue: V) => void) | undefined;
   #slidingExpiration: boolean;
   #entryTtls?: Map<K, number>;

--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -193,7 +193,7 @@ export class ProgressBar {
   max: number;
 
   #writer: WritableStreamDefaultWriter;
-  #id: ReturnType<typeof setInterval>;
+  #id;
   #startTime: number;
   #previousTime: number;
   #previousValue: number;

--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -193,7 +193,7 @@ export class ProgressBar {
   max: number;
 
   #writer: WritableStreamDefaultWriter;
-  #id: number;
+  #id: ReturnType<typeof setInterval>;
   #startTime: number;
   #previousTime: number;
   #previousValue: number;

--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -139,7 +139,7 @@ export class Spinner {
 
   #interval: number;
   #color: Color | undefined;
-  #intervalId: number | null = null;
+  #intervalId: ReturnType<typeof setInterval> | null = null;
   #output: typeof Deno.stdout | typeof Deno.stderr;
 
   /**

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,7 +10,7 @@ This package provides utilities for testing.
 import { assertSpyCalls, spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
 
-function secondInterval(cb: () => void): number {
+function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
   return setInterval(cb, 1000);
 }
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,7 +10,7 @@ This package provides utilities for testing.
 import { assertSpyCalls, spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
 
-function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
+function secondInterval(cb: () => void) {
   return setInterval(cb, 1000);
 }
 

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -42,7 +42,7 @@ interface GlobalContext {
 }
 
 let timerIdx = 1;
-const timers = new Map<number, number>();
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
 function hookFns() {
   timerIdx = 1;
   timers.clear();

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -42,7 +42,7 @@ interface GlobalContext {
 }
 
 let timerIdx = 1;
-const timers = new Map<number, ReturnType<typeof setTimeout>>();
+const timers = new Map();
 function hookFns() {
   timerIdx = 1;
   timers.clear();

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -293,7 +293,7 @@
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): number {
+ * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
  *   return setInterval(cb, 1000);
  * }
  *

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -293,7 +293,7 @@
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
+ * function secondInterval(cb: () => void) {
  *   return setInterval(cb, 1000);
  * }
  *

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -10,7 +10,7 @@
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
+ * function secondInterval(cb: () => void) {
  *   return setInterval(cb, 1000);
  * }
  *
@@ -138,17 +138,15 @@ function assertIsCallbackFunction(
   }
 }
 
-const fakeSetTimeout: typeof globalThis.setTimeout = function (
-  // deno-lint-ignore no-explicit-any
-  callback: string | ((...args: any[]) => void),
-  delay: number = 0,
-  // deno-lint-ignore no-explicit-any
-  ...args: any[]
-) {
+function fakeSetTimeout(
+  callback: string | ((...args: unknown[]) => unknown),
+  delay = 0,
+  ...args: unknown[]
+): number {
   assertIsCallbackFunction(callback, "setTimeout");
   if (!time) throw new TimeError("Cannot set timeout: time is not faked");
   return setTimer(callback, delay, args, false);
-};
+}
 
 function fakeClearTimeout(id?: unknown) {
   if (!time) throw new TimeError("Cannot clear timeout: time is not faked");
@@ -157,17 +155,15 @@ function fakeClearTimeout(id?: unknown) {
   }
 }
 
-const fakeSetInterval: typeof globalThis.setInterval = function (
-  // deno-lint-ignore no-explicit-any
-  callback: string | ((...args: any[]) => void),
-  delay: number = 0,
-  // deno-lint-ignore no-explicit-any
-  ...args: any[]
-) {
+function fakeSetInterval(
+  callback: string | ((...args: unknown[]) => unknown),
+  delay = 0,
+  ...args: unknown[]
+): number {
   assertIsCallbackFunction(callback, "setInterval");
   if (!time) throw new TimeError("Cannot set interval: time is not faked");
   return setTimer(callback, delay, args, true);
-};
+}
 
 function fakeClearInterval(id?: unknown) {
   if (!time) throw new TimeError("Cannot clear interval: time is not faked");
@@ -177,12 +173,11 @@ function fakeClearInterval(id?: unknown) {
 }
 
 function setTimer(
-  // deno-lint-ignore no-explicit-any
-  callback: (...args: any[]) => void,
+  callback: (...args: unknown[]) => unknown,
   delay = 0,
   args: unknown[],
   repeat = false,
-): ReturnType<typeof setTimeout> {
+): number {
   const id: number = timerId.next().value;
   delay = Math.max(repeat ? 1 : 0, Math.floor(delay));
   const due: number = now + delay;
@@ -200,7 +195,7 @@ function setTimer(
     repeat,
   });
   dueNodes.set(id, dueNode);
-  return id as unknown as ReturnType<typeof setTimeout>;
+  return id;
 }
 
 function fakeAbortSignalTimeout(delay: number): AbortSignal {
@@ -213,9 +208,11 @@ function fakeAbortSignalTimeout(delay: number): AbortSignal {
 
 function overrideGlobals() {
   globalThis.Date = FakeDate;
-  globalThis.setTimeout = fakeSetTimeout;
+  globalThis.setTimeout =
+    fakeSetTimeout as unknown as typeof globalThis.setTimeout;
   globalThis.clearTimeout = fakeClearTimeout;
-  globalThis.setInterval = fakeSetInterval;
+  globalThis.setInterval =
+    fakeSetInterval as unknown as typeof globalThis.setInterval;
   globalThis.clearInterval = fakeClearInterval;
   AbortSignal.timeout = fakeAbortSignalTimeout;
 }
@@ -269,7 +266,7 @@ let dueTree: RedBlackTree<DueNode>;
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
+ * function secondInterval(cb: () => void) {
  *   return setInterval(cb, 1000);
  * }
  *
@@ -633,7 +630,7 @@ export class FakeTime {
    * } from "@std/testing/mock";
    * import { FakeTime } from "@std/testing/time";
    *
-   * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
+   * function secondInterval(cb: () => void) {
    *   return setInterval(cb, 1000);
    * }
    *

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -10,7 +10,7 @@
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): number {
+ * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
  *   return setInterval(cb, 1000);
  * }
  *
@@ -139,9 +139,11 @@ function assertIsCallbackFunction(
 }
 
 const fakeSetTimeout: typeof globalThis.setTimeout = function (
-  callback,
-  delay = 0,
-  ...args
+  // deno-lint-ignore no-explicit-any
+  callback: string | ((...args: any[]) => void),
+  delay: number = 0,
+  // deno-lint-ignore no-explicit-any
+  ...args: any[]
 ) {
   assertIsCallbackFunction(callback, "setTimeout");
   if (!time) throw new TimeError("Cannot set timeout: time is not faked");
@@ -156,9 +158,11 @@ function fakeClearTimeout(id?: unknown) {
 }
 
 const fakeSetInterval: typeof globalThis.setInterval = function (
-  callback,
-  delay = 0,
-  ...args
+  // deno-lint-ignore no-explicit-any
+  callback: string | ((...args: any[]) => void),
+  delay: number = 0,
+  // deno-lint-ignore no-explicit-any
+  ...args: any[]
 ) {
   assertIsCallbackFunction(callback, "setInterval");
   if (!time) throw new TimeError("Cannot set interval: time is not faked");
@@ -178,7 +182,7 @@ function setTimer(
   delay = 0,
   args: unknown[],
   repeat = false,
-): number {
+): ReturnType<typeof setTimeout> {
   const id: number = timerId.next().value;
   delay = Math.max(repeat ? 1 : 0, Math.floor(delay));
   const due: number = now + delay;
@@ -196,7 +200,7 @@ function setTimer(
     repeat,
   });
   dueNodes.set(id, dueNode);
-  return id;
+  return id as unknown as ReturnType<typeof setTimeout>;
 }
 
 function fakeAbortSignalTimeout(delay: number): AbortSignal {
@@ -245,7 +249,7 @@ let now: number;
 let initializedAt: number;
 let advanceRate: number;
 let advanceFrequency: number;
-let advanceIntervalId: number | undefined;
+let advanceIntervalId: ReturnType<typeof setInterval> | undefined;
 let timerId: Generator<number>;
 let dueNodes: Map<number, DueNode>;
 let dueTree: RedBlackTree<DueNode>;
@@ -265,7 +269,7 @@ let dueTree: RedBlackTree<DueNode>;
  * } from "@std/testing/mock";
  * import { FakeTime } from "@std/testing/time";
  *
- * function secondInterval(cb: () => void): number {
+ * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
  *   return setInterval(cb, 1000);
  * }
  *
@@ -575,7 +579,7 @@ export class FakeTime {
       );
     }
     return await new Promise((resolve, reject) => {
-      let timer: number | null = null;
+      let timer: ReturnType<typeof setTimeout> | null = null;
       const abort = () =>
         FakeTime
           .restoreFor(() => {
@@ -629,7 +633,7 @@ export class FakeTime {
    * } from "@std/testing/mock";
    * import { FakeTime } from "@std/testing/time";
    *
-   * function secondInterval(cb: () => void): number {
+   * function secondInterval(cb: () => void): ReturnType<typeof setInterval> {
    *   return setInterval(cb, 1000);
    * }
    *

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -163,7 +163,7 @@ Deno.test("FakeTime controls timeouts", () => {
 
   setTimeout(cb, 1000, "a");
   setTimeout(cb, 1500, "b");
-  const timeout: number = setTimeout(cb, 1750, "c");
+  const timeout = setTimeout(cb, 1750, "c");
   setTimeout(cb, 2000, "d");
   time.tick(1250);
   expected.push({ args: ["a"], returned: 7000 });
@@ -199,7 +199,7 @@ Deno.test("FakeTime controls intervals", () => {
   const cb = spy(fromNow());
   const expected: SpyCall[] = [];
 
-  const interval: number = setInterval(cb, 1000);
+  const interval = setInterval(cb, 1000);
   time.tick(250);
   assertEquals(cb.calls, expected);
   time.tick(250);
@@ -226,7 +226,7 @@ Deno.test("FakeTime calls timeout and interval callbacks in correct order", () =
   const timeoutExpected: SpyCall[] = [];
   const intervalExpected: SpyCall[] = [];
 
-  const interval: number = setInterval(intervalCb, 1000);
+  const interval = setInterval(intervalCb, 1000);
   setTimeout(timeoutCb, 500);
   time.tick(250);
   assertEquals(intervalCb.calls, intervalExpected);

--- a/toml/_parser_test.ts
+++ b/toml/_parser_test.ts
@@ -489,7 +489,7 @@ Deno.test({
 Deno.test({
   name: "(private) deepAssign() works correctly",
   fn() {
-    const source = {
+    const source: Record<string, unknown> = {
       foo: {
         items: [
           {
@@ -528,7 +528,7 @@ Deno.test({
                 email: {
                   x: { main: "mail@example.com" },
                 },
-              } as unknown,
+              },
             },
           ],
         },


### PR DESCRIPTION
On Deno canary we are using newer built-in type declarations plus TypeScript 6. In that environment, global setTimeout() / setInterval() are typed as returning Timeout, not number.