### PR TITLE
fix(encoding): `encodeVarint()` throws when value or buffer overflows

### DIFF
--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -227,9 +227,14 @@ export function encodeVarint(
       `Cannot encode the input into varint as it should be non-negative integer: received ${num}`,
     );
   }
+  if (num > MaxUint64) {
+    throw new RangeError(
+      `Cannot encode the input ${num} into varint as it overflows uint64`,
+    );
+  }
   for (
     let i = offset;
-    i <= Math.min(buf.length, MaxVarintLen64);
+    i < buf.length;
     i += 1
   ) {
     if (num < MSBN) {
@@ -241,6 +246,6 @@ export function encodeVarint(
     num >>= SHIFTN;
   }
   throw new RangeError(
-    `Cannot encode the input ${num} into varint as it overflows uint64`,
+    "Cannot encode the input into varint: the provided buffer is too small",
   );
 }

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -113,6 +113,23 @@ Deno.test("encodeVarint() handles manual", () => {
 Deno.test("encodeVarint() throws on overflow uint64", () => {
   assertThrows(() => encodeVarint(1e+30), RangeError, "overflows uint64");
 });
+Deno.test("encodeVarint() throws on overflow uint64 with default buffer", () => {
+  // 0x1234567891234567891n is 73 bits, exceeds MaxUint64 (2^64 - 1).
+  // The default 10-byte buffer must not silently truncate the encoding.
+  assertThrows(
+    () => encodeVarint(0x1234567891234567891n),
+    RangeError,
+    "overflows uint64",
+  );
+});
+Deno.test("encodeVarint() throws when the buffer is too small", () => {
+  // MaxUint64 needs 10 bytes to encode; a 5-byte buffer is too small.
+  assertThrows(
+    () => encodeVarint(MaxUint64, new Uint8Array(5)),
+    RangeError,
+    "the provided buffer is too small",
+  );
+});
 Deno.test("encodeVarint() throws on overflow with negative", () => {
   assertThrows(
     () => encodeVarint(-1),


### PR DESCRIPTION
Fixes #7147.

`encodeVarint()` silently truncated when the input exceeded uint64 with the default 10-byte buffer. The loop bound `i <= Math.min(buf.length, MaxVarintLen64)` allowed an out-of-bounds write that `Uint8Array` silently dropped, and the final `num < MSBN` branch returned a tuple whose array length and reported offset disagreed:

```ts
encodeVarint(0x1234567891234567891n);
// [Uint8Array(10) [...10 bytes...], 11]   <- offset says 11 but array is 10
```

The fix adds an explicit `num > MaxUint64` check before the loop and tightens the loop bound to `i < buf.length`. The trailing throw now reports the specific failure mode (buffer too small), since uint64 overflow is caught upfront. Two regression tests cover both branches: a uint64-overflow input on the default buffer, and a valid uint64 value on a buffer that's too small.