### PR TITLE
fix(data-structures): deep-copy nodes in BinarySearchTree/RedBlackTree.from()

### DIFF
--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -274,6 +274,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
             ? BinarySearchNode.from(node.right)
             : null;
 
+          node.left = left;
+          node.right = right;
           if (left) {
             left.parent = node;
             nodes.push(left);

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -426,6 +426,24 @@ Deno.test("BinarySearchTree.from() handles default ascend comparator", () => {
   assertEquals([...tree].reverse(), expected.map((v: number) => 3 * v));
 });
 
+Deno.test("BinarySearchTree.from() deep-copies nodes so mutating the copy leaves the original intact", () => {
+  const values = [3, 10, 13, 4, 6, 7, 1, 14];
+  const original = BinarySearchTree.from(values);
+  const copy = BinarySearchTree.from(original);
+
+  // Removing from the copy must not affect the original.
+  assertStrictEquals(copy.remove(7), true);
+  assertStrictEquals(original.find(7), 7);
+  assertEquals([...original], [1, 3, 4, 6, 7, 10, 13, 14]);
+  assertEquals([...copy], [1, 3, 4, 6, 10, 13, 14]);
+
+  // Removing from the original must not affect the copy.
+  assertStrictEquals(original.remove(1), true);
+  assertStrictEquals(copy.find(1), 1);
+  assertEquals([...original], [3, 4, 6, 7, 10, 13, 14]);
+  assertEquals([...copy], [1, 3, 4, 6, 10, 13, 14]);
+});
+
 Deno.test("BinarySearchTree.from() handles descend comparator", () => {
   const values: number[] = [-10, 9, -1, 100, 9, 1, 0, 9, -100, 10, -9];
   const expected: number[] = [100, 10, 9, 1, 0, -1, -9, -10, -100];

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -231,8 +231,11 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
         const nodes: RedBlackNode<U>[] = [];
         const root = getRoot(collection);
         if (root) {
-          setRoot(result, root as unknown as RedBlackNode<U>);
-          nodes.push(root as unknown as RedBlackNode<U>);
+          const rootCopy = RedBlackNode.from(
+            root as unknown as RedBlackNode<U>,
+          );
+          setRoot(result, rootCopy);
+          nodes.push(rootCopy);
         }
         while (nodes.length) {
           const node: RedBlackNode<U> = nodes.pop()!;
@@ -243,6 +246,8 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
             ? RedBlackNode.from(node.right)
             : null;
 
+          node.left = left;
+          node.right = right;
           if (left) {
             left.parent = node;
             nodes.push(left);

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -429,6 +429,24 @@ Deno.test("RedBlackTree.from() handles default ascend comparator", () => {
   assertEquals([...tree.lvlValues()], [-3, 3, -30, 30, 0, -27, -300, 300, 27]);
 });
 
+Deno.test("RedBlackTree.from() deep-copies nodes so mutating the copy leaves the original intact", () => {
+  const values = [3, 10, 13, 4, 6, 7, 1, 14];
+  const original = RedBlackTree.from(values);
+  const copy = RedBlackTree.from(original);
+
+  // Removing from the copy must not affect the original.
+  assertStrictEquals(copy.remove(7), true);
+  assertStrictEquals(original.find(7), 7);
+  assertEquals([...original], [1, 3, 4, 6, 7, 10, 13, 14]);
+  assertEquals([...copy], [1, 3, 4, 6, 10, 13, 14]);
+
+  // Removing from the original must not affect the copy.
+  assertStrictEquals(original.remove(1), true);
+  assertStrictEquals(copy.find(1), 1);
+  assertEquals([...original], [3, 4, 6, 7, 10, 13, 14]);
+  assertEquals([...copy], [1, 3, 4, 6, 10, 13, 14]);
+});
+
 Deno.test("RedBlackTree.from() handles descend comparator", () => {
   const values: number[] = [-10, 9, -1, 100, 9, 1, 0, 9, -100, 10, -9];
   const expected: number[] = [100, 10, 9, 1, 0, -1, -9, -10, -100];


### PR DESCRIPTION
## Problem

`BinarySearchTree.from()` and `RedBlackTree.from()` are documented to create an
independent copy of an existing tree, but they only performed a partial copy.
The traversal that walks the source tree created a copy of each child node and
fixed up the child's `parent` pointer, but it never re-linked the parent copy's
`left`/`right` pointers to point at those new child copies. Because
`BinarySearchNode.from()` / `RedBlackNode.from()` seed a copy's `left`/`right`
with the *original* node's children, the returned tree ended up still
referencing the source tree's descendant nodes.

`RedBlackTree.from()` was additionally worse: it seeded the result with the
source tree's **root node itself** (via `setRoot(result, root)`) rather than a
copy of it.

The net effect is that the "copy" shares nodes with the original, so mutating
the copy corrupts the original (and vice versa):

```ts
import { BinarySearchTree } from "@std/data-structures";

const original = BinarySearchTree.from([3, 10, 13, 4, 6, 7, 1, 14]);
const copy = BinarySearchTree.from(original);

copy.remove(7);
original.find(7); // null  ❌ — 7 was removed from the original too
```

Fixes #6314
Fixes #6315

## Fix

- Re-link `node.left` / `node.right` to the freshly created child copies during
  the copy traversal in both `BinarySearchTree.from()` and
  `RedBlackTree.from()`.
- In `RedBlackTree.from()`, copy the root node before seeding the result with it
  (so the traversal no longer mutates the source root).

The mapped / custom-comparator paths are unchanged (they already rebuild the
tree via `insert()`).

## Verification

- Added regression tests for both trees asserting that a removal in either the
  copy or the original leaves the other intact. They fail on `main`
  (`original.find(7)` returns `null`) and pass with this change.
- `deno test data_structures/` → 350 passed, 0 failed.
- `deno fmt --check` and `deno lint` on the changed files are clean.
- `deno check` on the changed files passes.
