### PR TITLE
fix(fs): do not apply exts filter to directory entries

### DIFF
--- a/fs/testdata/walk/ext_with_subdir/subdir/y.rs
+++ b/fs/testdata/walk/ext_with_subdir/subdir/y.rs
@@ -1,0 +1,1 @@
+// Test fixture file for walk exts filter test.

--- a/fs/testdata/walk/ext_with_subdir/x.ts
+++ b/fs/testdata/walk/ext_with_subdir/x.ts
@@ -1,0 +1,1 @@
+// Test fixture file for walk exts filter test.

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -469,7 +469,7 @@ export async function* walk(
   if (exts) {
     exts = exts.map((ext) => ext.startsWith(".") ? ext : `.${ext}`);
   }
-  if (includeDirs && include(root, exts, match, skip)) {
+  if (includeDirs && include(root, undefined, match, skip)) {
     yield await createWalkEntry(root);
   }
   if (maxDepth < 1 || !include(root, undefined, undefined, skip)) {
@@ -898,7 +898,7 @@ export function* walkSync(
   if (maxDepth < 0) {
     return;
   }
-  if (includeDirs && include(root, exts, match, skip)) {
+  if (includeDirs && include(root, undefined, match, skip)) {
     yield createWalkEntrySync(root);
   }
   if (maxDepth < 1 || !include(root, undefined, undefined, skip)) {

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -113,24 +113,48 @@ Deno.test("walkSync() accepts includeFiles option set to false", () =>
     includeFiles: false,
   }));
 
+// https://github.com/denoland/std/issues/6736
+// Directories should not be filtered out by the exts option because they have
+// no file extension. Only files are subject to the exts filter.
 Deno.test("walk() accepts ext option as strings", async () =>
-  await assertWalkPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
+  await assertWalkPaths(testdataDir, "ext", [".", "y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));
 
 Deno.test("walk() accepts ext option as strings (excluding period prefix)", async () =>
-  await assertWalkPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
+  await assertWalkPaths(testdataDir, "ext", [".", "y.rs", "x.ts"], {
     exts: ["rs", "ts"],
   }));
 
 Deno.test("walkSync() accepts ext option as strings", () =>
-  assertWalkSyncPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
+  assertWalkSyncPaths(testdataDir, "ext", [".", "y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));
 
 Deno.test("walkSync() accepts ext option as strings (excluding period prefix)", () =>
-  assertWalkSyncPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
+  assertWalkSyncPaths(testdataDir, "ext", [".", "y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
+  }));
+
+// https://github.com/denoland/std/issues/6736
+// Subdirectories are included even when exts is set, and files within them
+// are still filtered by exts.
+Deno.test("walk() includes subdirs when using exts option", async () =>
+  await assertWalkPaths(testdataDir, "ext_with_subdir", [
+    ".",
+    "x.ts",
+    "subdir",
+  ], {
+    exts: [".ts"],
+  }));
+
+Deno.test("walkSync() includes subdirs when using exts option", () =>
+  assertWalkSyncPaths(testdataDir, "ext_with_subdir", [
+    ".",
+    "x.ts",
+    "subdir",
+  ], {
+    exts: [".ts"],
   }));
 
 Deno.test("walk() accepts ext option as regExps", async () =>


### PR DESCRIPTION
## Summary

Fixes #6736

When `includeDirs` is `true` (the default) and the `exts` option is set, directory entries were incorrectly being filtered out by the `exts` check because directories have no file extension. This meant that using `walk(path, { exts: ['.ts'] })` would not yield any directory entries at all, even though `includeDirs` defaults to `true`.

**Before:**
```ts
// Structure: mydir/ x.ts  subdir/  subdir/y.rs
Array.from(walk("mydir", { exts: [".ts"] }))
// => [{ path: "mydir/x.ts", ... }]
// Root dir and subdir are missing!
```

**After:**
```ts
Array.from(walk("mydir", { exts: [".ts"] }))
// => [
//   { path: "mydir", isDirectory: true, ... },       // root dir included
//   { path: "mydir/x.ts", isFile: true, ... },       // .ts file included
//   { path: "mydir/subdir", isDirectory: true, ... }, // subdir included
//   // mydir/subdir/y.rs excluded (not .ts)
// ]
```

## Changes

- `fs/walk.ts`: When yielding a directory entry (for the root path in both `walk` and `walkSync`), pass `undefined` for `exts` to the `include()` helper so that directory paths are not subject to the file-extension filter. The `match` and `skip` regexp filters still apply to directories.
- `fs/walk_test.ts`: Updated the existing `exts` tests to include the root directory `"."` in expected results. Added two new tests (`walk()` and `walkSync()`) verifying that subdirectories are included when the `exts` option is set.
- `fs/testdata/walk/ext_with_subdir/`: New testdata directory with `x.ts` and `subdir/y.rs` to exercise the subdirectory case.

## Test plan

- [ ] Existing `exts` tests now include the root dir `"."` in expected results
- [ ] New tests `walk() includes subdirs when using exts option` and `walkSync() includes subdirs when using exts option` pass
- [ ] All other walk tests continue to pass