### PR TITLE
feat(streams): stabilize `BatchStream`

### DIFF
--- a/streams/batch_stream.ts
+++ b/streams/batch_stream.ts
@@ -3,8 +3,8 @@
 
 /**
  * A {@linkcode TransformStream} that groups input chunks into fixed-size
- * batches. Emits a `T[]` every `size` input chunks and flushes any final
- * non-empty partial batch when the input closes.
+ * batches. Emits a `T[]` once `size` input chunks have been collected and
+ * flushes any final non-empty partial batch when the input closes.
  *
  * Input order is preserved.
  *
@@ -13,13 +13,11 @@
  * For resizing `Uint8Array` chunks at the byte level, see
  * {@linkcode FixedChunkStream}.
  *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
  * @typeParam T The type of the input chunks.
  *
  * @example Batch records for bulk upload
  * ```ts
- * import { BatchStream } from "@std/streams/unstable-batch-stream";
+ * import { BatchStream } from "@std/streams/batch-stream";
  * import { assertEquals } from "@std/assert";
  *
  * const records = ReadableStream.from([1, 2, 3, 4, 5])
@@ -30,7 +28,7 @@
  *
  * @example Type inference inside a pipeline
  * ```ts
- * import { BatchStream } from "@std/streams/unstable-batch-stream";
+ * import { BatchStream } from "@std/streams/batch-stream";
  * import { assertEquals } from "@std/assert";
  *
  * interface User {

--- a/streams/batch_stream_test.ts
+++ b/streams/batch_stream_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { BatchStream } from "./unstable_batch_stream.ts";
+import { BatchStream } from "./batch_stream.ts";
 
 Deno.test("BatchStream() emits at the configured size", async () => {
   const batches = await Array.fromAsync(

--- a/streams/deno.json
+++ b/streams/deno.json
@@ -4,7 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./unstable-abort-stream": "./unstable_abort_stream.ts",
-    "./unstable-batch-stream": "./unstable_batch_stream.ts",
+    "./batch-stream": "./batch_stream.ts",
     "./buffer": "./buffer.ts",
     "./byte-slice-stream": "./byte_slice_stream.ts",
     "./unstable-capped-delimiter-stream": "./unstable_capped_delimiter_stream.ts",

--- a/streams/mod.ts
+++ b/streams/mod.ts
@@ -18,6 +18,7 @@
  * @module
  */
 
+export * from "./batch_stream.ts";
 export * from "./buffer.ts";
 export * from "./byte_slice_stream.ts";
 export * from "./concat_readable_streams.ts";


### PR DESCRIPTION
Stabilizes `BatchStream`, unstable since #7110 (April). No behavior changes.

The mechanical bits:

- `unstable_batch_stream.ts` renamed to `batch_stream.ts` (same for the test file)
- export moves from `./unstable-batch-stream` to `./batch-stream`
- re-exported from `mod.ts`
- `@experimental` tag dropped

One doc edit worth a look: the summary now says a batch is emitted "once `size` input chunks have been collected" instead of "every `size` input chunks". Same behavior today. While vetting this I kept coming back to a time-based flush option (something like `maxWaitMs`, for long-lived sources such as queue consumers where a partial batch shouldn't wait forever). It fits cleanly as an additive `new BatchStream(size, options)` follow-up, so I deferred it rather than designing it in now. The softened wording keeps the stable doc contract compatible with that future option.

Test coverage is unchanged: 11 cases covering partial flush, empty input, backpressure, cancellation propagation, and type inference.
