### PR TITLE
fix(http/unstable): use relative import for unstable_structured_fields

### DIFF
--- a/http/unstable_message_signatures.ts
+++ b/http/unstable_message_signatures.ts
@@ -61,7 +61,7 @@ import type {
   Dictionary,
   InnerList,
   Item,
-} from "@std/http/unstable-structured-fields";
+} from "./unstable_structured_fields.ts";
 import {
   binary,
   innerList as sfInnerList,
@@ -76,7 +76,7 @@ import {
   serializeItem,
   serializeList,
   string as sfString,
-} from "@std/http/unstable-structured-fields";
+} from "./unstable_structured_fields.ts";
 
 const UTF8_ENCODER = new TextEncoder();
 const SF_KEY_REGEXP = /^[a-z*][a-z0-9_\-.*]*$/;


### PR DESCRIPTION
The 2026.05.26 release publish failed for @std/http@1.1.1 with
`export 'unstable-structured-fields' not found in jsr:@std/http`.
The cause is a self-import in `unstable_message_signatures.ts`: it
pulled types and helpers from `@std/http/unstable-structured-fields`
rather than from the sibling file. At publish time JSR resolves that
specifier against the previously published @std/http (1.1.0), which
does not yet expose the new `unstable-structured-fields` export — both
modules were added in this release cycle — so the module graph build
errors out before the new version can be published.

Switching the two import sites to a relative
`./unstable_structured_fields.ts` path avoids the registry lookup and
unblocks the release. No other real imports in the http package use the
`@std/http/*` self-specifier; the remaining occurrences are all inside
JSDoc examples and do not enter the module graph.