### PR TITLE
feat(net): add `isPortAvailable`

### DIFF
--- a/net/deno.json
+++ b/net/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./get-available-port": "./get_available_port.ts",
+    "./unstable-is-port-available": "./unstable_is_port_available.ts",
     "./unstable-ip": "./unstable_ip.ts",
     "./get-network-address": "./unstable_get_network_address.ts",
     "./unstable-get-network-address": "./unstable_get_network_address.ts"

--- a/net/unstable_is_port_available.ts
+++ b/net/unstable_is_port_available.ts
@@ -63,10 +63,11 @@ export function isPortAvailable(
   options?: IsPortAvailableOptions,
 ): boolean {
   try {
-    using _listener = Deno.listen({
-      port,
-      hostname: options?.hostname ?? "0.0.0.0",
-    });
+    using _listener = Deno.listen(
+      options?.hostname !== undefined
+        ? { port, hostname: options.hostname }
+        : { port },
+    );
     return true;
   } catch (e) {
     if (e instanceof Deno.errors.AddrInUse) {

--- a/net/unstable_is_port_available.ts
+++ b/net/unstable_is_port_available.ts
@@ -1,0 +1,77 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+/**
+ * Options for {@linkcode isPortAvailable}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface IsPortAvailableOptions {
+  /**
+   * The hostname to check the port on.
+   *
+   * @default {"0.0.0.0"}
+   */
+  hostname?: string;
+}
+
+/**
+ * Returns whether the given TCP port is available to listen on.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * > [!IMPORTANT]
+ * > This check is inherently racy: the port may be taken by another process
+ * > between the time this function returns and the time you attempt to listen
+ * > on it. When you control the listener, prefer passing `port: 0` to
+ * > {@linkcode Deno.serve} or {@linkcode Deno.listen} to let the operating
+ * > system assign an available port, or use
+ * > {@linkcode https://jsr.io/@std/net/doc/get-available-port/~/getAvailablePort | getAvailablePort}.
+ *
+ * This function requires the `--allow-net` permission. Any error other than
+ * {@linkcode Deno.errors.AddrInUse} is rethrown, including
+ * {@linkcode Deno.errors.PermissionDenied} for privileged ports (below 1024)
+ * or when the `net` permission has not been granted.
+ *
+ * @param port The port to check. Use `0` to check whether the operating system
+ * can assign an ephemeral port.
+ * @param options Options for checking the port.
+ * @returns `true` if the port is available to listen on, `false` if it is
+ * already in use.
+ *
+ * @example Usage
+ * ```ts
+ * import { isPortAvailable } from "@std/net/unstable-is-port-available";
+ * import { assert } from "@std/assert";
+ *
+ * using listener = Deno.listen({ port: 0 });
+ * const { port } = listener.addr;
+ *
+ * assert(!isPortAvailable(port));
+ * ```
+ *
+ * @example Check before serving
+ * ```ts no-assert ignore
+ * import { isPortAvailable } from "@std/net/unstable-is-port-available";
+ *
+ * if (isPortAvailable(8080)) {
+ *   Deno.serve({ port: 8080 }, () => new Response("Hello, world!"));
+ * }
+ * ```
+ */
+export function isPortAvailable(
+  port: number,
+  options?: IsPortAvailableOptions,
+): boolean {
+  try {
+    using _listener = Deno.listen({
+      port,
+      hostname: options?.hostname ?? "0.0.0.0",
+    });
+    return true;
+  } catch (e) {
+    if (e instanceof Deno.errors.AddrInUse) {
+      return false;
+    }
+    throw e;
+  }
+}

--- a/net/unstable_is_port_available.ts
+++ b/net/unstable_is_port_available.ts
@@ -27,13 +27,23 @@ export interface IsPortAvailableOptions {
  * > system assign an available port, or use
  * > {@linkcode https://jsr.io/@std/net/doc/get-available-port/~/getAvailablePort | getAvailablePort}.
  *
+ * Availability is TCP-only and per-interface, not global:
+ *
+ * - Only the TCP port namespace is checked. UDP uses a separate namespace, so
+ *   `true` says nothing about a UDP service bound to the same number.
+ * - The answer describes `hostname` alone. With the default `0.0.0.0`, a
+ *   process listening on `127.0.0.1` makes this return `false` on Linux and
+ *   macOS, while Windows applies different address-conflict rules and can
+ *   return `true` for the same situation.
+ * - `hostname: "localhost"` resolves to `::1` or `127.0.0.1` depending on the
+ *   system, and the two can give different answers.
+ *
  * This function requires the `--allow-net` permission. Any error other than
  * {@linkcode Deno.errors.AddrInUse} is rethrown, including
  * {@linkcode Deno.errors.PermissionDenied} for privileged ports (below 1024)
  * or when the `net` permission has not been granted.
  *
- * @param port The port to check. Use `0` to check whether the operating system
- * can assign an ephemeral port.
+ * @param port The port to check.
  * @param options Options for checking the port.
  * @returns `true` if the port is available to listen on, `false` if it is
  * already in use.
@@ -47,15 +57,6 @@ export interface IsPortAvailableOptions {
  * const { port } = listener.addr;
  *
  * assert(!isPortAvailable(port));
- * ```
- *
- * @example Check before serving
- * ```ts no-assert ignore
- * import { isPortAvailable } from "@std/net/unstable-is-port-available";
- *
- * if (isPortAvailable(8080)) {
- *   Deno.serve({ port: 8080 }, () => new Response("Hello, world!"));
- * }
  * ```
  */
 export function isPortAvailable(

--- a/net/unstable_is_port_available_test.ts
+++ b/net/unstable_is_port_available_test.ts
@@ -1,0 +1,28 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { isPortAvailable } from "./unstable_is_port_available.ts";
+import { assert, assertFalse, assertThrows } from "@std/assert";
+import { stub } from "@std/testing/mock";
+
+Deno.test("isPortAvailable() returns true for an available port", () => {
+  assert(isPortAvailable(0));
+});
+
+Deno.test("isPortAvailable() returns false for a port already in use", () => {
+  using listener = Deno.listen({ port: 0 });
+  const { port } = listener.addr;
+  assertFalse(isPortAvailable(port));
+});
+
+Deno.test("isPortAvailable() respects the hostname option", () => {
+  using listener = Deno.listen({ port: 0, hostname: "127.0.0.1" });
+  const { port } = listener.addr;
+  assertFalse(isPortAvailable(port, { hostname: "127.0.0.1" }));
+});
+
+Deno.test("isPortAvailable() rethrows errors other than AddrInUse", () => {
+  using _listen = stub(Deno, "listen", () => {
+    throw new Error("boom");
+  });
+  assertThrows(() => isPortAvailable(0), Error, "boom");
+});

--- a/net/unstable_is_port_available_test.ts
+++ b/net/unstable_is_port_available_test.ts
@@ -5,7 +5,11 @@ import { assert, assertFalse, assertThrows } from "@std/assert";
 import { stub } from "@std/testing/mock";
 
 Deno.test("isPortAvailable() returns true for an available port", () => {
-  assert(isPortAvailable(0));
+  const listener = Deno.listen({ port: 0 });
+  const { port } = listener.addr;
+  listener.close();
+
+  assert(isPortAvailable(port));
 });
 
 Deno.test("isPortAvailable() returns false for a port already in use", () => {
@@ -24,5 +28,5 @@ Deno.test("isPortAvailable() rethrows errors other than AddrInUse", () => {
   using _listen = stub(Deno, "listen", () => {
     throw new Error("boom");
   });
-  assertThrows(() => isPortAvailable(0), Error, "boom");
+  assertThrows(() => isPortAvailable(8080), Error, "boom");
 });


### PR DESCRIPTION
Closes #7196.

`@std/net` only had `getAvailablePort`, so there was no quick way to ask "is this specific port free?" without writing the `Deno.listen` plus catch yourself. This adds that:

```ts
isPortAvailable(port: number, options?: { hostname?: string }): boolean
```

It returns `true` when the TCP port can be listened on, `false` on `Deno.errors.AddrInUse`, and rethrows any other error (including `PermissionDenied` for privileged ports or a missing `net` permission). `hostname` defaults to `0.0.0.0`. Since `net` is stable, it lives in `unstable_is_port_available.ts` as the `@std/net/unstable-is-port-available` export and isn't re-exported from `mod.ts`.

The doc comment is upfront about the obvious race: the port can be taken between the check and your own `listen`, so it points back to `port: 0` / `getAvailablePort` for cases where you own the listener.

Tests cover an available port, a port already in use, the `hostname` option, and the rethrow path for errors other than `AddrInUse`. `deno task lint`, `deno fmt --check`, and `deno test -A --doc` pass locally.

One open question: happy to also add `getAvailablePorts(count, options?)` here if that would be useful, or keep this PR to the single function.
