### PR TITLE
fix(toml): handle Infinity/NaN and Date inside inline arrays

### DIFF
--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -134,10 +134,19 @@ class Dumper {
   }
   #printAsInlineValue(value: unknown): string | number {
     if (value instanceof Date) {
-      return `"${this.#printDate(value)}"`;
+      // TOML datetime literals are unquoted (e.g. 1979-05-27T07:32:00Z).
+      // The previous wrapping in quotes caused the value to round-trip as a
+      // string instead of a Date (#7162).
+      return this.#printDate(value);
     } else if (typeof value === "string" || value instanceof RegExp) {
       return JSON.stringify(value.toString());
     } else if (typeof value === "number") {
+      // TOML uses inf / -inf / nan as the keywords for non-finite numbers
+      // (#7162). Letting String(Infinity) / String(NaN) leak produces
+      // tokens that don't reparse.
+      if (Number.isNaN(value)) return "nan";
+      if (value === Infinity) return "inf";
+      if (value === -Infinity) return "-inf";
       return value;
     } else if (typeof value === "boolean") {
       return value.toString();
@@ -185,7 +194,12 @@ class Dumper {
     return `${title} = `;
   }
   #arrayDeclaration(keys: string[], value: unknown[]): string {
-    return `${this.#declaration(keys)}${JSON.stringify(value)}`;
+    // JSON.stringify(value) turned Infinity / -Infinity / NaN into `null` and
+    // wrapped Date values in extra quotes, producing arrays that round-trip
+    // incorrectly (#7162). Use the per-element inline formatter instead so
+    // primitive arrays use the same TOML literal forms as mixed-type arrays.
+    const inline = value.map((x) => this.#printAsInlineValue(x)).join(",");
+    return `${this.#declaration(keys)}[${inline}]`;
   }
   #strDeclaration(keys: string[], value: string): string {
     return `${this.#declaration(keys)}${JSON.stringify(value)}`;

--- a/toml/stringify_test.ts
+++ b/toml/stringify_test.ts
@@ -237,10 +237,12 @@ Deno.test({
         },
       },
     };
+    // TOML datetime literals are unquoted (see #7162). The previous
+    // `"2022-05-13T00:00:00.000"` form round-tripped as a string.
     const expected = `emptyArray = []
 mixedArray1 = [1,{b = 2}]
 mixedArray2 = [{b = 2},1]
-nestedArray1 = [[{b = 1,date = "2022-05-13T00:00:00.000"}]]
+nestedArray1 = [[{b = 1,date = 2022-05-13T00:00:00.000}]]
 nestedArray2 = [[[{b = 1}]]]
 nestedArray3 = [[],[{b = 1}]]
 
@@ -273,5 +275,48 @@ Deno.test({
 `.trim();
     const actual = stringify(src).trim();
     assertEquals(actual, expected);
+  },
+});
+
+// https://github.com/denoland/std/issues/7162 — inline array stringification
+// used JSON.stringify, which turns Infinity/-Infinity/NaN into null and
+// wraps Date values in quotes. Both forms broke round-trip through parse().
+Deno.test({
+  name: "stringify() emits inf/-inf/nan in primitive arrays (#7162)",
+  fn() {
+    assertEquals(
+      stringify({ x: [Infinity, -Infinity, NaN] }),
+      "x = [inf,-inf,nan]\n",
+    );
+  },
+});
+
+Deno.test({
+  name: "stringify() emits inf/-inf/nan in mixed arrays (#7162)",
+  fn() {
+    assertEquals(
+      stringify({ x: [Infinity, -Infinity, NaN, {}] }),
+      "x = [inf,-inf,nan,{}]\n",
+    );
+  },
+});
+
+Deno.test({
+  name: "stringify() does not quote Date values in primitive arrays (#7162)",
+  fn() {
+    assertEquals(
+      stringify({ x: [new Date(0)] }),
+      "x = [1970-01-01T00:00:00.000]\n",
+    );
+  },
+});
+
+Deno.test({
+  name: "stringify() does not quote Date values in mixed arrays (#7162)",
+  fn() {
+    assertEquals(
+      stringify({ x: [new Date(0), {}] }),
+      "x = [1970-01-01T00:00:00.000,{}]\n",
+    );
   },
 });


### PR DESCRIPTION
Partial fix for #7162.

`#arrayDeclaration` rendered primitive arrays by calling `JSON.stringify(value)`, which silently turned `Infinity` / `-Infinity` / `NaN` into the literal `null` and wrapped `Date` values in extra quotes. Both forms broke round-trip through `parse()`:

```ts
toml.stringify({ x: [Infinity, -Infinity, NaN] });
// x = [null,null,null]   (was supposed to be x = [inf,-inf,nan])

toml.stringify({ x: [new Date(0)] });
// x = ["1970-01-01T00:00:00.000"]   (reparsed as a string, not a Date)
```

The same flaw affected `#printAsInlineValue`, which is the path for mixed-type arrays — `Date` values were quoted there too, and non-finite numbers fell through as `String(Infinity)` / `String(NaN)` (not valid TOML).

The fix is two small edits:

1. `#arrayDeclaration` no longer calls `JSON.stringify`. It maps the array through `#printAsInlineValue` so primitive arrays use the same TOML literal forms as mixed-type arrays.
2. `#printAsInlineValue` emits `inf` / `-inf` / `nan` for non-finite numbers and leaves `Date` values unquoted, matching TOML's datetime literal syntax.

After:

```
x = [inf,-inf,nan]
x = [1970-01-01T00:00:00.000]
x = [inf,-inf,nan,{}]
x = [1970-01-01T00:00:00.000,{}]
```

The existing `handles mixed array` test pinned the buggy `date = \"2022-05-13T00:00:00.000\"` form inside a nested inline map. Updated to the correct unquoted form (and round-trip verified — `parse(stringify(...))` returns a `Date` instance again instead of a string).

Four new tests cover the issue's specific repros.

Not included in this PR:
- `{x: [null]}` / `{x: [1, null]}` — TOML disallows `null`, and the right behavior (skip vs. throw with a clearer message vs. coerce) is a design call worth its own discussion. Leaving for a follow-up.
- Datetime offset (the trailing `Z`) — `#printDate` drops the offset suffix in all TOML output, not just arrays. Restoring it is a broader change touching every Date round-trip and would balloon this PR. Happy to file separately.