### PR TITLE
docs(text/unstable): fix typeof->linkcode typo in SlugifyOptions jsdoc

### DIFF
--- a/text/unstable_slugify.ts
+++ b/text/unstable_slugify.ts
@@ -7,7 +7,7 @@ const wordSegmenter = new Intl.Segmenter("en-US", { granularity: "word" });
 export type SlugifyOptions = {
   /**
    * The regular expression to use for stripping characters.
-   * @default {typeof NON_WORD}
+   * @default {@linkcode NON_WORD_REGEXP}
    */
   strip: RegExp;
   /**


### PR DESCRIPTION
`@default` should be a value, not a type.