### PR TITLE
fix(toml): stringify special values in inline arrays correctly

### DIFF
--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -73,9 +73,7 @@ class Dumper {
         value instanceof Array
       ) {
         const arrayType = this.#getTypeOfArray(value);
-        if (arrayType === "ONLY_PRIMITIVE") {
-          out.push(this.#arrayDeclaration([prop], value));
-        } else if (arrayType === "ONLY_OBJECT_EXCLUDING_ARRAY") {
+        if (arrayType === "ONLY_OBJECT_EXCLUDING_ARRAY") {
           // array of objects
           for (let i = 0; i < value.length; i++) {
             out.push("");
@@ -83,7 +81,7 @@ class Dumper {
             out.push(...this.#printObject(value[i], [...keys, prop]));
           }
         } else {
-          // this is a complex array, use the inline format.
+          // this is a primitive or mixed array, use the inline format.
           const str = value.map((x) => this.#printAsInlineValue(x)).join(",");
           out.push(`${this.#declaration([prop])}[${str}]`);
         }
@@ -120,12 +118,17 @@ class Dumper {
     }
 
     const onlyPrimitive = this.#isPrimitive(arr[0]);
-    if (arr[0] instanceof Array) {
+    if (
+      arr[0] === null || arr[0] === undefined || arr[0] instanceof Array
+    ) {
       return "MIXED";
     }
     for (let i = 1; i < arr.length; i++) {
       if (
-        onlyPrimitive !== this.#isPrimitive(arr[i]) || arr[i] instanceof Array
+        onlyPrimitive !== this.#isPrimitive(arr[i]) ||
+        arr[i] === null ||
+        arr[i] === undefined ||
+        arr[i] instanceof Array
       ) {
         return "MIXED";
       }
@@ -133,11 +136,23 @@ class Dumper {
     return onlyPrimitive ? "ONLY_PRIMITIVE" : "ONLY_OBJECT_EXCLUDING_ARRAY";
   }
   #printAsInlineValue(value: unknown): string | number {
+    if (value === null || value === undefined) {
+      throw new Error("Cannot stringify null or undefined values");
+    }
     if (value instanceof Date) {
-      return `"${this.#printDate(value)}"`;
+      return this.#printDate(value);
     } else if (typeof value === "string" || value instanceof RegExp) {
       return JSON.stringify(value.toString());
     } else if (typeof value === "number") {
+      if (Number.isNaN(value)) {
+        return "nan";
+      }
+      if (value === Infinity) {
+        return "inf";
+      }
+      if (value === -Infinity) {
+        return "-inf";
+      }
       return value;
     } else if (typeof value === "boolean") {
       return value.toString();
@@ -147,9 +162,6 @@ class Dumper {
       const str = value.map((x) => this.#printAsInlineValue(x)).join(",");
       return `[${str}]`;
     } else if (typeof value === "object") {
-      if (!value) {
-        throw new Error("Should never reach");
-      }
       const str = Object.keys(value).map((key) => {
         return `${joinKeys([key])} = ${
           // deno-lint-ignore no-explicit-any
@@ -183,9 +195,6 @@ class Dumper {
       this.maxPad = title.length;
     }
     return `${title} = `;
-  }
-  #arrayDeclaration(keys: string[], value: unknown[]): string {
-    return `${this.#declaration(keys)}${JSON.stringify(value)}`;
   }
   #strDeclaration(keys: string[], value: string): string {
     return `${this.#declaration(keys)}${JSON.stringify(value)}`;

--- a/toml/stringify_test.ts
+++ b/toml/stringify_test.ts
@@ -92,13 +92,44 @@ Deno.test({
     assertThrows(
       () => stringify({ a: [[null]] }),
       Error,
-      "Should never reach",
+      "Cannot stringify null or undefined values",
     );
     assertThrows(
       () => stringify({ a: [[undefined]] }),
       Error,
-      "Should never reach",
+      "Cannot stringify null or undefined values",
     );
+    assertThrows(
+      () => stringify({ x: [null] }),
+      Error,
+      "Cannot stringify null or undefined values",
+    );
+    assertThrows(
+      () => stringify({ x: [1, null] }),
+      Error,
+      "Cannot stringify null or undefined values",
+    );
+  },
+});
+
+Deno.test({
+  name: "stringify() handles special values in inline arrays",
+  fn() {
+    const src = {
+      inf: [Infinity, -Infinity, NaN],
+      dates: [new Date(0)],
+      mixed: [Infinity, -Infinity, NaN, {}],
+      mixedDates: [new Date(0), {}],
+      regex: [/foo[bar]/],
+    };
+    const actual = stringify(src);
+    const expected = `inf = [inf,-inf,nan]
+dates = [1970-01-01T00:00:00.000]
+mixed = [inf,-inf,nan,{}]
+mixedDates = [1970-01-01T00:00:00.000,{}]
+regex = ["/foo[bar]/"]
+`;
+    assertEquals(actual, expected);
   },
 });
 
@@ -240,7 +271,7 @@ Deno.test({
     const expected = `emptyArray = []
 mixedArray1 = [1,{b = 2}]
 mixedArray2 = [{b = 2},1]
-nestedArray1 = [[{b = 1,date = "2022-05-13T00:00:00.000"}]]
+nestedArray1 = [[{b = 1,date = 2022-05-13T00:00:00.000}]]
 nestedArray2 = [[[{b = 1}]]]
 nestedArray3 = [[],[{b = 1}]]
 


### PR DESCRIPTION
Fixes #7162.

`stringify` serialized primitive arrays with `JSON.stringify`, which has several problems for TOML output:

- `Infinity`/`-Infinity`/`NaN` were turned into `null` (invalid TOML that fails to parse back)
- `Date` values were emitted as quoted ISO strings, so they parsed back as strings instead of `Date`s
- `RegExp` values became `{}`

Now all inline arrays are emitted element-by-element through `#printAsInlineValue`, matching how the same values are serialized at the top level:

```ts
stringify({ x: [Infinity, -Infinity, NaN] }) // x = [inf,-inf,nan]
stringify({ x: [new Date(0)] })              // x = [1970-01-01T00:00:00.000]
stringify({ x: [Infinity, -Infinity, NaN, {}] }) // x = [inf,-inf,nan,{}]
```

Arrays containing `null`/`undefined` (which TOML cannot represent) now throw `Error("Cannot stringify null or undefined values")` instead of an opaque `Object.keys` TypeError or `Error("Should never reach")`.

Testing: `deno test --allow-read --allow-run toml/` — 684 passed, 0 failed (111 ignored); `deno fmt --check` and `deno lint` clean on changed files.

AI disclosure: this PR was prepared with the assistance of AI tooling; the change was reviewed and verified locally as described above.