### PR TITLE
chore: format Releases.md in version_bump workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -28,6 +28,9 @@ jobs:
         run: |
           git fetch --unshallow origin
           deno bump-version --import-map import_map.json
+          # `deno bump-version` writes release notes as single long lines;
+          # format them so the release PR passes `deno fmt --check`.
+          deno fmt Releases.md
 
       - name: Commit and open release PR
         env:


### PR DESCRIPTION
The `deno bump-version` subcommand writes the `Releases.md` note as one
long line per commit, which fails the `deno fmt --check` lint step on the
generated release PR — the bullets need to be wrapped at 80 columns. The
previous `@deno/bump-workspaces` tool emitted pre-wrapped notes, so this
gap appeared when the workflow switched to `deno bump-version` in #7201.

This adds a `deno fmt Releases.md` step right after the bump so the
generated release PR is formatted and passes CI without a manual fixup.
The 2026.06.30 release PR (#7202) needed this format pass applied by
hand; with this change future release PRs won't.
