### PR TITLE
fix(testing): `FakeTime` fakes `node:timers` and `node:timers/promises` timer methods

### DIFF
--- a/testing/_time.ts
+++ b/testing/_time.ts
@@ -1,5 +1,42 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+type TimerFn = (...args: never[]) => unknown;
+
+/** Subset of the `node:timers` module object that fake time interacts with. */
+export interface NodeTimers {
+  setTimeout: TimerFn;
+  clearTimeout: TimerFn;
+  setInterval: TimerFn;
+  clearInterval: TimerFn;
+  promises: NodeTimersPromises;
+}
+
+/**
+ * Subset of the `node:timers/promises` module object that fake time interacts
+ * with.
+ */
+export interface NodeTimersPromises {
+  setTimeout: TimerFn;
+}
+
+// `process.getBuiltinModule()` is used instead of static `node:` imports so
+// that this module does not add `node:` specifiers to the module graph, and
+// so that runtimes without the Node compatibility layer skip the
+// `node:timers` faking instead of failing to load this module.
+const process = (globalThis as {
+  process?: { getBuiltinModule?: (id: string) => unknown };
+}).process;
+
+/** The `node:timers` module object, if the runtime provides it. */
+export const nodeTimers = process?.getBuiltinModule?.("node:timers") as
+  | NodeTimers
+  | undefined;
+
+/** The `node:timers/promises` module object, if the runtime provides it. */
+export const nodeTimersPromises = process?.getBuiltinModule?.(
+  "node:timers/promises",
+) as NodeTimersPromises | undefined;
+
 /** Used internally for testing that fake time uses real time correctly. */
 export const _internals = {
   Date,
@@ -8,4 +45,9 @@ export const _internals = {
   setInterval,
   clearInterval,
   AbortSignalTimeout: AbortSignal.timeout,
+  nodeTimersSetTimeout: nodeTimers?.setTimeout,
+  nodeTimersClearTimeout: nodeTimers?.clearTimeout,
+  nodeTimersSetInterval: nodeTimers?.setInterval,
+  nodeTimersClearInterval: nodeTimers?.clearInterval,
+  nodeTimersPromisesSetTimeout: nodeTimersPromises?.setTimeout,
 };

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -39,7 +39,7 @@
 import { RedBlackTree } from "@std/data-structures/red-black-tree";
 import { ascend } from "@std/data-structures/comparators";
 import type { DelayOptions } from "@std/async/delay";
-import { _internals } from "./_time.ts";
+import { _internals, nodeTimers, nodeTimersPromises } from "./_time.ts";
 
 export type { DelayOptions };
 
@@ -206,6 +206,28 @@ function fakeAbortSignalTimeout(delay: number): AbortSignal {
   return aborter.signal;
 }
 
+function fakeNodeTimersPromisesSetTimeout<T = void>(
+  delay?: number,
+  value?: T,
+  options?: { signal?: AbortSignal; ref?: boolean },
+): Promise<T> {
+  const signal = options?.signal;
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => {
+      fakeClearTimeout(id);
+      reject(signal!.reason);
+    };
+    const id = fakeSetTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve(value as T);
+    }, delay);
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
 function overrideGlobals() {
   globalThis.Date = FakeDate;
   globalThis.setTimeout =
@@ -215,6 +237,18 @@ function overrideGlobals() {
     fakeSetInterval as unknown as typeof globalThis.setInterval;
   globalThis.clearInterval = fakeClearInterval;
   AbortSignal.timeout = fakeAbortSignalTimeout;
+  if (nodeTimers) {
+    nodeTimers.setTimeout = fakeSetTimeout;
+    nodeTimers.clearTimeout = fakeClearTimeout;
+    nodeTimers.setInterval = fakeSetInterval;
+    nodeTimers.clearInterval = fakeClearInterval;
+    // In Deno the object attached at `nodeTimers.promises` and the
+    // `node:timers/promises` module object are distinct, so patch both.
+    nodeTimers.promises.setTimeout = fakeNodeTimersPromisesSetTimeout;
+  }
+  if (nodeTimersPromises) {
+    nodeTimersPromises.setTimeout = fakeNodeTimersPromisesSetTimeout;
+  }
 }
 
 function restoreGlobals() {
@@ -224,6 +258,16 @@ function restoreGlobals() {
   globalThis.setInterval = _internals.setInterval;
   globalThis.clearInterval = _internals.clearInterval;
   AbortSignal.timeout = _internals.AbortSignalTimeout;
+  if (nodeTimers) {
+    nodeTimers.setTimeout = _internals.nodeTimersSetTimeout!;
+    nodeTimers.clearTimeout = _internals.nodeTimersClearTimeout!;
+    nodeTimers.setInterval = _internals.nodeTimersSetInterval!;
+    nodeTimers.clearInterval = _internals.nodeTimersClearInterval!;
+    nodeTimers.promises.setTimeout = _internals.nodeTimersPromisesSetTimeout!;
+  }
+  if (nodeTimersPromises) {
+    nodeTimersPromises.setTimeout = _internals.nodeTimersPromisesSetTimeout!;
+  }
 }
 
 function* timerIdGen() {
@@ -286,6 +330,38 @@ let dueTree: RedBlackTree<DueNode>;
  *   clearInterval(intervalId);
  *   time.tick(1000);
  *   assertSpyCalls(cb, 4);
+ * });
+ * ```
+ *
+ * In addition to the global timer functions, on runtimes that provide the
+ * Node compatibility layer the timer methods on the `node:timers` and
+ * `node:timers/promises` module objects are also faked (`setTimeout`,
+ * `clearTimeout`, `setInterval` and `clearInterval` on `node:timers`, and
+ * `setTimeout` on `node:timers/promises`).
+ *
+ * Note that named imports such as
+ * `import { setTimeout } from "node:timers/promises"` capture the real
+ * implementation when the importing module is loaded and cannot be faked
+ * afterwards. Use the default import form to get fakeable timer methods.
+ *
+ * @example Faking `node:timers/promises`
+ * ```ts
+ * import { FakeTime } from "@std/testing/time";
+ * import { assertEquals } from "@std/assert";
+ * import timersPromises from "node:timers/promises";
+ *
+ * Deno.test("setTimeout from node:timers/promises is faked", async () => {
+ *   using time = new FakeTime();
+ *
+ *   let done = false;
+ *   const promise = timersPromises.setTimeout(1000, "done").then((value) => {
+ *     done = true;
+ *     return value;
+ *   });
+ *   await time.tickAsync(500);
+ *   assertEquals(done, false);
+ *   await time.tickAsync(500);
+ *   assertEquals(await promise, "done");
  * });
  * ```
  */

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -14,6 +14,8 @@ import { FakeTime, TimeError } from "./time.ts";
 import { _internals } from "./_time.ts";
 import { assertSpyCall, spy, type SpyCall } from "./mock.ts";
 import { deadline, delay } from "@std/async";
+import nodeTimers from "node:timers";
+import nodeTimersPromises from "node:timers/promises";
 
 function fromNow(): (..._args: unknown[]) => number {
   const start: number = Date.now();
@@ -215,6 +217,141 @@ Deno.test("FakeTime controls intervals", () => {
   clearInterval(interval);
   time.tick(1000);
   assertEquals(cb.calls, expected);
+});
+
+Deno.test("FakeTime node:timers functions unchanged if FakeTime is uninitialized", () => {
+  assertStrictEquals(nodeTimers.setTimeout, _internals.nodeTimersSetTimeout);
+  assertStrictEquals(
+    nodeTimers.clearTimeout,
+    _internals.nodeTimersClearTimeout,
+  );
+  assertStrictEquals(nodeTimers.setInterval, _internals.nodeTimersSetInterval);
+  assertStrictEquals(
+    nodeTimers.clearInterval,
+    _internals.nodeTimersClearInterval,
+  );
+  assertStrictEquals(
+    nodeTimers.promises.setTimeout,
+    _internals.nodeTimersPromisesSetTimeout,
+  );
+  assertStrictEquals(
+    nodeTimersPromises.setTimeout,
+    _internals.nodeTimersPromisesSetTimeout,
+  );
+});
+
+Deno.test("FakeTime fakes node:timers functions", () => {
+  {
+    using _time: FakeTime = new FakeTime();
+    assertNotEquals(nodeTimers.setTimeout, _internals.nodeTimersSetTimeout);
+    assertNotEquals(
+      nodeTimers.clearTimeout,
+      _internals.nodeTimersClearTimeout,
+    );
+    assertNotEquals(nodeTimers.setInterval, _internals.nodeTimersSetInterval);
+    assertNotEquals(
+      nodeTimers.clearInterval,
+      _internals.nodeTimersClearInterval,
+    );
+    assertNotEquals(
+      nodeTimers.promises.setTimeout,
+      _internals.nodeTimersPromisesSetTimeout,
+    );
+    assertNotEquals(
+      nodeTimersPromises.setTimeout,
+      _internals.nodeTimersPromisesSetTimeout,
+    );
+  }
+  assertStrictEquals(nodeTimers.setTimeout, _internals.nodeTimersSetTimeout);
+  assertStrictEquals(
+    nodeTimers.clearTimeout,
+    _internals.nodeTimersClearTimeout,
+  );
+  assertStrictEquals(nodeTimers.setInterval, _internals.nodeTimersSetInterval);
+  assertStrictEquals(
+    nodeTimers.clearInterval,
+    _internals.nodeTimersClearInterval,
+  );
+  assertStrictEquals(
+    nodeTimers.promises.setTimeout,
+    _internals.nodeTimersPromisesSetTimeout,
+  );
+  assertStrictEquals(
+    nodeTimersPromises.setTimeout,
+    _internals.nodeTimersPromisesSetTimeout,
+  );
+});
+
+Deno.test("FakeTime controls node:timers timeouts and intervals", () => {
+  using time: FakeTime = new FakeTime();
+  const timeoutCb = spy(fromNow());
+  const intervalCb = spy(fromNow());
+
+  nodeTimers.setTimeout(timeoutCb, 1000);
+  const interval = nodeTimers.setInterval(intervalCb, 1000);
+  time.tick(500);
+  assertEquals(timeoutCb.calls.length, 0);
+  assertEquals(intervalCb.calls.length, 0);
+  time.tick(500);
+  assertEquals(timeoutCb.calls.length, 1);
+  assertEquals(intervalCb.calls.length, 1);
+  time.tick(1000);
+  assertEquals(timeoutCb.calls.length, 1);
+  assertEquals(intervalCb.calls.length, 2);
+
+  nodeTimers.clearInterval(interval);
+  time.tick(1000);
+  assertEquals(intervalCb.calls.length, 2);
+
+  const timeout = nodeTimers.setTimeout(timeoutCb, 1000);
+  nodeTimers.clearTimeout(timeout);
+  time.tick(1000);
+  assertEquals(timeoutCb.calls.length, 1);
+});
+
+Deno.test("FakeTime controls node:timers/promises setTimeout", async () => {
+  using time: FakeTime = new FakeTime();
+
+  let done = false;
+  const promise = nodeTimersPromises.setTimeout(1000, "done").then((value) => {
+    done = true;
+    return value;
+  });
+  await time.tickAsync(500);
+  assertEquals(done, false);
+  await time.tickAsync(500);
+  assertEquals(await promise, "done");
+
+  // The object attached at `nodeTimers.promises` is also faked.
+  let attachedDone = false;
+  const attachedPromise = nodeTimers.promises.setTimeout(1000, "done").then(
+    (value) => {
+      attachedDone = true;
+      return value;
+    },
+  );
+  await time.tickAsync(500);
+  assertEquals(attachedDone, false);
+  await time.tickAsync(500);
+  assertEquals(await attachedPromise, "done");
+});
+
+Deno.test("FakeTime node:timers/promises setTimeout rejects on abort", async () => {
+  using time: FakeTime = new FakeTime();
+
+  const aborted = new AbortController();
+  aborted.abort();
+  await assertRejects(() =>
+    nodeTimersPromises.setTimeout(1000, "done", { signal: aborted.signal })
+  );
+
+  const controller = new AbortController();
+  const promise = nodeTimersPromises.setTimeout(1000, "done", {
+    signal: controller.signal,
+  });
+  controller.abort();
+  await assertRejects(() => promise);
+  await time.tickAsync(1000);
 });
 
 Deno.test("FakeTime calls timeout and interval callbacks in correct order", () => {

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -11,11 +11,33 @@ import {
   assertThrows,
 } from "@std/assert";
 import { FakeTime, TimeError } from "./time.ts";
-import { _internals } from "./_time.ts";
+import { _internals, nodeTimers as maybeNodeTimers } from "./_time.ts";
 import { assertSpyCall, spy, type SpyCall } from "./mock.ts";
 import { deadline, delay } from "@std/async";
-import nodeTimers from "node:timers";
-import nodeTimersPromises from "node:timers/promises";
+import nodeTimersDefault from "node:timers";
+import nodeTimersPromisesDefault from "node:timers/promises";
+
+// Deno 1.x ships Node typings without `promises` on the `node:timers` module
+// object and with an `AbortSignal` type that conflicts with the global one, so
+// the module objects are viewed through local types here. On runtimes without
+// `process.getBuiltinModule()` (such as Deno 1.x) `FakeTime` skips the
+// `node:timers` faking, so the related tests are ignored there.
+type NodeTimersPromisesSetTimeout = (
+  delay?: number,
+  value?: string,
+  options?: { signal?: AbortSignal },
+) => Promise<string>;
+const nodeTimers = nodeTimersDefault as unknown as {
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+  setInterval: typeof setInterval;
+  clearInterval: typeof clearInterval;
+  promises: { setTimeout: NodeTimersPromisesSetTimeout };
+};
+const nodeTimersPromises = nodeTimersPromisesDefault as unknown as {
+  setTimeout: NodeTimersPromisesSetTimeout;
+};
+const nodeTimersFaked = maybeNodeTimers !== undefined;
 
 function fromNow(): (..._args: unknown[]) => number {
   const start: number = Date.now();
@@ -219,7 +241,10 @@ Deno.test("FakeTime controls intervals", () => {
   assertEquals(cb.calls, expected);
 });
 
-Deno.test("FakeTime node:timers functions unchanged if FakeTime is uninitialized", () => {
+Deno.test({
+  name: "FakeTime node:timers functions unchanged if FakeTime is uninitialized",
+  ignore: !nodeTimersFaked,
+}, () => {
   assertStrictEquals(nodeTimers.setTimeout, _internals.nodeTimersSetTimeout);
   assertStrictEquals(
     nodeTimers.clearTimeout,
@@ -240,7 +265,10 @@ Deno.test("FakeTime node:timers functions unchanged if FakeTime is uninitialized
   );
 });
 
-Deno.test("FakeTime fakes node:timers functions", () => {
+Deno.test({
+  name: "FakeTime fakes node:timers functions",
+  ignore: !nodeTimersFaked,
+}, () => {
   {
     using _time: FakeTime = new FakeTime();
     assertNotEquals(nodeTimers.setTimeout, _internals.nodeTimersSetTimeout);
@@ -282,7 +310,10 @@ Deno.test("FakeTime fakes node:timers functions", () => {
   );
 });
 
-Deno.test("FakeTime controls node:timers timeouts and intervals", () => {
+Deno.test({
+  name: "FakeTime controls node:timers timeouts and intervals",
+  ignore: !nodeTimersFaked,
+}, () => {
   using time: FakeTime = new FakeTime();
   const timeoutCb = spy(fromNow());
   const intervalCb = spy(fromNow());
@@ -309,7 +340,10 @@ Deno.test("FakeTime controls node:timers timeouts and intervals", () => {
   assertEquals(timeoutCb.calls.length, 1);
 });
 
-Deno.test("FakeTime controls node:timers/promises setTimeout", async () => {
+Deno.test({
+  name: "FakeTime controls node:timers/promises setTimeout",
+  ignore: !nodeTimersFaked,
+}, async () => {
   using time: FakeTime = new FakeTime();
 
   let done = false;
@@ -336,7 +370,10 @@ Deno.test("FakeTime controls node:timers/promises setTimeout", async () => {
   assertEquals(await attachedPromise, "done");
 });
 
-Deno.test("FakeTime node:timers/promises setTimeout rejects on abort", async () => {
+Deno.test({
+  name: "FakeTime node:timers/promises setTimeout rejects on abort",
+  ignore: !nodeTimersFaked,
+}, async () => {
   using time: FakeTime = new FakeTime();
 
   const aborted = new AbortController();


### PR DESCRIPTION
Fixes #7177.

`FakeTime` only swaps the `globalThis` timer functions (plus `Date` and `AbortSignal.timeout`), but the `node:timers` polyfill never reads those globals — `timers.promises.setTimeout` constructs a `Timeout` that schedules through the internal `createTimer_` primitive, so the fake clock is invisible to anything entering through `node:timers`. The repro in the issue hangs because the real one-second timer never fires inside the test's fake-time window.

This patch makes `overrideGlobals()`/`restoreGlobals()` also swap the timer methods on the `node:timers` and `node:timers/promises` module objects: `setTimeout`/`clearTimeout`/`setInterval`/`clearInterval` delegate to the same fakes already used for the globals, and `node:timers/promises` `setTimeout` gets a promise fake built on the fake scheduler that honors `signal` (both pre-aborted and aborted mid-flight). In Deno the object attached at `timers.promises` and the `node:timers/promises` module object are distinct, so both are patched.

Two implementation notes:

- The module objects are obtained through `process.getBuiltinModule()` rather than static `node:` imports. A static import adds a `node:` edge to the published module graph, which `_tools/check_docs.ts` (via `@deno/doc`) fails to load; `getBuiltinModule` returns the same module object (the new tests compare against statically imported references), is synchronous, and lets runtimes without the Node compatibility layer skip the patching instead of failing to load `@std/testing/time`. Deno 1.x predates `getBuiltinModule`, so the faking and the corresponding tests are skipped there (verified locally against 1.46.3); the test file also views the module objects through local types, since the Node typings bundled with Deno 1.x lack `promises` on `node:timers` and declare an incompatible `AbortSignal` on `node:timers/promises`.
- Named imports such as `import { setTimeout } from "node:timers/promises"` capture the real implementation at module load and cannot be faked afterwards. This is documented in the `FakeTime` jsdoc along with a runnable example.

`setImmediate` and the promise-based `setInterval` are left unfaked, consistent with `FakeTime` not faking immediates on `globalThis` today; the jsdoc lists exactly which methods are faked.

The issue's repro shape is covered in `time_test.ts`, plus faked/restored identity checks mirroring the existing global-timer tests and abort rejection coverage for the promise fake. `deno task lint`, `deno fmt --check`, and `deno test -A --doc testing/` all pass locally.
