### PR TITLE
chore: declare fast-check as a bare specifier in deno.json imports

### DIFF
--- a/cli/_tools/compare_with_rust.ts
+++ b/cli/_tools/compare_with_rust.ts
@@ -3,7 +3,7 @@
 
 import { unicodeWidth } from "../unicode_width.ts";
 import { fromFileUrl } from "../../path/mod.ts";
-import fc from "npm:fast-check@3.8.0";
+import fc from "fast-check";
 
 // Note: This test is optional. It requires the Rust code to be compiled locally
 Deno.test("fast-check equality with unicode_width Rust crate", async (t) => {

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,7 @@
     "@deno/doc": "jsr:@deno/doc@^0.169.1",
     "npm:/typescript": "npm:typescript@5.8.2",
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/",
+    "fast-check": "npm:fast-check@3.8.0",
     "graphviz": "npm:node-graphviz@^0.1.1"
   },
   "unstable": ["webgpu", "fs"],


### PR DESCRIPTION
The `compare_with_rust.ts` FFI tool imported fast-check via an inline
`npm:fast-check@3.8.0` specifier, the only remaining inline `npm:` import
in the repo now that the other tooling dependencies live in the
`deno.json` import map. This declares fast-check there too and switches
the import to the bare `fast-check` specifier, matching how `graphviz`,
`typescript`, and the `@deno/*` tools are already referenced.

This is dev-tooling only and does not affect any published package: the
import map is a resolution table, not a dependency manifest, and the file
lives under `_tools/` so it is never reachable from any `@std/*`
package's exports.