### PR TITLE
fix(cli/unstable): speed up `ProgressBarStream` tests

### DIFF
--- a/cli/unstable_progress_bar_stream_test.ts
+++ b/cli/unstable_progress_bar_stream_test.ts
@@ -6,10 +6,11 @@ import { ProgressBarStream } from "./unstable_progress_bar_stream.ts";
 async function* getData(
   loops: number,
   bufferSize: number,
+  delay = 5,
 ): AsyncGenerator<Uint8Array> {
   for (let i = 0; i < loops; ++i) {
     yield new Uint8Array(bufferSize);
-    await new Promise((a) => setTimeout(a, Math.random() * 500 + 500));
+    await new Promise((a) => setTimeout(a, delay));
   }
 }
 
@@ -20,7 +21,12 @@ Deno.test("ProgressBarStream() flushes", async () => {
     const _ of ReadableStream
       .from(getData(10, 1000))
       .pipeThrough(
-        new ProgressBarStream({ writable, max: 10 * 1000, keepOpen: false }),
+        new ProgressBarStream({
+          writable,
+          max: 10 * 1000,
+          keepOpen: false,
+          interval: 1,
+        }),
       )
     // deno-lint-ignore no-empty
   ) {}
@@ -34,7 +40,12 @@ Deno.test("ProgressBarStream() cancels", async () => {
   await ReadableStream
     .from(getData(10, 1000))
     .pipeThrough(
-      new ProgressBarStream({ writable, max: 10 * 1000, keepOpen: false }),
+      new ProgressBarStream({
+        writable,
+        max: 10 * 1000,
+        keepOpen: false,
+        interval: 1,
+      }),
     )
     .cancel();
 


### PR DESCRIPTION
Closes #6674.

`ProgressBarStream() flushes` and `ProgressBarStream() cancels` slept 500–1000ms between each of 10 chunks, so each test took ~5–10s — almost all of it idle. The sleeps don't gate the assertion: it only checks that the writable side ends with a newline (\`0x0a\`), which is emitted by `bar.stop()` regardless of how many interval ticks fired.

Drop the per-chunk delay to 5ms and override `interval: 1` on the progress bar so the ticking path still exercises but doesn't dominate runtime. The two tests now run in ~110ms combined instead of ~15s.