### PR TITLE
fix(fs): return Generator from walkSync and expandGlobSync so iterator helpers are visible

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -428,7 +428,7 @@ export async function* expandGlob(
 export function* expandGlobSync(
   glob: string | URL,
   options?: ExpandGlobOptions,
-): IterableIterator<WalkEntry> {
+): Generator<WalkEntry> {
   let {
     root,
     exclude = [],
@@ -473,7 +473,7 @@ export function* expandGlobSync(
   function* advanceMatch(
     walkInfo: WalkEntry,
     globSegment: string,
-  ): IterableIterator<WalkEntry> {
+  ): Generator<WalkEntry> {
     if (!walkInfo.isDirectory) {
       return;
     } else if (globSegment === "..") {

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -428,7 +428,7 @@ export async function* expandGlob(
 export function* expandGlobSync(
   glob: string | URL,
   options?: ExpandGlobOptions,
-): Generator<WalkEntry> {
+): Generator<WalkEntry, void, undefined> {
   let {
     root,
     exclude = [],
@@ -473,7 +473,7 @@ export function* expandGlobSync(
   function* advanceMatch(
     walkInfo: WalkEntry,
     globSegment: string,
-  ): Generator<WalkEntry> {
+  ): Generator<WalkEntry, void, undefined> {
     if (!walkInfo.isDirectory) {
       return;
     } else if (globSegment === "..") {

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -878,7 +878,7 @@ export async function* walk(
 export function* walkSync(
   root: string | URL,
   options?: WalkOptions,
-): IterableIterator<WalkEntry> {
+): Generator<WalkEntry> {
   let {
     maxDepth = Infinity,
     includeFiles = true,

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -878,7 +878,7 @@ export async function* walk(
 export function* walkSync(
   root: string | URL,
   options?: WalkOptions,
-): Generator<WalkEntry> {
+): Generator<WalkEntry, void, undefined> {
   let {
     maxDepth = Infinity,
     includeFiles = true,


### PR DESCRIPTION
Fixes #7099.

`walkSync` and `expandGlobSync` are generator functions, so at runtime they already have iterator helpers (`map`, `filter`, `take`, `drop`, `toArray`, ...). Their declared return type `IterableIterator<WalkEntry>` hides those helpers from TypeScript and forces callers to wrap with `Array.from(...)` or write a manual loop just to use them.

From the issue:

```ts
const a = walkSync(".");
const b = a.map(v => v.name);
// Property 'map' does not exist on type 'IterableIterator<WalkEntry>'.
```

Narrowing the return type to `Generator<WalkEntry>` exposes the helpers. `Generator` extends `IterableIterator` so existing callers stay assignment-compatible:

```ts
walkSync(".").map((e) => e.name).toArray(); // now type-checks
expandGlobSync("*").map((e) => e.name).toArray(); // ditto
```

The async siblings (`walk`, `expandGlob`) are intentionally left as `AsyncIterableIterator<WalkEntry>`. The async iterator helpers aren't in the TypeScript lib that Deno currently ships, so claiming them on the return type would mislead callers into writing code that breaks at type-check time. Happy to change this if the right lib is on by default and I missed it.

Verification: ran `fs/walk_test.ts` + `fs/expand_glob_test.ts` with `-A`, 63 pass / 4 fail — the 4 failures (`accepts skip option as regExps` ×2, `walks fifo files on unix` ×2) reproduce on clean `origin/main` so they're pre-existing and unrelated.