### PR TITLE
docs: document error-class selection guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -213,6 +213,29 @@ the starting description.
  */
 ```
 
+### Error Classes
+
+Throw the built-in error class whose meaning matches the failure:
+
+- `TypeError` when an argument has the wrong type or shape.
+- `RangeError` when a value is outside its allowed range.
+- `SyntaxError` when textual input cannot be parsed. This keeps `parse()`
+  functions consistent with `JSON.parse()`.
+
+```
+Bad: throw new Error("Cannot parse input x: value is empty")
+Good: throw new SyntaxError("Cannot parse input x: value is empty")
+```
+
+When an error carries structured data, subclass the closest built-in class so
+`instanceof` checks against the built-in keep working. For example,
+`XmlSyntaxError` and `YamlSyntaxError` extend `SyntaxError` and add `line`,
+`column`, and `offset` properties.
+
+Define a new class extending `Error` only for a domain condition callers are
+expected to catch, such as `RetryError` in `@std/async`. Plain `Error` and
+`EvalError` still appear in older packages; do not imitate them in new code.
+
 ### Error Messages
 
 User-facing error messages should be clear, concise, and consistent. Error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,16 @@ Module files (`mod.ts`) need a `@module` tag.
 
 Exception: `@std/assert` uses periods in error messages (downstream compat).
 
+## Error Classes
+
+- `TypeError` for wrong argument type or shape, `RangeError` for out-of-range
+  values, `SyntaxError` for unparsable textual input
+- Subclass a built-in to carry structured data: `YamlSyntaxError` extends
+  `SyntaxError` and adds position info
+- New `Error` subclasses only for domain conditions callers catch (`RetryError`,
+  `ChannelClosedError`)
+- Plain `Error` and `EvalError` are legacy; do not use in new code
+
 ## CI Pipeline
 
 Tests run on Ubuntu, Windows, and macOS against Deno v1.x and v2.x. Canary is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,13 +108,9 @@ Exception: `@std/assert` uses periods in error messages (downstream compat).
 
 ## Error Classes
 
-- `TypeError` for wrong argument type or shape, `RangeError` for out-of-range
-  values, `SyntaxError` for unparsable textual input
-- Subclass a built-in to carry structured data: `YamlSyntaxError` extends
-  `SyntaxError` and adds position info
-- New `Error` subclasses only for domain conditions callers catch (`RetryError`,
-  `ChannelClosedError`)
-- Plain `Error` and `EvalError` are legacy; do not use in new code
+Follow
+[Error Classes in CONTRIBUTING.md](./.github/CONTRIBUTING.md#error-classes) when
+choosing which error class to throw.
 
 ## CI Pipeline
 


### PR DESCRIPTION
This writes down the error-class doctrine that #5340 established but CONTRIBUTING.md never captured: which built-in to throw, when to subclass one, and when a custom class is justified. AGENTS.md gets the condensed version, next to the message-style rules it already mirrors.

Nothing here is invented. It comes from a `throw new` survey of main (tests excluded):

- `TypeError` for wrong argument type or shape: http 55, cbor 21, data-structures 15
- `RangeError` for out-of-range values: cbor 33, async 15, encoding 12
- `SyntaxError` for unparsable textual input: http 59, toml 21, csv 10, jsonc 10, ini 5. Established by the #5340 campaign (#5446, #5452, #5347, #5346) to align `parse()` functions with `JSON.parse()`
- Built-in subclasses carrying position info: `XmlSyntaxError` (#7233), `YamlSyntaxError` (#7235)
- Custom classes only for domain conditions callers catch: `RetryError`, `ChannelClosedError`, `CircuitBreakerOpenError`, `MockError`, `TimeError`, `HttpError`

Plain `Error` (datetime 19, fs 18) and `EvalError` (msgpack 27) predate the campaign, so the text calls them legacy instead of pretending the tree is uniform.
