### PR TITLE
chore: enable no-import-prefix lint rule

### DIFF
--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -5,7 +5,7 @@ import { walk } from "../fs/walk.ts";
 import { relative } from "../path/relative.ts";
 import { dirname } from "../path/dirname.ts";
 import * as colors from "../fmt/colors.ts";
-import ts from "npm:typescript@5.8.3";
+import ts from "typescript";
 import { getEntrypoints } from "./utils.ts";
 import { fromFileUrl } from "@std/path/from-file-url";
 

--- a/crypto/_benches/bench.ts
+++ b/crypto/_benches/bench.ts
@@ -4,8 +4,6 @@ import { crypto as stdCrypto, type DIGEST_ALGORITHM_NAMES } from "../mod.ts";
 
 import nodeCrypto from "node:crypto";
 
-import { crypto as oldCrypto } from "jsr:@std/crypto@0.220.1";
-
 const webCrypto = globalThis.crypto;
 
 const BENCHMARKED_DIGEST_ALGORITHM_NAMES = [
@@ -56,17 +54,6 @@ for (
         await stdCrypto.subtle.digest(name, [buffer]);
       },
     });
-
-    if (name.startsWith("FNV")) {
-      Deno.bench({
-        group: `digesting ${humanLength}`,
-        name:
-          `${name} from std/crypto (v0.220.1) TypeScript digesting ${humanLength}`,
-        async fn() {
-          await oldCrypto.subtle.digest(name, buffer);
-        },
-      });
-    }
 
     if (
       (WEB_CRYPTO_DIGEST_ALGORITHM_NAMES as readonly string[]).includes(name)

--- a/deno.json
+++ b/deno.json
@@ -9,10 +9,10 @@
   "imports": {
     "@deno/graph": "jsr:@deno/graph@^0.89.2",
     "@deno/doc": "jsr:@deno/doc@^0.169.1",
-    "npm:/typescript": "npm:typescript@5.8.2",
     "automation/": "https://raw.githubusercontent.com/denoland/automation/0.10.0/",
     "fast-check": "npm:fast-check@3.8.0",
-    "graphviz": "npm:node-graphviz@^0.1.1"
+    "graphviz": "npm:node-graphviz@^0.1.1",
+    "typescript": "npm:typescript@5.8.3"
   },
   "unstable": ["webgpu", "fs"],
   "tasks": {
@@ -52,6 +52,7 @@
       "tags": ["recommended", "jsr"],
       "include": [
         "camelcase",
+        "no-import-prefix",
         "no-sync-fn-in-async-fn",
         "single-var-declarator",
         "no-console"

--- a/html/_tools/generate_data.ts
+++ b/html/_tools/generate_data.ts
@@ -3,6 +3,9 @@
 
 // JSON version of the full canonical list of named HTML entities
 // https://html.spec.whatwg.org/multipage/named-characters.html
+// This is a one-off codegen fetch of a spec data file, not a project
+// dependency, so it is imported directly rather than via the import map.
+// deno-lint-ignore no-import-prefix
 import entityList from "https://html.spec.whatwg.org/entities.json" with {
   type: "json",
 };


### PR DESCRIPTION
This enables the `no-import-prefix` lint rule so that tooling and
benchmark files can no longer reach for inline `npm:`, `jsr:`, or
`https:` specifiers; dependencies must be declared in `deno.json` and
referenced by their bare specifier. This keeps the versions used by std's
tooling in one place instead of pinned ad hoc at each import site.

Turning the rule on flagged four inline specifiers. `fast-check` was
already moved to the import map in #7225, and the remaining three are
handled here: `check_mod_exports.ts` now imports `typescript` via a bare
specifier (replacing the orphaned `npm:/typescript` entry that nothing
resolved, and reconciling the version with the `5.8.3` the tool actually
used); the crypto benchmark drops its comparison against the years-old
`jsr:@std/crypto@0.220.1` TypeScript FNV implementation, which no longer
tells us anything useful now that the migration to Wasm is long done; and
the one-off HTML entity-table codegen keeps its direct
`https://html.spec.whatwg.org/entities.json` import behind a targeted
`deno-lint-ignore`, since a spec data file fetched by a regeneration
script is not a project dependency.