### PR TITLE
feat(tar/unstable): add `Symbol.asyncDispose` to `TarStreamEntry`

### DIFF
--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -131,6 +131,25 @@ export interface TarStreamEntry {
    * The content of the entry, if the entry is a file.
    */
   readable?: ReadableStream<Uint8Array>;
+  /**
+   * Cancels {@linkcode TarStreamEntry.readable} if it has not already been
+   * consumed, so the next entry can be read. This lets callers use the
+   * `await using` form to skip entries without an explicit `cancel()` call:
+   *
+   * ```ts ignore
+   * import { UntarStream } from "@std/tar/untar-stream";
+   *
+   * for await (
+   *   await using entry of (await Deno.open("./out.tar"))
+   *     .readable
+   *     .pipeThrough(new UntarStream())
+   * ) {
+   *   if (entry.path.endsWith(".log")) continue;
+   *   // …consume entry.readable as usual…
+   * }
+   * ```
+   */
+  [Symbol.asyncDispose](): Promise<void>;
 }
 
 /**
@@ -287,6 +306,9 @@ export class UntarStream
           "prefix" in header && header.prefix.length ? header.prefix + "/" : ""
         ) + header.name,
         header,
+        async [Symbol.asyncDispose]() {
+          await this.readable?.cancel();
+        },
       };
       if (!["1", "2", "3", "4", "5", "6"].includes(header.typeflag)) {
         entry.readable = this.#readableFile(header.size);

--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -145,7 +145,7 @@ export interface TarStreamEntry {
    *     .pipeThrough(new UntarStream())
    * ) {
    *   if (entry.path.endsWith(".log")) continue;
-   *   // …consume entry.readable as usual…
+   *   // ...consume entry.readable as usual...
    * }
    * ```
    */

