### PR TITLE
fix(toml): emit TOML literals for Infinity/NaN/Date in arrays

### DIFF
--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -153,7 +153,10 @@ class Dumper {
     ) {
       const str = value.map((x) => this.#printAsInlineValue(x)).join(",");
       return `[${str}]`;
-    } else if (value && typeof value === "object" && !(value instanceof Date)) {
+    } else if (
+      value && typeof value === "object" &&
+      !(value instanceof Date) && !(value instanceof RegExp)
+    ) {
       const str = Object.keys(value).map((key) => {
         return `${joinKeys([key])} = ${
           // deno-lint-ignore no-explicit-any

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -132,24 +132,28 @@ class Dumper {
     }
     return onlyPrimitive ? "ONLY_PRIMITIVE" : "ONLY_OBJECT_EXCLUDING_ARRAY";
   }
-  #printAsInlineValue(value: unknown): string | number {
+  #printPrimitive(value: unknown): string {
     if (value instanceof Date) {
-      return `"${this.#printDate(value)}"`;
+      return this.#printDate(value);
     } else if (typeof value === "string" || value instanceof RegExp) {
       return JSON.stringify(value.toString());
     } else if (typeof value === "number") {
-      return value;
+      if (Number.isNaN(value)) return "nan";
+      if (value === Infinity) return "inf";
+      if (value === -Infinity) return "-inf";
+      return String(value);
     } else if (typeof value === "boolean") {
       return value.toString();
-    } else if (
+    }
+    throw new Error("Should never reach");
+  }
+  #printAsInlineValue(value: unknown): string {
+    if (
       value instanceof Array
     ) {
       const str = value.map((x) => this.#printAsInlineValue(x)).join(",");
       return `[${str}]`;
-    } else if (typeof value === "object") {
-      if (!value) {
-        throw new Error("Should never reach");
-      }
+    } else if (value && typeof value === "object" && !(value instanceof Date)) {
       const str = Object.keys(value).map((key) => {
         return `${joinKeys([key])} = ${
           // deno-lint-ignore no-explicit-any
@@ -157,8 +161,7 @@ class Dumper {
       }).join(",");
       return `{${str}}`;
     }
-
-    throw new Error("Should never reach");
+    return this.#printPrimitive(value);
   }
   #isSimplySerializable(value: unknown): boolean {
     return (
@@ -185,7 +188,8 @@ class Dumper {
     return `${title} = `;
   }
   #arrayDeclaration(keys: string[], value: unknown[]): string {
-    return `${this.#declaration(keys)}${JSON.stringify(value)}`;
+    const items = value.map((v) => this.#printPrimitive(v)).join(",");
+    return `${this.#declaration(keys)}[${items}]`;
   }
   #strDeclaration(keys: string[], value: string): string {
     return `${this.#declaration(keys)}${JSON.stringify(value)}`;

--- a/toml/stringify_test.ts
+++ b/toml/stringify_test.ts
@@ -314,6 +314,17 @@ Deno.test({
   },
 });
 
+// https://github.com/denoland/std/issues/7162 - regression: a RegExp in a mixed
+// array must serialize through the primitive path, not be swallowed by the
+// inline-table branch (which would emit an empty `{}` and drop the value).
+Deno.test({
+  name: "stringify() keeps a RegExp value in mixed arrays",
+  fn() {
+    const actual = stringify({ x: [/foo/, {}] });
+    assertEquals(actual, `x = ["/foo/",{}]\n`);
+  },
+});
+
 // https://github.com/denoland/std/issues/7162 - regression check for the new
 // #printPrimitive path that replaced JSON.stringify: finite numbers in
 // primitive arrays must keep their JSON representation.

--- a/toml/stringify_test.ts
+++ b/toml/stringify_test.ts
@@ -240,7 +240,7 @@ Deno.test({
     const expected = `emptyArray = []
 mixedArray1 = [1,{b = 2}]
 mixedArray2 = [{b = 2},1]
-nestedArray1 = [[{b = 1,date = "2022-05-13T00:00:00.000"}]]
+nestedArray1 = [[{b = 1,date = 2022-05-13T00:00:00.000}]]
 nestedArray2 = [[[{b = 1}]]]
 nestedArray3 = [[],[{b = 1}]]
 
@@ -273,5 +273,76 @@ Deno.test({
 `.trim();
     const actual = stringify(src).trim();
     assertEquals(actual, expected);
+  },
+});
+
+// https://github.com/denoland/std/issues/7162
+Deno.test({
+  name:
+    "stringify() emits TOML float literals for Infinity/NaN in primitive arrays",
+  fn() {
+    const actual = stringify({ x: [Infinity, -Infinity, NaN] });
+    assertEquals(actual, "x = [inf,-inf,nan]\n");
+  },
+});
+
+// https://github.com/denoland/std/issues/7162
+Deno.test({
+  name: "stringify() emits TOML datetime literal for Date in primitive arrays",
+  fn() {
+    const actual = stringify({ x: [new Date(0)] });
+    assertEquals(actual, "x = [1970-01-01T00:00:00.000]\n");
+  },
+});
+
+// https://github.com/denoland/std/issues/7162
+Deno.test({
+  name:
+    "stringify() emits TOML float literals for Infinity/NaN in mixed arrays",
+  fn() {
+    const actual = stringify({ x: [Infinity, -Infinity, NaN, {}] });
+    assertEquals(actual, "x = [inf,-inf,nan,{}]\n");
+  },
+});
+
+// https://github.com/denoland/std/issues/7162
+Deno.test({
+  name: "stringify() emits TOML datetime literal for Date in mixed arrays",
+  fn() {
+    const actual = stringify({ x: [new Date(0), {}] });
+    assertEquals(actual, "x = [1970-01-01T00:00:00.000,{}]\n");
+  },
+});
+
+// https://github.com/denoland/std/issues/7162 - regression check for the new
+// #printPrimitive path that replaced JSON.stringify: finite numbers in
+// primitive arrays must keep their JSON representation.
+Deno.test({
+  name: "stringify() preserves finite numbers in primitive arrays",
+  fn() {
+    const actual = stringify({ x: [1, -1, 0, 3.14, 1e6] });
+    assertEquals(actual, "x = [1,-1,0,3.14,1000000]\n");
+  },
+});
+
+// https://github.com/denoland/std/issues/7162 - bare numeric and Date scalar
+// declarations (not array elements) must be unaffected by the array fixes.
+Deno.test({
+  name: "stringify() preserves scalar Infinity/NaN/Date declarations",
+  fn() {
+    const actual = stringify({
+      pi: Infinity,
+      bad: NaN,
+      neg: -Infinity,
+      when: new Date(0),
+    });
+    assertEquals(
+      actual,
+      `pi = inf
+bad = nan
+neg = -inf
+when = 1970-01-01T00:00:00.000
+`,
+    );
   },
 });


### PR DESCRIPTION
Primitive and mixed array stringification went through code paths that produced invalid TOML for non-finite numbers and Date values. The issue author flagged six distinct cases in #7162; this PR addresses the four with a deterministic spec-aligned fix and leaves the two `null`-related ones for maintainer guidance, since they are a design call.

## What changed

`#arrayDeclaration` (primitive arrays) previously routed values through `JSON.stringify`, which has no representation for Infinity, -Infinity, NaN, or TOML datetime literals. `#printAsInlineValue` (mixed arrays) returned numbers verbatim (so Infinity printed as the JS identifier) and wrapped Dates in string quotes.

A new private helper `#printPrimitive` produces TOML-compliant literals for `Date`, `string`, `RegExp`, `number` (including `inf`/`-inf`/`nan`) and `boolean`. Both array paths now route primitives through it.

Behaviour for `null`/`undefined` inside arrays is unchanged - the code still throws `Should never reach`. The issue author flagged this as a design call (TOML has no `null`), so it stays as-is until maintainers decide between a clearer error message, silent skip, or another shape.

## Before/after

```ts
// primitive array
stringify({x: [Infinity, -Infinity, NaN]})
// before: x = [null,null,null]
// after:  x = [inf,-inf,nan]

stringify({x: [new Date(0)]})
// before: x = [\"1970-01-01T00:00:00.000Z\"]
// after:  x = [1970-01-01T00:00:00.000]

// mixed array
stringify({x: [Infinity, -Infinity, NaN, {}]})
// before: x = [Infinity,-Infinity,NaN,{}]   (invalid TOML)
// after:  x = [inf,-inf,nan,{}]

stringify({x: [new Date(0), {}]})
// before: x = [\"1970-01-01T00:00:00.000\",{}]
// after:  x = [1970-01-01T00:00:00.000,{}]
```

## Tests

Six new cases in `toml/stringify_test.ts`:

- positive: Infinity/-Infinity/NaN in primitive arrays render as `inf`/`-inf`/`nan`
- positive: Date in primitive arrays renders as a bare TOML datetime literal
- positive: Infinity/-Infinity/NaN in mixed arrays
- positive: Date in mixed arrays
- regression-check: finite numbers in primitive arrays keep their JSON-style representation (covers the new `#printPrimitive` path that replaced `JSON.stringify`)
- regression-check: scalar Infinity/NaN/Date declarations (not array elements) are unaffected

One existing test (`stringify() handles mixed array`) had a date inside a mixed inline-table that was previously emitted with quotes. The expected output is updated to the spec-aligned bare datetime literal.

\`deno test --allow-all toml/\` -> 689 passed, 0 failed, 111 ignored.
\`deno fmt\` and \`deno lint\` clean on the changed files.

Fixes #7162 (partial - null handling left for maintainer guidance).