### PR TITLE
fix: updates for Deno v2.9

### DIFF
--- a/assert/unstable_equals_test.ts
+++ b/assert/unstable_equals_test.ts
@@ -36,7 +36,10 @@ Deno.test(`assertEquals() truncates unchanged lines of large diffs when "${DIFF_
   }));
   stack.use(stub(Deno.env, "get", (key) => {
     if (key === DIFF_CONTEXT_LENGTH) return (10).toString();
-    throw new Error(`Unexpected env var key: ${key}`);
+    // Return undefined rather than throwing for other keys: formatting the diff
+    // can cause Deno to lazily initialize its `node:process` shim, which reads
+    // unrelated env vars (e.g. `NODE_OPTIONS`) through `Deno.env.get`.
+    return undefined;
   }));
 
   const a = Array.from({ length: 1000 }, (_, i) => i);

--- a/crypto/crypto_test.ts
+++ b/crypto/crypto_test.ts
@@ -350,11 +350,13 @@ Deno.test("digest() throws on invalid input", async () => {
     "Cannot digest the data: A chunk is not ArrayBuffer nor ArrayBufferView",
   );
 
+  // Only the error class is asserted: the message is produced by the Deno
+  // runtime and its wording differs across versions (e.g. "Unrecognized
+  // algorithm name" vs. "Algorithm 'BLAK' is not supported").
   await assertRejects(
     async () =>
       await stdCrypto.subtle.digest("BLAK" as DigestAlgorithmName, inputBytes),
     DOMException,
-    "Unrecognized algorithm name",
   );
 });
 
@@ -1763,11 +1765,13 @@ for (const algorithm of DIGEST_ALGORITHM_NAMES) {
 }
 
 Deno.test("digest() throws on invalid algorithm", async () => {
+  // Only the error class is asserted: the message is produced by the Deno
+  // runtime and its wording differs across versions (e.g. "Unrecognized
+  // algorithm name" vs. "Algorithm 'invalid' is not supported").
   await assertRejects(
     // @ts-ignore Algorithm name is invalid on purpose
     async () => await stdCrypto.subtle.digest("invalid", new Uint8Array(0)),
     DOMException,
-    "Unrecognized algorithm name",
   );
 });
 

--- a/testing/_test_helpers.ts
+++ b/testing/_test_helpers.ts
@@ -59,6 +59,16 @@ export class TestContext implements Deno.TestContext {
     }
     return !ignore;
   }
+
+  // `Deno.TestContext.assertSnapshot` was added in a newer Deno release. It is
+  // not used by these tests, but the method must exist for the class to satisfy
+  // the interface. `unknown` is used instead of `Deno.TestSnapshotOptions` so
+  // this stays valid on older Deno versions that lack that type.
+  assertSnapshot(_actual: unknown, _options?: unknown): Promise<void> {
+    throw new Error(
+      "Mock TestContext does not implement assertSnapshot",
+    );
+  }
 }
 
 async function assertDescribeOptions(

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -19,10 +19,14 @@ const SNAPSHOT_MODULE_URL = toFileUrl(join(
 
 function formatTestOutput(string: string) {
   // Strip colors and obfuscate any timings
-  return stripAnsiCode(string).replace(/([0-9])+m?s/g, "--ms").replace(
-    /(?<=running ([0-9])+ test(s)? from )(.*)(?=test.ts)/g,
-    "<tempDir>/",
-  ).replace(/\(file:\/\/.+\)/g, "(file://<path>)");
+  return stripAnsiCode(string).replace(
+    /[0-9]+(?:\.[0-9]+)?(?:µ|m|n)?s/g,
+    "--ms",
+  )
+    .replace(
+      /(?<=running ([0-9])+ test(s)? from )(.*)(?=test.ts)/g,
+      "<tempDir>/",
+    ).replace(/\(file:\/\/.+\)/g, "(file://<path>)");
 }
 
 function formatTestError(string: string) {


### PR DESCRIPTION
## Summary

CI has been failing on recent Deno versions (#7198). Several independent breakages, all caused by changes in newer Deno, are fixed here; `v1.x` still passes, so each change stays compatible across versions.

1. **Microsecond timings** — Deno's test runner now prints sub-ms durations as `µs`, so `testing/snapshot_test.ts`'s timing-normalization regex was broadened from `ms`/`s` to also cover `µs`/`ns`.
2. **`assertSnapshot` on `Deno.TestContext`** — the interface gained `assertSnapshot`, so the mock `TestContext` in `testing/_test_helpers.ts` gets a stub method to keep type-checking.
3. **`assert/unstable_equals_test.ts` env stub** — the `Deno.env.get` stub threw on unexpected keys, but formatting a diff makes Deno read `NODE_OPTIONS` internally, so the stub now returns `undefined` for other keys.
4. **`crypto/crypto_test.ts` error message** — the WebCrypto invalid-algorithm message changed between versions, so the test asserts only the `DOMException` type rather than the message text.

Verified locally on Deno 2.9.0 with `deno task test`, `test:browser`, `fmt`, and `lint`.

Fixes the breakage in #7198; the nightly run that catches this sooner is in #7200.