### PR TITLE
docs: document how PR titles determine version bumps

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,6 +32,22 @@ and [architecture guide](./ARCHITECTURE.md) before contributing.
 > request that precedes the pull request that implements the new package.
 <!--deno-fmt-ignore-end-->
 
+### PR titles and version bumps
+
+Pull requests are squash-merged: the PR title becomes the commit subject on
+`main`, and the release tooling derives each package's next version from those
+subjects. The title alone decides the bump.
+
+A scope with the `/unstable` suffix always releases as a patch, even for `feat`
+(normally a minor bump) and `BREAKING` (normally a major bump). For example,
+`BREAKING(http/unstable): rename an option` releases a patch of `@std/http`.
+Unstable APIs are not covered by the semver contract, so changes to them never
+raise a version beyond a patch.
+
+A change confined to unstable APIs must carry the `/unstable` suffix in its
+scope. Without it, the title reads as a change to stable APIs and inflates the
+package's version bump.
+
 ## Suggesting a new feature
 
 When new features are accepted, they are initially accepted as 'unstable'


### PR DESCRIPTION
CONTRIBUTING.md shows the conventional-commit title format but not what titles do: they are the release mechanism. This adds a "PR titles and version bumps" subsection under Pull Requests, writing down two rules that already operate mechanically:

- PRs are squash-merged, so the PR title becomes the commit subject, and `deno bump-version` derives each package's next version from those subjects alone.
- A `/unstable`-suffixed scope always releases as a patch, regardless of type. This is hard-coded in the bump tool ([cli/tools/bump_version.rs](https://github.com/denoland/deno/blob/main/cli/tools/bump_version.rs)) and matches existing releases: `@std/http` 1.0.6 (patch) shipped two `BREAKING(http/unstable)` (#5938, #5939) and 1.1.2 (patch) shipped `feat(http/unstable)` (#7117).

The subsection also spells out the rule reviewers already enforce: a change confined to unstable APIs must carry the `/unstable` suffix, or it inflates the package's version bump.

Verified with `deno task ok`.