### PR TITLE
docs: standardize Resources link prefixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ High-quality APIs for [Deno](https://deno.com/) and the web. Use fearlessly.
 ## Resources
 
 - [Package list](https://jsr.io/@std)
-- [Architecture guide](./.github/ARCHITECTURE.md)
+- [Architecture guide](.github/ARCHITECTURE.md)
 - [Design documentation](.github/ARCHITECTURE.md#design)
 - [Contributing guidelines](.github/CONTRIBUTING.md)
-- [Frequently asked questions (FAQ)](./.github/FAQ.md)
+- [Frequently asked questions (FAQ)](.github/FAQ.md)
 - [Test coverage explorer](https://std-coverage.deno.dev/)
 
 ## Releases


### PR DESCRIPTION
## Summary

The Resources section of the README mixed link prefixes inconsistently:
two links used `./.github/...` and two used `.github/...` (both render
identically on GitHub). This drops the `./` from the Architecture guide
and FAQ lines so all four links share the same form.

Two-line diff. No other changes.

Closes bartlomieju/agent-job-board#29

## Test plan

- [x] `git diff` shows only the two intended line changes
- [ ] Verify rendered README on GitHub still links correctly to `.github/ARCHITECTURE.md` and `.github/FAQ.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)