### PR TITLE
docs(path): clarify URL handling in basename, dirname, extname

### DIFF
--- a/path/basename.ts
+++ b/path/basename.ts
@@ -25,10 +25,13 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  * }
  * ```
  *
- * @param path Path to extract the name from.
+ * @param path Path to extract the name from. When passed as a `URL`
+ * instance, its protocol must be `file:`. For other protocols, pass the URL
+ * as a string or pass its `pathname` property.
  * @param suffix Suffix to remove from extracted name.
  *
  * @returns The basename of the path.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function basename(path: string | URL, suffix = ""): string {
   return isWindows

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -22,8 +22,11 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
  * }
  * ```
  *
- * @param path Path to extract the directory from.
+ * @param path Path to extract the directory from. When passed as a `URL`
+ * instance, its protocol must be `file:`. For other protocols, pass the URL
+ * as a string or pass its `pathname` property.
  * @returns The directory path.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function dirname(path: string | URL): string {
   return isWindows ? windowsDirname(path) : posixDirname(path);

--- a/path/extname.ts
+++ b/path/extname.ts
@@ -21,8 +21,11 @@ import { extname as windowsExtname } from "./windows/extname.ts";
  * }
  * ```
  *
- * @param path Path with extension.
+ * @param path Path with extension. When passed as a `URL` instance, its
+ * protocol must be `file:`. For other protocols, pass the URL as a string or
+ * pass its `pathname` property.
  * @returns The file extension. E.g. returns `.ts` for `file.ts`.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function extname(path: string | URL): string {
   return isWindows ? windowsExtname(path) : posixExtname(path);

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -28,6 +28,9 @@ import { isPosixPathSeparator } from "./_util.ts";
  *
  * @example Working with URLs
  *
+ * Only `URL` instances with the `file:` protocol are accepted. To process a
+ * non-`file:` URL, pass it as a string or pass its `pathname` property.
+ *
  * Note: This function doesn't automatically strip hash and query parts from
  * URLs. If your URL contains a hash or query, remove them before passing the
  * URL to the function. This can be done by passing the URL to `new URL(url)`,
@@ -41,11 +44,13 @@ import { isPosixPathSeparator } from "./_util.ts";
  * assertEquals(basename("https://deno.land/std/path/mod.ts", ".ts"), "mod");
  * assertEquals(basename("https://deno.land/std/path/mod.ts?a=b"), "mod.ts?a=b");
  * assertEquals(basename("https://deno.land/std/path/mod.ts#header"), "mod.ts#header");
+ * assertEquals(basename(new URL("https://deno.land/std/path/mod.ts").pathname), "mod.ts");
  * ```
  *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function basename(path: string | URL, suffix = ""): string {
   if (path instanceof URL) {

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -22,6 +22,9 @@ import { fromFileUrl } from "./from_file_url.ts";
  *
  * @example Working with URLs
  *
+ * Only `URL` instances with the `file:` protocol are accepted. To process a
+ * non-`file:` URL, pass it as a string or pass its `pathname` property.
+ *
  * ```ts
  * import { dirname } from "@std/path/posix/dirname";
  * import { assertEquals } from "@std/assert";
@@ -29,10 +32,12 @@ import { fromFileUrl } from "./from_file_url.ts";
  * assertEquals(dirname("https://deno.land/std/path/mod.ts"), "https://deno.land/std/path");
  * assertEquals(dirname("https://deno.land/std/path/mod.ts?a=b"), "https://deno.land/std/path");
  * assertEquals(dirname("https://deno.land/std/path/mod.ts#header"), "https://deno.land/std/path");
+ * assertEquals(dirname(new URL("https://deno.land/std/path/mod.ts").pathname), "/std/path");
  * ```
  *
  * @param path The path to get the directory from.
  * @returns The directory path.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function dirname(path: string | URL): string {
   if (path instanceof URL) {

--- a/path/posix/extname.ts
+++ b/path/posix/extname.ts
@@ -24,6 +24,9 @@ import { fromFileUrl } from "./from_file_url.ts";
  *
  * @example Working with URLs
  *
+ * Only `URL` instances with the `file:` protocol are accepted. To process a
+ * non-`file:` URL, pass it as a string or pass its `pathname` property.
+ *
  * Note: This function doesn't automatically strip hash and query parts from
  * URLs. If your URL contains a hash or query, remove them before passing the
  * URL to the function. This can be done by passing the URL to `new URL(url)`,
@@ -36,10 +39,12 @@ import { fromFileUrl } from "./from_file_url.ts";
  * assertEquals(extname("https://deno.land/std/path/mod.ts"), ".ts");
  * assertEquals(extname("https://deno.land/std/path/mod.ts?a=b"), ".ts?a=b");
  * assertEquals(extname("https://deno.land/std/path/mod.ts#header"), ".ts#header");
+ * assertEquals(extname(new URL("https://deno.land/std/path/mod.ts").pathname), ".ts");
  * ```
  *
  * @param path The path to get the extension from.
  * @returns The extension (ex. for `file.ts` returns `.ts`).
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function extname(path: string | URL): string {
   if (path instanceof URL) {

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -30,6 +30,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function basename(path: string | URL, suffix = ""): string {
   if (path instanceof URL) {

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -25,6 +25,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  *
  * @param path The path to get the directory from.
  * @returns The directory path.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function dirname(path: string | URL): string {
   if (path instanceof URL) {

--- a/path/windows/extname.ts
+++ b/path/windows/extname.ts
@@ -20,6 +20,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  *
  * @param path The path to get the extension from.
  * @returns The extension of the `path`.
+ * @throws {TypeError} If `path` is a `URL` instance whose protocol is not `file:`.
  */
 export function extname(path: string | URL): string {
   if (path instanceof URL) {


### PR DESCRIPTION
The path APIs reject URL instances whose protocol is not `file:`, but the JSDoc "Working with URLs" sections only show string examples with `https://` URLs, which works fine. Users coming from `@std/url` (now deprecated) follow the migration note and reach for `basename(new URL("https://..."))`, which throws `URL must be a file URL: received "https:"`.

This documents the existing contract rather than changing runtime behavior. Existing tests (`path/basename_test.ts`, `path/dirname_test.ts`) explicitly assert that non-`file:` URLs throw, so the runtime behavior is intentional.

Changes:

- Add a sentence in the "Working with URLs" section of `path/posix/basename.ts`, `path/posix/dirname.ts`, and `path/posix/extname.ts` stating that `URL` instances must use the `file:` protocol, with guidance to pass the URL as a string or use `.pathname` for other protocols.
- Add `@throws {TypeError}` to all six platform-specific variants and to the platform-detecting wrappers in `path/`.
- Add one extra `assertEquals` to the posix examples showing the `.pathname` pattern.

The example snippets pass `deno test --doc`. The full `deno test -A path/` suite is green (91 passed, 0 failed).

Closes #7133