### PR TITLE
fix(async/unstable): return a proper async generator from abortable() when no signal is provided

### DIFF
--- a/async/unstable_abortable.ts
+++ b/async/unstable_abortable.ts
@@ -3,23 +3,36 @@
 
 /** Options for {@linkcode abortable}. */
 export interface AbortableOptions {
-  /** The signal to abort the promise with. */
+  /**
+   * The signal to abort the promise or iteration with. When `undefined`, the
+   * input is never aborted.
+   *
+   * @default {undefined}
+   */
   signal?: AbortSignal | undefined;
 }
 
 /**
  * Make a {@linkcode Promise} abortable with the given signal.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * The signal can also be passed inside an {@linkcode AbortableOptions}
+ * object. When `options.signal` is `undefined`, the promise is returned
+ * unchanged and never aborts.
+ *
  * @throws {DOMException} If the signal is already aborted and `signal.reason`
  * is undefined. Otherwise, throws `signal.reason`.
  * @typeParam T The type of the provided and returned promise.
  * @param p The promise to make abortable.
- * @param signal The signal to abort the promise with.
+ * @param signal The signal to abort the promise with, or an
+ * {@linkcode AbortableOptions} object carrying an optional signal.
  * @returns A promise that can be aborted.
  *
  * @example Error-handling a timeout
  * ```ts
- * import { abortable, delay } from "@std/async";
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { delay } from "@std/async/delay";
  * import { assertRejects, assertEquals } from "@std/assert";
  *
  * const promise = delay(1_000);
@@ -34,7 +47,8 @@ export interface AbortableOptions {
  *
  * @example Error-handling an abort
  * ```ts
- * import { abortable, delay } from "@std/async";
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { delay } from "@std/async/delay";
  * import { assertRejects, assertEquals } from "@std/assert";
  *
  * const promise = delay(1_000);
@@ -48,6 +62,19 @@ export interface AbortableOptions {
  *   "This is my reason"
  * );
  * ```
+ *
+ * @example Passing an optional signal through options
+ * ```ts
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { assertEquals } from "@std/assert";
+ *
+ * async function process(options: { signal?: AbortSignal } = {}) {
+ *   return await abortable(Promise.resolve("Hello"), options);
+ * }
+ *
+ * // Without a signal, the promise resolves as usual
+ * assertEquals(await process(), "Hello");
+ * ```
  */
 export function abortable<T>(
   p: Promise<T>,
@@ -56,16 +83,24 @@ export function abortable<T>(
 /**
  * Make an {@linkcode AsyncIterable} abortable with the given signal.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * The signal can also be passed inside an {@linkcode AbortableOptions}
+ * object. When `options.signal` is `undefined`, the returned generator
+ * mirrors the input and never aborts.
+ *
  * @throws {DOMException} If the signal is already aborted and `signal.reason`
  * is undefined. Otherwise, throws `signal.reason`.
  * @typeParam T The type of the provided and returned async iterable.
  * @param p The async iterable to make abortable.
- * @param signal The signal to abort the promise with.
+ * @param signal The signal to abort the iteration with, or an
+ * {@linkcode AbortableOptions} object carrying an optional signal.
  * @returns An async iterable that can be aborted.
  *
  * @example Error-handling a timeout
  * ```ts
- * import { abortable, delay } from "@std/async";
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { delay } from "@std/async/delay";
  * import { assertRejects, assertEquals } from "@std/assert";
  *
  * const asyncIter = async function* () {
@@ -91,7 +126,8 @@ export function abortable<T>(
  *
  * @example Error-handling an abort
  * ```ts
- * import { abortable, delay } from "@std/async";
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { delay } from "@std/async/delay";
  * import { assertRejects, assertEquals } from "@std/assert";
  *
  * const asyncIter = async function* () {
@@ -115,6 +151,21 @@ export function abortable<T>(
  * );
  * assertEquals(items, []);
  * ```
+ *
+ * @example Passing an optional signal through options
+ * ```ts
+ * import { abortable } from "@std/async/unstable-abortable";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const asyncIter = async function* () {
+ *   yield "Hello";
+ *   yield "World";
+ * };
+ *
+ * // Without a signal, iteration proceeds as usual
+ * const items = await Array.fromAsync(abortable(asyncIter(), {}));
+ * assertEquals(items, ["Hello", "World"]);
+ * ```
  */
 
 export function abortable<T>(
@@ -124,10 +175,12 @@ export function abortable<T>(
 export function abortable<T>(
   p: Promise<T> | AsyncIterable<T>,
   signal: AbortSignal | AbortableOptions,
-): Promise<T> | AsyncIterable<T> {
+): Promise<T> | AsyncGenerator<T> {
   if (!(signal instanceof AbortSignal)) {
     if (!signal.signal) {
-      return p;
+      // The iterable overload promises an AsyncGenerator, so a plain
+      // iterable still needs wrapping to gain next/return/throw.
+      return p instanceof Promise ? p : passthroughAsyncIterable(p);
     }
     signal = signal.signal;
   }
@@ -136,6 +189,12 @@ export function abortable<T>(
   } else {
     return abortableAsyncIterable(p, signal);
   }
+}
+
+async function* passthroughAsyncIterable<T>(
+  p: AsyncIterable<T>,
+): AsyncGenerator<T> {
+  return yield* p;
 }
 
 function abortablePromise<T>(

--- a/async/unstable_abortable.ts
+++ b/async/unstable_abortable.ts
@@ -191,9 +191,11 @@ export function abortable<T>(
   }
 }
 
+// TNext is `undefined` to satisfy pre-5.6 TypeScript (Deno v1.x), where
+// AsyncIterator defaults TNext to `undefined` instead of `any` (TS2766).
 async function* passthroughAsyncIterable<T>(
   p: AsyncIterable<T>,
-): AsyncGenerator<T> {
+): AsyncGenerator<T, unknown, undefined> {
   return yield* p;
 }
 

--- a/async/unstable_abortable_test.ts
+++ b/async/unstable_abortable_test.ts
@@ -228,6 +228,33 @@ Deno.test("abortable() does not throw when the signal is already aborted and the
   );
 });
 
+Deno.test("abortable.AsyncIterable() yields all items when no signal is provided", async () => {
+  const a = async function* () {
+    yield "Hello";
+    yield "World";
+  };
+  const items = await Array.fromAsync(abortable(a(), {}));
+  assertEquals(items, ["Hello", "World"]);
+});
+
+Deno.test("abortable.AsyncIterable() returns a proper async generator when no signal is provided", async () => {
+  let finallyRan = false;
+  const iterable: AsyncIterable<number> = {
+    async *[Symbol.asyncIterator]() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        finallyRan = true;
+      }
+    },
+  };
+  const gen = abortable(iterable, {});
+  assertEquals(await gen.next(), { value: 1, done: false });
+  assertEquals(await gen.return(undefined), { value: undefined, done: true });
+  assertEquals(finallyRan, true);
+});
+
 Deno.test("abortable() is a no-op when no signal is provided", async () => {
   const signal: AbortSignal | undefined = undefined;
   const { promise, resolve } = Promise.withResolvers<string>();


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #7277.** Review 7962c79 and ed1ad91 (the fix and a one-line type tweak for Deno v1.x). The first commit, ed9fd59, is that PR's `try/finally` fix and rebases away once it merges.

`abortable(iterable, { signal: undefined })` returns the raw iterable while the overload promises an `AsyncGenerator<T>`. The types say `.return()` exists. It doesn't:

```ts
const gen = abortable(plainIterable, {}); // typed AsyncGenerator<number>
await gen.return(undefined); // TypeError: gen.return is not a function
```

Type-checks clean, crashes at runtime. It also breaks the invariant the suite pins down for the signal path ("behaves just like original"): with a signal you always get a generator, without one you get whatever you passed in.

The fix wraps the no-signal iterable in a `yield*` delegating generator. Delegation forwards `next()` values, `return()`, and `throw()` to the source and closes it on early exit, so the passthrough behaves like the input while honoring the declared type. Promises keep the identity return, since `Promise<T>` was already honest. Wrapping, rather than weakening the overload to `AsyncIterable<T>`, keeps `abortable` consistent with `delay`, `deadline`, and `pooledMap`: every std API with an optional signal returns the same shape whether or not the signal is set.

This also fills the doc gaps ahead of stabilizing the options form from #6971, which landed without documenting it:

- Both overloads now describe the options form and the never-aborts semantics of an undefined signal, each with a runnable example
- Added the `@experimental` markers, matching `unstable_pool.ts`
- Example imports now point at `@std/async/unstable-abortable` instead of `@std/async`, which resolves to the stable function and would reject the options form

The new generator test fails on main with the TypeError above. With the fix: all 30 abortable tests and 6 doc snippets pass.
