### PR TITLE
ci: add nightly test run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,92 @@
+name: nightly
+
+# Runs the test suite on a schedule so breakages caused by new Deno releases
+# are caught even when there is no push or pull request activity. On failure it
+# pings @bartlomieju via a tracking issue.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Every day at 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        deno:
+          - v2.x
+          - canary
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno }}
+          cache: true
+
+      - name: Run tests
+        run: |
+          deno task test
+          deno task test:with-unsafe-proto
+
+      - name: Lint
+        run: deno task lint
+
+      - name: Format
+        run: deno fmt --check
+
+  notify:
+    needs: test
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = "Nightly CI failed";
+            const body = [
+              "The [nightly CI run](" + runUrl + ") failed. This usually means a",
+              "recent Deno release broke `@std`.",
+              "",
+              "cc @bartlomieju",
+            ].join("\n");
+
+            const { data: issues } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+            });
+
+            if (issues.total_count > 0) {
+              const issue = issues.items[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Nightly CI failed again: ${runUrl}\n\ncc @bartlomieju`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["ci"],
+              });
+            }


### PR DESCRIPTION
## Summary

CI only runs on `push` and `pull_request`, so breakages introduced by a new
Deno release aren't noticed until the next PR happens to run against it (see
#7198, where the runner's switch to microsecond timings broke the snapshot
tests). This adds a scheduled workflow to catch that sooner.

`.github/workflows/nightly.yml`:

- Runs daily at 06:00 UTC (plus `workflow_dispatch` for manual runs).
- Runs `deno task test`, `test:with-unsafe-proto`, `lint`, and `fmt --check`
  against both **`v2.x` (stable)** and **canary** on ubuntu.
- On a *scheduled* failure, a `notify` job opens a tracking issue (labeled
  `ci`) that cc's **@bartlomieju**, or comments on the existing open one with
  the run link — so repeated failures don't spam new issues. It skips
  notifying on manual `workflow_dispatch` runs to avoid noise during testing.

Closes #7198.

Depends on / pairs with #7199, which fixes the current breakage.