### PR TITLE
ci: only run nightly workflow on denoland/std, not forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   test:
+    # Only run on the upstream repository, not on forks.
+    if: github.repository == 'denoland/std'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
Scheduled workflows run on forks that keep the default branch, which
wastes their Actions minutes and produces failures unrelated to upstream.

Guard the `test` job with `if: github.repository == 'denoland/std'` so the
nightly run only executes on the upstream repository. The `notify` job
already declares `needs: test`, so it is skipped on forks as well.