### PR TITLE
ci: unpin Node.js, test against lts/* and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          # TODO(kt3k): change this back to latest when the issue below resolved
-          # https://github.com/nodejs/node/issues/58826
-          - 24.2.0
+          - lts/*
+          - latest
         os:
           - ubuntu-latest
 


### PR DESCRIPTION
Unpins the Node CI matrix from 24.2.0 and runs the tests against `lts/*` and `latest` instead.

The pin was a workaround for nodejs/node#58826, an `fs.chown` crash on uid -1 that @kt3k hit on Node 24.3. The fix shipped in Node 24.4.0 on July 9, 2025, so the TODO to restore `latest` has been actionable for a year.

Why two entries: latest is Node 26, which ships V8 14 builtins like `Uint8Array.prototype.toBase64`. Node 24 LTS does not have them, and it is what most `@std` consumers on npm run until 2028. Keeping `lts/*` in the matrix means a change that leans on a 26-only builtin fails CI instead of failing users.

Tested by CI itself. The test-node job now runs twice, once per Node line.