### PR TITLE
fix(dotenv): make stringify and parse lossless for tricky values

### DIFF
--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -8,7 +8,7 @@ type LineParseResult = {
 };
 
 const KEY_VALUE_REGEXP =
-  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\r?\n?(?<notInterpolated>(.|\r\n|\n)*?)\r?\n?'|"\r?\n?(?<interpolated>(.|\r\n|\n)*?)\r?\n?"|(?<unquoted>[^\r\n#]*)) *#*.*$/gm;
+  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\r?\n?(?<notInterpolated>(.|\r\n|\n)*?)\r?\n?'|"\r?\n?(?<interpolated>(?:[^"\\]|\\[\s\S]|\r\n|\n)*?)\r?\n?"|(?<unquoted>[^\r\n#]*)) *#*.*$/gm;
 
 const VALID_KEY_REGEXP = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -19,12 +19,15 @@ const CHARACTERS_MAP: { [key: string]: string } = {
   "\\n": "\n",
   "\\r": "\r",
   "\\t": "\t",
+  '\\"': '"',
+  "\\'": "'",
+  "\\\\": "\\",
 };
 
 function expandCharacters(str: string): string {
   return str.replace(
-    /\\([nrt])/g,
-    ($1: keyof typeof CHARACTERS_MAP): string => CHARACTERS_MAP[$1] ?? "",
+    /\\[\s\S]/g,
+    (match: string): string => CHARACTERS_MAP[match] ?? match,
   );
 }
 

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -8,7 +8,7 @@ type LineParseResult = {
 };
 
 const KEY_VALUE_REGEXP =
