### PR TITLE
docs: remove test coverage explorer link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ High-quality APIs for [Deno](https://deno.com/) and the web. Use fearlessly.
 - [Design documentation](.github/ARCHITECTURE.md#design)
 - [Contributing guidelines](.github/CONTRIBUTING.md)
 - [Frequently asked questions (FAQ)](./.github/FAQ.md)
-- [Test coverage explorer](https://std-coverage.deno.dev/)
 
 ## Releases
 


### PR DESCRIPTION
* Drop the link to https://std-coverage.deno.dev/ — this deployment
  is being decommissioned.