### PR TITLE
fix: accept no streams in concatReadableStreams

### DIFF
--- a/streams/concat_readable_streams.ts
+++ b/streams/concat_readable_streams.ts
@@ -29,6 +29,10 @@
 export function concatReadableStreams<T>(
   ...streams: ReadableStream<T>[]
 ): ReadableStream<T> {
+  if (streams.length === 0) {
+    return ReadableStream.from([]);
+  }
+
   let i = 0;
   return new ReadableStream<T>({
     async pull(controller) {

--- a/streams/concat_readable_streams_test.ts
+++ b/streams/concat_readable_streams_test.ts
@@ -26,6 +26,15 @@ Deno.test("concatStreams()", async () => {
   );
 });
 
+Deno.test("concatStreams() with no streams", async () => {
+  assertEquals(
+    await Array.fromAsync(
+      concatReadableStreams(),
+    ),
+    [],
+  );
+});
+
 Deno.test("concatStreams() with empty streams", async () => {
   const readable1 = ReadableStream.from([]);
   const readable2 = ReadableStream.from([]);


### PR DESCRIPTION
I was surprised to find that this case is not contemplated. My gut feeling is that we should return an empty stream.