### PR TITLE
fix(yaml): stringify astral characters (emoji) without escaping

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -77,6 +77,27 @@ const DEPRECATED_BOOLEANS_SYNTAX = new Set([
 ]);
 
 /**
+ * Returns the Unicode code point at `index`, combining a surrogate pair into a
+ * single value (reference Unicode 3.0 section "3.7 Surrogates"). A combined
+ * code point is greater than 0xffff, so callers can detect a consumed pair and
+ * advance their index by an extra unit.
+ *
+ * `charCodeAt` is used rather than `codePointAt` so the result is always a
+ * number; it returns NaN for an out-of-range index, which never matches the
+ * surrogate ranges below.
+ */
+function codePointAt(string: string, index: number): number {
+  const char = string.charCodeAt(index);
+  if (char >= 0xd800 && char <= 0xdbff /* high surrogate */) {
+    const nextChar = string.charCodeAt(index + 1);
+    if (nextChar >= 0xdc00 && nextChar <= 0xdfff /* low surrogate */) {
+      return (char - 0xd800) * 0x400 + nextChar - 0xdc00 + 0x10000;
+    }
+  }
+  return char;
+}
+
+/**
  * Encodes a Unicode character code point as a hexadecimal escape sequence.
  */
 function charCodeToHexString(charCode: number): string {
@@ -192,7 +213,7 @@ function chooseScalarStyle(
   let hasLineBreak = false;
   let hasFoldableLine = false; // only checked if shouldTrackWidth
   let previousLineBreak = -1; // count the first line correctly
-  let plain = isPlainSafeFirst(string.codePointAt(0)!) &&
+  let plain = isPlainSafeFirst(codePointAt(string, 0)) &&
     !isWhiteSpace(string.charCodeAt(string.length - 1));
 
   let char: number;
@@ -203,7 +224,7 @@ function chooseScalarStyle(
     for (i = 0; i < string.length; i++) {
       // iterate by code point so astral characters (e.g. emoji) are inspected
       // as a whole rather than as their non-printable surrogate halves
-      char = string.codePointAt(i)!;
+      char = codePointAt(string, i);
       if (!isPrintable(char)) {
         return STYLE_DOUBLE;
       }
@@ -213,7 +234,7 @@ function chooseScalarStyle(
   } else {
     // Case: block styles permitted.
     for (i = 0; i < string.length; i++) {
-      char = string.codePointAt(i)!;
+      char = codePointAt(string, i);
       if (char === LINE_FEED) {
         hasLineBreak = true;
         // Check if any line can be folded.
@@ -345,26 +366,15 @@ function foldString(string: string, width: number): string {
 // Escapes a double-quoted string.
 function escapeString(string: string): string {
   let result = "";
-  let char;
-  let nextChar;
-  let escapeSeq;
-
   for (let i = 0; i < string.length; i++) {
-    char = string.charCodeAt(i);
-    // Check for surrogate pairs (reference Unicode 3.0 section "3.7 Surrogates").
-    if (char >= 0xd800 && char <= 0xdbff /* high surrogate */) {
-      nextChar = string.charCodeAt(i + 1);
-      if (nextChar >= 0xdc00 && nextChar <= 0xdfff /* low surrogate */) {
-        // Combine the surrogate pair and store it escaped.
-        result += charCodeToHexString(
-          (char - 0xd800) * 0x400 + nextChar - 0xdc00 + 0x10000,
-        );
-        // Advance index one extra since we already used that char here.
-        i++;
-        continue;
-      }
+    const char = codePointAt(string, i);
+    if (char > 0xffff) {
+      // a combined surrogate pair — store it escaped and skip its low surrogate
+      result += charCodeToHexString(char);
+      i++;
+      continue;
     }
-    escapeSeq = ESCAPE_SEQUENCES.get(char);
+    const escapeSeq = ESCAPE_SEQUENCES.get(char);
     result += !escapeSeq && isPrintable(char)
       ? string[i]
       : escapeSeq || charCodeToHexString(char);

--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -77,27 +77,6 @@ const DEPRECATED_BOOLEANS_SYNTAX = new Set([
 ]);
 
 /**
- * Returns the Unicode code point at `index`, combining a surrogate pair into a
- * single value (reference Unicode 3.0 section "3.7 Surrogates"). A combined
- * code point is greater than 0xffff, so callers can detect a consumed pair and
- * advance their index by an extra unit.
- *
- * `charCodeAt` is used rather than `codePointAt` so the result is always a
- * number; it returns NaN for an out-of-range index, which never matches the
- * surrogate ranges below.
- */
-function codePointAt(string: string, index: number): number {
-  const char = string.charCodeAt(index);
-  if (char >= 0xd800 && char <= 0xdbff /* high surrogate */) {
-    const nextChar = string.charCodeAt(index + 1);
-    if (nextChar >= 0xdc00 && nextChar <= 0xdfff /* low surrogate */) {
-      return (char - 0xd800) * 0x400 + nextChar - 0xdc00 + 0x10000;
-    }
-  }
-  return char;
-}
-
-/**
  * Encodes a Unicode character code point as a hexadecimal escape sequence.
  */
 function charCodeToHexString(charCode: number): string {
@@ -213,7 +192,7 @@ function chooseScalarStyle(
   let hasLineBreak = false;
   let hasFoldableLine = false; // only checked if shouldTrackWidth
   let previousLineBreak = -1; // count the first line correctly
-  let plain = isPlainSafeFirst(codePointAt(string, 0)) &&
+  let plain = isPlainSafeFirst(string.codePointAt(0)!) &&
     !isWhiteSpace(string.charCodeAt(string.length - 1));
 
   let char: number;
@@ -224,7 +203,7 @@ function chooseScalarStyle(
     for (i = 0; i < string.length; i++) {
       // iterate by code point so astral characters (e.g. emoji) are inspected
       // as a whole rather than as their non-printable surrogate halves
-      char = codePointAt(string, i);
+      char = string.codePointAt(i)!;
       if (!isPrintable(char)) {
         return STYLE_DOUBLE;
       }
@@ -234,7 +213,7 @@ function chooseScalarStyle(
   } else {
     // Case: block styles permitted.
     for (i = 0; i < string.length; i++) {
-      char = codePointAt(string, i);
+      char = string.codePointAt(i)!;
       if (char === LINE_FEED) {
         hasLineBreak = true;
         // Check if any line can be folded.
@@ -367,9 +346,9 @@ function foldString(string: string, width: number): string {
 function escapeString(string: string): string {
   let result = "";
   for (let i = 0; i < string.length; i++) {
-    const char = codePointAt(string, i);
+    const char = string.codePointAt(i)!;
     if (char > 0xffff) {
-      // a combined surrogate pair — store it escaped and skip its low surrogate
+      // an astral code point — store it escaped and skip its low surrogate
       result += charCodeToHexString(char);
       i++;
       continue;

--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -192,7 +192,7 @@ function chooseScalarStyle(
   let hasLineBreak = false;
   let hasFoldableLine = false; // only checked if shouldTrackWidth
   let previousLineBreak = -1; // count the first line correctly
-  let plain = isPlainSafeFirst(string.charCodeAt(0)) &&
+  let plain = isPlainSafeFirst(string.codePointAt(0)!) &&
     !isWhiteSpace(string.charCodeAt(string.length - 1));
 
   let char: number;
@@ -201,16 +201,19 @@ function chooseScalarStyle(
     // Case: no block styles.
     // Check for disallowed characters to rule out plain and single.
     for (i = 0; i < string.length; i++) {
-      char = string.charCodeAt(i);
+      // iterate by code point so astral characters (e.g. emoji) are inspected
+      // as a whole rather than as their non-printable surrogate halves
+      char = string.codePointAt(i)!;
       if (!isPrintable(char)) {
         return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
+      if (char > 0xffff) i++;
     }
   } else {
     // Case: block styles permitted.
     for (i = 0; i < string.length; i++) {
-      char = string.charCodeAt(i);
+      char = string.codePointAt(i)!;
       if (char === LINE_FEED) {
         hasLineBreak = true;
         // Check if any line can be folded.
@@ -225,6 +228,7 @@ function chooseScalarStyle(
         return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
+      if (char > 0xffff) i++;
     }
     // in case the end is missing a \n
     hasFoldableLine = hasFoldableLine ||

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -342,7 +342,9 @@ Deno.test({
     assertEquals(stringify("\x03"), `"\\x03"\n`);
     assertEquals(stringify("\x08"), `"\\b"\n`);
     assertEquals(stringify("\uffff"), `"\\uFFFF"\n`);
-    assertEquals(stringify("🐱"), `"\\U0001F431"\n`);
+    // printable astral characters (e.g. emoji) are emitted literally
+    assertEquals(stringify("🐱"), `🐱\n`);
+    assertEquals(stringify("🎨 Check Format"), `🎨 Check Format\n`);
   },
 });
 


### PR DESCRIPTION
## What

`stringify()` hex-escapes astral characters such as emoji instead of emitting them literally:

```ts
import { stringify } from "@std/yaml";

stringify({ name: "🎨 Check Format" });
// before: name: "\U0001F3A8 Check Format"
// after:  name: 🎨 Check Format
```

The output was valid YAML but needlessly hard to read. Non-astral emoji (e.g. `✂️`, which is in the BMP) were already emitted literally, so the behavior was also inconsistent.

## Why

`chooseScalarStyle()` iterated the string with `charCodeAt()`, inspecting UTF-16 code units. An astral character is stored as a surrogate pair, and each half (`0xD800`–`0xDFFF`) falls outside every range in `isPrintable()`. That forced the dumper into double-quoted style, where `escapeString()` then hex-escaped the code point.

## Fix

Iterate by **code point** in `chooseScalarStyle()` via `codePointAt()`, skipping the trailing low surrogate, so astral characters are inspected as a whole — matching the surrogate-pair handling already present in `escapeString()`. Genuinely non-printable characters (control codes, U+FFFF, line/paragraph separators) remain escaped.

`DumperState` is shared, so both `stringify` and `unstable_stringify` are fixed.

## Tests

Updated the "special characters" test, which previously asserted the escaped (buggy) output, and added an emoji-in-a-phrase case. Verified round-tripping through `parse()` for emoji, CJK, and ZWJ sequences (e.g. `👨‍👩‍👧`). Full `yaml/` suite passes.