### PR TITLE
fix(text): inline title case mapping to avoid JSON import attribute

### DIFF
--- a/text/_title_case_mapping.ts
+++ b/text/_title_case_mapping.ts
@@ -1,4 +1,13 @@
-{
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+// This data is generated from the Unicode Character Database. See
+// `_tools/generate_title_case_data.ts` for the generation script. The mapping
+// is inlined as a TypeScript module rather than imported from JSON so that
+// bundlers (notably Vite) that don't handle JSON imports from JSR correctly
+// can still consume the module. See https://github.com/denoland/std/issues/7128.
+
+export const titleCaseMapping: Record<string, string> = {
   "ß": "Ss",
   "Ǆ": "ǅ",
   "ǅ": "ǅ",
@@ -133,5 +142,5 @@
   "ﬔ": "Մե",
   "ﬕ": "Մի",
   "ﬖ": "Վն",
-  "ﬗ": "Մխ"
-}
+  "ﬗ": "Մխ",
+};

--- a/text/_title_case_util.ts
+++ b/text/_title_case_util.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // This module is browser compatible.
-import _titleCaseMapping from "./title_case_mapping.json" with { type: "json" };
-const titleCaseMap = new Map(Object.entries(_titleCaseMapping));
+import { titleCaseMapping } from "./_title_case_mapping.ts";
+const titleCaseMap = new Map(Object.entries(titleCaseMapping));
 
 /** The case for the remaining characters in the string */
 export type TrailingCase = "lower" | "unchanged";

--- a/text/_tools/generate_title_case_data.ts
+++ b/text/_tools/generate_title_case_data.ts
@@ -86,7 +86,26 @@ for (let i = 0; i < 0x110000; i++) {
   }
 }
 
+const HEADER = `\
+// Copyright 2018-${new Date().getFullYear()} the Deno authors. MIT license.
+// This module is browser compatible.
+
+// This data is generated from the Unicode Character Database. See
+// \`_tools/generate_title_case_data.ts\` for the generation script. The mapping
+// is inlined as a TypeScript module rather than imported from JSON so that
+// bundlers (notably Vite) that don't handle JSON imports from JSR correctly
+// can still consume the module. See https://github.com/denoland/std/issues/7128.
+
+export const titleCaseMapping: Record<string, string> = {
+`;
+
+const FOOTER = "};\n";
+
+const entries = Object.entries(data)
+  .map(([k, v]) => `  ${JSON.stringify(k)}: ${JSON.stringify(v)},\n`)
+  .join("");
+
 await Deno.writeTextFile(
-  new URL(import.meta.resolve("../title_case_mapping.json")),
-  JSON.stringify(data, null, 2) + "\n",
+  new URL(import.meta.resolve("../_title_case_mapping.ts")),
+  HEADER + entries + FOOTER,
 );


### PR DESCRIPTION
Fixes: https://github.com/denoland/std/issues/7128

When Vite resolves @std/text/unstable-to-title-case, it follows that import to JSR and ends up requesting https://jsr.io/@std/text/1.0.18/title_case_mapping.json?import. The catch: hitting that URL in an HTTP client returns the JSR registry's HTML browse page for the file, not the raw JSON

Vite no longer needs to fetch a .json file from JSR when bundling @std/text/unstable-to-title-case, so the builtin:vite-json "expected value at line 1 column 1" crash from [#7128](https://github.com/denoland/std/issues/7128) goes away. No public API change.

PS: There are other cases like this in the code as well, but not many