### PR TITLE
fix(async): pooledMap surfaces errors thrown by the input iterable

### DIFF
--- a/async/pool.ts
+++ b/async/pool.ts
@@ -89,13 +89,20 @@ export function pooledMap<T, R>(
       // Wait until all ongoing events have processed, then close the writer.
       await Promise.all(executing);
       writer.close();
-    } catch {
+    } catch (iterError) {
       const errors = [];
       for (const result of await Promise.allSettled(executing)) {
         if (result.status === "rejected") {
           errors.push(result.reason);
         }
       }
+      // The catch fires both when a transformation rejects and when the
+      // input iterable itself throws. When it's a transformation rejection
+      // the same reason is already in `executing`, but when the iterable
+      // throws the original error would otherwise be swallowed, leaving
+      // callers with an empty AggregateError (see #6716). Add it only if
+      // it isn't already accounted for.
+      if (!errors.includes(iterError)) errors.push(iterError);
       writer.write(Promise.reject(
         new AggregateError(errors, ERROR_WHILE_MAPPING_MESSAGE),
       )).catch(() => {});

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -83,9 +83,9 @@ Deno.test(
   "pooledMap() surfaces errors thrown by the input iterable (#6716)",
   async () => {
     const sentinel = new Error("Iterator failed on first step!");
-    async function* errorThrowing() {
+    // deno-lint-ignore require-yield
+    async function* errorThrowing(): AsyncGenerator<number> {
       throw sentinel;
-      yield 1;
     }
     const results = pooledMap(
       2,

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -2,6 +2,7 @@
 import { delay } from "./delay.ts";
 import { pooledMap } from "./pool.ts";
 import {
+  assert,
   assertEquals,
   assertGreaterOrEqual,
   assertLess,
@@ -77,6 +78,40 @@ Deno.test("pooledMap() returns ordered items", async () => {
   const returned = await Array.fromAsync(results);
   assertEquals(returned, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 });
+
+Deno.test(
+  "pooledMap() surfaces errors thrown by the input iterable (#6716)",
+  async () => {
+    const sentinel = new Error("Iterator failed on first step!");
+    async function* errorThrowing() {
+      throw sentinel;
+      yield 1;
+    }
+    const results = pooledMap(
+      2,
+      errorThrowing(),
+      (i: number) => Promise.resolve(i),
+    );
+    let caught: unknown;
+    try {
+      for await (const _ of results) {
+        // drain
+      }
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof AggregateError);
+    const ag = caught as AggregateError;
+    assertEquals(
+      ag.message,
+      "Cannot complete the mapping as an error was thrown from an item",
+    );
+    // The previous behavior left `errors` empty; the iterable's error was
+    // swallowed. Now it must be present so callers can introspect it.
+    assertEquals(ag.errors.length, 1);
+    assertEquals(ag.errors[0], sentinel);
+  },
+);
 
 Deno.test("pooledMap() checks browser compat", async () => {
   // Simulates the environment where Symbol.asyncIterator is not available


### PR DESCRIPTION
Fixes #6716.

When an async iterable passed to `pooledMap` throws (rather than a transformation), the catch block discarded the error and built an `AggregateError` populated solely from the executing transformations. With no transformation rejections in flight, callers saw only:

```
AggregateError: Cannot complete the mapping as an error was thrown from an item
    errors: []
```

The underlying cause was unrecoverable.

Repro from the issue:

```ts
import { pooledMap } from "jsr:@std/async/pool";

async function* errorThrowingIterator() {
  throw new Error("Iterator failed on first step!");
  yield 1;
}

const results = pooledMap(2, errorThrowingIterator(), async (i) => i * 2);
for await (const _ of results) {}
// AggregateError, errors: [] — the real cause is lost
```

After the patch the iterable's error rides through in `AggregateError.errors`:

```
message: Cannot complete the mapping as an error was thrown from an item
errors:  [ "Iterator failed on first step!" ]
```

Implementation: bind the catch's value as `iterError` and `errors.push(iterError)` only when it isn't already in `errors`. The `Promise.race` rejections from the executing pool are already surfaced via the existing `allSettled` walk, so the `includes` check prevents the common transformation-rejection path from duplicating its own reason.

Tests:
- New `pooledMap() surfaces errors thrown by the input iterable (#6716)` pins the iterable-throws case.
- The existing `pooledMap() handles errors` test (which exercises `Promise.race` rejections, not iterable throws) still produces exactly two rejections, confirming no double-counting.

All 6 `pool_test.ts` tests pass.