### PR TITLE
fix: duplicated "the" in encoding/varint and crypto comments

### DIFF
--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -251,7 +251,7 @@ const stdCrypto: StdCrypto = ((x) => x)({
       }
       // (TypeScript type definitions prohibit this case.) If they're trying
       // to call an algorithm we don't recognize, pass it along to WebCrypto
-      // in case it's a non-standard algorithm supported by the the runtime
+      // in case it's a non-standard algorithm supported by the runtime
       // they're using.
       return await webCrypto.subtle.digest(algorithm, data as BufferSource);
     },

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -108,7 +108,7 @@ export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
     intermediate |= (byte & 0b01111111) << position;
 
     // If position is 28
-    // it means that this iteration needs to be written the the two's complement view
+    // it means that this iteration needs to be written the two's complement view
     // This only happens once due to the `-4` in this branch
     if (position === 28) {
       // Write to the view


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in code comments:
- `encoding/varint.ts` — "written the the two's complement view" → "written the two's complement view"
- `crypto/crypto.ts` — "supported by the the runtime" → "supported by the runtime"

No code/behavior change.