### PR TITLE
fix(csv): function parse option fieldsPerRecord when negative records may have less fields

### DIFF
--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -228,16 +228,26 @@ export function convertRowToObject(
   row: readonly string[],
   headers: readonly string[],
   zeroBasedLine: number,
+  /* allow less fields in a row than headers */
+  allowLessRowFields = false,
 ) {
-  if (row.length !== headers.length) {
+  if (!allowLessRowFields && row.length !== headers.length) {
     throw new Error(
       `Syntax error on line ${
         zeroBasedLine + 1
       }: The record has ${row.length} fields, but the header has ${headers.length} fields`,
     );
   }
+  if (allowLessRowFields && row.length > headers.length) {
+    throw new Error(
+      `Syntax error on line ${
+        zeroBasedLine + 1
+      }: The record has ${row.length} fields, but the header allows maximum ${headers.length} fields`,
+    );
+  }
   const out: Record<string, unknown> = {};
   for (const [index, header] of headers.entries()) {
+    if (index === row.length) break;
     out[header] = row[index];
   }
   return out;

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -524,7 +524,12 @@ export function parse<const T extends ParseOptions>(
 
     const zeroBasedFirstLineIndex = options.skipFirstRow ? 1 : 0;
     return r.map((row, i) => {
-      return convertRowToObject(row, headers, zeroBasedFirstLineIndex + i);
+      return convertRowToObject(
+        row,
+        headers,
+        zeroBasedFirstLineIndex + i,
+        (options?.fieldsPerRecord ?? 0) < 0,
+      );
     }) as ParseResult<ParseOptions, T>;
   }
   return r as ParseResult<ParseOptions, T>;

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -309,6 +309,29 @@ Deno.test({
         );
       },
     });
+
+    await t.step({
+      name: "Allow less row fields than columns",
+      fn() {
+        const input = "a,b,c\nd,e";
+        const output = [{
+          foo: "a",
+          bar: "b",
+          baz: "c",
+        }, {
+          foo: "d",
+          bar: "e",
+        }];
+        assertEquals(
+          parse(input, {
+            skipFirstRow: false,
+            columns: ["foo", "bar", "baz"],
+            fieldsPerRecord: -1,
+          }),
+          output,
+        );
+      },
+    });
     await t.step({
       name: "NegativeFieldsPerRecord",
       fn() {
@@ -318,6 +341,19 @@ Deno.test({
           ["d", "e"],
         ];
         assertEquals(parse(input, { fieldsPerRecord: -1 }), output);
+      },
+    });
+    await t.step({
+      name: "LessFieldsPerRecordThanFirstLine",
+      fn() {
+        const input = `a,b,c\nd,e`;
+        const output = [
+          { a: "d", "b": "e" },
+        ];
+        assertEquals(
+          parse(input, { skipFirstRow: true, fieldsPerRecord: -1 }),
+          output,
+        );
       },
     });
     await t.step({
@@ -857,6 +893,22 @@ c"d,e`;
             }),
           Error,
           "Syntax error on line 2: The record has 4 fields, but the header has 3 fields",
+        );
+      },
+    });
+    await t.step({
+      name: "mismatching number of headers and fields 3",
+      fn() {
+        const input = "a,b,c\nd,e,,g";
+        assertThrows(
+          () =>
+            parse(input, {
+              skipFirstRow: true,
+              columns: ["foo", "bar", "baz"],
+              fieldsPerRecord: -1,
+            }),
+          Error,
+          "Syntax error on line 2: The record has 4 fields, but the header allows maximum 3 fields",
         );
       },
     });


### PR DESCRIPTION
# problem
When invoked for object (not array) return, csv/parse function not work with [fieldsPerRecord](https://jsr.io/@std/csv/doc/~/ParseOptions), which states `If negative, no check is made and records may have a variable number of fields.`
It throws error instead like `The record has 5 fields, but the header has 6 fields`

# fix
Make it allow row to have less fields than header has. (see small commit's test change)
(It still does not allow more fields in row than header, as it is not clear what to do in the case)

I believe https://github.com/denoland/std/pull/7141 is the better solution (dropping extra fields in the row than header)