### PR TITLE
feat: Buffer readDiscard

### DIFF
--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -194,15 +194,18 @@ export class Buffer implements Writer, WriterSync, Reader, ReaderSync {
    *
    * const buf = new Buffer();
    * await buf.write(new TextEncoder().encode("Hello, world!"));
-   * buf.readDiscard(3);
+   * buf.discard(3);
    * assertEquals(buf.length, 10);
    * ```
    *
    * @param n The number of bytes to discard.
+   * @throws {RangeError} If `n` is not an integer, is negative, or exceeds the buffer length.
    */
-  readDiscard(n: number) {
-    if (n < 0 || n > this.length) {
-      throw new Error("Buffer read discard out of range");
+  discard(n: number) {
+    if (!Number.isInteger(n) || n < 0 || n > this.length) {
+      throw new RangeError(
+        `Cannot discard bytes as "n" must be an integer >= 0 and <= ${this.length}: received ${n}`,
+      );
     }
     this.#off += n;
   }

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -184,6 +184,30 @@ export class Buffer implements Writer, WriterSync, Reader, ReaderSync {
   }
 
   /**
+   * Discards first `n` unread bytes from the buffer.
+   * It throws if `n` is negative or greater than the length of the buffer.
+   *
+   * @example Usage
+   * ```ts
+   * import { Buffer } from "@std/io/buffer";
+   * import { assertEquals } from "@std/assert/equals";
+   *
+   * const buf = new Buffer();
+   * await buf.write(new TextEncoder().encode("Hello, world!"));
+   * buf.readDiscard(3);
+   * assertEquals(buf.length, 10);
+   * ```
+   *
+   * @param n The number of bytes to discard.
+   */
+  readDiscard(n: number) {
+    if (n < 0 || n > this.length) {
+      throw new Error("Buffer read discard out of range");
+    }
+    this.#off += n;
+  }
+
+  /**
    * Resets the contents
    *
    * @example Usage

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -400,3 +400,15 @@ Deno.test("Buffer.bytes() with copy set to false after Buffer.grow()", () => {
   assertEquals(actualBytes.byteLength, bufSize);
   assertEquals(actualBytes.buffer.byteLength, actualBytes.byteLength);
 });
+
+Deno.test("Buffer.readDiscard()", () => {
+  const bytes = Uint8Array.of(10, 11, 12, 13);
+  const reader = new Buffer();
+  writeAllSync(reader, bytes);
+
+  assertEquals(reader.bytes(), bytes.subarray(0, 4));
+  reader.readDiscard(1);
+  assertEquals(reader.bytes(), bytes.subarray(1, 4));
+  reader.readDiscard(2);
+  assertEquals(reader.bytes(), bytes.subarray(3, 4));
+});

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -404,11 +404,16 @@ Deno.test("Buffer.bytes() with copy set to false after Buffer.grow()", () => {
 Deno.test("Buffer.readDiscard()", () => {
   const bytes = Uint8Array.of(10, 11, 12, 13);
   const reader = new Buffer();
-  writeAllSync(reader, bytes);
 
+  writeAllSync(reader, bytes);
   assertEquals(reader.bytes(), bytes.subarray(0, 4));
+
+  assertThrows(() => reader.readDiscard(5));
+  assertEquals(reader.bytes(), bytes.subarray(0, 4));
+
   reader.readDiscard(1);
   assertEquals(reader.bytes(), bytes.subarray(1, 4));
+
   reader.readDiscard(2);
   assertEquals(reader.bytes(), bytes.subarray(3, 4));
 });

--- a/io/buffer_test.ts
+++ b/io/buffer_test.ts
@@ -401,19 +401,39 @@ Deno.test("Buffer.bytes() with copy set to false after Buffer.grow()", () => {
   assertEquals(actualBytes.buffer.byteLength, actualBytes.byteLength);
 });
 
-Deno.test("Buffer.readDiscard()", () => {
+Deno.test("Buffer.discard()", () => {
   const bytes = Uint8Array.of(10, 11, 12, 13);
   const reader = new Buffer();
+
+  function assertDiscardThrows(n: number) {
+    const bytesBefore = reader.bytes({ copy: true });
+    assertThrows(
+      () => reader.discard(n),
+      RangeError,
+      "Cannot discard bytes",
+    );
+    assertEquals(reader.bytes(), bytesBefore);
+  }
+
+  assertDiscardThrows(1);
+
+  reader.discard(0);
+  assert(reader.empty());
 
   writeAllSync(reader, bytes);
   assertEquals(reader.bytes(), bytes.subarray(0, 4));
 
-  assertThrows(() => reader.readDiscard(5));
+  assertDiscardThrows(-1);
+  assertDiscardThrows(5);
+  assertDiscardThrows(0.5);
+  assertDiscardThrows(NaN);
+
+  reader.discard(0);
   assertEquals(reader.bytes(), bytes.subarray(0, 4));
 
-  reader.readDiscard(1);
+  reader.discard(1);
   assertEquals(reader.bytes(), bytes.subarray(1, 4));
 
-  reader.readDiscard(2);
+  reader.discard(2);
   assertEquals(reader.bytes(), bytes.subarray(3, 4));
 });


### PR DESCRIPTION
`Buffer` class is used by parsers.
Sometimes parser needs to advance read position without copying bytes.
For example, zero-copy parser peeks available `bytes()`, then consumes some of them and advances read position.

`Buffer` class hides read position as `#off` private field.
The only function that advances read position is `read(p)`/`readSync(p)`, which accept buffer as argument.

```typescript
// currently available workaround
function readDiscard(buf: Buffer, n: number) {
  buf.readSync({ byteLength: n, set() {} });
}
```

Go provides [https://pkg.go.dev/bytes#Buffer.Next](Next(n)) function, which advances read position without copying bytes.
This PR proposes `readDiscard(n)` (please suggest better name), which doesn't return value.

There is `truncate(n)` function, which does opposite, it keeps "first N bytes", not "after N bytes"