### PR TITLE
deprecation(testing): `bdd` and `unstable-bdd` modules

### DIFF
--- a/testing/_test_suite.ts
+++ b/testing/_test_suite.ts
@@ -10,7 +10,12 @@ export const globalSanitizersState = {
 };
 const assertionState = getAssertionState();
 
-/** The options for creating a test suite with the describe function. */
+/**
+ * The options for creating a test suite with the describe function.
+ *
+ * @deprecated This will be removed in 2.0.0 together with `describe` from
+ * `@std/testing/bdd`. Use `node:test`'s `describe()` instead.
+ */
 export interface DescribeDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
   /** The body of the test suite */
   fn?: () => void | undefined;
@@ -38,7 +43,12 @@ export interface DescribeDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
     | ((this: T) => void | Promise<void>)[];
 }
 
-/** The options for creating an individual test case with the it function. */
+/**
+ * The options for creating an individual test case with the it function.
+ *
+ * @deprecated This will be removed in 2.0.0 together with `it` from
+ * `@std/testing/bdd`. Use `node:test`'s `it()` instead.
+ */
 export interface ItDefinition<T> extends Omit<Deno.TestDefinition, "fn"> {
   /** The body of the test case */
   fn: (this: T, t: Deno.TestContext) => void | Promise<void>;
@@ -55,6 +65,9 @@ export type HookNames = "beforeAll" | "afterAll" | "beforeEach" | "afterEach";
 
 /**
  * A group of tests.
+ *
+ * @deprecated This will be removed in 2.0.0 together with `describe` from
+ * `@std/testing/bdd`. Use `node:test`'s `describe()` instead.
  */
 export interface TestSuite<T> {
   /** The symbol to use for grouping the test suite */

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -4,6 +4,29 @@
  * A {@link https://en.wikipedia.org/wiki/Behavior-driven_development | BDD} interface
  * to `Deno.test()` API.
  *
+ * > [!WARNING]
+ * > **Deprecated**: A BDD interface is available through the `node:test`
+ * > module, which is supported first-class by `deno test`. Use `node:test`'s
+ * > `describe()` and `it()`, or the flat `Deno.test()` style with the
+ * > `Deno.test.beforeAll()`/`beforeEach()`/`afterEach()`/`afterAll()` hooks
+ * > (Deno 2.5+), instead. This module will be removed in 2.0.0.
+ *
+ * Migration is mostly a matter of changing the import:
+ *
+ * ```ts ignore
+ * // Before
+ * import { describe, it, beforeEach } from "@std/testing/bdd";
+ *
+ * // After
+ * import { describe, it, beforeEach } from "node:test";
+ * ```
+ *
+ * `it.only`, `it.skip` and `it.todo` (and the `describe` equivalents) are
+ * available in `node:test` as well. Note that `node:test` suites don't accept
+ * `Deno.test` options such as `sanitizeOps`, `sanitizeResources` or
+ * `permissions`; tests that rely on per-suite options can migrate to the flat
+ * `Deno.test()` style instead, which accepts them per test.
+ *
  * With `@std/testing/bdd` module you can write your tests in a familiar format for
  * grouping tests and adding setup/teardown hooks used by other JavaScript testing
  * frameworks like Jasmine, Jest, and Mocha.
@@ -399,6 +422,9 @@
  * });
  * ```
  *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s BDD interface
+ * or the flat `Deno.test()` style instead.
+ *
  * @module
  */
 
@@ -414,7 +440,12 @@ import {
 } from "./_test_suite.ts";
 export type { DescribeDefinition, ItDefinition, TestSuite };
 
-/** The arguments for an ItFunction. */
+/**
+ * The arguments for an ItFunction.
+ *
+ * @deprecated This will be removed in 2.0.0 together with {@linkcode it}.
+ * Use `node:test`'s `it()` instead.
+ */
 export type ItArgs<T> =
   | [options: ItDefinition<T>]
   | [
@@ -526,7 +557,12 @@ function itDefinition<T>(...args: ItArgs<T>): ItDefinition<T> {
   };
 }
 
-/** Registers an individual test case. */
+/**
+ * Registers an individual test case.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `it()` or
+ * `Deno.test()` instead.
+ */
 // deno-lint-ignore deno-style-guide/naming-convention
 export interface it {
   <T>(...args: ItArgs<T>): void;
@@ -562,6 +598,9 @@ export interface it {
  *
  * @typeParam T The self type of the function to implement the test case
  * @param args The test case
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `it()` or
+ * `Deno.test()` instead.
  */
 export function it<T>(...args: ItArgs<T>) {
   if (TestSuiteInternal.runningCount > 0) {
@@ -742,6 +781,9 @@ it.skip = function itSkip<T>(...args: ItArgs<T>): void {
  *
  * @typeParam T The self type of the function to implement the test case
  * @param args The test case
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `test()` or
+ * `Deno.test()` instead.
  */
 export function test<T>(...args: ItArgs<T>) {
   it(...args);
@@ -864,6 +906,9 @@ function addHook<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the setup behavior.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `before()` or
+ * `Deno.test.beforeAll()` (Deno 2.5+) instead.
  */
 export function beforeAll<T>(
   fn: (this: T) => void | Promise<void>,
@@ -895,6 +940,9 @@ export function beforeAll<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the setup behavior.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `before()` or
+ * `Deno.test.beforeAll()` (Deno 2.5+) instead.
  */
 export function before<T>(
   fn: (this: T) => void | Promise<void>,
@@ -924,6 +972,9 @@ export function before<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the teardown behavior.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `after()` or
+ * `Deno.test.afterAll()` (Deno 2.5+) instead.
  */
 export function afterAll<T>(
   fn: (this: T) => void | Promise<void>,
@@ -955,6 +1006,9 @@ export function afterAll<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the teardown behavior.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `after()` or
+ * `Deno.test.afterAll()` (Deno 2.5+) instead.
  */
 export function after<T>(
   fn: (this: T) => void | Promise<void>,
@@ -984,6 +1038,9 @@ export function after<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the shared setup behavior
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `beforeEach()`
+ * or `Deno.test.beforeEach()` (Deno 2.5+) instead.
  */
 export function beforeEach<T>(
   fn: (this: T) => void | Promise<void>,
@@ -1013,6 +1070,9 @@ export function beforeEach<T>(
  *
  * @typeParam T The self type of the function
  * @param fn The function to implement the shared teardown behavior
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `afterEach()`
+ * or `Deno.test.afterEach()` (Deno 2.5+) instead.
  */
 export function afterEach<T>(
   fn: (this: T) => void | Promise<void>,
@@ -1020,7 +1080,12 @@ export function afterEach<T>(
   addHook("afterEach", fn);
 }
 
-/** The arguments for a DescribeFunction. */
+/**
+ * The arguments for a DescribeFunction.
+ *
+ * @deprecated This will be removed in 2.0.0 together with {@linkcode describe}.
+ * Use `node:test`'s `describe()` instead.
+ */
 export type DescribeArgs<T> =
   | [options: DescribeDefinition<T>]
   | [name: string]
@@ -1146,7 +1211,12 @@ function describeDefinition<T>(
   };
 }
 
-/** Registers a test suite. */
+/**
+ * Registers a test suite.
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `describe()`
+ * instead.
+ */
 // deno-lint-ignore deno-style-guide/naming-convention
 export interface describe {
   <T>(...args: DescribeArgs<T>): TestSuite<T>;
@@ -1180,6 +1250,9 @@ export interface describe {
  * @typeParam T The self type of the test suite body.
  * @param args The test suite body.
  * @returns The test suite
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `describe()`
+ * instead.
  */
 export function describe<T>(
   ...args: DescribeArgs<T>

--- a/testing/unstable_bdd.ts
+++ b/testing/unstable_bdd.ts
@@ -23,6 +23,9 @@ import { describe as describe_, it as it_, test as test_ } from "./bdd.ts";
  * @typeParam T The self type of the test suite body.
  * @param args The test suite body.
  * @returns The test suite
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `describe()`,
+ * which also supports `describe.todo()`, instead.
  */
 const describe = describe_ as typeof describe_ & describe;
 
@@ -44,6 +47,9 @@ const describe = describe_ as typeof describe_ & describe;
  *
  * @typeParam T The self type of the function to implement the test case
  * @param args The test case
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `it()`, which
+ * also supports `it.todo()`, instead.
  */
 const it = it_ as typeof it_ & it;
 
@@ -65,6 +71,9 @@ const it = it_ as typeof it_ & it;
  *
  * @typeParam T The self type of the function to implement the test case
  * @param args The test case
+ *
+ * @deprecated This will be removed in 2.0.0. Use `node:test`'s `test()`, which
+ * also supports `test.todo()`, instead.
  */
 const test = test_ as typeof test_ & test;
 
@@ -95,7 +104,12 @@ interface test {
   todo<T>(...args: ItArgs<T>): void;
 }
 
-/** Options for {@linkcode configureGlobalSanitizers}. */
+/**
+ * Options for {@linkcode configureGlobalSanitizers}.
+ *
+ * @deprecated This will be removed in 2.0.0 together with
+ * {@linkcode configureGlobalSanitizers}.
+ */
 export type ConfigureGlobalSanitizersOptions = {
   sanitizeOps?: boolean;
   sanitizeResources?: boolean;
@@ -110,6 +124,10 @@ export type ConfigureGlobalSanitizersOptions = {
  * import { configureGlobalSanitizers } from "@std/testing/unstable-bdd";
  * configureGlobalSanitizers({ sanitizeResources: false })
  * ```
+ *
+ * @deprecated This will be removed in 2.0.0. There is no global equivalent;
+ * pass `sanitizeOps`, `sanitizeResources` or `sanitizeExit` options to
+ * individual `Deno.test()` calls instead.
  */
 export function configureGlobalSanitizers(
   options: ConfigureGlobalSanitizersOptions,


### PR DESCRIPTION
A BDD interface is available through the `node:test` module, which is
supported first-class by `deno test`: `describe()`/`it()`/`test()` with
`before`/`beforeEach`/`afterEach`/`after` hooks and the `.only`, `.skip`
and `.todo` variants. The flat `Deno.test()` style additionally gained
`Deno.test.beforeAll()`/`beforeEach()`/`afterEach()`/`afterAll()` hooks
in Deno 2.5. This deprecates the `@std/testing/bdd` and
`@std/testing/unstable-bdd` exports in favor of those built-ins, slated
for removal in `@std/testing@2.0.0`, and adds a migration guide to the
module docs.

One behavioral difference is documented in the migration notes:
`node:test` suites don't accept `Deno.test` options such as
`sanitizeOps`, `sanitizeResources` or `permissions`, so tests relying on
per-suite options (or on `configureGlobalSanitizers`) should migrate to
the flat `Deno.test()` style, which accepts them per test.

Ref #7208