### PR TITLE
docs: make AGENTS.md error message style a reference to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,14 +97,9 @@ Module files (`mod.ts`) need a `@module` tag.
 
 ## Error Message Style
 
-- Sentence case, no trailing period
-- Active voice: "Cannot parse input x" not "Input x cannot be parsed"
-- No contractions: "Cannot" not "Can't"
-- Quote string values: `Cannot parse input "hello, world"`
-- Use colons for context: `Cannot parse input x: value is empty`
-- State current and desired state when possible
-
-Exception: `@std/assert` uses periods in error messages (downstream compat).
+Follow
+[Error Messages in CONTRIBUTING.md](./.github/CONTRIBUTING.md#error-messages)
+when writing user-facing error messages.
 
 ## CI Pipeline
 


### PR DESCRIPTION
Follow-up to #7279. Same fix, one section up: the Error Message Style bullets in AGENTS.md were a copy of CONTRIBUTING.md's Error Messages section, now they are a reference. Both error sections in AGENTS.md point at CONTRIBUTING.md, so the rules live in one place.

Requested by @bartlomieju in https://github.com/denoland/std/pull/7279#discussion_r3702770214.
