### PR TITLE
feat(collections): add averageOf

### DIFF
--- a/collections/average_of.ts
+++ b/collections/average_of.ts
@@ -1,0 +1,61 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// This module is browser compatible.
+
+/**
+ * Applies the given selector to all elements in the given collection and
+ * calculates the average of the results.
+ *
+ * @typeParam T The type of the array elements.
+ *
+ * @param array The array to calculate the average of.
+ * @param selector The selector function to get the value to average. The
+ * function receives the element and its index.
+ *
+ * @returns The average of all elements in the collection.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { averageOf } from "@std/collections/average-of";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const people = [
+ *   { name: "Anna", age: 34 },
+ *   { name: "Kim", age: 42 },
+ *   { name: "John", age: 23 },
+ * ];
+ *
+ * const averageAge = averageOf(people, (person) => person.age);
+ *
+ * assertEquals(averageAge, 33);
+ * ```
+ *
+ * @example Using the index parameter
+ * ```ts
+ * import { averageOf } from "@std/collections/average-of";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const array = [10, 20, 30];
+ * const result = averageOf(array, (_, index) => index * 10);
+ *
+ * assertEquals(result, 10);
+ * ```
+ */
+export function averageOf<T>(
+  array: Iterable<T>,
+  selector: (el: T, index: number) => number,
+): number {
+  let sum = 0;
+  let count = 0;
+  let index = 0;
+
+  for (const i of array) {
+    sum += selector(i, index++);
+    count++;
+  }
+
+  if (count === 0) {
+    return NaN;
+  }
+
+  return sum / count;
+}

--- a/collections/average_of_test.ts
+++ b/collections/average_of_test.ts
@@ -1,0 +1,136 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { averageOf } from "./average_of.ts";
+
+Deno.test("averageOf() handles object properties", () => {
+  const people = [
+    { name: "Anna", age: 34 },
+    { name: "Kim", age: 42 },
+    { name: "John", age: 23 },
+  ];
+
+  const actual = averageOf(people, (person) => person.age);
+
+  assertEquals(actual, 33);
+});
+
+Deno.test("averageOf() handles regular average", () => {
+  const array = [1, 2, 3];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, 2);
+});
+
+Deno.test("averageOf() handles negatives", () => {
+  const array = [-1, -2, -3];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, -2);
+});
+
+Deno.test("averageOf() handles mixed negatives and positives", () => {
+  const array = [-1, 2, 3, -5];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, -0.25);
+});
+
+Deno.test("averageOf() handles selector transformation", () => {
+  const array = [1, 3, 5, 3];
+
+  const actual = averageOf(array, (i) => i + 10);
+
+  assertEquals(actual, 13);
+});
+
+Deno.test("averageOf() handles negative object properties", () => {
+  const people = [
+    { name: "Anna", age: -34 },
+    { name: "Kim", age: -42 },
+    { name: "John", age: -23 },
+  ];
+
+  const actual = averageOf(people, (person) => person.age);
+
+  assertEquals(actual, -33);
+});
+
+Deno.test("averageOf() handles mixed object properties", () => {
+  const people = [
+    { name: "Anna", age: -34 },
+    { name: "Kim", age: 42 },
+    { name: "John", age: -23 },
+  ];
+
+  const actual = averageOf(people, (person) => person.age);
+
+  assertEquals(actual, -5);
+});
+
+Deno.test("averageOf() handles single element", () => {
+  const array = [42];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, 42);
+});
+
+Deno.test("averageOf() handles no mutation", () => {
+  const array = [1, 2, 3, 4];
+
+  averageOf(array, (i) => i + 2);
+
+  assertEquals(array, [1, 2, 3, 4]);
+});
+
+Deno.test("averageOf() handles empty array results in NaN", () => {
+  const array: number[] = [];
+
+  const actual = averageOf(array, (i) => i + 2);
+
+  assertEquals(actual, NaN);
+});
+
+Deno.test("averageOf() handles Infinity and -Infinity resulting in NaN", () => {
+  const array = [
+    1,
+    2,
+    Number.POSITIVE_INFINITY,
+    3,
+    4,
+    Number.NEGATIVE_INFINITY,
+    5,
+  ];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, NaN);
+});
+
+Deno.test("averageOf() handles Infinity", () => {
+  const array = [1, 2, Infinity, 3, 4];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, Infinity);
+});
+
+Deno.test("averageOf() passes index to selector", () => {
+  const array = [10, 20, 30];
+
+  const actual = averageOf(array, (_, index) => index * 10);
+
+  assertEquals(actual, 10);
+});
+
+Deno.test("averageOf() handles decimal results", () => {
+  const array = [1, 2];
+
+  const actual = averageOf(array, (i) => i);
+
+  assertEquals(actual, 1.5);
+});

--- a/collections/deno.json
+++ b/collections/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./aggregate-groups": "./aggregate_groups.ts",
+    "./average-of": "./average_of.ts",
     "./associate-by": "./associate_by.ts",
     "./associate-with": "./associate_with.ts",
     "./chunk": "./chunk.ts",

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -29,6 +29,7 @@
  */
 
 export * from "./aggregate_groups.ts";
+export * from "./average_of.ts";
 export * from "./associate_by.ts";
 export * from "./associate_with.ts";
 export * from "./chunk.ts";


### PR DESCRIPTION
## What

Adds `averageOf` function to `@std/collections`. Applies a selector to all elements in a collection and returns the arithmetic mean of the results.

## Why

`sumOf` exists but there is no corresponding `averageOf`. This is a common utility (Lodash has `meanBy`, Python has `statistics.mean`). Fills a clear gap in the collection API.

## Changes

- Added `collections/average_of.ts` — implementation mirroring `sumOf` pattern (same signature, same `Iterable<T>` + index support)
- Added `collections/average_of_test.ts` — 14 tests covering basic usage, edge cases (empty, single element, negatives, Infinity, NaN), no mutation, index parameter, decimal results
- Updated `collections/mod.ts` — added export
- Updated `collections/deno.json` — added sub-path export `./average-of`

## Behavior

- Returns `NaN` for empty arrays (mathematically correct for undefined mean)
- Follows existing patterns: browser compatible, immutable, `Iterable<T>` input