### PR TITLE
feat(async): add withPermit method to Semaphore

### DIFF
--- a/async/unstable_semaphore.ts
+++ b/async/unstable_semaphore.ts
@@ -144,4 +144,29 @@ export class Semaphore {
       this.#count++;
     }
   }
+
+  /**
+   * Convenience method to run a function once a permit is available,
+   * automatically releasing the permit when the function completes.
+   *
+   * @example Usage
+   * ```ts
+   * import { Semaphore } from "@std/async/unstable-semaphore";
+   * import { assertEquals } from "@std/assert";
+   *
+   * const sem = new Semaphore(1);
+   * const result = await sem.withPermit(async () => {
+   *   return "result";
+   * });
+   * assertEquals(result, "result");
+   * ```
+   *
+   * @typeParam T The type of the value resolved from the function.
+   * @param fn Function to run with a permit.
+   * @returns The result of the function.
+   */
+  async withPermit<T>(fn: () => T | Promise<T>): Promise<T> {
+    using _permit = await this.acquire();
+    return await fn();
+  }
 }

--- a/async/unstable_semaphore_test.ts
+++ b/async/unstable_semaphore_test.ts
@@ -5,8 +5,10 @@ import {
   assertEquals,
   assertExists,
   assertFalse,
+  assertRejects,
   assertThrows,
 } from "@std/assert";
+import { delay } from "@std/async";
 import { Semaphore } from "./unstable_semaphore.ts";
 
 /** Helper to assert that a promise is blocked until released */
@@ -15,7 +17,7 @@ async function assertBlocks(
   release: () => void,
 ): Promise<void> {
   let blocked = true;
-  const p = acquirePromise.then(() => blocked = false);
+  const p = acquirePromise.then(() => (blocked = false));
   await Promise.resolve();
   assert(blocked);
   release();
@@ -64,26 +66,35 @@ Deno.test("Semaphore.acquire() resolves waiters in FIFO order", async () => {
   assertEquals(order, [1, 2, 3]);
 });
 
-Deno.test("Semaphore.acquire() returns Disposable that releases on dispose", async () => {
-  const sem = new Semaphore(1);
-  const permit = await sem.acquire();
-  await assertBlocks(sem.acquire(), () => permit[Symbol.dispose]());
-});
+Deno.test(
+  "Semaphore.acquire() returns Disposable that releases on dispose",
+  async () => {
+    const sem = new Semaphore(1);
+    const permit = await sem.acquire();
+    await assertBlocks(sem.acquire(), () => permit[Symbol.dispose]());
+  },
+);
 
-Deno.test("Semaphore.tryAcquire() returns Disposable when permit available", async () => {
-  const sem = new Semaphore(1);
-  const permit = sem.tryAcquire();
-  assertExists(permit);
-  // Check that Disposable has returned and is working
-  await assertBlocks(sem.acquire(), () => permit[Symbol.dispose]());
-});
+Deno.test(
+  "Semaphore.tryAcquire() returns Disposable when permit available",
+  async () => {
+    const sem = new Semaphore(1);
+    const permit = sem.tryAcquire();
+    assertExists(permit);
+    // Check that Disposable has returned and is working
+    await assertBlocks(sem.acquire(), () => permit[Symbol.dispose]());
+  },
+);
 
-Deno.test("Semaphore.tryAcquire() returns undefined when no permits available", async () => {
-  const sem = new Semaphore(1);
-  await sem.acquire();
-  const permit = sem.tryAcquire();
-  assertEquals(permit, undefined);
-});
+Deno.test(
+  "Semaphore.tryAcquire() returns undefined when no permits available",
+  async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+    const permit = sem.tryAcquire();
+    assertEquals(permit, undefined);
+  },
+);
 
 Deno.test("Semaphore.release() ignores extra releases beyond max", async () => {
   const sem = new Semaphore(2);
@@ -97,3 +108,114 @@ Deno.test("Semaphore.release() ignores extra releases beyond max", async () => {
   // Third acquire should block
   await assertBlocks(sem.acquire(), () => sem.release());
 });
+
+Deno.test(
+  "Semaphore.withPermit() executes a synchronous function and returns its result",
+  async () => {
+    const sem = new Semaphore(1);
+
+    const result = await sem.withPermit(() => {
+      return "sync success";
+    });
+
+    assertEquals(result, "sync success");
+
+    // Verify the permit was successfully released by trying to acquire it again
+    using permit = sem.tryAcquire();
+    assertExists(permit);
+  },
+);
+
+Deno.test(
+  "Semaphore.withPermit() executes an asynchronous function and returns its result",
+  async () => {
+    const sem = new Semaphore(1);
+
+    const result = await sem.withPermit(async () => {
+      await delay(10);
+      return "async success";
+    });
+
+    assertEquals(result, "async success");
+
+    // Verify the permit was released
+    using permit = sem.tryAcquire();
+    assertExists(permit);
+  },
+);
+
+Deno.test(
+  "Semaphore.withPermit() releases permit if synchronous function throws an error",
+  async () => {
+    const sem = new Semaphore(1);
+
+    await assertRejects(
+      () =>
+        sem.withPermit(() => {
+          throw new Error("Sync Error");
+        }),
+      Error,
+      "Sync Error",
+    );
+
+    // The permit MUST be available even though the function threw an exception
+    using permit = sem.tryAcquire();
+    assertExists(permit);
+  },
+);
+
+Deno.test(
+  "Semaphore.withPermit() releases permit if asynchronous function rejects",
+  async () => {
+    const sem = new Semaphore(1);
+
+    await assertRejects(
+      () =>
+        sem.withPermit(async () => {
+          await delay(10);
+          throw new Error("Async Error");
+        }),
+      Error,
+      "Async Error",
+    );
+
+    // The permit MUST be available even though the promise rejected
+    using permit = sem.tryAcquire();
+    assertExists(permit);
+  },
+);
+
+Deno.test(
+  "Semaphore.withPermit() properly queues and limits concurrency to max permits",
+  async () => {
+    const maxPermits = 2;
+    const sem = new Semaphore(maxPermits);
+
+    let activeCount = 0;
+    let maxActiveCount = 0;
+
+    // Create an array of 5 asynchronous tasks
+    const tasks = Array.from({ length: 5 }).map(() => {
+      return sem.withPermit(async () => {
+        activeCount++;
+
+        // Record the maximum concurrent executions at any given time
+        if (activeCount > maxActiveCount) {
+          maxActiveCount = activeCount;
+        }
+
+        await delay(20); // Simulate some asynchronous work
+        activeCount--;
+      });
+    });
+
+    // Execute all tasks concurrently
+    await Promise.all(tasks);
+
+    // The maximum number of concurrent tasks should never exceed the semaphore's max capacity
+    assertEquals(maxActiveCount, maxPermits);
+
+    // All tasks should have finished properly, leaving activeCount at 0
+    assertEquals(activeCount, 0);
+  },
+);


### PR DESCRIPTION
This is a common API pattern found in many concurrency libraries. It provides a highly convenient way to return the result of a protected task directly as an expression, entirely removing the boilerplate of manual semaphore management.

Usage Example:
```
const sem = new Semaphore(2);
const result = await sem.withPermit(async () => {
  return "task completed";
});
console.log(result); // "task completed"
```