### PR TITLE
fix(yaml): quote leading-zero numeric strings

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -173,6 +173,10 @@ function needIndentIndicator(string: string): boolean {
   return LEADING_SPACE_REGEXP.test(string);
 }
 
+function isAmbiguousLeadingZeroNumber(string: string): boolean {
+  return /^-?0\d+$/.test(string);
+}
+
 // Determines which scalar styles are possible and returns the preferred style.
 // lineWidth = -1 => no limit.
 // Pre-conditions: str.length > 0.
@@ -238,7 +242,8 @@ function chooseScalarStyle(
   if (!hasLineBreak && !hasFoldableLine) {
     // Strings interpretable as another type have to be quoted;
     // e.g. the string 'true' vs. the boolean true.
-    return plain && !implicitTypes.some((type) => type.resolve(string))
+    return plain && !isAmbiguousLeadingZeroNumber(string) &&
+        !implicitTypes.some((type) => type.resolve(string))
       ? STYLE_PLAIN
       : quoteStyle === "'"
       ? STYLE_SINGLE

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -70,6 +70,18 @@ Deno.test({
 });
 
 Deno.test({
+  name: "stringify() quotes leading-zero numeric strings",
+  fn() {
+    assertEquals(stringify("00"), "'00'\n");
+    assertEquals(stringify("07"), "'07'\n");
+    assertEquals(stringify("08"), "'08'\n");
+    assertEquals(stringify("09"), "'09'\n");
+    assertEquals(stringify("010"), "'010'\n");
+    assertEquals(stringify("-08"), "'-08'\n");
+  },
+});
+
+Deno.test({
   name: "numbers can be stringified directly",
   fn() {
     const number = 1.01;


### PR DESCRIPTION
## Summary

- Quote leading-zero numeric-looking strings in YAML stringify output so values like `08` and `09` are not emitted as plain scalars.
- Add regression coverage for `00`, `07`, `08`, `09`, `010`, and `-08`.

Closes bartlomieju/orchid-inbox#73

## Testing

- `deno fmt --check`
- `deno lint` (passed with existing workspace-member warning for `@std/crypto`)
- `deno test yaml/stringify_test.ts`
- `deno test -A --trace-leaks --coverage --doc --clean yaml`

`deno task test` was attempted, but the VM killed the process with exit 137 during the parallel full suite before any failure was reported. A full non-parallel equivalent was also attempted and stopped at the VM level before reporting a test failure.