### PR TITLE
ci: pin publish workflow to latest stable Deno

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: canary
+          deno-version: v2.x
           cache: true
 
       - name: Format


### PR DESCRIPTION
The `release-2026.07.30` release never made it to JSR. The workspace publish
workflow ran, but failed at the `Test` step and skipped `Publish to JSR`
entirely. The cause was the workflow pinning `deno-version: canary`: that
canary build had a `URLPattern` typing regression where Deno's Node `url`
types no longer line up with the global `URLPattern`, producing 24 TS2322
errors in `http/unstable_route.ts` and its test. Since `deno task test`
type-checks, the step exited non-zero and publishing was skipped.

The same failure still reproduces on today's nightly run, so re-running the
release as-is would fail the same way. #7224 already moved regular CI off
canary, but the publish workflow was missed. Publishing shouldn't be gated on
an unreleased Deno at all, so this switches it to `v2.x`, matching the rest
of CI.