### PR TITLE
fix(csv): strip leading byte-order mark in CsvParseStream

### DIFF
--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -65,9 +65,12 @@ export interface CsvParseStreamOptions {
   columns?: readonly string[];
 }
 
+const BYTE_ORDER_MARK = "﻿";
+
 class StreamLineReader implements LineReader {
   #reader: ReadableStreamDefaultReader<string>;
   #done = false;
+  #firstLine = true;
   constructor(reader: ReadableStreamDefaultReader<string>) {
     this.#reader = reader;
   }
@@ -78,8 +81,16 @@ class StreamLineReader implements LineReader {
       this.#done = true;
       return null;
     } else {
+      let line = value!;
+      if (this.#firstLine) {
+        this.#firstLine = false;
+        // Strip leading byte-order mark, matching the behaviour of parse().
+        if (line.startsWith(BYTE_ORDER_MARK)) {
+          line = line.slice(BYTE_ORDER_MARK.length);
+        }
+      }
       // NOTE: Remove trailing CR for compatibility with golang's `encoding/csv`
-      return stripLastCR(value!);
+      return stripLastCR(line);
     }
   }
 

--- a/csv/parse_stream_test.ts
+++ b/csv/parse_stream_test.ts
@@ -580,3 +580,29 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "CsvParseStream strips leading byte-order mark from first field",
+  permissions: "none",
+  fn: async () => {
+    const BOM = "﻿";
+    const source = ReadableStream.from([`${BOM}a,b\n`, "1,2\n"]);
+    const records = await Array.fromAsync(
+      source.pipeThrough(new CsvParseStream()),
+    );
+    assertEquals(records, [["a", "b"], ["1", "2"]]);
+  },
+});
+
+Deno.test({
+  name: "CsvParseStream strips leading byte-order mark when using skipFirstRow",
+  permissions: "none",
+  fn: async () => {
+    const BOM = "﻿";
+    const source = ReadableStream.from([`${BOM}name,age\n`, "Alice,34\n"]);
+    const records = await Array.fromAsync(
+      source.pipeThrough(new CsvParseStream({ skipFirstRow: true })),
+    );
+    assertEquals(records, [{ name: "Alice", age: "34" }]);
+  },
+});


### PR DESCRIPTION
The synchronous `parse()` function already strips a leading UTF-8
byte-order mark (U+FEFF) from its input, but `CsvParseStream` did not.

When a CSV file begins with a BOM -- common output from Excel and other
Windows tools -- the first field name arrives as `"﻿name"` instead
of `"name"`. That corrupts header-based lookups silently:

```ts
const source = ReadableStream.from(["﻿name,age\n", "Alice,34\n"]);
const records = await Array.fromAsync(
  source.pipeThrough(new CsvParseStream({ skipFirstRow: true })),
);
// before this fix:
// [{ "﻿name": "Alice", age: "34" }]   -- BOM leaks into key
// after:
// [{ name: "Alice", age: "34" }]
```

The fix adds a `#firstLine` flag to `StreamLineReader` and strips the
BOM from the first line it reads, exactly matching what `parse()` does
via its `BYTE_ORDER_MARK` constant.

Two new tests cover the regression: one for plain `string[][]` output and
one for `skipFirstRow: true` (object output, where the BOM corrupts the
header key).