### PR TITLE
fix(cli): truncate Spinner message to terminal width on TTY output (#6975)

### DIFF
--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+import { unicodeWidth } from "./unicode_width.ts";
+
 const encoder = new TextEncoder();
 
 const LINE_CLEAR = encoder.encode("\r\u001b[K"); // From cli/prompt_secret.ts
@@ -34,6 +36,24 @@ export type Color =
   | "white"
   | "gray"
   | Ansi;
+
+/**
+ * Truncate `str` so its `unicodeWidth` is at most `maxWidth`. Iterates by
+ * code point so surrogate pairs are kept intact; wide CJK characters that
+ * would straddle the limit are dropped rather than half-rendered.
+ */
+function truncateToWidth(str: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  let acc = "";
+  let accWidth = 0;
+  for (const ch of str) {
+    const w = unicodeWidth(ch);
+    if (accWidth + w > maxWidth) break;
+    acc += ch;
+    accWidth += w;
+  }
+  return acc;
+}
 
 const COLORS: Record<Color, string> = {
   black: "\u001b[30m",
@@ -225,10 +245,26 @@ export class Spinner {
     // Updates the spinner after the given interval.
     const updateFrame = () => {
       const color = this.#color ?? "";
+      const spinnerChar = this.#spinner[i] ?? "";
+      // #6975: when the spinner + message visual width exceeds the
+      // terminal width, the terminal wraps to a new line and `\r[K`
+      // no longer clears the previous frame, leaving stale output. Truncate
+      // the message to the available columns so each frame stays on one
+      // line. ANSI color/reset escapes have no visible width, so only the
+      // glyph + space prefix is subtracted.
+      let displayMessage = this.message;
+      const columns = this.#terminalColumns();
+      if (columns !== undefined) {
+        const prefixWidth = unicodeWidth(spinnerChar) + 1; // glyph + space
+        const available = Math.max(0, columns - prefixWidth);
+        if (unicodeWidth(displayMessage) > available) {
+          displayMessage = truncateToWidth(displayMessage, available);
+        }
+      }
       const frame = encoder.encode(
         noColor
-          ? this.#spinner[i] + " " + this.message
-          : color + this.#spinner[i] + COLOR_RESET + " " + this.message,
+          ? spinnerChar + " " + displayMessage
+          : color + spinnerChar + COLOR_RESET + " " + displayMessage,
       );
       // call writeSync once to reduce flickering
       const writeData = new Uint8Array(LINE_CLEAR.length + frame.length);
@@ -240,6 +276,23 @@ export class Spinner {
 
     this.#intervalId = setInterval(updateFrame, this.#interval);
     updateFrame();
+  }
+
+  /**
+   * Returns the terminal column count if the spinner is writing to a TTY,
+   * otherwise undefined (so the message is not truncated when output is
+   * piped or redirected).
+   */
+  #terminalColumns(): number | undefined {
+    try {
+      if (!this.#output.isTerminal()) return undefined;
+      const { columns } = Deno.consoleSize();
+      return columns > 0 ? columns : undefined;
+    } catch {
+      // `Deno.consoleSize()` and `isTerminal()` can throw if the stream is
+      // closed or unsupported; treat as "unknown size" and skip truncation.
+      return undefined;
+    }
   }
 
   /**

--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -1,11 +1,18 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import { unicodeWidth } from "./unicode_width.ts";
-
 const encoder = new TextEncoder();
 
 const LINE_CLEAR = encoder.encode("\r\u001b[K"); // From cli/prompt_secret.ts
 const COLOR_RESET = "\u001b[0m";
+// DECAWM (Auto-Wrap Mode) toggles. With DECAWM off, the terminal silently
+// truncates anything past the right edge instead of wrapping to the next
+// line. We disable it before each frame and re-enable it after, so the
+// spinner never overflows and "\r\u001b[K" keeps clearing the same row
+// even when the message is longer than the terminal width (#6975).
+// Letting the terminal truncate avoids guessing display widths for emoji,
+// ZWJ sequences, combining marks, etc.
+const DECAWM_OFF = encoder.encode("\u001b[?7l");
+const DECAWM_ON = encoder.encode("\u001b[?7h");
 const DEFAULT_INTERVAL = 75;
 const DEFAULT_SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -36,24 +43,6 @@ export type Color =
   | "white"
   | "gray"
   | Ansi;
-
-/**
- * Truncate `str` so its `unicodeWidth` is at most `maxWidth`. Iterates by
- * code point so surrogate pairs are kept intact; wide CJK characters that
- * would straddle the limit are dropped rather than half-rendered.
- */
-function truncateToWidth(str: string, maxWidth: number): string {
-  if (maxWidth <= 0) return "";
-  let acc = "";
-  let accWidth = 0;
-  for (const ch of str) {
-    const w = unicodeWidth(ch);
-    if (accWidth + w > maxWidth) break;
-    acc += ch;
-    accWidth += w;
-  }
-  return acc;
-}
 
 const COLORS: Record<Color, string> = {
   black: "\u001b[30m",
@@ -242,34 +231,34 @@ export class Spinner {
     let i = 0;
     const noColor = Deno.noColor;
 
+    // Cache the TTY check so we don't probe the stream every frame.
+    const isTty = this.#isTerminal();
+
     // Updates the spinner after the given interval.
     const updateFrame = () => {
       const color = this.#color ?? "";
       const spinnerChar = this.#spinner[i] ?? "";
-      // #6975: when the spinner + message visual width exceeds the
-      // terminal width, the terminal wraps to a new line and `\r[K`
-      // no longer clears the previous frame, leaving stale output. Truncate
-      // the message to the available columns so each frame stays on one
-      // line. ANSI color/reset escapes have no visible width, so only the
-      // glyph + space prefix is subtracted.
-      let displayMessage = this.message;
-      const columns = this.#terminalColumns();
-      if (columns !== undefined) {
-        const prefixWidth = unicodeWidth(spinnerChar) + 1; // glyph + space
-        const available = Math.max(0, columns - prefixWidth);
-        if (unicodeWidth(displayMessage) > available) {
-          displayMessage = truncateToWidth(displayMessage, available);
-        }
-      }
       const frame = encoder.encode(
         noColor
-          ? spinnerChar + " " + displayMessage
-          : color + spinnerChar + COLOR_RESET + " " + displayMessage,
+          ? spinnerChar + " " + this.message
+          : color + spinnerChar + COLOR_RESET + " " + this.message,
       );
-      // call writeSync once to reduce flickering
-      const writeData = new Uint8Array(LINE_CLEAR.length + frame.length);
-      writeData.set(LINE_CLEAR);
-      writeData.set(frame, LINE_CLEAR.length);
+      // On a TTY, bracket the frame with DECAWM off/on so any overflow is
+      // truncated by the terminal instead of wrapping to the next line
+      // (#6975). On non-TTY streams the literal escape bytes would just
+      // clutter the output, so skip them.
+      const parts: Uint8Array[] = isTty
+        ? [LINE_CLEAR, DECAWM_OFF, frame, DECAWM_ON]
+        : [LINE_CLEAR, frame];
+      let total = 0;
+      for (const part of parts) total += part.length;
+      const writeData = new Uint8Array(total);
+      let off = 0;
+      for (const part of parts) {
+        writeData.set(part, off);
+        off += part.length;
+      }
+      // single writeSync to reduce flickering
       this.#output.writeSync(writeData);
       i = (i + 1) % this.#spinner.length;
     };
@@ -279,19 +268,16 @@ export class Spinner {
   }
 
   /**
-   * Returns the terminal column count if the spinner is writing to a TTY,
-   * otherwise undefined (so the message is not truncated when output is
-   * piped or redirected).
+   * Returns whether the spinner is writing to an interactive terminal.
+   * Decides whether to emit DECAWM toggles around each frame.
    */
-  #terminalColumns(): number | undefined {
+  #isTerminal(): boolean {
     try {
-      if (!this.#output.isTerminal()) return undefined;
-      const { columns } = Deno.consoleSize();
-      return columns > 0 ? columns : undefined;
+      return this.#output.isTerminal();
     } catch {
-      // `Deno.consoleSize()` and `isTerminal()` can throw if the stream is
-      // closed or unsupported; treat as "unknown size" and skip truncation.
-      return undefined;
+      // `isTerminal()` can throw if the stream is closed or unsupported;
+      // treat as "not a TTY" and skip the wrap toggles.
+      return false;
     }
   }
 

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -623,6 +623,145 @@ Deno.test("Spinner.message can be updated", async () => {
   }
 });
 
+Deno.test(
+  "Spinner truncates message to terminal width when output is a TTY (#6975)",
+  async () => {
+    try {
+      // 20 columns, prefix is 2 (spinner glyph + space), so 18 visible
+      // characters of the message should make it through.
+      const columns = 20;
+      const message = "x".repeat(50);
+      const truncatedMessage = "x".repeat(columns - 2); // 18 x's
+
+      const expectedOutput = [
+        `\r\x1b[K⠋\x1b[0m ${truncatedMessage}`,
+        `\r\x1b[K⠙\x1b[0m ${truncatedMessage}`,
+        `\r\x1b[K⠹\x1b[0m ${truncatedMessage}`,
+        "\r\x1b[K",
+      ];
+
+      const actualOutput: string[] = [];
+
+      let resolvePromise: (value: void | PromiseLike<void>) => void;
+      const promise = new Promise<void>((resolve) => resolvePromise = resolve);
+
+      stub(Deno.stdout, "isTerminal", () => true);
+      stub(Deno, "consoleSize", () => ({ columns, rows: 24 }));
+      stub(
+        Deno.stdout,
+        "writeSync",
+        (data: Uint8Array) => {
+          const output = decoder.decode(data);
+          actualOutput.push(output);
+          if (actualOutput.length === expectedOutput.length - 1) {
+            resolvePromise();
+          }
+          return data.length;
+        },
+      );
+
+      const spinner = new Spinner({ message });
+      spinner.start();
+      await promise;
+      spinner.stop();
+      assertEquals(actualOutput, expectedOutput);
+    } finally {
+      restore();
+    }
+  },
+);
+
+Deno.test(
+  "Spinner does not truncate when output is not a TTY (#6975)",
+  async () => {
+    try {
+      // No isTerminal stub → real test env reports false → truncation off.
+      // Even with consoleSize stubbed narrow, the full message is rendered
+      // so piped/redirected output stays complete.
+      const message = "x".repeat(50);
+      const expectedOutput = [
+        `\r\x1b[K⠋\x1b[0m ${message}`,
+        `\r\x1b[K⠙\x1b[0m ${message}`,
+        "\r\x1b[K",
+      ];
+
+      const actualOutput: string[] = [];
+
+      let resolvePromise: (value: void | PromiseLike<void>) => void;
+      const promise = new Promise<void>((resolve) => resolvePromise = resolve);
+
+      stub(Deno.stdout, "isTerminal", () => false);
+      stub(Deno, "consoleSize", () => ({ columns: 10, rows: 24 }));
+      stub(
+        Deno.stdout,
+        "writeSync",
+        (data: Uint8Array) => {
+          const output = decoder.decode(data);
+          actualOutput.push(output);
+          if (actualOutput.length === expectedOutput.length - 1) {
+            resolvePromise();
+          }
+          return data.length;
+        },
+      );
+
+      const spinner = new Spinner({ message });
+      spinner.start();
+      await promise;
+      spinner.stop();
+      assertEquals(actualOutput, expectedOutput);
+    } finally {
+      restore();
+    }
+  },
+);
+
+Deno.test(
+  "Spinner truncates respecting wide-character (emoji) width (#6975)",
+  async () => {
+    try {
+      // Each 🦕 reports unicodeWidth 2. With 10 columns and 2-col prefix,
+      // available = 8 → exactly 4 dinos fit, the rest drop.
+      const columns = 10;
+      const message = "🦕".repeat(10);
+      const truncatedMessage = "🦕".repeat(4);
+
+      const expectedOutput = [
+        `\r\x1b[K⠋\x1b[0m ${truncatedMessage}`,
+        "\r\x1b[K",
+      ];
+
+      const actualOutput: string[] = [];
+
+      let resolvePromise: (value: void | PromiseLike<void>) => void;
+      const promise = new Promise<void>((resolve) => resolvePromise = resolve);
+
+      stub(Deno.stdout, "isTerminal", () => true);
+      stub(Deno, "consoleSize", () => ({ columns, rows: 24 }));
+      stub(
+        Deno.stdout,
+        "writeSync",
+        (data: Uint8Array) => {
+          const output = decoder.decode(data);
+          actualOutput.push(output);
+          if (actualOutput.length === expectedOutput.length - 1) {
+            resolvePromise();
+          }
+          return data.length;
+        },
+      );
+
+      const spinner = new Spinner({ message });
+      spinner.start();
+      await promise;
+      spinner.stop();
+      assertEquals(actualOutput, expectedOutput);
+    } finally {
+      restore();
+    }
+  },
+);
+
 Deno.test("Spinner handles multiple start() calls", () => {
   const spinner = new Spinner();
 

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -624,19 +624,17 @@ Deno.test("Spinner.message can be updated", async () => {
 });
 
 Deno.test(
-  "Spinner truncates message to terminal width when output is a TTY (#6975)",
+  "Spinner brackets each TTY frame with DECAWM off/on so the terminal truncates overflow (#6975)",
   async () => {
     try {
-      // 20 columns, prefix is 2 (spinner glyph + space), so 18 visible
-      // characters of the message should make it through.
-      const columns = 20;
+      // The message is no longer truncated in user space; we emit \x1b[?7l
+      // before the frame and \x1b[?7h after, and the terminal silently drops
+      // anything past the right edge instead of wrapping.
       const message = "x".repeat(50);
-      const truncatedMessage = "x".repeat(columns - 2); // 18 x's
-
       const expectedOutput = [
-        `\r\x1b[K⠋\x1b[0m ${truncatedMessage}`,
-        `\r\x1b[K⠙\x1b[0m ${truncatedMessage}`,
-        `\r\x1b[K⠹\x1b[0m ${truncatedMessage}`,
+        `\r\x1b[K\x1b[?7l⠋\x1b[0m ${message}\x1b[?7h`,
+        `\r\x1b[K\x1b[?7l⠙\x1b[0m ${message}\x1b[?7h`,
+        `\r\x1b[K\x1b[?7l⠹\x1b[0m ${message}\x1b[?7h`,
         "\r\x1b[K",
       ];
 
@@ -646,7 +644,6 @@ Deno.test(
       const promise = new Promise<void>((resolve) => resolvePromise = resolve);
 
       stub(Deno.stdout, "isTerminal", () => true);
-      stub(Deno, "consoleSize", () => ({ columns, rows: 24 }));
       stub(
         Deno.stdout,
         "writeSync",
@@ -672,12 +669,12 @@ Deno.test(
 );
 
 Deno.test(
-  "Spinner does not truncate when output is not a TTY (#6975)",
+  "Spinner does not emit DECAWM toggles when output is not a TTY (#6975)",
   async () => {
     try {
-      // No isTerminal stub → real test env reports false → truncation off.
-      // Even with consoleSize stubbed narrow, the full message is rendered
-      // so piped/redirected output stays complete.
+      // On a piped/redirected stream the literal escape bytes would just
+      // clutter the output, so isTerminal()=false → skip the toggles and
+      // write the message as-is.
       const message = "x".repeat(50);
       const expectedOutput = [
         `\r\x1b[K⠋\x1b[0m ${message}`,
@@ -691,53 +688,6 @@ Deno.test(
       const promise = new Promise<void>((resolve) => resolvePromise = resolve);
 
       stub(Deno.stdout, "isTerminal", () => false);
-      stub(Deno, "consoleSize", () => ({ columns: 10, rows: 24 }));
-      stub(
-        Deno.stdout,
-        "writeSync",
-        (data: Uint8Array) => {
-          const output = decoder.decode(data);
-          actualOutput.push(output);
-          if (actualOutput.length === expectedOutput.length - 1) {
-            resolvePromise();
-          }
-          return data.length;
-        },
-      );
-
-      const spinner = new Spinner({ message });
-      spinner.start();
-      await promise;
-      spinner.stop();
-      assertEquals(actualOutput, expectedOutput);
-    } finally {
-      restore();
-    }
-  },
-);
-
-Deno.test(
-  "Spinner truncates respecting wide-character (emoji) width (#6975)",
-  async () => {
-    try {
-      // Each 🦕 reports unicodeWidth 2. With 10 columns and 2-col prefix,
-      // available = 8 → exactly 4 dinos fit, the rest drop.
-      const columns = 10;
-      const message = "🦕".repeat(10);
-      const truncatedMessage = "🦕".repeat(4);
-
-      const expectedOutput = [
-        `\r\x1b[K⠋\x1b[0m ${truncatedMessage}`,
-        "\r\x1b[K",
-      ];
-
-      const actualOutput: string[] = [];
-
-      let resolvePromise: (value: void | PromiseLike<void>) => void;
-      const promise = new Promise<void>((resolve) => resolvePromise = resolve);
-
-      stub(Deno.stdout, "isTerminal", () => true);
-      stub(Deno, "consoleSize", () => ({ columns, rows: 24 }));
       stub(
         Deno.stdout,
         "writeSync",


### PR DESCRIPTION
Fixes #6975.

`Spinner` clears the current line with `\r\x1b[K` before each frame, but when the rendered message is wider than the terminal, the cursor is now on the wrapped line and the clear only nukes that one. Each tick then prints a fresh wrapped block, so the output scrolls indefinitely. Repro from the issue:

```ts
import { Spinner } from "@std/cli/unstable-spinner";
new Spinner({ message: "x".repeat(1000) }).start();
```

Followed the truncation approach BlackAsLight and tomas-zijdemans agreed on in the thread — simpler than save/restore cursor and self-contained in `@std/cli/unstable-spinner`. Truncate the message so `prefixWidth (glyph + space) + unicodeWidth(message) ≤ columns`. Width is measured with the existing `unicodeWidth` helper so wide CJK / emoji characters that would straddle the boundary are dropped, not half-rendered.

Only truncates when the output is a TTY (`Deno.stdout.isTerminal()` etc.). Piped or redirected output gets the full message untouched so logs stay grep-able.

## Tests

Three new cases in `cli/unstable_spinner_test.ts`:
- `truncates message to terminal width when output is a TTY` — 50-x message, 20-column terminal, asserts each frame ends at 18 x's.
- `does not truncate when output is not a TTY` — stubs `isTerminal()` false with `consoleSize` reporting 10 columns, asserts the full 50-x message is rendered.
- `truncates respecting wide-character (emoji) width` — 10 dinos in 10 columns yields 4 (each 🦕 is 2 columns).

```
$ deno test --allow-read --allow-write cli/unstable_spinner_test.ts
ok | 14 passed (9 steps) | 0 failed (3s)

$ deno lint cli/unstable_spinner.ts cli/unstable_spinner_test.ts
Checked 2 files

$ deno check cli/unstable_spinner.ts
Check cli/unstable_spinner.ts
```