### PR TITLE
BREAKING(xml): clean up public API

### DIFF
--- a/xml/_parse_sync.ts
+++ b/xml/_parse_sync.ts
@@ -17,7 +17,7 @@ import type {
   ParseOptions,
   XmlCDataNode,
   XmlCommentNode,
-  XmlDeclarationEvent,
+  XmlDeclaration,
   XmlDocument,
   XmlElement,
   XmlName,
@@ -114,7 +114,7 @@ export function parseSync(xml: string, options?: ParseOptions): XmlDocument {
   // Tree building state
   const stack: MutableElement[] = [];
   let root: MutableElement | undefined;
-  let declaration: XmlDeclarationEvent | undefined;
+  let declaration: XmlDeclaration | undefined;
   let rootClosed = false; // Track whether root element has been closed
 
   // Namespace tracking (lazy initialization for performance)

--- a/xml/_parse_sync_test.ts
+++ b/xml/_parse_sync_test.ts
@@ -415,6 +415,18 @@ Deno.test("parseSync() with trackPosition false reports zero positions", () => {
   throw new Error("Expected XmlSyntaxError");
 });
 
+Deno.test("parseSync() with trackPosition false omits position from error message", () => {
+  try {
+    parseSync("<root><unclosed>", { trackPosition: false });
+  } catch (e) {
+    if (e instanceof XmlSyntaxError) {
+      assertEquals(e.message, "Unclosed element <unclosed>");
+      return;
+    }
+  }
+  throw new Error("Expected XmlSyntaxError");
+});
+
 Deno.test("parseSync() extracts standalone yes from declaration", () => {
   // Tests standalone attribute extraction
   const doc = parseSync('<?xml version="1.0" standalone="yes"?><root/>');

--- a/xml/_parser.ts
+++ b/xml/_parser.ts
@@ -16,9 +16,9 @@ import type {
   ParseStreamOptions,
   XmlAttributeIterator,
   XmlEventCallbacks,
-  XmlTokenCallbacks,
 } from "./types.ts";
 import { XmlSyntaxError } from "./types.ts";
+import type { XmlTokenCallbacks } from "./_tokenizer.ts";
 import { decodeEntities } from "./_entities.ts";
 import {
   validateNamespaceBinding,

--- a/xml/_tokenizer.ts
+++ b/xml/_tokenizer.ts
@@ -11,9 +11,12 @@
  */
 
 import {
+  type XmlContentCallback,
+  type XmlDeclarationCallback,
+  type XmlDoctypeCallback,
   type XmlPosition,
+  type XmlProcessingInstructionCallback,
   XmlSyntaxError,
-  type XmlTokenCallbacks,
 } from "./types.ts";
 import {
   isIllegalXmlLiteralChar,
@@ -23,6 +26,52 @@ import {
   validateXmlDeclaration,
 } from "./_common.ts";
 import { isNameChar, isNameStartChar } from "./_name_chars.ts";
+
+/**
+ * Callbacks for tokenizer output - enables zero-allocation token emission.
+ *
+ * Instead of creating token objects, the tokenizer invokes these callbacks
+ * directly with primitive values.
+ */
+export interface XmlTokenCallbacks {
+  /** Called when a start tag opens (e.g., `<element`). */
+  onStartTagOpen?(
+    name: string,
+    line: number,
+    column: number,
+    offset: number,
+  ): void;
+
+  /** Called for each attribute in a start tag. */
+  onAttribute?(name: string, value: string): void;
+
+  /** Called when a start tag closes (e.g., `>` or `/>`). */
+  onStartTagClose?(selfClosing: boolean): void;
+
+  /** Called when an end tag is encountered (e.g., `</element>`). */
+  onEndTag?(name: string, line: number, column: number, offset: number): void;
+
+  /** Called for text content between tags. */
+  onText?: XmlContentCallback;
+
+  /** Called for CDATA sections. */
+  onCData?: XmlContentCallback;
+
+  /** Called for XML comments. */
+  onComment?: XmlContentCallback;
+
+  /** Called for processing instructions. */
+  onProcessingInstruction?: XmlProcessingInstructionCallback;
+
+  /** Called for XML declarations. */
+  onDeclaration?: XmlDeclarationCallback;
+
+  /** Called for DOCTYPE declarations. */
+  onDoctype?: XmlDoctypeCallback;
+
+  /** Called for internal entity declarations in the DTD. */
+  onEntityDeclaration?(name: string, value: string): void;
+}
 
 /** Options for the XML tokenizer. */
 interface XmlTokenizerOptions {

--- a/xml/_tokenizer_test.ts
+++ b/xml/_tokenizer_test.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { XmlTokenizer } from "./_tokenizer.ts";
-import type { XmlTokenCallbacks } from "./types.ts";
+import { type XmlTokenCallbacks, XmlTokenizer } from "./_tokenizer.ts";
 import { XmlSyntaxError } from "./types.ts";
 
 /** Token type for testing - recreates the old token structure for assertions. */

--- a/xml/parse_stream_test.ts
+++ b/xml/parse_stream_test.ts
@@ -168,6 +168,53 @@ Deno.test("parseXmlStream() handles declaration", async () => {
   assertEquals(encoding, "UTF-8");
 });
 
+Deno.test("parseXmlStream() invokes onDoctype when disallowDoctype is false", async () => {
+  const xml = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0//EN" ' +
+    '"http://www.w3.org/TR/xhtml1/DTD/xhtml1.dtd"><html/>';
+  const stream = ReadableStream.from([xml]);
+
+  const doctypes: Array<{
+    name: string;
+    publicId: string | undefined;
+    systemId: string | undefined;
+  }> = [];
+
+  await parseXmlStream(
+    stream,
+    {
+      onDoctype(name, publicId, systemId) {
+        doctypes.push({ name, publicId, systemId });
+      },
+    },
+    { disallowDoctype: false },
+  );
+
+  assertEquals(doctypes, [{
+    name: "html",
+    publicId: "-//W3C//DTD XHTML 1.0//EN",
+    systemId: "http://www.w3.org/TR/xhtml1/DTD/xhtml1.dtd",
+  }]);
+});
+
+Deno.test("parseXmlStream() rejects DOCTYPE by default without invoking onDoctype", async () => {
+  const xml = "<!DOCTYPE root><root/>";
+  const stream = ReadableStream.from([xml]);
+
+  let called = false;
+
+  await assertRejects(
+    () =>
+      parseXmlStream(stream, {
+        onDoctype() {
+          called = true;
+        },
+      }),
+    XmlSyntaxError,
+    "DOCTYPE",
+  );
+  assertEquals(called, false);
+});
+
 Deno.test("parseXmlStream() ignores whitespace when configured", async () => {
   const xml = "<root>\n  <item/>\n</root>";
   const stream = ReadableStream.from([xml]);

--- a/xml/stringify.ts
+++ b/xml/stringify.ts
@@ -9,7 +9,7 @@
 
 import type {
   StringifyOptions,
-  XmlDeclarationEvent,
+  XmlDeclaration,
   XmlDocument,
   XmlElement,
   XmlNode,
@@ -64,7 +64,7 @@ export function stringify(
 }
 
 /** Serializes an XML declaration to a string. */
-function serializeDeclaration(decl: XmlDeclarationEvent): string {
+function serializeDeclaration(decl: XmlDeclaration): string {
   const encoding = decl.encoding !== undefined
     ? ` encoding="${decl.encoding}"`
     : "";

--- a/xml/types.ts
+++ b/xml/types.ts
@@ -110,93 +110,8 @@ export interface XmlName {
 }
 
 /**
- * An XML attribute with its qualified name and value.
- */
-export interface XmlAttribute {
-  /** The qualified name of the attribute. */
-  readonly name: XmlName;
-  /** The decoded attribute value. */
-  readonly value: string;
-}
-
-// ============================================================================
-// Event Types (for streaming parser)
-// ============================================================================
-
-/**
- * Event emitted when an element start tag is encountered.
- */
-export interface XmlStartElementEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "start_element";
-  /** The qualified name of the element. */
-  readonly name: XmlName;
-  /** The attributes on the element. */
-  readonly attributes: ReadonlyArray<XmlAttribute>;
-  /** Whether this is a self-closing tag (`<foo/>`). */
-  readonly selfClosing: boolean;
-}
-
-/**
- * Event emitted when an element end tag is encountered.
- */
-export interface XmlEndElementEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "end_element";
-  /** The qualified name of the element. */
-  readonly name: XmlName;
-}
-
-/**
- * Event emitted for text content.
- */
-export interface XmlTextEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "text";
-  /** The decoded text content. */
-  readonly text: string;
-}
-
-/**
- * Event emitted for CDATA sections.
- *
- * @see {@link https://www.w3.org/TR/xml/#sec-cdata-sect | XML 1.0 §2.7 CDATA Sections}
- */
-export interface XmlCDataEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "cdata";
-  /** The raw CDATA content (not entity-decoded). */
-  readonly text: string;
-}
-
-/**
- * Event emitted for comments.
- *
- * @see {@link https://www.w3.org/TR/xml/#sec-comments | XML 1.0 §2.5 Comments}
- */
-export interface XmlCommentEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "comment";
-  /** The comment text (excluding `<!--` and `-->`). */
-  readonly text: string;
-}
-
-/**
- * Event emitted for processing instructions.
- *
- * @see {@link https://www.w3.org/TR/xml/#sec-pi | XML 1.0 §2.6 Processing Instructions}
- */
-export interface XmlProcessingInstructionEvent extends XmlPosition {
-  /** The event type discriminant. */
-  readonly type: "processing_instruction";
-  /** The PI target (e.g., "xml-stylesheet"). */
-  readonly target: string;
-  /** The PI content after the target. */
-  readonly content: string;
-}
-
-/**
- * Event emitted for the XML declaration.
+ * The XML declaration of a document, exposed as
+ * {@linkcode XmlDocument.declaration}.
  *
  * @see {@link https://www.w3.org/TR/xml/#sec-prolog-dtd | XML 1.0 §2.8 Prolog}
  */
@@ -210,18 +125,6 @@ export interface XmlDeclarationEvent extends XmlPosition {
   /** Whether the document is standalone (§2.9). */
   readonly standalone?: "yes" | "no";
 }
-
-/**
- * Discriminated union of all XML events emitted by the streaming parser.
- */
-export type XmlEvent =
-  | XmlStartElementEvent
-  | XmlEndElementEvent
-  | XmlTextEvent
-  | XmlCDataEvent
-  | XmlCommentEvent
-  | XmlProcessingInstructionEvent
-  | XmlDeclarationEvent;
 
 /**
  * Base options shared by parsing functions.
@@ -451,53 +354,7 @@ export type XmlProcessingInstructionCallback = (
 ) => void;
 
 /**
- * Callbacks for tokenizer output - enables zero-allocation token emission.
- *
- * Instead of creating token objects, the tokenizer invokes these callbacks
- * directly with primitive values.
- */
-export interface XmlTokenCallbacks {
-  /** Called when a start tag opens (e.g., `<element`). */
-  onStartTagOpen?(
-    name: string,
-    line: number,
-    column: number,
-    offset: number,
-  ): void;
-
-  /** Called for each attribute in a start tag. */
-  onAttribute?(name: string, value: string): void;
-
-  /** Called when a start tag closes (e.g., `>` or `/>`). */
-  onStartTagClose?(selfClosing: boolean): void;
-
-  /** Called when an end tag is encountered (e.g., `</element>`). */
-  onEndTag?(name: string, line: number, column: number, offset: number): void;
-
-  /** Called for text content between tags. */
-  onText?: XmlContentCallback;
-
-  /** Called for CDATA sections. */
-  onCData?: XmlContentCallback;
-
-  /** Called for XML comments. */
-  onComment?: XmlContentCallback;
-
-  /** Called for processing instructions. */
-  onProcessingInstruction?: XmlProcessingInstructionCallback;
-
-  /** Called for XML declarations. */
-  onDeclaration?: XmlDeclarationCallback;
-
-  /** Called for DOCTYPE declarations. */
-  onDoctype?: XmlDoctypeCallback;
-
-  /** Called for internal entity declarations in the DTD. */
-  onEntityDeclaration?(name: string, value: string): void;
-}
-
-/**
- * Reusable attribute accessor that avoids allocating XmlAttribute arrays.
+ * Reusable attribute accessor that avoids allocating attribute object arrays.
  *
  * Instead of creating an array of attribute objects, attributes are accessed
  * by index through this interface. The implementation reuses internal arrays
@@ -531,7 +388,7 @@ export interface XmlAttributeIterator {
 /**
  * Callbacks for event-level output - enables zero-allocation event emission.
  *
- * The parser invokes these callbacks instead of creating XmlEvent objects.
+ * The parser invokes these callbacks instead of creating event objects.
  */
 export interface XmlEventCallbacks {
   /** Called for XML declarations. */

--- a/xml/types.ts
+++ b/xml/types.ts
@@ -15,7 +15,7 @@ export interface XmlPosition {
   readonly line: number;
   /** Column number (1-indexed). */
   readonly column: number;
-  /** Byte offset in the input. */
+  /** Character offset in the input string (in UTF-16 code units, 0-indexed). */
   readonly offset: number;
 }
 
@@ -59,7 +59,8 @@ export class XmlSyntaxError extends SyntaxError {
    */
   readonly column: number;
   /**
-   * The byte offset where the error occurred.
+   * The character offset in the input string where the error occurred
+   * (in UTF-16 code units, 0-indexed).
    *
    * @example Usage
    * ```ts
@@ -287,7 +288,11 @@ export interface XmlElement {
   readonly type: "element";
   /** The qualified name of the element. */
   readonly name: XmlName;
-  /** Attribute lookup by local name. */
+  /**
+   * Attribute values keyed by the raw qualified attribute name as written in
+   * the document, including any namespace prefix (e.g. `"id"`, `"xlink:href"`,
+   * `"xmlns"`, `"xmlns:ns"`).
+   */
   readonly attributes: Readonly<Record<string, string>>;
   /** The child nodes of this element. */
   readonly children: ReadonlyArray<XmlNode>;

--- a/xml/types.ts
+++ b/xml/types.ts
@@ -33,7 +33,8 @@ export interface XmlPosition {
  */
 export class XmlSyntaxError extends SyntaxError {
   /**
-   * The line number where the error occurred (1-indexed).
+   * The line number where the error occurred (1-indexed), or `0` when
+   * position tracking is disabled.
    *
    * @example Usage
    * ```ts
@@ -46,7 +47,8 @@ export class XmlSyntaxError extends SyntaxError {
    */
   readonly line: number;
   /**
-   * The column number where the error occurred (1-indexed).
+   * The column number where the error occurred (1-indexed), or `0` when
+   * position tracking is disabled.
    *
    * @example Usage
    * ```ts
@@ -76,11 +78,18 @@ export class XmlSyntaxError extends SyntaxError {
   /**
    * Constructs a new XmlSyntaxError.
    *
+   * The position is appended to the message, unless `position.line` is `0`
+   * (the sentinel used when position tracking is disabled).
+   *
    * @param message The error message describing the syntax issue.
    * @param position The position in the XML source where the error occurred.
    */
   constructor(message: string, position: XmlPosition) {
-    super(`${message} at line ${position.line}, column ${position.column}`);
+    super(
+      position.line === 0
+        ? message
+        : `${message} at line ${position.line}, column ${position.column}`,
+    );
     this.name = "XmlSyntaxError";
     this.line = position.line;
     this.column = position.column;
@@ -116,8 +125,8 @@ export interface XmlName {
  *
  * @see {@link https://www.w3.org/TR/xml/#sec-prolog-dtd | XML 1.0 §2.8 Prolog}
  */
-export interface XmlDeclarationEvent extends XmlPosition {
-  /** The event type discriminant. */
+export interface XmlDeclaration extends XmlPosition {
+  /** The type discriminant. */
   readonly type: "declaration";
   /** The XML version as declared in the document (e.g. `"1.0"` or `"1.1"`). */
   readonly version: string;
@@ -312,7 +321,7 @@ export type XmlNode =
  */
 export interface XmlDocument {
   /** The XML declaration, if present. */
-  readonly declaration?: XmlDeclarationEvent;
+  readonly declaration?: XmlDeclaration;
   /** The root element of the document. */
   readonly root: XmlElement;
 }
@@ -399,7 +408,13 @@ export interface XmlEventCallbacks {
   /** Called for XML declarations. */
   onDeclaration?: XmlDeclarationCallback;
 
-  /** Called for DOCTYPE declarations. */
+  /**
+   * Called for DOCTYPE declarations.
+   *
+   * Only invoked when the {@linkcode BaseParseOptions.disallowDoctype}
+   * option is set to `false`; with the default (`true`), a DOCTYPE
+   * declaration throws an {@linkcode XmlSyntaxError} instead.
+   */
   onDoctype?: XmlDoctypeCallback;
 
   /**

--- a/xml/types_test.ts
+++ b/xml/types_test.ts
@@ -112,6 +112,19 @@ Deno.test("XmlSyntaxError contains position information", () => {
   assertEquals(error.message, "Test error at line 5, column 10");
 });
 
+Deno.test("XmlSyntaxError omits position from message when line is 0", () => {
+  const error = new XmlSyntaxError("Test error", {
+    line: 0,
+    column: 0,
+    offset: 0,
+  });
+
+  assertEquals(error.message, "Test error");
+  assertEquals(error.line, 0);
+  assertEquals(error.column, 0);
+  assertEquals(error.offset, 0);
+});
+
 Deno.test("XmlSyntaxError is instanceof SyntaxError", () => {
   const error = new XmlSyntaxError("Test", { line: 1, column: 1, offset: 0 });
   assertEquals(error instanceof SyntaxError, true);


### PR DESCRIPTION
## Summary

Cleanup of the `@std/xml` public API in preparation for a future
stabilization proposal. The goal is to remove surface that should not be
stabilized and fix documentation that did not match actual behavior, so
the API that remains is the API we would commit to at 1.0.0.

## Breaking changes

- Remove unused exported types. The `XmlEvent` union and its event
  interfaces (`XmlStartElementEvent`, `XmlEndElementEvent`, `XmlTextEvent`,
  `XmlCDataEvent`, `XmlCommentEvent`, `XmlProcessingInstructionEvent`) and
  `XmlAttribute` were leftovers from a pre-callback event-object design and
  appeared in no public function signature. `XmlTokenCallbacks` is the
  tokenizer's internal contract and has moved to `_tokenizer.ts`.
- Rename `XmlDeclarationEvent` to `XmlDeclaration`. It survives only as the
  type of `XmlDocument.declaration`, so the `Event` suffix was a misnomer.
- `XmlSyntaxError` no longer appends ` at line 0, column 0` to messages
  when position tracking is disabled. `line: 0` is documented as the
  sentinel for "position unknown".

## Documentation fixes

- `XmlPosition.offset` and `XmlSyntaxError.offset` are UTF-16 code-unit
  offsets into the input string, not byte offsets.
- `XmlElement.attributes` is keyed by the raw qualified attribute name
  (e.g. `xlink:href`, `xmlns:ns`), not the local name.
- `XmlEventCallbacks.onDoctype` now documents that it only fires when
  `disallowDoctype: false` is set; under the default, a DOCTYPE throws.

## Tests

- Public-level `parseXmlStream()` DOCTYPE tests: `onDoctype` receives name,
  public ID, and system ID; the default rejects DOCTYPE without invoking
  the callback (previously only covered at the internal tokenizer level).
- Tests for the position-suffix behavior of `XmlSyntaxError`.

## Test plan

- [x] `deno task ok` passes locally

---

_This PR was developed with the assistance of an AI agent in Cursor; all
changes were reviewed and verified by me._


---

> [!NOTE]
> Recreates #7206, which was closed automatically when I accidentally deleted the head fork. The branch is identical to the original PR head.
