### PR TITLE
fix(async/unstable): honor abort in pooledMapSettled after source is exhausted

### DIFF
--- a/async/unstable_pool_settled.ts
+++ b/async/unstable_pool_settled.ts
@@ -31,6 +31,10 @@ export interface PooledMapSettledOptions {
  * allowed to finish and their settled results are yielded, then the iterator
  * rejects with the original error from the input iterable.
  *
+ * The pool applies no backpressure: items are processed at full concurrency
+ * regardless of how quickly results are read, and completed results are
+ * buffered until consumed.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
@@ -173,6 +177,7 @@ export function pooledMapSettled<T, R>(
             : await nextPromise;
 
           if (next.done) break;
+          signal?.throwIfAborted();
 
           const item = next.value;
           const p = settle(() => iteratorFn(item));
@@ -191,7 +196,11 @@ export function pooledMapSettled<T, R>(
         }
       }
 
-      await Promise.all(executing);
+      if (abortDeferred) {
+        await Promise.race([Promise.all(executing), abortDeferred.promise]);
+      } else {
+        await Promise.all(executing);
+      }
       writer.close().catch(() => {});
     } catch (caughtError) {
       const wasAborted = signal?.aborted ?? false;

--- a/async/unstable_pool_settled_test.ts
+++ b/async/unstable_pool_settled_test.ts
@@ -334,6 +334,69 @@ Deno.test({
   sanitizeResources: false,
 });
 
+Deno.test("pooledMapSettled() rejects with abort reason after source is exhausted", async () => {
+  const controller = new AbortController();
+  const gates = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+  const collected: PromiseSettledResult<number>[] = [];
+
+  const iteration = assertRejects(
+    async () => {
+      for await (
+        const result of pooledMapSettled(
+          [1, 2],
+          (i) => gates[i - 1]!.promise.then(() => i),
+          // poolLimit exceeds the item count so the producer drains the
+          // source and reaches its final wait while items are in flight
+          { poolLimit: 3, signal: controller.signal },
+        )
+      ) {
+        collected.push(result);
+      }
+    },
+    Error,
+    "late abort",
+  );
+
+  await delay(10);
+  controller.abort(new Error("late abort"));
+  for (const gate of gates) gate.resolve();
+
+  await iteration;
+  assertEquals(collected, [
+    { status: "fulfilled", value: 1 },
+    { status: "fulfilled", value: 2 },
+  ]);
+});
+
+Deno.test("pooledMapSettled() does not start new items after sync abort from source", async () => {
+  const controller = new AbortController();
+  const started: number[] = [];
+
+  function* source() {
+    yield 1;
+    controller.abort(new Error("aborted"));
+    yield 2;
+  }
+
+  await assertRejects(
+    () =>
+      Array.fromAsync(
+        pooledMapSettled(
+          source(),
+          (i) => {
+            started.push(i);
+            return i;
+          },
+          { poolLimit: 2, signal: controller.signal },
+        ),
+      ),
+    Error,
+    "aborted",
+  );
+
+  assertEquals(started, [1]);
+});
+
 Deno.test("pooledMapSettled() checks browser compat", async () => {
   const asyncIterFunc = ReadableStream.prototype[Symbol.asyncIterator];
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
`pooledMapSettled` swallows an abort that fires after the source iterable is exhausted. The docs promise the iterator rejects with the signal's reason once in-flight items settle, but in that window the producer is parked at `await Promise.all(executing)`, and settled wrappers never reject, so the iterator completes cleanly instead. This PR races that final wait against the abort signal, the same way `unstable_pool.ts` already does since #7240.

Two more small things while in there:

- Added the `signal?.throwIfAborted()` check after pulling from the source, matching `pooledMap`. Without it, a source that aborts synchronously mid-iteration still starts one more item.
- Documented that the pool applies no backpressure. It never did, but nothing said so.

Both regression tests fail on main. The fix makes them pass.
