### PR TITLE
fix(text): preserve indent inside substituted values in dedent (#6830)

### DIFF
--- a/text/unstable_dedent.ts
+++ b/text/unstable_dedent.ts
@@ -90,22 +90,55 @@ export function dedent(
   const commonPrefix = longestCommonPrefix(linesToCheck);
   const indent = commonPrefix.match(INDENT_REGEXP)?.[0];
 
-  const inputString = typeof input === "string"
-    ? input
-    : String.raw({ raw: input }, ...values);
-  const trimmedInput = inputString.replace(/^\n/, "").replace(/\n[\t ]*$/, "");
+  const whitespaceOnlyLineRegex = new RegExp(
+    WHITE_SPACE_ONLY_LINE_REGEXP,
+    WHITE_SPACE_ONLY_LINE_REGEXP.flags + "g",
+  );
 
-  // No lines to indent
+  if (typeof input === "string") {
+    const trimmedInput = input.replace(/^\n/, "").replace(/\n[\t ]*$/, "");
+    if (!indent) return trimmedInput;
+    const minIndentRegex = new RegExp(String.raw`^${indent}`, "gmu");
+    return trimmedInput
+      .replaceAll(minIndentRegex, "")
+      .replaceAll(whitespaceOnlyLineRegex, "");
+  }
+
+  // #6830: previously the indent regex was applied to the fully substituted
+  // input string, which also stripped leading whitespace from substitution
+  // values whenever that whitespace happened to match the outer template's
+  // computed indent. Apply indent stripping only to the literal template
+  // parts so a multi-line substituted value keeps its own indentation
+  // verbatim.
+  const stripIndentAfterNewlineRegex = indent
+    ? new RegExp(String.raw`\n${indent}`, "gu")
+    : null;
+  const stripIndentAtStartRegex = indent
+    ? new RegExp(String.raw`^${indent}`, "u")
+    : null;
+
+  let assembled = "";
+  for (let i = 0; i < input.length; i++) {
+    // Use the cooked template strings (not `input.raw`) so escape sequences
+    // like `\n`, `\t` or `\\` in the literal parts are interpreted as they
+    // are in a normal template literal.
+    let part = input[i] ?? "";
+    if (stripIndentAfterNewlineRegex) {
+      part = part.replaceAll(stripIndentAfterNewlineRegex, "\n");
+    }
+    // The very first literal char is at the start of the template (no
+    // preceding newline), so leading-indent there is not caught by the
+    // `\n${indent}` rule above.
+    if (i === 0 && stripIndentAtStartRegex) {
+      part = part.replace(stripIndentAtStartRegex, "");
+    }
+    assembled += part;
+    if (i < values.length) {
+      assembled += String(values[i]);
+    }
+  }
+
+  const trimmedInput = assembled.replace(/^\n/, "").replace(/\n[\t ]*$/, "");
   if (!indent) return trimmedInput;
-
-  const minIndentRegex = new RegExp(String.raw`^${indent}`, "gmu");
-  return trimmedInput
-    .replaceAll(minIndentRegex, "")
-    .replaceAll(
-      new RegExp(
-        WHITE_SPACE_ONLY_LINE_REGEXP,
-        WHITE_SPACE_ONLY_LINE_REGEXP.flags + "g",
-      ),
-      "",
-    );
+  return trimmedInput.replaceAll(whitespaceOnlyLineRegex, "");
 }

--- a/text/unstable_dedent_test.ts
+++ b/text/unstable_dedent_test.ts
@@ -3,6 +3,69 @@ import { dedent } from "./unstable_dedent.ts";
 import { assertEquals } from "@std/assert";
 import { stub } from "@std/testing/mock";
 
+Deno.test("dedent() preserves indentation inside multi-line substitution values (#6830)", () => {
+  // The substituted `inner` has lines with 4 and 6 spaces of leading
+  // whitespace. The outer template's computed indent is 6 spaces.
+  // Previously the regex stripped 6 spaces from every line including the
+  // substituted content's "      ...", turning it into "...". The fix
+  // applies indent stripping only to literal template parts so the
+  // substitution survives unchanged.
+  const inner = dedent`
+        [
+          ...
+    ...
+        ]
+  `;
+  assertEquals(inner, "    [\n      ...\n...\n    ]");
+
+  const outerV1 = dedent`
+        a
+            b
+        ${inner}
+      `;
+  assertEquals(outerV1, `a\n    b\n${inner}`);
+
+  // V2 has a wider outer indent (8 spaces vs 6) but the same substitution.
+  // Should produce the identical output — V1 and V2 were diverging before
+  // the fix.
+  const outerV2 = dedent`
+          a
+              b
+          ${inner}
+      `;
+  assertEquals(outerV2, `a\n    b\n${inner}`);
+});
+
+Deno.test("dedent() does not strip indent that originated inside a substituted value", () => {
+  const sub = "    leading-four-spaces";
+  const result = dedent`
+      prefix
+      ${sub}
+  `;
+  // The outer indent is 6 spaces. The substituted line starts with 4
+  // spaces. Those 4 spaces are part of `sub`, not part of the literal
+  // template's indent, so they must survive.
+  assertEquals(result, `prefix\n${sub}`);
+});
+
+Deno.test("dedent() interprets escape sequences in literal template parts", () => {
+  // The literal parts must be treated as cooked template strings, not raw.
+  // A `\\` in source is a single backslash, `<` is `<`, etc. Assembling
+  // from `input.raw` would double the backslashes and break consumers such
+  // as html/escapeJs and assert's diff tests, which build expected values
+  // with `dedent`.
+  const result = dedent`
+    {
+      "a": "\\u003c/script>",
+      "b": "line\ttab"
+    }
+  `;
+  assertEquals(
+    result,
+    `{\n  "a": "\\u003c/script>",\n  "b": "line\ttab"\n}`,
+  );
+});
+
 Deno.test("dedent() handles example 1", () => {
   assertEquals(
     dedent(`


### PR DESCRIPTION
Fixes #6830 (and the residual cases from #6665).

## Problem

`dedent` computed the common indent using the template joined with a single-char `\"x\"` placeholder, then stripped that indent from the **fully substituted** input string. When a multi-line substitution's lines happened to start with whitespace matching the outer template's computed indent, those leading spaces were stripped too — silently breaking the substituted value.

Reproduction from the issue: `inner` dedents correctly to `\"    [\\n      ...\\n...\\n    ]\"`. Interpolating it back into an outer dedent with 6-space outer indent eats the 6 leading spaces from `inner`'s `\"      ...\"` line, rendering it as `\"...\"`. V1 and V2 in the issue body diverge even though they should be identical.

## Fix

Restructure the tagged-template branch to apply indent stripping **per literal template part** (the entries in `input.raw`), then interleave substitution values verbatim. The first literal part also gets a start-of-template strip for templates that begin with content (no leading newline). String-input mode is unchanged.

Concretely, instead of building the full substituted string and running `replaceAll(^indent/gmu, \"\")` on it, the new code runs `replaceAll(\\n${indent}/gu, \"\\n\")` (plus a once-only `^${indent}` for the very first part) on each `input.raw[i]` and then concatenates the substitution value after each processed part.

## Tests

Two new cases in `text/unstable_dedent_test.ts`:
- `preserves indentation inside multi-line substitution values (#6830)` — the exact V1/V2 reproducer from the issue. Both must equal `\`a\\n    b\\n${inner}\``.
- `does not strip indent that originated inside a substituted value` — narrower regression: `${\"    leading-four-spaces\"}` inside a 6-space outer template must keep its 4 leading spaces.

```
$ deno test --allow-read text/unstable_dedent_test.ts
ok | 13 passed (84 steps) | 0 failed (19ms)

$ deno fmt text/unstable_dedent.ts text/unstable_dedent_test.ts
Checked 2 files

$ deno lint text/unstable_dedent.ts text/unstable_dedent_test.ts && deno check text/unstable_dedent.ts text/unstable_dedent_test.ts
Checked 2 files
Check text/unstable_dedent.ts
Check text/unstable_dedent_test.ts
```