-  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\r?\n?(?<notInterpolated>(.|\r\n|\n)*?)\r?\n?'|"\r?\n?(?<interpolated>(?:[^"\\]|\\[\s\S]|\r\n|\n)*?)\r?\n?"|(?<unquoted>[^\r\n#]*)) *#*.*$/gm;
+  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\r?\n?(?<notInterpolated>(.|\r\n|\n)*?)\r?\n?'|"\r?\n?(?<interpolated>(?:[^"\\]|\\[\s\S])*?)\r?\n?"|(?<unquoted>[^\r\n#]*)) *#*.*$/gm;
 
 const VALID_KEY_REGEXP = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -59,6 +59,8 @@ function expand(str: string, variablesMap: Record<string, string>): string {
  * Parse `.env` file output in an object.
  *
  * Note: The key needs to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.
+ * Double-quoted values expand `\n`, `\r`, `\t`, `\"`, `\'`, and `\\` escape
+ * sequences.
  *
  * @example Usage
  * ```ts

--- a/dotenv/stringify.ts
+++ b/dotenv/stringify.ts
@@ -28,9 +28,21 @@ export function stringify(object: Record<string, string>): string {
         `key starts with a '#' indicates a comment and is ignored: '${key}'`,
       );
       continue;
-    } else if (escapedValue.includes("\n") || escapedValue.includes("'")) {
-      // escape inner new lines
-      escapedValue = escapedValue.replaceAll("\n", "\\n");
+    } else if (
+      escapedValue.includes("\n") ||
+      escapedValue.includes("\r") ||
+      escapedValue.includes("\t") ||
+      escapedValue.includes("'") ||
+      escapedValue.includes("\\")
+    ) {
+      // Escape backslashes first so we don't double-escape sequences we add
+      // below (e.g. so a literal `\n` (backslash-n) is preserved distinctly
+      // from a real newline).
+      escapedValue = escapedValue
+        .replaceAll("\\", "\\\\")
+        .replaceAll("\n", "\\n")
+        .replaceAll("\r", "\\r")
+        .replaceAll("\t", "\\t");
       quote = `"`;
     } else if (escapedValue.match(/\W/)) {
       quote = "'";

--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -2,6 +2,7 @@
 
 import { assertEquals } from "@std/assert";
 import { stringify } from "./stringify.ts";
+import { parse } from "./parse.ts";
 
 Deno.test("stringify()", async (t) => {
   await t.step(
@@ -83,4 +84,72 @@ Deno.test("stringify()", async (t) => {
       stringify({ PARSE: "par'se" }),
       `PARSE="par'se"`,
     ));
+});
+
+Deno.test("stringify() round-trips through parse() for tricky values", () => {
+  // Regression for https://github.com/denoland/std/issues/7055 — values
+  // containing combinations of quotes, apostrophes, real newlines, and
+  // literal backslash-n (or other escape-like character pairs) must round-trip
+  // losslessly.
+  const trickyChars = [
+    "'",
+    '"',
+    "\\",
+    "\\n",
+    "\\r",
+    "\\t",
+    "\n",
+    "\r",
+    "\t",
+    "$",
+    "{",
+    "}",
+    " ",
+    "=",
+  ];
+
+  function combos<T>(arr: T[], k: number): T[][] {
+    if (k === 0) return [[]];
+    if (arr.length < k) return [];
+    const [first, ...rest] = arr;
+    return [
+      ...combos(rest, k - 1).map((c) => [first!, ...c]),
+      ...combos(rest, k),
+    ];
+  }
+
+  for (const k of [1, 2, 3]) {
+    for (const c of combos(trickyChars, k)) {
+      const value = `start_${c.join("")}_end`;
+      const roundTripped = parse(stringify({ TEST_VAR: value })).TEST_VAR;
+      assertEquals(
+        roundTripped,
+        value,
+        `round-trip mismatch for value ${JSON.stringify(value)}`,
+      );
+    }
+  }
+});
+
+Deno.test("stringify() round-trips JSON-encoded payloads", () => {
+  const payloads = [
+    { foo: "bar" },
+    { greeting: "hello\nworld" },
+    { quoted: `He said "hi"` },
+    { apostrophe: "don't" },
+    { mixed: `She said "don't"` },
+    { path: "C:\\Users\\test" },
+    { literal: "value with \\n inside" },
+  ];
+
+  for (const payload of payloads) {
+    const encoded = JSON.stringify(payload);
+    const roundTripped = parse(stringify({ DATA: encoded })).DATA;
+    assertEquals(
+      roundTripped,
+      encoded,
+      `JSON round-trip mismatch for ${encoded}`,
+    );
+    assertEquals(JSON.parse(roundTripped!), payload);
+  }
 });


### PR DESCRIPTION
Fixes #7055.

## Summary

Fixes `@std/dotenv`'s `stringify`/`parse` so they round-trip losslessly for values containing quotes, apostrophes, real newlines, literal `\n`/`\r`/`\t` sequences, and literal backslashes.

Previously `stringify` wrapped such values in `"..."`, escaped inner `"` and real `\n`, but did **not** escape pre-existing backslashes — so a value containing a literal `\n` (backslash + n) became indistinguishable from a real newline after parsing. The parse regex also didn't understand `\"` and would terminate the value at the first inner `"`.

Repro from the issue (verified failing on `0.225.6`):

```ts
import { parse, stringify } from "jsr:@std/dotenv@0.225.6";
const value = `start_'"_end`;
parse(stringify({ TEST_VAR: value })).TEST_VAR; // -> "start_'\\" (wrong)
```

After this fix the same call returns the original value, as do the other three cases listed in the issue.

## Changes

- **`dotenv/stringify.ts`**: in the double-quoted branch, escape backslashes first, then `\n`/`\r`/`\t`, then `"`. Trigger the double-quoted branch on `\r`/`\t`/`\\` in addition to `\n`/`'`.
- **`dotenv/parse.ts`**: update `KEY_VALUE_REGEXP` so the inner alternation for `"..."` values is `(?:[^"\\]|\\[\s\S]|\r\n|\n)*?`, allowing `\"` (and other `\X`) to appear inside without terminating the value. Extend `expandCharacters` to decode `\\`, `\"`, `\'` (unknown `\X` escapes are preserved verbatim for backward compatibility).
- **`dotenv/stringify_test.ts`**: add a property-style round-trip test that exhausts combinations of tricky characters (matching the reproduction in the source issue), plus a JSON-payload round-trip test.

## Behaviour notes

- Hand-written `.env` files that contain `\\` inside double-quoted values will now decode `\\` → `\` (the conventional dotenv behaviour). Previously `\\` was passed through as two characters. Files that wrote literal backslashes in single quotes or unquoted are unaffected.
- Unknown `\X` escapes in double-quoted values remain as `\X` (e.g. `"C:\Users"` still parses to `C:\Users`).

## Test plan

- [x] `deno fmt --check`
- [x] `deno lint dotenv/`
- [x] `deno test -A --doc dotenv/` (23 tests pass, including new round-trip property tests)