### PR TITLE
chore(cache): stop relying on globalThis.gc being untyped

### DIFF
--- a/cache/_serialize_arg_list_test.ts
+++ b/cache/_serialize_arg_list_test.ts
@@ -142,13 +142,13 @@ Deno.test("_serializeArgList() cleans up cache entries when finalization callbac
 });
 
 Deno.test("_serializeArgList() allows garbage collection for weak keys", async () => {
-  // @ts-expect-error - Triggering true garbage collection is only available
-  // with `--v8-flags="--expose-gc"`, so we mock `FinalizationRegistry` with
-  // `using` and some `Symbol.dispose` trickery if it's not available. Run this
-  // test with `deno test --v8-flags="--expose-gc"` to test actual gc behavior
+  // Triggering true garbage collection is only available with
+  // `--v8-flags="--expose-gc"`, so we mock `FinalizationRegistry` with `using`
+  // and some `Symbol.dispose` trickery if it's not available. Run this test
+  // with `deno test --v8-flags="--expose-gc"` to test actual gc behavior
   // (however, even calling `globalThis.gc` doesn't _guarantee_ garbage
   // collection, so this may be flaky between v8 versions etc.)
-  const gc = globalThis.gc as undefined | (() => void);
+  const gc = Reflect.get(globalThis, "gc") as (() => void) | undefined;
 
   class MockFinalizationRegistry<T> extends FinalizationRegistry<T> {
     #cleanupCallback: (heldValue: T) => void;


### PR DESCRIPTION
Deno canary types `globalThis.gc`, so the `@ts-expect-error` above it is now unused and `deno test` fails with TS2578. Reading `gc` through `Reflect.get` works on both stable and canary, and keeps the test honest about `gc` being optional.

Partly solves #7219. The other 24 canary errors are a Deno-side` URLPattern` type collision, filed separately: https://github.com/denoland/deno/issues/36346

Tested on 2.9.3 and canary 2.9.4+41e97d3, including `deno test --v8-flags="--expose-gc" cache/`