### PR TITLE
fix(ini): quote ambiguous string values in stringify to preserve round-trip type

### DIFF
--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -43,6 +43,20 @@ function sort([_a, valA]: [string, unknown], [_b, valB]: [string, unknown]) {
 }
 
 function defaultReplacer(_key: string, value: unknown, _section?: string) {
+  if (typeof value === "string") {
+    // Quote strings that would be misread by the parser as a different type.
+    // parseValue converts "true"/"false" to boolean, "null" to null, and
+    // bare numeric strings to number. Wrap those in double quotes so a
+    // parse(stringify(obj)) round-trip preserves the original string value.
+    if (
+      value === "true" ||
+      value === "false" ||
+      value === "null" ||
+      (!isNaN(+value) && value !== "")
+    ) {
+      return `"${value}"`;
+    }
+  }
   return `${value}`;
 }
 

--- a/ini/stringify_test.ts
+++ b/ini/stringify_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import { stringify } from "./mod.ts";
+import { parse, stringify } from "./mod.ts";
 import { assertEquals } from "@std/assert";
 
 Deno.test({
@@ -39,5 +39,35 @@ Deno.test({
     assertEquals(stringify({ a: false }), "a=false");
     assertEquals(stringify({ a: null }), "a=null");
     assertEquals(stringify({ a: undefined }), "a=undefined");
+
+    // String values that look like other types must be quoted so that
+    // parse(stringify(obj)) preserves the original string value.
+    assertEquals(stringify({ a: "true" }), `a="true"`);
+    assertEquals(stringify({ a: "false" }), `a="false"`);
+    assertEquals(stringify({ a: "null" }), `a="null"`);
+    assertEquals(stringify({ a: "123" }), `a="123"`);
+    assertEquals(stringify({ a: "0" }), `a="0"`);
+    assertEquals(stringify({ a: "3.14" }), `a="3.14"`);
+    // Plain strings that cannot be mistaken for another type are not quoted.
+    assertEquals(stringify({ a: "hello" }), "a=hello");
+    assertEquals(stringify({ a: "123foo" }), "a=123foo");
+  },
+});
+
+Deno.test({
+  name: "stringify() round-trips string values that look like other types",
+  fn() {
+    // All of these were silently corrupted before the fix: the string was
+    // written without quotes and then parsed back as a different type.
+    const obj = {
+      boolTrue: "true",
+      boolFalse: "false",
+      nullVal: "null",
+      num: "42",
+      float: "1.5",
+      zero: "0",
+    };
+    const roundTripped = parse(stringify(obj));
+    assertEquals(roundTripped, obj);
   },
 });


### PR DESCRIPTION
Fixes #4809.

When you call stringify on an object whose values are strings that happen
to look like another type, the output loses type information. For example:

    stringify({ key: "true" })  // produces: key=true
    parse("key=true")           // returns:  { key: true }  (boolean, not string)

The same happens with "false", "null", and any numeric string like "123".
The string is written bare, and parseValue then converts it back to the
wrong type. A round-trip through parse(stringify(obj)) silently changes
"true" to true, "null" to null, "123" to 123, and so on.

The root cause is in defaultReplacer, which just does template literal
interpolation without checking whether the string value would be
misread by parseValue. parseValue already supports double-quoted strings
via QUOTED_VALUE_REGEXP and returns them as-is. So the fix is to have
defaultReplacer wrap the ambiguous strings in double quotes.

Plain strings that cannot be mistaken for another type (like "hello" or
"123foo") are left unquoted as before.

I added assertions for the individual quoted outputs and a round-trip test
covering all the affected cases. All 18 tests pass, deno fmt and deno lint
are clean.