--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -148,6 +148,15 @@ export interface TarStreamEntry {
    *   // ...consume entry.readable as usual...
    * }
    * ```
+   *
+   * Because disposal cancels {@linkcode TarStreamEntry.readable}, it can reject
+   * in two cases that are easy to miss under implicit `await using` disposal:
+   *
+   * - If `readable` has already **errored**, `cancel()` rejects. Leaving the
+   *   loop body via a thrown error then surfaces a `SuppressedError` wrapping
+   *   both the original error and the cancellation rejection.
+   * - If `readable` is **locked** (a reader was acquired without releasing it,
+   *   or a `pipeTo()` is in progress), `cancel()` throws a `TypeError`.
    */
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -168,7 +177,10 @@ export interface TarStreamEntry {
  * When expanding the archive, as demonstrated in the example, one must decide
  * to either consume the ReadableStream property, if present, or cancel it. The
  * next entry won't be resolved until the previous ReadableStream is either
- * consumed or cancelled.
+ * consumed or cancelled. Each entry also implements
+ * {@linkcode Symbol.asyncDispose}, so binding it with `await using` cancels an
+ * unconsumed `readable` automatically — handy for skipping entries with
+ * `continue` without hanging the loop.
  *
  * ### Understanding Compressed
  * A tar archive may be compressed, often identified by an additional file

--- a/tar/untar_stream_test.ts
+++ b/tar/untar_stream_test.ts
@@ -268,3 +268,44 @@ Deno.test("UntarStream() with extra checksum digits", async () => {
     entry.readable?.cancel();
   }
 });
+
+Deno.test("UntarStream() entry can be skipped with `await using`", async () => {
+  const text = new TextEncoder().encode("Hello World!");
+  const readable = ReadableStream.from<TarStreamInput>([
+    {
+      type: "file",
+      path: "./a.txt",
+      size: text.length,
+      readable: ReadableStream.from([text.slice()]),
+    },
+    {
+      type: "file",
+      path: "./b.txt",
+      size: text.length,
+      readable: ReadableStream.from([text.slice()]),
+    },
+  ])
+    .pipeThrough(new TarStream())
+    .pipeThrough(new UntarStream());
+
+  const seen: string[] = [];
+  for await (await using entry of readable) {
+    seen.push(entry.path);
+    // Intentionally do not consume or cancel `entry.readable` — the
+    // `await using` form must dispose it so the next entry can be read.
+  }
+  assertEquals(seen, ["./a.txt", "./b.txt"]);
+});
+
+Deno.test("UntarStream() asyncDispose is a no-op when readable is absent", async () => {
+  const readable = ReadableStream.from<TarStreamInput>([
+    { type: "directory", path: "./dir" },
+  ])
+    .pipeThrough(new TarStream())
+    .pipeThrough(new UntarStream());
+
+  for await (const entry of readable) {
+    assertEquals(entry.readable, undefined);
+    await entry[Symbol.asyncDispose]();
+  }
+});

--- a/tar/untar_stream_test.ts
+++ b/tar/untar_stream_test.ts
@@ -309,3 +309,62 @@ Deno.test("UntarStream() asyncDispose is a no-op when readable is absent", async
     await entry[Symbol.asyncDispose]();
   }
 });
+
+Deno.test("UntarStream() disposing an entry leaves the next entry positioned correctly", async () => {
+  const encoder = new TextEncoder();
+  const first = encoder.encode("first entry contents");
+  const second = encoder.encode("second entry contents, a different length");
+  const readable = ReadableStream.from<TarStreamInput>([
+    {
+      type: "file",
+      path: "./a.txt",
+      size: first.length,
+      readable: ReadableStream.from([first.slice()]),
+    },
+    {
+      type: "file",
+      path: "./b.txt",
+      size: second.length,
+      readable: ReadableStream.from([second.slice()]),
+    },
+  ])
+    .pipeThrough(new TarStream())
+    .pipeThrough(new UntarStream());
+
+  const reader = readable[Symbol.asyncIterator]();
+
+  // Skip the first entry by disposing it without consuming `readable`.
+  const a = (await reader.next()).value!;
+  assertEquals(a.path, "./a.txt");
+  await a[Symbol.asyncDispose]();
+
+  // The second entry's bytes must match exactly. Disposal consuming the wrong
+  // number of blocks would still yield the right path here while silently
+  // shifting the contents, so assert the actual bytes to pin the invariant.
+  const b = (await reader.next()).value!;
+  assertEquals(b.path, "./b.txt");
+  const buffer = new Uint8Array(await new Response(b.readable).arrayBuffer());
+  assertEquals(buffer, second);
+
+  assertEquals((await reader.next()).done, true);
+});
+
+Deno.test("UntarStream() asyncDispose is idempotent", async () => {
+  const text = new TextEncoder().encode("Hello World!");
+  const readable = ReadableStream.from<TarStreamInput>([
+    {
+      type: "file",
+      path: "./a.txt",
+      size: text.length,
+      readable: ReadableStream.from([text.slice()]),
+    },
+  ])
+    .pipeThrough(new TarStream())
+    .pipeThrough(new UntarStream());
+
+  for await (const entry of readable) {
+    await entry[Symbol.asyncDispose]();
+    // A second disposal after the readable is already cancelled must not throw.
+    await entry[Symbol.asyncDispose]();
+  }
+});


### PR DESCRIPTION
Refs #6019.

The most common footgun with `UntarStream` (raised by @lowlighter, @dsherret, and others on the issue) is that requesting the next entry hangs forever if the previous `entry.readable` was neither consumed nor cancelled — e.g. `if (entry.path.endsWith(…)) continue;` in the loop body.

This adds `[Symbol.asyncDispose]` to `TarStreamEntry`, which cancels `entry.readable` if it exists. Callers can then use the explicit-resource-management form to skip entries without remembering to call `cancel()`:

```ts
for await (await using entry of stream.pipeThrough(new UntarStream())) {
  if (entry.path.endsWith(".log")) continue;
  // …consume entry.readable as usual…
}
```

Existing manual `entry.readable?.cancel()` usage keeps working unchanged; nothing else about the streaming contract changes.

### Type-level breaking change

Adding `[Symbol.asyncDispose]` as a **required** member of the exported `TarStreamEntry` interface is a type-level breaking change: any code that builds a `TarStreamEntry` object literal (test mocks, adapters, anything wrapping the stream) stops typechecking until it adds a dispose method. The package is `0.1.10` and the API is `@experimental`/unstable, so this is acceptable — flagging it explicitly per review.
