### PR TITLE
fix(cbor): stop leaking inherited keys into encoded objects

### DIFF
--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -217,7 +217,7 @@ function encodeObject(
   offset: number,
 ): number {
   output[offset] = 0b101_00000;
-  // Must iterate the same keys as calcObjectEncodingSize().
+  // Must iterate the same keys as calcEncodingSize().
   const keys = Object.keys(input);
   offset = encodeHeader(0b101_00000, keys.length, output, offset);
   for (const key of keys) {

--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -51,7 +51,7 @@ export function calcEncodingSize(x: CborType): number {
     for (const y of x) size += calcEncodingSize(y[0]) + calcEncodingSize(y[1]);
     return size;
   }
-  // Iterate own keys only, matching encodeObject's pair count.
+  // Must iterate the same keys as encodeObject().
   const keys = Object.keys(x);
   let size = 0;
   for (const y of keys) {
@@ -217,8 +217,7 @@ function encodeObject(
   offset: number,
 ): number {
   output[offset] = 0b101_00000;
-  // Iterate the same own keys the header counts; for-in would also visit
-  // inherited enumerable keys and desync the pair count.
+  // Must iterate the same keys as calcObjectEncodingSize().
   const keys = Object.keys(input);
   offset = encodeHeader(0b101_00000, keys.length, output, offset);
   for (const key of keys) {

--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -51,13 +51,13 @@ export function calcEncodingSize(x: CborType): number {
     for (const y of x) size += calcEncodingSize(y[0]) + calcEncodingSize(y[1]);
     return size;
   }
-  let pairs = 0;
+  // Iterate own keys only, matching encodeObject's pair count.
+  const keys = Object.keys(x);
   let size = 0;
-  for (const y in x) {
-    ++pairs;
+  for (const y of keys) {
     size += calcHeaderSize(y.length) + y.length + calcEncodingSize(x[y]);
   }
-  return size + calcHeaderSize(pairs);
+  return size + calcHeaderSize(keys.length);
 }
 
 export function encode(
@@ -217,8 +217,11 @@ function encodeObject(
   offset: number,
 ): number {
   output[offset] = 0b101_00000;
-  offset = encodeHeader(0b101_00000, Object.keys(input).length, output, offset);
-  for (const key in input) {
+  // Iterate the same own keys the header counts; for-in would also visit
+  // inherited enumerable keys and desync the pair count.
+  const keys = Object.keys(input);
+  offset = encodeHeader(0b101_00000, keys.length, output, offset);
+  for (const key of keys) {
     offset = encodeString(key, output, offset);
     offset = encode(input[key], output, offset);
   }

--- a/cbor/encode_cbor_test.ts
+++ b/cbor/encode_cbor_test.ts
@@ -440,6 +440,21 @@ Deno.test("encodeCbor() encoding objects", () => {
   // Can't test the next two bracket up due to JavaScript limitations.
 });
 
+Deno.test("encodeCbor() ignores inherited enumerable properties", () => {
+  const input: { [k: string]: CborType } = Object.assign(
+    Object.create({ inherited: 1 }),
+    { own: 2 },
+  );
+  assertEquals(
+    encodeCbor(input),
+    new Uint8Array([
+      0b101_00001,
+      ...encodeCbor("own"),
+      ...encodeCbor(2),
+    ]),
+  );
+});
+
 Deno.test("encodeCbor() encoding CborTag()", () => {
   const bytes = new Uint8Array(random(0, 24)).map((_) => random(0, 256));
   assertEquals(


### PR DESCRIPTION
encodeObject() writes the CBOR map header from Object.keys(input).length but iterates entries with for-in, which also visits inherited enumerable keys. When the two disagree, the declared pair count no longer matches the pairs written. The header lies.

**Concrete failure:**

```
const obj = Object.assign(Object.create({ inherited: "boom" }), { own: 1 });
encodeCbor(obj);
```
On main this returns 21 bytes: a valid 6-byte map declaring one pair, then "inherited": "boom" appended as trailing garbage. The inherited value leaks into the wire bytes, and strict decoders reject the trailing data. Same story if something pollutes Object.prototype with an enumerable property: every encoded object grows a stowaway pair.

The fix makes calcObjectEncodingSize() and encodeObject() iterate the same Object.keys() array the header count comes from, so count, buffer size, and written pairs can't drift apart.

Review focus: the two loops in cbor/_common_encode.ts. Output for plain objects without inherited enumerables is byte-for-byte unchanged.

Tested with the existing cbor suite (83 pass) plus the repro above, which returns the correct 6 bytes on this branch. Happy to add it as a regression test in encode_cbor_test.ts if wanted.