### PR TITLE
fix(cli): render content in promptSelect when terminal height is too small

### DIFF
--- a/cli/_prompt_select.ts
+++ b/cli/_prompt_select.ts
@@ -70,9 +70,9 @@ export function handlePromptSelect<V>(
     }
   }
 
-  let visibleLines = visibleLinesInit ?? Math.min(
-    availableHeight,
-    values.length,
+  let visibleLines = visibleLinesInit ?? Math.max(
+    1,
+    Math.min(availableHeight, values.length),
   );
 
   while (true) {
@@ -186,7 +186,7 @@ export function handlePromptSelect<V>(
     } else {
       availableHeight = Deno.consoleSize().rows - SAFE_PADDING;
     }
-    visibleLines = Math.min(availableHeight, visibleLines);
+    visibleLines = Math.max(1, Math.min(availableHeight, visibleLines));
 
     clearLength = 1 + // message
       (hasUpArrow ? 1 : 0) +

--- a/cli/unstable_prompt_select_test.ts
+++ b/cli/unstable_prompt_select_test.ts
@@ -1194,3 +1194,60 @@ Deno.test("promptSelect() handles fitToRemainingHeight option", () => {
   assertEquals(expectedOutput, actualOutput);
   restore();
 });
+
+Deno.test("promptSelect() always shows at least one item when height is too small", () => {
+  stub(Deno.stdin, "setRaw");
+  stub(Deno.stdin, "isTerminal", () => true);
+  // rows(4) - SAFE_PADDING(4) = 0 available height, which previously collapsed
+  // visibleLines to 0 and rendered only a scroll indicator with no content.
+  stub(Deno, "consoleSize", () => ({ columns: 80, rows: 4 }));
+
+  const expectedOutput = [
+    "\x1b[?25l",
+    "Please select a browser:\r\n",
+    "❯ safari\r\n",
+    "  ...\r\n",
+    "\x1b[?25h",
+  ];
+
+  const actualOutput: string[] = [];
+
+  stub(
+    Deno.stdout,
+    "writeSync",
+    (data: Uint8Array) => {
+      const output = decoder.decode(data);
+      actualOutput.push(output);
+      return data.length;
+    },
+  );
+
+  let readIndex = 0;
+
+  const inputs = [
+    "\r",
+  ];
+
+  stub(
+    Deno.stdin,
+    "readSync",
+    (data: Uint8Array) => {
+      const input = inputs[readIndex++];
+      const bytes = encoder.encode(input);
+      data.set(bytes);
+      return bytes.length;
+    },
+  );
+
+  const browser = promptSelect("Please select a browser:", [
+    "safari",
+    "chrome",
+    "firefox",
+    "brave",
+    "edge",
+  ]);
+
+  assertEquals(browser, "safari");
+  assertEquals(expectedOutput, actualOutput);
+  restore();
+});


### PR DESCRIPTION
## Problem

`promptSelect()` (and `promptMultipleSelect()`, which share `handlePromptSelect`) could render **only a scroll indicator (`...`) with no selectable content** when there wasn't enough vertical space.

This happens whenever the available terminal height is `0` or negative — e.g. a small terminal, or `fitToRemainingHeight: true` with the cursor near the bottom of the screen. `availableHeight = rows - SAFE_PADDING(4)` becomes `≤ 0`, which collapses `visibleLines` to `0`, so no items are sliced into the visible window and only the "more content" indicator is printed.

Reproduction (80×4 terminal):

```
Please select a browser:
  ...
```

## Fix

Clamp `visibleLines` to at least `1` in both places it is computed, so at least one item is always visible:

```
Please select a browser:
❯ safari
  ...
```

## Tests

Added `promptSelect() always shows at least one item when height is too small`, which stubs a 4-row terminal and asserts the active item is rendered. All existing `promptSelect`/`promptMultipleSelect` tests still pass.