### PR TITLE
ci: stop uploading coverage to Deno Deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    permissions:
-      id-token: write # Required for deployctl
     strategy:
       fail-fast: false
       matrix:
@@ -67,14 +65,6 @@ jobs:
         with:
           files: ./coverage/lcov.info
           name: ${{ matrix.os }}-${{ matrix.deno }}
-
-      - name: Upload coverage to Deploy
-        uses: denoland/deployctl@v1
-        with:
-          project: std-coverage
-          root: coverage/html
-          entrypoint: jsr:@std/http@1/file-server
-        if: matrix.deno == 'v2.x' && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
 
   test-node:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The `Upload coverage to Deploy` step has been failing on every push to `main`
since the `std-coverage` Deno Deploy project stopped authorizing our token:

```
APIError: The authorization token is not valid: You don't have permission to
access the project 'std-coverage'. Please ensure your workflow file references
the correct project
```

Because the step is gated on `v2.x` + `ubuntu-latest` + `push`, it turns exactly
one job in the matrix red while the other eleven pass and every test succeeds —
see the run for #7267, where the failure is entirely in this upload step.

Rather than reauthorize it, this removes it. Coverage reporting is already
handled by Codecov in the step directly above, which consumes the same
`coverage/lcov.info` on every matrix combination and is what posts patch
coverage on pull requests. The Deploy upload only published a browsable HTML
report, which is still available locally through `deno task cov:lin`,
`cov:mac`, or `cov:win` — those run the tests and open
`coverage/html/index.html` directly.

The job-level `permissions` block goes with it, since `id-token: write` existed
solely for `deployctl`. The job now inherits the workflow-level
`permissions: contents: read`, which is what `actions/checkout` needs and is
narrower than this repository's `write` default. Nothing else in the repository
references `deployctl` or `std-coverage`; `workspace_publish.yml` keeps its own
`id-token: write`, which JSR requires for OIDC publishing.
