### PR TITLE
test(dotenv): cover reported quote newline round trips

### DIFF
--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -87,7 +87,7 @@ Deno.test("stringify()", async (t) => {
 });
 
 Deno.test("stringify() round-trips through parse() for tricky values", () => {
-  // Regression for https://github.com/denoland/std/issues/7055 — values
+  // Regression for https://github.com/denoland/std/issues/7055. Values
   // containing combinations of quotes, apostrophes, real newlines, and
   // literal backslash-n (or other escape-like character pairs) must round-trip
   // losslessly.
@@ -128,6 +128,19 @@ Deno.test("stringify() round-trips through parse() for tricky values", () => {
         `round-trip mismatch for value ${JSON.stringify(value)}`,
       );
     }
+  }
+});
+
+Deno.test("stringify() round-trips reported quote and newline combinations", () => {
+  const values = [
+    `start_'"_end`,
+    "start_'\\n_end",
+    'start_"\n_end',
+    "start_\\n\n_end",
+  ];
+
+  for (const value of values) {
+    assertEquals(parse(stringify({ TEST_VAR: value })).TEST_VAR, value);
   }
 });
 


### PR DESCRIPTION
Closes bartlomieju/orchid-inbox#69

## Summary
- add explicit regression coverage for the four reported dotenv stringify/parse round-trip failures
- keep the broader tricky-character round-trip test and clean up its issue reference wording

## Testing
- deno fmt --check
- deno lint
- deno test --allow-read --allow-env dotenv/stringify_test.ts dotenv/parse_test.ts
- deno test -A --parallel --trace-leaks --coverage --doc --clean dotenv
- deno task test, failed in unrelated suites in this VM: ANSI color expectations under fmt/internal/cli despite NO_COLOR=1, fs walk regex counts, and a CBOR test allocating more than 4 GiB
