### PR TITLE
fix(cbor): accept `readonly` input data in encoders

### DIFF
--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -1,7 +1,14 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { CborTag } from "./tag.ts";
-import type { CborType } from "./types.ts";
+import type { CborInputType } from "./types.ts";
+
+// Narrows to ReadonlyMap (which TS's instanceof Map doesn't do on its own).
+function isReadonlyMap(
+  x: unknown,
+): x is ReadonlyMap<CborInputType, CborInputType> {
+  return x instanceof Map;
+}
 
 function calcBytes(x: bigint): number {
   let bytes = 0;
@@ -20,7 +27,7 @@ function calcHeaderSize(x: number | bigint): number {
   return 9;
 }
 
-export function calcEncodingSize(x: CborType): number {
+export function calcEncodingSize(x: CborInputType): number {
   if (x == undefined || typeof x === "boolean") return 1;
   if (typeof x === "number") {
     return x % 1 === 0 ? calcHeaderSize(x < 0 ? -x - 1 : x) : 9;
@@ -46,7 +53,7 @@ export function calcEncodingSize(x: CborType): number {
     for (const y of x) size += calcEncodingSize(y);
     return size;
   }
-  if (x instanceof Map) {
+  if (isReadonlyMap(x)) {
     let size = 3 + calcHeaderSize(x.size);
     for (const y of x) size += calcEncodingSize(y[0]) + calcEncodingSize(y[1]);
     return size;
@@ -61,7 +68,7 @@ export function calcEncodingSize(x: CborType): number {
 }
 
 export function encode(
-  input: CborType,
+  input: CborInputType,
   output: Uint8Array,
   offset: number,
 ): number {
@@ -86,8 +93,9 @@ export function encode(
         return encodeDate(input, output, offset);
       } else if (input instanceof CborTag) {
         return encodeTag(input, output, offset);
-      } else if (input instanceof Map) return encodeMap(input, output, offset);
-      else if (input instanceof Array) {
+      } else if (isReadonlyMap(input)) {
+        return encodeMap(input, output, offset);
+      } else if (input instanceof Array) {
         return encodeArray(input, output, offset);
       } else return encodeObject(input, output, offset);
   }
@@ -202,7 +210,7 @@ function encodeString(
 }
 
 function encodeArray(
-  input: CborType[],
+  input: readonly CborInputType[],
   output: Uint8Array,
   offset: number,
 ): number {
@@ -212,7 +220,7 @@ function encodeArray(
 }
 
 function encodeObject(
-  input: { [k: string]: CborType },
+  input: { readonly [k: string]: CborInputType },
   output: Uint8Array,
   offset: number,
 ): number {
@@ -231,7 +239,7 @@ function encodeDate(input: Date, output: Uint8Array, offset: number): number {
 }
 
 function encodeTag(
-  input: CborTag<CborType>,
+  input: CborTag<CborInputType>,
   output: Uint8Array,
   offset: number,
 ): number {
@@ -255,7 +263,7 @@ function encodeTag(
 }
 
 function encodeMap(
-  input: Map<CborType, CborType>,
+  input: ReadonlyMap<CborInputType, CborInputType>,
   output: Uint8Array,
   offset: number,
 ): number {

--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { CborTag } from "./tag.ts";
-import type { CborInputType } from "./types.ts";
+import type { ReadonlyCborType } from "./types.ts";
 
 // Narrows to ReadonlyMap (which TS's instanceof Map doesn't do on its own).
 function isReadonlyMap(
   x: unknown,
-): x is ReadonlyMap<CborInputType, CborInputType> {
+): x is ReadonlyMap<ReadonlyCborType, ReadonlyCborType> {
   return x instanceof Map;
 }
 
@@ -27,7 +27,7 @@ function calcHeaderSize(x: number | bigint): number {
   return 9;
 }
 
-export function calcEncodingSize(x: CborInputType): number {
+export function calcEncodingSize(x: ReadonlyCborType): number {
   if (x == undefined || typeof x === "boolean") return 1;
   if (typeof x === "number") {
     return x % 1 === 0 ? calcHeaderSize(x < 0 ? -x - 1 : x) : 9;
@@ -68,7 +68,7 @@ export function calcEncodingSize(x: CborInputType): number {
 }
 
 export function encode(
-  input: CborInputType,
+  input: ReadonlyCborType,
   output: Uint8Array,
   offset: number,
 ): number {
@@ -210,7 +210,7 @@ function encodeString(
 }
 
 function encodeArray(
-  input: readonly CborInputType[],
+  input: readonly ReadonlyCborType[],
   output: Uint8Array,
   offset: number,
 ): number {
@@ -220,7 +220,7 @@ function encodeArray(
 }
 
 function encodeObject(
-  input: { readonly [k: string]: CborInputType },
+  input: { readonly [k: string]: ReadonlyCborType },
   output: Uint8Array,
   offset: number,
 ): number {
@@ -239,7 +239,7 @@ function encodeDate(input: Date, output: Uint8Array, offset: number): number {
 }
 
 function encodeTag(
-  input: CborTag<CborInputType>,
+  input: CborTag<ReadonlyCborType>,
   output: Uint8Array,
   offset: number,
 ): number {
@@ -263,7 +263,7 @@ function encodeTag(
 }
 
 function encodeMap(
-  input: ReadonlyMap<CborInputType, CborInputType>,
+  input: ReadonlyMap<ReadonlyCborType, ReadonlyCborType>,
   output: Uint8Array,
   offset: number,
 ): number {

--- a/cbor/encode_cbor.ts
+++ b/cbor/encode_cbor.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { calcEncodingSize, encode } from "./_common_encode.ts";
-import type { CborInputType } from "./types.ts";
+import type { CborType, ReadonlyCborType } from "./types.ts";
 
 /**
- * Encodes a {@link CborInputType} value into a CBOR format represented as a
- * {@link Uint8Array}.
+ * Encodes a {@link CborType} or {@link ReadonlyCborType} value into a CBOR
+ * format represented as a {@link Uint8Array}.
  * [RFC 8949 - Concise Binary Object Representation (CBOR)](https://datatracker.ietf.org/doc/html/rfc8949)
  *
  * @example Usage
@@ -32,10 +32,11 @@ import type { CborInputType } from "./types.ts";
  * assertEquals(decodedMessage, rawMessage);
  * ```
  *
- * @param value The value to encode of type {@link CborInputType}.
+ * @param value The value to encode of type {@link CborType} or
+ *              {@link ReadonlyCborType}.
  * @returns A {@link Uint8Array} representing the encoded data.
  */
-export function encodeCbor(value: CborInputType): Uint8Array {
+export function encodeCbor(value: CborType | ReadonlyCborType): Uint8Array {
   const output = new Uint8Array(calcEncodingSize(value));
   const o = encode(value, output, 0);
   if (o !== output.length) return output.subarray(0, o);

--- a/cbor/encode_cbor.ts
+++ b/cbor/encode_cbor.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { calcEncodingSize, encode } from "./_common_encode.ts";
-import type { CborType } from "./types.ts";
+import type { CborInputType } from "./types.ts";
 
 /**
- * Encodes a {@link CborType} value into a CBOR format represented as a
+ * Encodes a {@link CborInputType} value into a CBOR format represented as a
  * {@link Uint8Array}.
  * [RFC 8949 - Concise Binary Object Representation (CBOR)](https://datatracker.ietf.org/doc/html/rfc8949)
  *
@@ -32,10 +32,10 @@ import type { CborType } from "./types.ts";
  * assertEquals(decodedMessage, rawMessage);
  * ```
  *
- * @param value The value to encode of type {@link CborType}.
+ * @param value The value to encode of type {@link CborInputType}.
  * @returns A {@link Uint8Array} representing the encoded data.
  */
-export function encodeCbor(value: CborType): Uint8Array {
+export function encodeCbor(value: CborInputType): Uint8Array {
   const output = new Uint8Array(calcEncodingSize(value));
   const o = encode(value, output, 0);
   if (o !== output.length) return output.subarray(0, o);

--- a/cbor/encode_cbor_sequence.ts
+++ b/cbor/encode_cbor_sequence.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { calcEncodingSize, encode } from "./_common_encode.ts";
-import type { CborType } from "./types.ts";
+import type { CborInputType } from "./types.ts";
 
 /**
- * Encodes an array of {@link CborType} values into a CBOR format sequence
- * represented as a {@link Uint8Array}.
+ * Encodes an array of {@link CborInputType} values into a CBOR format
+ * sequence represented as a {@link Uint8Array}.
  * [RFC 8949 - Concise Binary Object Representation (CBOR)](https://datatracker.ietf.org/doc/html/rfc8949)
  *
  * @example Usage
@@ -31,10 +31,12 @@ import type { CborType } from "./types.ts";
  * assertEquals(decodedMessage, rawMessage);
  * ```
  *
- * @param values An array of values to encode of type {@link CborType}
+ * @param values An array of values to encode of type {@link CborInputType}
  * @returns A {@link Uint8Array} representing the encoded data.
  */
-export function encodeCborSequence(values: CborType[]): Uint8Array {
+export function encodeCborSequence(
+  values: readonly CborInputType[],
+): Uint8Array {
   let o = 0;
   for (const value of values) o += calcEncodingSize(value);
   const output = new Uint8Array(o);

--- a/cbor/encode_cbor_sequence.ts
+++ b/cbor/encode_cbor_sequence.ts
@@ -1,11 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { calcEncodingSize, encode } from "./_common_encode.ts";
-import type { CborInputType } from "./types.ts";
+import type { CborType, ReadonlyCborType } from "./types.ts";
 
 /**
- * Encodes an array of {@link CborInputType} values into a CBOR format
- * sequence represented as a {@link Uint8Array}.
+ * Encodes an array of {@link CborType} or {@link ReadonlyCborType} values
+ * into a CBOR format sequence represented as a {@link Uint8Array}.
  * [RFC 8949 - Concise Binary Object Representation (CBOR)](https://datatracker.ietf.org/doc/html/rfc8949)
  *
  * @example Usage
@@ -31,11 +31,12 @@ import type { CborInputType } from "./types.ts";
  * assertEquals(decodedMessage, rawMessage);
  * ```
  *
- * @param values An array of values to encode of type {@link CborInputType}
+ * @param values An array of values to encode, each of type {@link CborType}
+ *               or {@link ReadonlyCborType}.
  * @returns A {@link Uint8Array} representing the encoded data.
  */
 export function encodeCborSequence(
-  values: readonly CborInputType[],
+  values: readonly (CborType | ReadonlyCborType)[],
 ): Uint8Array {
   let o = 0;
   for (const value of values) o += calcEncodingSize(value);

--- a/cbor/encode_cbor_sequence_test.ts
+++ b/cbor/encode_cbor_sequence_test.ts
@@ -2,10 +2,21 @@
 
 import { assertEquals } from "@std/assert";
 import { encodeCborSequence } from "./encode_cbor_sequence.ts";
+import type { CborType } from "./types.ts";
 
 Deno.test("encodeCborSequence() correctly encoding", () => {
   assertEquals(
     encodeCborSequence([0, 0]),
     Uint8Array.from([0b000_00000, 0b000_00000]),
+  );
+});
+
+Deno.test("encodeCborSequence() accepting readonly array input", () => {
+  const values = [1, "two", { three: 3n }] as const;
+  const mutable: CborType[] = [1, "two", { three: 3n }];
+  // `readonly CborInputType[]` is now an accepted input.
+  assertEquals(
+    encodeCborSequence(values),
+    encodeCborSequence(mutable),
   );
 });

--- a/cbor/encode_cbor_sequence_test.ts
+++ b/cbor/encode_cbor_sequence_test.ts
@@ -14,7 +14,6 @@ Deno.test("encodeCborSequence() correctly encoding", () => {
 Deno.test("encodeCborSequence() accepting readonly array input", () => {
   const values = [1, "two", { three: 3n }] as const;
   const mutable: CborType[] = [1, "two", { three: 3n }];
-  // `readonly CborInputType[]` is now an accepted input.
   assertEquals(
     encodeCborSequence(values),
     encodeCborSequence(mutable),

--- a/cbor/encode_cbor_test.ts
+++ b/cbor/encode_cbor_test.ts
@@ -500,9 +500,6 @@ Deno.test("encodeCbor() rejecting CborTag()", () => {
 });
 
 Deno.test("encodeCbor() accepting `as const` (deeply readonly) input", () => {
-  // Regression test for #5831. Before, this call failed type-checking
-  // (`readonly` properties weren't assignable to `CborType`). The encoded
-  // bytes are identical to the mutable equivalent.
   const data = {
     a: 1,
     b: { c: 2n },
@@ -514,7 +511,6 @@ Deno.test("encodeCbor() accepting `as const` (deeply readonly) input", () => {
 
 Deno.test("encodeCbor() accepting readonly array literals", () => {
   const tuple = ["hello", 42, { nested: "value" }] as const;
-  // `readonly [3, ...]` is now assignable to the encoder input type.
   assertEquals(
     encodeCbor(tuple),
     encodeCbor(["hello", 42, { nested: "value" }]),
@@ -528,7 +524,6 @@ Deno.test("encodeCbor() accepting ReadonlyMap input", () => {
     [[5], { a: 6 }],
   ]);
 
-  // `ReadonlyMap<...>` is now assignable to the encoder input type.
   assertEquals(
     encodeCbor(map),
     encodeCbor(
@@ -548,7 +543,6 @@ Deno.test("encodeCbor() accepting readonly index signature", () => {
 
 Deno.test("encodeCbor() accepting CborTag with readonly content", () => {
   const data = [1, { inner: 2 }] as const;
-  // The tag content type widens to accept `CborInputType`.
   assertEquals(
     encodeCbor(new CborTag(1, data)),
     encodeCbor(new CborTag(1, structuredClone(data))),

--- a/cbor/encode_cbor_test.ts
+++ b/cbor/encode_cbor_test.ts
@@ -498,3 +498,59 @@ Deno.test("encodeCbor() rejecting CborTag()", () => {
     `Cannot encode Tag Item: Tag Number (${num}) exceeds 2 ** 64 - 1`,
   );
 });
+
+Deno.test("encodeCbor() accepting `as const` (deeply readonly) input", () => {
+  // Regression test for #5831. Before, this call failed type-checking
+  // (`readonly` properties weren't assignable to `CborType`). The encoded
+  // bytes are identical to the mutable equivalent.
+  const data = {
+    a: 1,
+    b: { c: 2n },
+    d: [3, { e: 4 }],
+  } as const;
+
+  assertEquals(encodeCbor(data), encodeCbor(structuredClone(data)));
+});
+
+Deno.test("encodeCbor() accepting readonly array literals", () => {
+  const tuple = ["hello", 42, { nested: "value" }] as const;
+  // `readonly [3, ...]` is now assignable to the encoder input type.
+  assertEquals(
+    encodeCbor(tuple),
+    encodeCbor(["hello", 42, { nested: "value" }]),
+  );
+});
+
+Deno.test("encodeCbor() accepting ReadonlyMap input", () => {
+  const map: ReadonlyMap<CborType, CborType> = new Map<CborType, CborType>([
+    [1, 2],
+    ["3", 4],
+    [[5], { a: 6 }],
+  ]);
+
+  // `ReadonlyMap<...>` is now assignable to the encoder input type.
+  assertEquals(
+    encodeCbor(map),
+    encodeCbor(
+      new Map<CborType, CborType>([
+        [1, 2],
+        ["3", 4],
+        [[5], { a: 6 }],
+      ]),
+    ),
+  );
+});
+
+Deno.test("encodeCbor() accepting readonly index signature", () => {
+  const obj: { readonly [k: string]: number } = { x: 1, y: 2, z: 3 };
+  assertEquals(encodeCbor(obj), encodeCbor({ x: 1, y: 2, z: 3 }));
+});
+
+Deno.test("encodeCbor() accepting CborTag with readonly content", () => {
+  const data = [1, { inner: 2 }] as const;
+  // The tag content type widens to accept `CborInputType`.
+  assertEquals(
+    encodeCbor(new CborTag(1, data)),
+    encodeCbor(new CborTag(1, structuredClone(data))),
+  );
+});

--- a/cbor/sequence_encoder_stream.ts
+++ b/cbor/sequence_encoder_stream.ts
@@ -145,7 +145,9 @@ export class CborSequenceEncoderStream
     } else yield encodeCbor(x);
   }
 
-  async *#encodeArray(x: CborStreamInput[]): AsyncGenerator<Uint8Array> {
+  async *#encodeArray(
+    x: readonly CborStreamInput[],
+  ): AsyncGenerator<Uint8Array> {
     if (x.length < 24) yield new Uint8Array([0b100_00000 + x.length]);
     else if (x.length < 2 ** 8) yield new Uint8Array([0b100_11000, x.length]);
     else if (x.length < 2 ** 16) {
@@ -162,7 +164,7 @@ export class CborSequenceEncoderStream
   }
 
   async *#encodeObject(
-    x: { [k: string]: CborStreamInput },
+    x: { readonly [k: string]: CborStreamInput },
   ): AsyncGenerator<Uint8Array> {
     const len = Object.keys(x).length;
     if (len < 24) yield new Uint8Array([0b101_00000 + len]);

--- a/cbor/tag.ts
+++ b/cbor/tag.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import type {
-  CborInputType,
   CborStreamInput,
   CborStreamOutput,
   CborType,
+  ReadonlyCborType,
 } from "./types.ts";
 
 /**
@@ -35,11 +35,11 @@ import type {
  * ```
  *
  * @typeParam T The type of the tag's content, which can be a
- * {@link CborType}, {@link CborInputType}, {@link CborStreamInput}, or
+ * {@link CborType}, {@link ReadonlyCborType}, {@link CborStreamInput}, or
  * {@link CborStreamOutput}.
  */
 export class CborTag<
-  T extends CborType | CborInputType | CborStreamInput | CborStreamOutput,
+  T extends CborType | ReadonlyCborType | CborStreamInput | CborStreamOutput,
 > {
   /**
    * A {@link number} or {@link bigint} representing the CBOR tag number, used

--- a/cbor/tag.ts
+++ b/cbor/tag.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import type { CborStreamInput, CborStreamOutput, CborType } from "./types.ts";
+import type {
+  CborInputType,
+  CborStreamInput,
+  CborStreamOutput,
+  CborType,
+} from "./types.ts";
 
 /**
  * Represents a CBOR tag, which pairs a tag number with content, used to convey
@@ -30,9 +35,12 @@ import type { CborStreamInput, CborStreamOutput, CborType } from "./types.ts";
  * ```
  *
  * @typeParam T The type of the tag's content, which can be a
- * {@link CborType}, {@link CborStreamInput}, or {@link CborStreamOutput}.
+ * {@link CborType}, {@link CborInputType}, {@link CborStreamInput}, or
+ * {@link CborStreamOutput}.
  */
-export class CborTag<T extends CborType | CborStreamInput | CborStreamOutput> {
+export class CborTag<
+  T extends CborType | CborInputType | CborStreamInput | CborStreamOutput,
+> {
   /**
    * A {@link number} or {@link bigint} representing the CBOR tag number, used
    * to identify the type of the tagged content.

--- a/cbor/types.ts
+++ b/cbor/types.ts
@@ -28,6 +28,9 @@ export type CborPrimitiveType =
  * This type specifies the encodable and decodable values for
  * {@link encodeCbor}, {@link decodeCbor}, {@link encodeCborSequence}, and
  * {@link decodeCborSequence}.
+ *
+ * The encoder functions also accept {@link CborInputType}, which permits
+ * `readonly` arrays, `ReadonlyMap`, and `readonly` index signatures.
  */
 export type CborType =
   | CborPrimitiveType
@@ -39,14 +42,44 @@ export type CborType =
   };
 
 /**
+ * Readonly-friendly input type for {@link encodeCbor} and
+ * {@link encodeCborSequence}. Lets you pass `as const` literals,
+ * `ReadonlyMap`s, and frozen arrays without casting.
+ *
+ * @example Usage
+ * ```ts
+ * import { encodeCbor } from "@std/cbor";
+ *
+ * const data = {
+ *   a: 1,
+ *   b: { c: 2n },
+ *   d: [3, { e: 4 }],
+ * } as const;
+ *
+ * encodeCbor(data);
+ * ```
+ */
+export type CborInputType =
+  | CborPrimitiveType
+  | CborTag<CborInputType>
+  | ReadonlyMap<CborInputType, CborInputType>
+  | readonly CborInputType[]
+  | {
+    readonly [k: string]: CborInputType;
+  };
+
+/**
  * Specifies the encodable value types for the {@link CborSequenceEncoderStream}
  * and {@link CborArrayEncoderStream}.
+ *
+ * Arrays and index signatures are `readonly` so `as const` literals work
+ * without casting.
  */
 export type CborStreamInput =
   | CborPrimitiveType
   | CborTag<CborStreamInput>
-  | CborStreamInput[]
-  | { [k: string]: CborStreamInput }
+  | readonly CborStreamInput[]
+  | { readonly [k: string]: CborStreamInput }
   | CborByteEncoderStream
   | CborTextEncoderStream
   | CborArrayEncoderStream

--- a/cbor/types.ts
+++ b/cbor/types.ts
@@ -59,6 +59,13 @@ export type CborType =
  * encodeCbor(data);
  * ```
  */
+// Note: encoder signatures take `CborType | ReadonlyCborType` rather than
+// just `ReadonlyCborType`. Mutable `Map`/array/index-signature are all
+// assignable to their readonly counterparts, so the union looks redundant,
+// but `CborTag<T>` has a writable `tagContent: T` field, which makes it
+// invariant in `T`. That means `CborTag<CborType>` is NOT assignable to
+// `CborTag<ReadonlyCborType>`, and existing callers passing
+// `CborTag<CborType>` instances would break if the union were collapsed.
 export type ReadonlyCborType =
   | CborPrimitiveType
   | CborTag<ReadonlyCborType>

--- a/cbor/types.ts
+++ b/cbor/types.ts
@@ -29,7 +29,7 @@ export type CborPrimitiveType =
  * {@link encodeCbor}, {@link decodeCbor}, {@link encodeCborSequence}, and
  * {@link decodeCborSequence}.
  *
- * The encoder functions also accept {@link CborInputType}, which permits
+ * The encoder functions also accept {@link ReadonlyCborType}, which permits
  * `readonly` arrays, `ReadonlyMap`, and `readonly` index signatures.
  */
 export type CborType =
@@ -42,7 +42,7 @@ export type CborType =
   };
 
 /**
- * Readonly-friendly input type for {@link encodeCbor} and
+ * Readonly variant of {@link CborType} accepted by {@link encodeCbor} and
  * {@link encodeCborSequence}. Lets you pass `as const` literals,
  * `ReadonlyMap`s, and frozen arrays without casting.
  *
@@ -59,13 +59,13 @@ export type CborType =
  * encodeCbor(data);
  * ```
  */
-export type CborInputType =
+export type ReadonlyCborType =
   | CborPrimitiveType
-  | CborTag<CborInputType>
-  | ReadonlyMap<CborInputType, CborInputType>
-  | readonly CborInputType[]
+  | CborTag<ReadonlyCborType>
+  | ReadonlyMap<ReadonlyCborType, ReadonlyCborType>
+  | readonly ReadonlyCborType[]
   | {
-    readonly [k: string]: CborInputType;
+    readonly [k: string]: ReadonlyCborType;
   };
 
 /**


### PR DESCRIPTION
Closes #5831 for the `@std/cbor` module. Same shape as the `@std/msgpack` fix in #5832.

The encoder functions and the encoder streams never mutate their inputs, but the existing `CborType` requires `CborType[]`, `Map<CborType, CborType>`, and a mutable `{ [k: string]: CborType }` index signature. That means you can't pass an `as const` literal, a `ReadonlyMap`, or a `readonly T[]` to `encodeCbor` without a cast, even though the runtime behavior is identical. Repro from the issue:

```ts
import { encodeCbor } from "jsr:@std/cbor";

const data = {
  a: 1,
  b: { c: 2n },
  d: [3, { e: 4 }],
} as const;

encodeCbor(data); // TS2345 before this PR
```

I added a separate input-only type `ReadonlyCborType` instead of changing `CborType` in place, because `CborType` is also the decoder output (`decodeCbor` returns `CborType`) and changing it in place would be a breaking change for consumers that mutate decoded values. `ReadonlyCborType` mirrors `CborType` but with `readonly ReadonlyCborType[]`, `ReadonlyMap<ReadonlyCborType, ReadonlyCborType>`, and `{ readonly [k: string]: ReadonlyCborType }`. Encoders accept `ReadonlyCborType`; decoders still return `CborType`. `CborStreamInput` is input-only, so I widened it in place rather than adding a second type.

`CborTag<T>`'s constraint widens from `T extends CborType | CborStreamInput | CborStreamOutput` to also accept `ReadonlyCborType` so `new CborTag(1, readonlyValue)` type-checks. This widens the constraint, doesn't narrow it, so existing instantiations stay valid.

In `_common_encode.ts`, `x instanceof Map` doesn't narrow `ReadonlyMap` on its own (TS treats them as separate types), so there's a small `isReadonlyMap` predicate. The `#encodeArray` and `#encodeObject` stream helpers widen to accept readonly variants.

Existing callers passing mutable `CborType` keep working because mutable subtypes assign to readonly supertypes.

Regression tests in `encode_cbor_test.ts` cover deeply-readonly `as const` literals (exact repro from #5831), readonly tuples, `ReadonlyMap` input, readonly index signatures, and a `CborTag` with readonly content. `encode_cbor_sequence_test.ts` covers a readonly array of values.

Ran locally: `deno check cbor/`, `deno lint cbor/`, `deno fmt --check cbor/` all clean. `deno test --allow-all cbor/` shows 89 passed, 0 failed.