### PR TITLE
fix(async): close the source iterator when an abortable() iterable is returned early

### DIFF
--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -146,22 +146,21 @@ async function* abortableAsyncIterable<T>(
   signal.addEventListener("abort", abort, { once: true });
 
   const it = p[Symbol.asyncIterator]();
+  let completed = false;
   try {
     while (true) {
-      const race = Promise.race([promise, it.next()]);
-      race.catch(() => {
-        signal.removeEventListener("abort", abort);
-      });
-      const { done, value } = await race;
+      const { done, value } = await Promise.race([promise, it.next()]);
       if (done) {
-        signal.removeEventListener("abort", abort);
+        completed = true;
         const result = await it.return?.(value);
         return result?.value;
       }
       yield value;
     }
-  } catch (e) {
-    await it.return?.();
-    throw e;
+  } finally {
+    signal.removeEventListener("abort", abort);
+    // Close the source on abort or early consumer exit; the done path has
+    // already closed it with the forwarded return value.
+    if (!completed) await it.return?.();
   }
 }

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -202,6 +202,23 @@ Deno.test("abortable.AsyncIterable() behaves just like original when return is c
   assertEquals(await abortableIterator.next(), await normalIterator.next());
 });
 
+Deno.test("abortable.AsyncIterable() closes the source iterator when the consumer stops early", async () => {
+  const c = new AbortController();
+  let finallyRan = false;
+  async function* gen() {
+    try {
+      yield 1;
+      yield 2;
+    } finally {
+      finallyRan = true;
+    }
+  }
+  for await (const _ of abortable(gen(), c.signal)) {
+    break;
+  }
+  assertEquals(finallyRan, true);
+});
+
 Deno.test("abortable() does not throw when the signal is already aborted and the promise is already rejected", async () => {
   const promise = Promise.reject(new Error("Rejected"));
   const signal = AbortSignal.abort();

--- a/async/unstable_abortable.ts
+++ b/async/unstable_abortable.ts
@@ -161,22 +161,21 @@ async function* abortableAsyncIterable<T>(
   signal.addEventListener("abort", abort, { once: true });
 
   const it = p[Symbol.asyncIterator]();
+  let completed = false;
   try {
     while (true) {
-      const race = Promise.race([promise, it.next()]);
-      race.catch(() => {
-        signal.removeEventListener("abort", abort);
-      });
-      const { done, value } = await race;
+      const { done, value } = await Promise.race([promise, it.next()]);
       if (done) {
-        signal.removeEventListener("abort", abort);
+        completed = true;
         const result = await it.return?.(value);
         return result?.value;
       }
       yield value;
     }
-  } catch (e) {
-    await it.return?.();
-    throw e;
+  } finally {
+    signal.removeEventListener("abort", abort);
+    // Close the source on abort or early consumer exit; the done path has
+    // already closed it with the forwarded return value.
+    if (!completed) await it.return?.();
   }
 }

--- a/async/unstable_abortable_test.ts
+++ b/async/unstable_abortable_test.ts
@@ -202,6 +202,23 @@ Deno.test("abortable.AsyncIterable() behaves just like original when return is c
   assertEquals(await abortableIterator.next(), await normalIterator.next());
 });
 
+Deno.test("abortable.AsyncIterable() closes the source iterator when the consumer stops early", async () => {
+  const c = new AbortController();
+  let finallyRan = false;
+  async function* gen() {
+    try {
+      yield 1;
+      yield 2;
+    } finally {
+      finallyRan = true;
+    }
+  }
+  for await (const _ of abortable(gen(), c.signal)) {
+    break;
+  }
+  assertEquals(finallyRan, true);
+});
+
 Deno.test("abortable() does not throw when the signal is already aborted and the promise is already rejected", async () => {
   const promise = Promise.reject(new Error("Rejected"));
   const signal = AbortSignal.abort();


### PR DESCRIPTION
`abortable()` wrapped around an async iterable never closes the source when the consumer exits early. Break out of a `for await`, and the source's `finally` blocks never run:

```ts
async function* gen() {
  try {
    yield 1;
    yield 2;
  } finally {
    console.log("cleanup"); // never runs on main
  }
}

for await (const _ of abortable(gen(), signal)) {
  break;
}
```

Iterating `gen()` directly runs the cleanup. Wrapping it in `abortable()` silently drops it.

The cause: the wrapper generator only has `try/catch`. A consumer `break` calls the wrapper's `.return()`, which unwinds with return semantics. `catch` never fires. #5560 fixed `.return()` propagation for the abort path but missed this one.

The fix restructures the loop around a single `try/finally` that removes the abort listener and closes the source. That also replaces the `race.catch(...)` listener-removal hack and the `catch { it.return; throw }` block: all three exit paths (done, abort, early return) now converge on the same cleanup. The one spot worth a close look is the `completed` flag. It keeps the `done` path from closing the source twice, since that path already forwards the done value through `it.return(value)`.

Same change in `abortable.ts` and `unstable_abortable.ts`, which copy the implementation verbatim.

The regression test fails on main and passes with the fix. No other behavior changes: all 314 async tests pass, including the #5560 and #6312 regression tests.
